### PR TITLE
fix: 修复时间块事件无法显示在事件日志 (Issue #83)

### DIFF
--- a/src/lib/services/timeblock.service.ts
+++ b/src/lib/services/timeblock.service.ts
@@ -11,8 +11,7 @@
  */
 
 import { ExoMindEnvironment } from '../environment/environment';
-import { getEventLogService } from './eventlog.service';
-import type { Tag } from '../types/event';
+import { getEventStorage } from '../storage/event-storage';
 import type { TimeBlock, TimeBlockData, ActiveBlockData, TimerConfig } from '../types/event';
 
 // 存储键
@@ -132,13 +131,18 @@ export class TimeBlockServiceImpl implements TimeBlockService {
 
     const endId = crypto.randomUUID();
 
-    // 创建结束事件（通过 EventLogService，与 ChatPage 保持一致）
+    // 创建结束事件（通过 EventStorage，与 ChatPage 保持一致）
     await this.addBlockEvent(endId, `${activeData.name} 完成`, 'block_end');
 
-    // 身心反馈作为独立事件添加到事件日志
+    // 身心反馈作为独立事件添加到事件日志（通过 EventStorage）
     if (feedback) {
-      const feedbackTags = new Set<Tag>(['block_feedback']);
-      await getEventLogService().addEvent(feedback, feedbackTags);
+      const storage = getEventStorage();
+      await storage.addEvent({
+        id: crypto.randomUUID(),
+        content: feedback,
+        createdAt: new Date().toISOString(),
+        type: 'block_feedback',
+      });
     }
 
     // 保存已完成的时间块
@@ -192,14 +196,20 @@ export class TimeBlockServiceImpl implements TimeBlockService {
     return () => this.listeners.delete(callback);
   }
 
-  /** 添加时间块事件（通过 EventLogService，与 ChatPage 保持一致） */
+  /** 添加时间块事件（通过 EventStorage，与 ChatPage 保持一致） */
   private async addBlockEvent(
     _eventId: string,
     content: string,
     tag: 'block_start' | 'block_end',
   ): Promise<void> {
-    const tags = new Set<Tag>([tag]);
-    await getEventLogService().addEvent(content, tags);
+    // 使用 EventStorage 保存事件，与 ChatPage 保持一致
+    const storage = getEventStorage();
+    await storage.addEvent({
+      id: crypto.randomUUID(),
+      content,
+      createdAt: new Date().toISOString(),
+      type: tag,
+    });
   }
 
   private notifyChange(block: ActiveBlockData | null): void {


### PR DESCRIPTION
## 背景

2026-02-11 用户反馈 Issue #83：时间块内容不能显示在事件日志里了。

## 现象

1. 在时间块控件中开始一个时间块
2. 打开事件日志页面（/eventlog）
3. 看不到 `block_start` 事件
4. 结束时间块后，也看不到 `block_end` 事件
5. 添加身心反馈后，也看不到 `block_feedback` 事件

## 根因

| 组件 | 使用的存储 | 存储位置 |
|------|-----------|---------|
| TimeBlockService | EventLogService -> env.storage | localStorage |
| ChatPage | EventStorage | PouchDB |

时间块事件被保存到 `localStorage`（通过 EventLogService），但事件日志页面从 `PouchDB`（通过 EventStorage）读取事件，导致数据在两个不同的存储中，无法显示。

## 修复原理

统一使用 `EventStorage`（PouchDB）作为事件存储：

```
┌─────────────────────────────────────────────────────────────┐
│                    修复前                                   │
├─────────────────────────────────────────────────────────────┤
│  TimeBlockService → EventLogService → localStorage         │
│                              ↓                              │
│  ChatPage ← EventStorage ← PouchDB                         │
│  （读不到数据，因为在不同存储）                               │
└─────────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────────┐
│                    修复后                                   │
├─────────────────────────────────────────────────────────────┤
│  TimeBlockService → EventStorage → PouchDB                 │
│                              ↓                              │
│  ChatPage ← EventStorage ← PouchDB                         │
│  （统一存储，数据一致）                                       │
└─────────────────────────────────────────────────────────────┘
```

## 变更文件

- `src/lib/services/timeblock.service.ts`

## 验收标准

- [x] 类型检查通过 (`tsc --noEmit`)
- [x] 手动测试：开始时间块 -> 事件日志显示 `block_start` 事件
- [x] 手动测试：结束时间块 -> 事件日志显示 `block_end` 事件
- [x] 手动测试：添加身心反馈 -> 事件日志显示 `block_feedback` 事件

## 何时发现

2026-02-11 Issue #83 用户反馈

## 何时修复

2026-02-11 创建 PR #84

## 参考资料

- Issue #83: https://github.com/exomind-team/exomind/issues/83
- PR #32: 修复时间块事件无法记录到 eventlog 的 Bug
- EventStorage: `src/lib/storage/event-storage.ts`
- TimeBlockService: `src/lib/services/timeblock.service.ts`

## 关联 Issue

- Issue #83 (发现问题)