### PR TITLE
fix: 修复 issue #89 输入框多行滚动与发送交互

### DIFF
--- a/src/components/TimeBlockWidget.tsx
+++ b/src/components/TimeBlockWidget.tsx
@@ -230,7 +230,7 @@ export function TimeBlockWidget({ expanded: controlledExpanded, onExpandedChange
   const isPaused = timerState === 'paused';
 
   return (
-    <div className="border-b bg-muted/30">
+    <div className="border-b bg-muted/30" data-testid="timeblock-widget">
       {/* 状态栏 */}
       <div className="flex items-center justify-between px-4 py-3">
         {/* 左侧：控制按钮 */}

--- a/src/components/VoiceMessageInput.tsx
+++ b/src/components/VoiceMessageInput.tsx
@@ -11,10 +11,10 @@
  * └─────────────────────────────────────────┘
  */
 
-import { useState, KeyboardEvent, useCallback } from 'react';
+import { useState, KeyboardEvent, useCallback, useRef, useEffect } from 'react';
 import { Send } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import { VoiceInputButton } from './VoiceInputButton';
 import type { IASRPort, IASRConfig } from '@/lib/ports/asr-port';
 
@@ -39,6 +39,10 @@ export interface VoiceMessageInputProps {
   inputClassName?: string;
   /** 按钮大小 */
   buttonSize?: number;
+  /** 输入框最小行数 */
+  minRows?: number;
+  /** 输入框最大行数（超过后内部滚动） */
+  maxRows?: number;
 }
 
 export function VoiceMessageInput({
@@ -52,8 +56,35 @@ export function VoiceMessageInput({
   enableShortcut = true,
   inputClassName,
   buttonSize = 40,
+  minRows = 2,
+  maxRows = 6,
 }: VoiceMessageInputProps) {
   const [value, setValue] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const resizeTextarea = useCallback((target?: HTMLTextAreaElement | null) => {
+    const el = target ?? textareaRef.current;
+    if (!el) return;
+
+    const computed = window.getComputedStyle(el);
+    const lineHeight = Number.parseFloat(computed.lineHeight) || 20;
+    const paddingTop = Number.parseFloat(computed.paddingTop) || 0;
+    const paddingBottom = Number.parseFloat(computed.paddingBottom) || 0;
+    const borderTop = Number.parseFloat(computed.borderTopWidth) || 0;
+    const borderBottom = Number.parseFloat(computed.borderBottomWidth) || 0;
+    const vertical = paddingTop + paddingBottom + borderTop + borderBottom;
+    const minHeight = Math.ceil(lineHeight * minRows + vertical);
+    const maxHeight = Math.ceil(lineHeight * maxRows + vertical);
+
+    el.style.height = 'auto';
+    const nextHeight = Math.max(minHeight, Math.min(el.scrollHeight, maxHeight));
+    el.style.height = `${nextHeight}px`;
+    el.style.overflowY = el.scrollHeight > maxHeight ? 'auto' : 'hidden';
+  }, [maxRows, minRows]);
+
+  useEffect(() => {
+    resizeTextarea();
+  }, [value, resizeTextarea]);
 
   // 发送消息
   const handleSend = useCallback(() => {
@@ -65,7 +96,7 @@ export function VoiceMessageInput({
   }, [value, onSend]);
 
   // 键盘事件
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSend();
@@ -86,7 +117,7 @@ export function VoiceMessageInput({
   }, []);
 
   return (
-    <div className="flex items-center gap-2 px-3 py-2 border-t bg-card shrink-0 safe-area-pb">
+    <div className="flex items-end gap-2 px-3 py-2 border-t bg-card shrink-0 safe-area-pb">
       {/* 语音输入按钮 */}
       <VoiceInputButton
         onResult={handleVoiceResult}
@@ -103,14 +134,23 @@ export function VoiceMessageInput({
       />
 
       {/* 文本输入框 */}
-      <Input
+      <Textarea
+        ref={textareaRef}
         value={value}
-        onChange={(e) => setValue(e.target.value)}
+        onChange={(e) => {
+          setValue(e.target.value);
+          resizeTextarea(e.target);
+        }}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
         className={inputClassName}
+        rows={minRows}
+        data-testid="event-input-textarea"
+        data-gramm="false"
+        spellCheck={false}
         style={{
           flex: 1,
+          minHeight: '56px',
         }}
       />
 
@@ -120,6 +160,8 @@ export function VoiceMessageInput({
         disabled={!value.trim()}
         size="icon"
         className="shrink-0"
+        type="button"
+        data-testid="event-send-button"
       >
         <Send size={18} />
       </Button>

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-9 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 resize-none",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea }
+

--- a/tests/e2e/eventlog-input-multiline.test.ts
+++ b/tests/e2e/eventlog-input-multiline.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('事件日志输入框 - 多行与滚动', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/eventlog');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('应使用多行输入框并保持较高初始高度', async ({ page }) => {
+    const textarea = page.locator('[data-testid="event-input-textarea"]');
+    await expect(textarea).toBeVisible();
+
+    const height = await textarea.evaluate((el) => (el as HTMLTextAreaElement).clientHeight);
+    expect(height).toBeGreaterThanOrEqual(48);
+  });
+
+  test('Enter 应发送消息并显示在事件列表', async ({ page }) => {
+    const textarea = page.locator('[data-testid="event-input-textarea"]');
+    const content = `e2e-${Date.now()}`;
+
+    await textarea.fill(content);
+    await textarea.press('Enter');
+
+    await expect(page.locator('[data-testid="event-list"]')).toContainText(content);
+  });
+
+  test('Shift+Enter 应插入换行而不是发送', async ({ page }) => {
+    const textarea = page.locator('[data-testid="event-input-textarea"]');
+
+    await textarea.click();
+    await textarea.type('第一行');
+    await textarea.press('Shift+Enter');
+    await textarea.type('第二行');
+
+    await expect(textarea).toHaveValue('第一行\n第二行');
+  });
+
+  test('文本过长时输入框应内部纵向滚动', async ({ page }) => {
+    const textarea = page.locator('[data-testid="event-input-textarea"]');
+    const longText = Array.from({ length: 24 }, (_, idx) => `第${idx + 1}行内容`).join('\n');
+
+    await textarea.fill(longText);
+
+    const metrics = await textarea.evaluate((el) => {
+      const node = el as HTMLTextAreaElement;
+      const style = window.getComputedStyle(node);
+      return {
+        clientHeight: node.clientHeight,
+        scrollHeight: node.scrollHeight,
+        overflowY: style.overflowY,
+      };
+    });
+
+    expect(metrics.scrollHeight).toBeGreaterThan(metrics.clientHeight);
+    expect(metrics.overflowY).toBe('auto');
+  });
+});
+

--- a/tests/e2e/eventlog.test.ts
+++ b/tests/e2e/eventlog.test.ts
@@ -32,7 +32,7 @@ test.describe('事件日志页面 (EventLog)', () => {
 
   test('应该渲染 ChatPage 组件', async ({ page }) => {
     // 验证页面标题文本
-    await expect(page.getByText('事件日志')).toBeVisible();
+    await expect(page.locator('main h2').filter({ hasText: '事件日志' }).first()).toBeVisible();
 
     // 验证同步状态徽章存在
     await expect(page.locator('text=未同步')).toBeVisible();
@@ -48,10 +48,10 @@ test.describe('事件日志页面 (EventLog)', () => {
 
   test('应该显示消息输入框', async ({ page }) => {
     // 验证输入框占位符
-    await expect(page.locator('input[placeholder*="输入内容记录事件"]')).toBeVisible();
+    await expect(page.locator('[data-testid="event-input-textarea"][placeholder*="输入内容记录事件"]')).toBeVisible();
 
     // 验证发送按钮存在
-    await expect(page.locator('button[type="submit"]')).toBeVisible();
+    await expect(page.locator('[data-testid="event-send-button"]')).toBeVisible();
   });
 
   test('侧边栏应该高亮当前激活的导航项', async ({ page }) => {
@@ -73,7 +73,7 @@ test.describe('事件日志页面 (EventLog)', () => {
     await expect(mainContent).toBeVisible();
 
     // 验证头部区域存在（包含标题和状态）
-    await expect(page.getByText('事件日志')).toBeVisible();
+    await expect(page.locator('main h2').filter({ hasText: '事件日志' }).first()).toBeVisible();
 
     // 验证 TimeBlock 控件栏存在
     await expect(page.locator('[data-testid="timeblock-widget"], .timeblock-widget')).toBeVisible();
@@ -88,7 +88,7 @@ test.describe('事件日志页面 (EventLog)', () => {
     await expect(page).toHaveURL('/');
 
     // 返回事件日志页面
-    await page.locator('a:has-text("事件日志")').click();
+    await page.locator('[data-testid="device-panel"] a:has-text("事件日志")').click();
     await page.waitForLoadState('networkidle');
 
     // 验证返回事件日志页面
@@ -144,12 +144,12 @@ test.describe('事件日志页面 - 输入交互', () => {
   });
 
   test('输入框应该可聚焦', async ({ page }) => {
-    const input = page.locator('input[placeholder*="输入内容记录事件"]');
+    const input = page.locator('[data-testid="event-input-textarea"]');
     await expect(input).toBeEnabled();
   });
 
   test('输入内容后应该能触发发送逻辑', async ({ page }) => {
-    const input = page.locator('input[placeholder*="输入内容记录事件"]');
+    const input = page.locator('[data-testid="event-input-textarea"]');
 
     // 输入测试内容
     await input.fill('测试事件内容');


### PR DESCRIPTION
﻿## 背景
修复 issue #89：输入框目前是单行横向扩展，无法像 Telegram/微信那样多行编辑与纵向滚动。

## 方案与实现
采用 **方案 B（textarea + 自适应高度）**，不引入富文本编辑器。

### 主要改动
- `src/components/VoiceMessageInput.tsx`
  - 输入控件由单行 `input` 改为多行 `textarea`
  - 默认更高（2 行视觉高度）
  - 自动增高到上限后，输入框内部纵向滚动
  - 保持交互：`Enter` 发送，`Shift+Enter` 换行
  - 增加稳定选择器：`data-testid="event-input-textarea"`、`data-testid="event-send-button"`
- `src/components/ui/textarea.tsx`（新增）
- `tests/e2e/eventlog-input-multiline.test.ts`（新增）
  - 实测覆盖：多行输入、发送、换行、滚动
- `tests/e2e/eventlog.test.ts`
  - 调整选择器以避免 strict mode 冲突
- `src/components/TimeBlockWidget.tsx`
  - 增加 `data-testid="timeblock-widget"`，稳定现有 e2e 断言

## 自动化验证
- `bun run test tests/components/VoiceMessageInput.test.tsx --run` ✅
- `bunx playwright test tests/e2e/eventlog-input-multiline.test.ts --config tests/e2e/playwright.issue77.config.ts` ✅
- `bunx playwright test tests/e2e/eventlog-input-multiline.test.ts tests/e2e/eventlog.test.ts --config tests/e2e/playwright.issue77.config.ts` ✅（17 passed）
- `bun run build` ✅

## 手动测试（端口 9647）
```powershell
$env:EXOMIND_WEB_PORT='9647'; $env:EXOMIND_HMR_PORT='9648'; bun run dev
```

打开：`http://localhost:9647/eventlog`

## 已知备注（移动端）
- 手机端通过局域网地址访问（如 `http://192.168.x.x:9647`）时，可能出现 EventLog 无法发送。
- 你的实测已确认：将该地址加入浏览器 **Insecure origins treated as secure** 列表后可恢复。
- 建议评审时按上述方式配置后再进行移动端回归。

## 评审清单
- [ ] 输入框初始高度明显大于旧版（约 2 行）
- [ ] 长文本输入时，输入框先增高，再出现内部纵向滚动
- [ ] `Enter` 发送消息成功，消息出现在事件列表
- [ ] `Shift+Enter` 仅换行，不会发送
- [ ] 移动端宽度下，语音按钮/发送按钮布局无错位
- [ ] 未引入富文本编辑器相关依赖或实现
- [ ] 在端口 `9647` 手动回归通过
- [ ] 移动端在配置 Insecure origins 后发送正常

Closes #89
