### PR TITLE
fix: 修复 issue #79，支持多 worktree 的环境变量端口配置

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,8 +32,9 @@ EXOMIND_POUCHDB_PORT=6984
 # ASR 后端服务端口
 EXOMIND_ASR_PORT=1949
 # 前端可选覆盖地址（优先级高于端口）
-VITE_SYNC_SERVER_URL=http://localhost:6984
-VITE_ASR_SERVER_URL=http://localhost:1949
+# 仅在需要固定地址时取消注释；多 worktree 场景建议保持注释，避免覆盖 EXOMIND_*_PORT。
+# VITE_SYNC_SERVER_URL=http://localhost:6984
+# VITE_ASR_SERVER_URL=http://localhost:1949
 
 # === 调试选项 ===
 # DEBUG=*

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,19 @@ HTTPS_PROXY=http://127.0.0.1:7890
 NODE_ENV=development
 LOG_LEVEL=info
 
+# === ExoMind 开发端口（多 worktree 推荐）===
+# Vite 开发端口
+EXOMIND_WEB_PORT=1420
+# Vite HMR 端口（建议与 Web 端口区分）
+EXOMIND_HMR_PORT=1421
+# PouchDB 同步服务端口
+EXOMIND_POUCHDB_PORT=6984
+# ASR 后端服务端口
+EXOMIND_ASR_PORT=1949
+# 前端可选覆盖地址（优先级高于端口）
+VITE_SYNC_SERVER_URL=http://localhost:6984
+VITE_ASR_SERVER_URL=http://localhost:1949
+
 # === 调试选项 ===
 # DEBUG=*
 # VERBOSE=true

--- a/dev.ps1
+++ b/dev.ps1
@@ -2,8 +2,44 @@
 
 $ErrorActionPreference = "Stop"
 
+function Resolve-Port {
+    param(
+        [string]$Value,
+        [int]$Default
+    )
+
+    $parsed = 0
+    if ([int]::TryParse($Value, [ref]$parsed) -and $parsed -ge 1 -and $parsed -le 65535) {
+        return $parsed
+    }
+
+    return $Default
+}
+
+$webPort = Resolve-Port $env:EXOMIND_WEB_PORT 1420
+$hmrPort = Resolve-Port $env:EXOMIND_HMR_PORT (if ($webPort -lt 65535) { $webPort + 1 } else { 1421 })
+$pouchdbPort = Resolve-Port $env:EXOMIND_POUCHDB_PORT 6984
+$asrPort = Resolve-Port $env:EXOMIND_ASR_PORT 1949
+
+$env:EXOMIND_WEB_PORT = "$webPort"
+$env:EXOMIND_HMR_PORT = "$hmrPort"
+$env:EXOMIND_POUCHDB_PORT = "$pouchdbPort"
+$env:EXOMIND_ASR_PORT = "$asrPort"
+
+if (-not $env:VITE_SYNC_SERVER_URL) {
+    $env:VITE_SYNC_SERVER_URL = "http://localhost:$pouchdbPort"
+}
+if (-not $env:VITE_ASR_SERVER_URL) {
+    $env:VITE_ASR_SERVER_URL = "http://localhost:$asrPort"
+}
+
 Write-Host "ExoMind 多设备同步开发环境" -ForegroundColor Cyan
 Write-Host "================================" -ForegroundColor Cyan
+Write-Host "端口配置:" -ForegroundColor White
+Write-Host "  - Web:      $webPort" -ForegroundColor White
+Write-Host "  - HMR:      $hmrPort" -ForegroundColor White
+Write-Host "  - PouchDB:  $pouchdbPort" -ForegroundColor White
+Write-Host "  - ASR:      $asrPort" -ForegroundColor White
 
 # 检查并安装依赖
 if (-not (Test-Path "node_modules/@pouchdb/server")) {
@@ -11,33 +47,37 @@ if (-not (Test-Path "node_modules/@pouchdb/server")) {
     bun add @pouchdb/server @pouchdb/core @pouchdb/adapter-idb pouchdb
 }
 
+$stdoutLog = "server/server.log"
+$stderrLog = "server/server.error.log"
+
 # 启动服务器（后台）
 Write-Host "[1/2] 启动 PouchDB 同步服务器..." -ForegroundColor Green
-$serverProcess = Start-Process -FilePath "bun" -ArgumentList "run", "server/pouchdb-server.js" -NoNewWindow -PassThru -RedirectStandardOutput "server/server.log" -RedirectStandardError "server/server.error.log"
+$serverProcess = Start-Process -FilePath "bun" -ArgumentList "run", "server/pouchdb-server.js" -NoNewWindow -PassThru -RedirectStandardOutput $stdoutLog -RedirectStandardError $stderrLog
 
 # 等待服务器启动
 Start-Sleep -Seconds 3
 
 # 检查服务器是否运行
-$serverLog = Get-Content "server/logs/stdout.log" -Tail 5 -ErrorAction SilentlyContinue
+$serverLog = Get-Content $stdoutLog -Tail 20 -ErrorAction SilentlyContinue
 if ($serverLog -match "running|PouchDB|Server") {
-    Write-Host "[OK] 服务器已启动在 http://localhost:6984" -ForegroundColor Green
+    Write-Host "[OK] 服务器已启动在 http://localhost:$pouchdbPort" -ForegroundColor Green
 } else {
-    Write-Host "[ERROR] 服务器启动失败，查看 server/logs/stdout.log" -ForegroundColor Red
-    Get-Content "server/logs/stdout.log" -Tail 20 -ErrorAction SilentlyContinue
+    Write-Host "[ERROR] 服务器启动失败，查看 $stdoutLog 和 $stderrLog" -ForegroundColor Red
+    Get-Content $stdoutLog -Tail 20 -ErrorAction SilentlyContinue
+    Get-Content $stderrLog -Tail 20 -ErrorAction SilentlyContinue
     exit 1
 }
 
 # 打开测试浏览器
 Write-Host "[2/2] 打开测试浏览器..." -ForegroundColor Green
-Write-Host "   - 主窗口: http://localhost:5173" -ForegroundColor White
+Write-Host "   - 主窗口: http://localhost:$webPort" -ForegroundColor White
 Write-Host "   - 第二窗口需手动打开并登录不同账户测试同步" -ForegroundColor White
 
 # 打开主窗口
-Start-Process "http://localhost:5173"
+Start-Process "http://localhost:$webPort"
 
 Write-Host "" -ForegroundColor Cyan
-Write-Host "提示：在第二浏览器打开 http://localhost:5173 并登录不同账户测试多设备同步" -ForegroundColor Yellow
+Write-Host "提示：在第二浏览器打开 http://localhost:$webPort 并登录不同账户测试多设备同步" -ForegroundColor Yellow
 Write-Host "按 Ctrl+C 停止所有服务" -ForegroundColor Yellow
 
 # 启动 Vite 前端

--- a/docs/development/port-env-configuration.md
+++ b/docs/development/port-env-configuration.md
@@ -1,0 +1,61 @@
+# 多 Worktree 端口配置指南
+
+## 背景
+
+当同一台机器同时运行多个 ExoMind worktree（例如功能测试分支 + 部署验证分支）时，默认端口会冲突。  
+Issue: `#79`
+
+## 支持的环境变量
+
+| 变量名 | 默认值 | 作用 |
+|---|---:|---|
+| `EXOMIND_WEB_PORT` | `1420` | Vite 开发服务端口 |
+| `EXOMIND_HMR_PORT` | `1421` | Vite HMR WebSocket 端口 |
+| `EXOMIND_POUCHDB_PORT` | `6984` | PouchDB 同步服务端口 |
+| `EXOMIND_ASR_PORT` | `1949` | ASR 后端服务端口 |
+| `VITE_SYNC_SERVER_URL` | `http://localhost:6984` | 前端同步服务地址（优先级高于 `EXOMIND_POUCHDB_PORT`） |
+| `VITE_ASR_SERVER_URL` | `http://localhost:1949` | 前端 ASR 服务地址（优先级高于 `EXOMIND_ASR_PORT`） |
+
+## 优先级规则
+
+1. 前端同步地址：`VITE_SYNC_SERVER_URL` > `EXOMIND_POUCHDB_PORT` 组装地址 > 默认地址  
+2. 前端 ASR 地址：`VITE_ASR_SERVER_URL` > `EXOMIND_ASR_PORT` 组装地址 > 默认地址  
+3. Vite 端口：`EXOMIND_WEB_PORT` 和 `EXOMIND_HMR_PORT`（若未设置 HMR 端口，则自动使用 `WEB_PORT + 1`）
+
+## 推荐：每个 worktree 一组端口
+
+### Worktree A
+
+```powershell
+$env:EXOMIND_WEB_PORT='1420'
+$env:EXOMIND_HMR_PORT='1421'
+$env:EXOMIND_POUCHDB_PORT='6984'
+$env:EXOMIND_ASR_PORT='1949'
+bun run dev:sync
+```
+
+### Worktree B
+
+```powershell
+$env:EXOMIND_WEB_PORT='1520'
+$env:EXOMIND_HMR_PORT='1521'
+$env:EXOMIND_POUCHDB_PORT='7084'
+$env:EXOMIND_ASR_PORT='2049'
+bun run dev:sync
+```
+
+## 仅前端开发（不启动同步脚本）
+
+```powershell
+$env:EXOMIND_WEB_PORT='1919'
+$env:EXOMIND_HMR_PORT='1920'
+bun run dev
+```
+
+## 验证要点
+
+1. 启动日志中 Web/PouchDB/ASR 端口与环境变量一致。  
+2. 浏览器访问地址与 `EXOMIND_WEB_PORT` 一致。  
+3. 同步页面默认服务器地址与端口配置一致。  
+4. 修改环境变量后，重启进程即可生效。
+

--- a/docs/plans/2026-02-11-issue-79-port-env-config.md
+++ b/docs/plans/2026-02-11-issue-79-port-env-config.md
@@ -1,0 +1,184 @@
+# Issue #79 Port Env Config Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 让 ExoMind 在同一台机器的多个 worktree 中可通过环境变量配置端口，避免 Vite/PouchDB/ASR 端口冲突。
+
+**Architecture:** 新增统一端口解析模块，所有开发入口（Vite 配置、PowerShell 启动脚本、前端默认同步地址、ASR 默认地址、PouchDB 服务配置）都从同一组环境变量读取。默认值保持向后兼容，且支持无效值回退。
+
+**Tech Stack:** Vite 6, React 18, Bun, Node.js ESM, PowerShell, Vitest, GitHub CLI
+
+---
+
+### Task 1: 端口解析模块与失败测试（TDD Red）
+
+**Files:**
+- Create: `src/config/port-env.ts`
+- Create: `tests/config/port-env.test.ts`
+
+**Step 1: 写失败测试（端口解析规则）**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_PORTS,
+  parsePort,
+  resolveDevPorts,
+  resolveSyncServerUrl,
+  resolveAsrServerUrl,
+} from '@/config/port-env';
+
+describe('port env', () => {
+  it('parsePort: 非法值回退默认值', () => {
+    expect(parsePort(undefined, 1420)).toBe(1420);
+    expect(parsePort('abc', 1420)).toBe(1420);
+    expect(parsePort('70000', 1420)).toBe(1420);
+  });
+});
+```
+
+**Step 2: 运行测试确认失败**
+
+Run: `bun run test tests/config/port-env.test.ts --run`  
+Expected: FAIL，报 `Cannot find module '@/config/port-env'`
+
+**Step 3: 最小实现让测试可通过**
+
+在 `src/config/port-env.ts` 实现：
+- `DEFAULT_PORTS`：`web=1420`、`hmr=1421`、`pouchdb=6984`、`asr=1949`
+- `parsePort(value, fallback)`：只接受 `1..65535` 整数
+- `resolveDevPorts(env)`：读取 `EXOMIND_WEB_PORT` / `EXOMIND_HMR_PORT`
+- `resolveSyncServerUrl(env)`：优先 `VITE_SYNC_SERVER_URL`，否则用 `EXOMIND_POUCHDB_PORT` 组装
+- `resolveAsrServerUrl(env)`：优先 `VITE_ASR_SERVER_URL`，否则用 `EXOMIND_ASR_PORT` 组装
+
+**Step 4: 运行测试确认通过**
+
+Run: `bun run test tests/config/port-env.test.ts --run`  
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/config/port-env.ts tests/config/port-env.test.ts
+git commit -m "test+feat: add shared port env resolver"
+```
+
+### Task 2: 接入 Vite/服务端/前端默认地址（TDD Green）
+
+**Files:**
+- Modify: `vite.config.ts`
+- Modify: `server/config.js`
+- Modify: `src/components/Chat/ChatPage.tsx`
+- Modify: `src/ui/pages/SyncTestPage.tsx`
+- Modify: `src/lib/adapters/asr/volcano-http-asr.ts`
+- Modify: `src/backend/server.ts`
+
+**Step 1: 写集成测试（先失败）**
+
+在 `tests/config/port-env.test.ts` 新增案例：
+- `resolveDevPorts` 正确读取 `EXOMIND_WEB_PORT=1919`、`EXOMIND_HMR_PORT=1929`
+- `resolveSyncServerUrl` 在无 `VITE_SYNC_SERVER_URL` 时读取 `EXOMIND_POUCHDB_PORT=1930`
+- `resolveAsrServerUrl` 在无 `VITE_ASR_SERVER_URL` 时读取 `EXOMIND_ASR_PORT=1931`
+
+**Step 2: 运行测试确认失败**
+
+Run: `bun run test tests/config/port-env.test.ts --run`  
+Expected: FAIL（函数行为尚未完整实现）
+
+**Step 3: 最小实现修改**
+
+- `vite.config.ts`：
+  - 使用 `loadEnv(mode, process.cwd(), '')`
+  - `server.port` 读取 `resolveDevPorts(env).web`
+  - `server.hmr.port` 读取 `resolveDevPorts(env).hmr`
+- `server/config.js`：
+  - `port` 从 `process.env.EXOMIND_POUCHDB_PORT` 解析，默认 6984
+- `src/components/Chat/ChatPage.tsx`：
+  - 用 `resolveSyncServerUrl(import.meta.env)` 拼接 `database/${currentUser}`
+- `src/ui/pages/SyncTestPage.tsx`：
+  - 默认 `serverUrl` 改为 `resolveSyncServerUrl(import.meta.env)`
+- `src/lib/adapters/asr/volcano-http-asr.ts`：
+  - 默认地址改为 `resolveAsrServerUrl(import.meta.env)`
+- `src/backend/server.ts`：
+  - `PORT` 优先级增加 `EXOMIND_ASR_PORT`
+
+**Step 4: 运行测试确认通过**
+
+Run: `bun run test tests/config/port-env.test.ts --run`  
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add vite.config.ts server/config.js src/components/Chat/ChatPage.tsx src/ui/pages/SyncTestPage.tsx src/lib/adapters/asr/volcano-http-asr.ts src/backend/server.ts
+git commit -m "fix: wire all dev ports to environment variables"
+```
+
+### Task 3: 启动脚本与文档
+
+**Files:**
+- Modify: `dev.ps1`
+- Modify: `.env.example`
+- Create: `docs/development/port-env-configuration.md`
+
+**Step 1: 写脚本行为测试（轻量手工验证步骤）**
+
+验证清单：
+- 无环境变量时打印默认地址（1420 / 6984 / 1949）
+- 设置 `EXOMIND_WEB_PORT` 后打开浏览器 URL 改为新端口
+- 设置 `EXOMIND_POUCHDB_PORT` 后日志与实际服务端口一致
+
+**Step 2: 实现脚本与文档**
+
+- `dev.ps1`：
+  - 读取 `EXOMIND_WEB_PORT`、`EXOMIND_POUCHDB_PORT`、`EXOMIND_ASR_PORT`
+  - 将 `VITE_SYNC_SERVER_URL`、`VITE_ASR_SERVER_URL` 在运行时默认导出为对应 localhost URL
+  - 打印动态端口，不再写死 `5173/6984`
+- `.env.example`：
+  - 添加三类端口变量和说明
+- `docs/development/port-env-configuration.md`：
+  - 说明单 worktree 与多 worktree 的端口配置示例
+  - 给出 PowerShell 与 Bun 启动示例
+
+**Step 3: Commit**
+
+```bash
+git add dev.ps1 .env.example docs/development/port-env-configuration.md
+git commit -m "docs+chore: add multi-worktree port configuration guide"
+```
+
+### Task 4: 验证、推送与 PR
+
+**Files:**
+- Modify: `docs/plans/2026-02-11-issue-79-port-env-config.md`（如需补充验证记录）
+
+**Step 1: 自动化验证**
+
+Run:
+- `bun run test tests/config/port-env.test.ts --run`
+- `node -e "process.env.EXOMIND_POUCHDB_PORT='1920'; import('./server/config.js').then(m=>console.log(m.default.port))"`
+
+Expected:
+- 测试全绿
+- 输出 `1920`
+
+**Step 2: 手工验证（命令级）**
+
+Run:
+- `$env:EXOMIND_WEB_PORT='1919'; bun run dev -- --strictPort`
+
+Expected:
+- Vite Local 地址为 `http://localhost:1919/`
+
+**Step 3: 分支推送与 PR**
+
+Run:
+- `git push -u origin fix/issue-79-port-env`
+- `gh pr create --base dev --head fix/issue-79-port-env --title "fix: issue #79 support env-based ports for multi-worktree dev" --body "<PR说明>"`
+
+PR body 包含：
+- 问题复现证据
+- 变更清单
+- 验证命令与结果
+- 关联 `Closes #79`
+

--- a/server/config.js
+++ b/server/config.js
@@ -1,9 +1,17 @@
 // server/config.js
 // PouchDB Server 配置文件
 
+function parsePort(value, fallback) {
+  const port = Number.parseInt(value ?? '', 10);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    return fallback;
+  }
+  return port;
+}
+
 export default {
   // 服务端口
-  port: 6986,
+  port: parsePort(process.env.EXOMIND_POUCHDB_PORT, 6984),
 
   // 数据库存储目录
   dataDir: './data',

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -40,9 +40,20 @@ interface ASRResponse {
   audio_info?: { duration: number };
 }
 
+function parsePort(value: string | undefined, fallback: number): number {
+  const port = Number.parseInt(value ?? '', 10);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    return fallback;
+  }
+  return port;
+}
+
 // 配置 - 从环境变量读取（支持 VITE_ 和 VOLCANO_ 前缀）
 const CONFIG = {
-  PORT: parseInt(process.env.VOLCANO_PORT || process.env.VITE_VOLCANO_PORT || '1949'),
+  PORT: parsePort(
+    process.env.EXOMIND_ASR_PORT || process.env.VOLCANO_PORT || process.env.VITE_VOLCANO_PORT,
+    1949
+  ),
   APP_KEY: process.env.VOLCANO_APP_KEY || process.env.VITE_VOLCANO_APP_KEY || '',
   ACCESS_KEY: process.env.VOLCANO_ACCESS_KEY || process.env.VITE_VOLCANO_ACCESS_KEY || '',
   RESOURCE_ID: process.env.VOLCANO_RESOURCE_ID || process.env.VITE_VOLCANO_RESOURCE_ID || 'volc.bigasr.sauc.duration',

--- a/src/components/Chat/ChatPage.tsx
+++ b/src/components/Chat/ChatPage.tsx
@@ -19,6 +19,7 @@ import { TimeBlockWidget } from '@/components/TimeBlockWidget';
 import type { Event } from '@/lib/types/event';
 import { getEventStorage, type Event as StorageEvent, type EventStorage } from '@/lib/storage/event-storage';
 import { useSyncStore } from '@/ui/stores/sync-store';
+import { resolveSyncServerUrl } from '@/config/port-env';
 
 export function ChatPage() {
   const [events, setEvents] = useState<Event[]>([]);
@@ -58,7 +59,8 @@ export function ChatPage() {
     // 如果已登录，连接到远程同步
     if (isLoggedIn && currentUser) {
       setSyncStatus('syncing');
-      const remoteUrl = `http://localhost:6984/database/${currentUser}`;
+      const syncServerUrl = resolveSyncServerUrl(import.meta.env as Record<string, string | undefined>);
+      const remoteUrl = `${syncServerUrl}/database/${currentUser}`;
       storage.syncToRemote(remoteUrl).then(() => {
         setSyncStatus('connected');
         console.log('[ChatPage] 远程同步已启动');

--- a/src/config/port-env.ts
+++ b/src/config/port-env.ts
@@ -1,0 +1,50 @@
+export const DEFAULT_PORTS = {
+  web: 1420,
+  hmr: 1421,
+  pouchdb: 6984,
+  asr: 1949,
+} as const;
+
+type EnvMap = Record<string, string | undefined>;
+
+export function parsePort(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+
+  const port = Number.parseInt(value, 10);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    return fallback;
+  }
+
+  return port;
+}
+
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+export function resolveDevPorts(env: EnvMap): { web: number; hmr: number } {
+  const web = parsePort(env.EXOMIND_WEB_PORT, DEFAULT_PORTS.web);
+  const fallbackHmr = web < 65535 ? web + 1 : DEFAULT_PORTS.hmr;
+  const hmr = parsePort(env.EXOMIND_HMR_PORT, fallbackHmr);
+
+  return { web, hmr };
+}
+
+export function resolveSyncServerUrl(env: EnvMap): string {
+  if (env.VITE_SYNC_SERVER_URL) {
+    return normalizeBaseUrl(env.VITE_SYNC_SERVER_URL);
+  }
+
+  const port = parsePort(env.EXOMIND_POUCHDB_PORT, DEFAULT_PORTS.pouchdb);
+  return `http://localhost:${port}`;
+}
+
+export function resolveAsrServerUrl(env: EnvMap): string {
+  if (env.VITE_ASR_SERVER_URL) {
+    return normalizeBaseUrl(env.VITE_ASR_SERVER_URL);
+  }
+
+  const port = parsePort(env.EXOMIND_ASR_PORT, DEFAULT_PORTS.asr);
+  return `http://localhost:${port}`;
+}
+

--- a/src/lib/adapters/asr/volcano-http-asr.ts
+++ b/src/lib/adapters/asr/volcano-http-asr.ts
@@ -15,6 +15,7 @@
  */
 
 import type { IASRPort, ASRInput, ASRResult, ASRPartialResult } from '../../environment/interfaces/asr.port';
+import { resolveAsrServerUrl } from '@/config/port-env';
 
 // ========== 配置 ==========
 
@@ -26,7 +27,7 @@ export interface VolcanoHTTPASRConfig {
 }
 
 const DEFAULT_CONFIG: VolcanoHTTPASRConfig = {
-  serverUrl: (import.meta.env?.VITE_ASR_SERVER_URL as string) || 'http://localhost:1949',
+  serverUrl: resolveAsrServerUrl(import.meta.env as Record<string, string | undefined>),
   timeout: 30000, // 30秒超时
 };
 

--- a/src/pages/VoiceChatPage.tsx
+++ b/src/pages/VoiceChatPage.tsx
@@ -13,9 +13,11 @@
 import { useEffect, useState } from 'react';
 import { getVoiceChatService, setASRAdapterType, ASRAdapterType } from '../lib/services/voice-chat.service';
 import type { ASRResult } from '../lib/environment/interfaces/asr.port';
+import { resolveAsrServerUrl } from '@/config/port-env';
 
 export function VoiceChatPage() {
   const service = getVoiceChatService();
+  const defaultAsrServerUrl = resolveAsrServerUrl(import.meta.env as Record<string, string | undefined>);
 
   const [isRecording, setIsRecording] = useState(false);
   const [duration, setDuration] = useState(0);
@@ -42,10 +44,10 @@ export function VoiceChatPage() {
         addLog('【配置环境变量】');
         addLog('  VITE_VOLCANO_APP_KEY=xxx');
         addLog('  VITE_VOLCANO_ACCESS_KEY=xxx');
-        addLog('  VITE_ASR_SERVER_URL=http://localhost:1949');
+        addLog(`  VITE_ASR_SERVER_URL=${defaultAsrServerUrl}`);
       }
     }, 500);
-  }, []);
+  }, [defaultAsrServerUrl]);
 
   // 轮询服务状态
   useEffect(() => {

--- a/src/ui/pages/SyncTestPage.tsx
+++ b/src/ui/pages/SyncTestPage.tsx
@@ -14,6 +14,7 @@ import {
   useSyncStore,
 } from '@/ui/stores/sync-store';
 import type { Conflict } from '@/environment/interfaces/sync.port';
+import { resolveSyncServerUrl } from '@/config/port-env';
 
 interface LogEntry {
   level: 'INFO' | 'SUCCESS' | 'WARN' | 'ERROR';
@@ -22,9 +23,10 @@ interface LogEntry {
 }
 
 export function SyncTestPage() {
+  const defaultSyncServerUrl = resolveSyncServerUrl(import.meta.env as Record<string, string | undefined>);
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const logsRef = useRef<HTMLDivElement>(null);
-  const [serverUrl, setServerUrl] = useState('http://localhost:6984');
+  const [serverUrl, setServerUrl] = useState(defaultSyncServerUrl);
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
 
@@ -173,7 +175,7 @@ export function SyncTestPage() {
             <Label htmlFor="serverUrl">服务器地址</Label>
             <Input
               id="serverUrl"
-              placeholder="http://localhost:6984"
+              placeholder={defaultSyncServerUrl}
               value={serverUrl}
               onChange={(e) => setServerUrl(e.target.value)}
             />

--- a/tests/config/port-env.test.ts
+++ b/tests/config/port-env.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_PORTS,
+  parsePort,
+  resolveAsrServerUrl,
+  resolveDevPorts,
+  resolveSyncServerUrl,
+} from '@/config/port-env';
+
+describe('port env resolver', () => {
+  it('parsePort should fallback for invalid values', () => {
+    expect(parsePort(undefined, DEFAULT_PORTS.web)).toBe(DEFAULT_PORTS.web);
+    expect(parsePort('', DEFAULT_PORTS.web)).toBe(DEFAULT_PORTS.web);
+    expect(parsePort('abc', DEFAULT_PORTS.web)).toBe(DEFAULT_PORTS.web);
+    expect(parsePort('0', DEFAULT_PORTS.web)).toBe(DEFAULT_PORTS.web);
+    expect(parsePort('65536', DEFAULT_PORTS.web)).toBe(DEFAULT_PORTS.web);
+  });
+
+  it('parsePort should accept valid port values', () => {
+    expect(parsePort('1', DEFAULT_PORTS.web)).toBe(1);
+    expect(parsePort('1919', DEFAULT_PORTS.web)).toBe(1919);
+    expect(parsePort('65535', DEFAULT_PORTS.web)).toBe(65535);
+  });
+
+  it('resolveDevPorts should read EXOMIND_* env values', () => {
+    const ports = resolveDevPorts({
+      EXOMIND_WEB_PORT: '1919',
+      EXOMIND_HMR_PORT: '1929',
+    });
+
+    expect(ports.web).toBe(1919);
+    expect(ports.hmr).toBe(1929);
+  });
+
+  it('resolveDevPorts should auto-derive HMR port from web port', () => {
+    const ports = resolveDevPorts({
+      EXOMIND_WEB_PORT: '1810',
+    });
+
+    expect(ports.web).toBe(1810);
+    expect(ports.hmr).toBe(1811);
+  });
+
+  it('resolveSyncServerUrl should prefer VITE_SYNC_SERVER_URL', () => {
+    const serverUrl = resolveSyncServerUrl({
+      VITE_SYNC_SERVER_URL: 'http://localhost:18080/',
+      EXOMIND_POUCHDB_PORT: '1930',
+    });
+
+    expect(serverUrl).toBe('http://localhost:18080');
+  });
+
+  it('resolveSyncServerUrl should fallback to EXOMIND_POUCHDB_PORT', () => {
+    const serverUrl = resolveSyncServerUrl({
+      EXOMIND_POUCHDB_PORT: '1930',
+    });
+
+    expect(serverUrl).toBe('http://localhost:1930');
+  });
+
+  it('resolveAsrServerUrl should prefer VITE_ASR_SERVER_URL', () => {
+    const serverUrl = resolveAsrServerUrl({
+      VITE_ASR_SERVER_URL: 'http://localhost:19049',
+      EXOMIND_ASR_PORT: '1931',
+    });
+
+    expect(serverUrl).toBe('http://localhost:19049');
+  });
+
+  it('resolveAsrServerUrl should fallback to EXOMIND_ASR_PORT', () => {
+    const serverUrl = resolveAsrServerUrl({
+      EXOMIND_ASR_PORT: '1931',
+    });
+
+    expect(serverUrl).toBe('http://localhost:1931');
+  });
+});

--- a/tests/config/vite-env-prefix.test.ts
+++ b/tests/config/vite-env-prefix.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import viteConfig from '../../vite.config';
+
+describe('vite env prefix config', () => {
+  it('should expose EXOMIND_ env vars to import.meta.env', async () => {
+    const resolved =
+      typeof viteConfig === 'function'
+        ? await viteConfig({ command: 'serve', mode: 'test', isSsrBuild: false, isPreview: false })
+        : viteConfig;
+
+    const envPrefix = Array.isArray(resolved.envPrefix)
+      ? resolved.envPrefix
+      : [resolved.envPrefix];
+
+    expect(envPrefix).toContain('VITE_');
+    expect(envPrefix).toContain('EXOMIND_');
+  });
+});
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,38 +1,44 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import { resolveDevPorts } from "./src/config/port-env";
 
 // https://vitejs.dev/config/
-export default defineConfig(async () => ({
-  plugins: [react()],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const devPorts = resolveDevPorts(env);
 
-  envDir: '.',
+  return {
+    plugins: [react()],
 
-  optimizeDeps: {
-    include: ['spark-md5', 'vuvuzela'],
-    exclude: ['pouchdb', 'pouchdb-find', 'pouchdb-browser'],
-  },
+    envDir: ".",
 
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-      // Force the npm polyfill package instead of Node builtin externalization.
-      "events": "events/",
+    optimizeDeps: {
+      include: ["spark-md5", "vuvuzela"],
+      exclude: ["pouchdb", "pouchdb-find", "pouchdb-browser"],
     },
-  },
 
-  clearScreen: false,
-  server: {
-    port: 1420,
-    strictPort: true,
-    host: '0.0.0.0',
-    hmr: {
-      protocol: "ws",
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+        // Force the npm polyfill package instead of Node builtin externalization.
+        events: "events/",
+      },
+    },
+
+    clearScreen: false,
+    server: {
+      port: devPorts.web,
+      strictPort: true,
       host: "0.0.0.0",
-      port: 1421,
+      hmr: {
+        protocol: "ws",
+        host: "0.0.0.0",
+        port: devPorts.hmr,
+      },
+      watch: {
+        ignored: ["**/src-tauri/**"],
+      },
     },
-    watch: {
-      ignored: ["**/src-tauri/**"],
-    },
-  },
-}));
+  };
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig(({ mode }) => {
     plugins: [react()],
 
     envDir: ".",
+    envPrefix: ["VITE_", "EXOMIND_"],
 
     optimizeDeps: {
       include: ["spark-md5", "vuvuzela"],


### PR DESCRIPTION
﻿## 概述
本 PR 修复 issue #79，将开发端口从硬编码改为环境变量驱动，支持同一台机器上多个 git worktree 并行运行，避免端口冲突。

## 主要改动
- 新增统一端口解析模块：`src/config/port-env.ts`
- 新增测试：
  - `tests/config/port-env.test.ts`
  - `tests/config/vite-env-prefix.test.ts`
- 更新 Vite 端口与环境变量暴露：
  - 支持 `EXOMIND_WEB_PORT`
  - 支持 `EXOMIND_HMR_PORT`
  - 增加 `envPrefix: ["VITE_", "EXOMIND_"]`
- PouchDB 服务端口改为读取 `EXOMIND_POUCHDB_PORT`
- ASR 后端支持读取 `EXOMIND_ASR_PORT`（兼容原有回退）
- 前端同步/ASR 默认地址不再写死 `localhost:6984/1949`，改为环境变量解析
- 更新 `dev.ps1`：
  - 统一解析并打印生效端口
  - 默认注入 `VITE_SYNC_SERVER_URL` 与 `VITE_ASR_SERVER_URL`
  - 移除写死的 `5173/6984` 输出
- 新增文档：
  - `docs/development/port-env-configuration.md`
  - `docs/plans/2026-02-11-issue-79-port-env-config.md`

## 验证结果
- `bun run test tests/config/port-env.test.ts tests/config/vite-env-prefix.test.ts --run`
  - 通过（9/9）
- `bun run build`
  - 通过
- `node -e 'process.env.EXOMIND_POUCHDB_PORT="3021"; import("./server/config.js").then(m => console.log(m.default.port));'`
  - 输出：`3021`
- 手工验证：
  - `EXOMIND_WEB_PORT=3119 bun run dev`
  - Vite 实际启动地址：`http://localhost:3119/`
  - HMR 监听端口：`3120`

## 备注
仓库存在与本 PR 无关的既有失败测试（`tests/components/ChatPage.test.tsx`），本 PR 未改动该区域。

Closes #79
