### PR TITLE
feat: 消息懒加载 (issue #65, option B)

### DIFF
--- a/docs/plans/2026-02-12-issue-65-eventlog-lazy-loading.md
+++ b/docs/plans/2026-02-12-issue-65-eventlog-lazy-loading.md
@@ -1,0 +1,110 @@
+﻿# Issue #65 EventLog 懒加载（方案 B）Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 为 `/eventlog` 实现“存储分页 + 顶部无限滚动”，在不改变核心业务行为的前提下显著降低首屏加载成本。
+
+**Architecture:** 在 `EventStorage` 增加基于 cursor 的分页读取接口，保留现有 `getEvents()` 兼容路径；`ChatPage` 改为首屏拉取最近一页、滚动到顶部拉取更早页，并通过滚动高度差修正避免视口跳动。分页返回顺序保持“新到旧”，UI 层统一转换成“旧到新”渲染。
+
+**Tech Stack:** React 18, TypeScript, PouchDB, Vitest, Testing Library
+
+---
+
+### Task 1: 为 EventStorage 增加分页读取能力
+
+**Files:**
+- Modify: `src/lib/storage/event-storage.ts`
+- Test: `tests/storage/event-storage.test.ts`
+
+**Step 1: Write the failing test**
+
+在 `tests/storage/event-storage.test.ts` 新增 `getEventsPage` 用例：
+- 首次分页应返回最近 N 条、`hasMore=true`、`nextCursor` 有值
+- 使用 `nextCursor` 拉取下一页时不重复且顺序正确
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun test tests/storage/event-storage.test.ts`
+Expected: `getEventsPage` 相关断言失败（方法不存在或行为不符）
+
+**Step 3: Write minimal implementation**
+
+在 `src/lib/storage/event-storage.ts` 增加：
+- `EventPageCursor` / `EventPageResult` 类型
+- `getEventsPage({ limit, cursor })` 方法
+- 设计文档 `by_created_at` 改为复合 key（时间 + 文档 ID）以稳定分页游标
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun test tests/storage/event-storage.test.ts`
+Expected: 全部通过
+
+**Step 5: Commit**
+
+```bash
+git add src/lib/storage/event-storage.ts tests/storage/event-storage.test.ts
+git commit -m "feat: add cursor pagination for event storage"
+```
+
+### Task 2: ChatPage 接入分页与顶部无限滚动
+
+**Files:**
+- Modify: `src/components/Chat/ChatPage.tsx`
+- Create: `src/components/Chat/chat-event-pagination.ts`
+- Test: `tests/unit/chat/chat-event-pagination.test.ts`
+
+**Step 1: Write the failing test**
+
+新增纯函数测试：
+- 将“新到旧”分页数据转换为“旧到新”显示顺序
+- prepend 历史页时按 ID 去重
+- 合并新消息时保持时间升序
+
+**Step 2: Run test to verify it fails**
+
+Run: `bun test tests/unit/chat/chat-event-pagination.test.ts`
+Expected: 模块不存在或断言失败
+
+**Step 3: Write minimal implementation**
+
+- 新建 `chat-event-pagination.ts` 承担转换/合并去重纯逻辑
+- `ChatPage` 改为：
+  - 首屏调用 `getEventsPage({limit: 50})`
+  - 列表 `onScroll` 顶部触发 `loadOlderEvents`
+  - 使用滚动高度差修正避免跳屏
+  - 发送消息/远程变更后只刷新最新页并合并
+
+**Step 4: Run test to verify it passes**
+
+Run: `bun test tests/unit/chat/chat-event-pagination.test.ts`
+Expected: 全部通过
+
+**Step 5: Commit**
+
+```bash
+git add src/components/Chat/ChatPage.tsx src/components/Chat/chat-event-pagination.ts tests/unit/chat/chat-event-pagination.test.ts
+git commit -m "feat: add reverse infinite scroll for eventlog"
+```
+
+### Task 3: 回归验证与文档更新
+
+**Files:**
+- Modify: `docs/specs/` or `docs/plans/`（若需补充行为说明）
+
+**Step 1: Run targeted tests**
+
+Run: `bun test tests/storage/event-storage.test.ts tests/unit/chat/chat-event-pagination.test.ts tests/components/ChatPage.test.tsx`
+Expected: 通过
+
+**Step 2: Run build**
+
+Run: `bun run build`
+Expected: 构建通过
+
+**Step 3: Commit**
+
+```bash
+git add docs/
+git commit -m "docs: document eventlog lazy loading behavior"
+```
+

--- a/src/components/Chat/ChatPage.tsx
+++ b/src/components/Chat/ChatPage.tsx
@@ -17,47 +17,138 @@ import { Badge } from '@/components/ui/badge';
 import { VoiceMessageInput } from '@/components/VoiceMessageInput';
 import { TimeBlockWidget } from '@/components/TimeBlockWidget';
 import type { Event } from '@/lib/types/event';
-import { getEventStorage, type Event as StorageEvent, type EventStorage } from '@/lib/storage/event-storage';
+import { getEventStorage, type EventPageCursor, type EventStorage } from '@/lib/storage/event-storage';
 import { buildRemoteDbUrl } from '@/lib/sync/remote-db-url';
 import { useSyncStore } from '@/ui/stores/sync-store';
 import { resolveSyncServerUrl } from '@/config/port-env';
+import {
+  mergeLatestEventsAscending,
+  normalizeStorageEventsAscending,
+  prependOlderEventsAscending,
+} from './chat-event-pagination';
+
+const PAGE_SIZE = 50;
+const TOP_LOAD_THRESHOLD = 40;
+const NEAR_BOTTOM_THRESHOLD = 120;
 
 export function ChatPage() {
   const [events, setEvents] = useState<Event[]>([]);
   const [syncStatus, setSyncStatus] = useState<'connected' | 'disconnected' | 'syncing'>('disconnected');
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const [isInitialLoading, setIsInitialLoading] = useState(true);
+  const [hasMore, setHasMore] = useState(false);
   const listEndRef = useRef<HTMLDivElement>(null);
+  const listContainerRef = useRef<HTMLDivElement>(null);
   const storageRef = useRef<EventStorage | null>(null);
+  const nextCursorRef = useRef<EventPageCursor | null>(null);
+  const loadingOlderRef = useRef(false);
+  const shouldStickToBottomRef = useRef(true);
   const { currentUser, isLoggedIn } = useSyncStore();
+
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
+    listEndRef.current?.scrollIntoView({ behavior, block: 'end' });
+  }, []);
+
+  const isNearBottom = useCallback(() => {
+    const container = listContainerRef.current;
+    if (!container) {
+      return true;
+    }
+
+    const distanceToBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
+    return distanceToBottom <= NEAR_BOTTOM_THRESHOLD;
+  }, []);
+
+  const loadInitialEvents = useCallback(async (storage: EventStorage) => {
+    setIsInitialLoading(true);
+    const page = await storage.getEventsPage({ limit: PAGE_SIZE });
+    setEvents(normalizeStorageEventsAscending(page.events));
+    setHasMore(page.hasMore);
+    nextCursorRef.current = page.nextCursor;
+    shouldStickToBottomRef.current = true;
+
+    requestAnimationFrame(() => {
+      scrollToBottom('auto');
+    });
+    setIsInitialLoading(false);
+  }, [scrollToBottom]);
+
+  const refreshLatestEvents = useCallback(async (storage: EventStorage) => {
+    const page = await storage.getEventsPage({ limit: PAGE_SIZE });
+    const latestAsc = normalizeStorageEventsAscending(page.events);
+
+    setEvents((prev) => mergeLatestEventsAscending(prev, latestAsc));
+    setHasMore((prev) => prev || page.hasMore);
+
+    if (!nextCursorRef.current) {
+      nextCursorRef.current = page.nextCursor;
+    }
+
+    requestAnimationFrame(() => {
+      if (shouldStickToBottomRef.current) {
+        scrollToBottom('smooth');
+      }
+    });
+  }, [scrollToBottom]);
+
+  const loadOlderEvents = useCallback(async () => {
+    const storage = storageRef.current;
+    const cursor = nextCursorRef.current;
+
+    if (!storage || !cursor || !hasMore || loadingOlderRef.current) {
+      return;
+    }
+
+    const container = listContainerRef.current;
+    const previousScrollHeight = container?.scrollHeight ?? 0;
+
+    loadingOlderRef.current = true;
+    setLoadingOlder(true);
+
+    try {
+      const page = await storage.getEventsPage({
+        limit: PAGE_SIZE,
+        cursor,
+      });
+
+      const olderAsc = normalizeStorageEventsAscending(page.events);
+      setEvents((prev) => prependOlderEventsAscending(prev, olderAsc));
+      setHasMore(page.hasMore);
+      nextCursorRef.current = page.nextCursor;
+
+      requestAnimationFrame(() => {
+        const currentContainer = listContainerRef.current;
+        if (!currentContainer) return;
+
+        const nextScrollHeight = currentContainer.scrollHeight;
+        currentContainer.scrollTop = Math.max(0, nextScrollHeight - previousScrollHeight);
+      });
+    } finally {
+      loadingOlderRef.current = false;
+      setLoadingOlder(false);
+    }
+  }, [hasMore]);
+
+  const handleListScroll = useCallback(() => {
+    const container = listContainerRef.current;
+    if (!container) return;
+
+    if (container.scrollTop <= TOP_LOAD_THRESHOLD) {
+      void loadOlderEvents();
+    }
+  }, [loadOlderEvents]);
 
   // 初始化 EventStorage 和加载事件
   useEffect(() => {
-    // 使用共享的 EventStorage 单例，与 TimeBlockService 保持一致
     const storage = getEventStorage(currentUser || undefined);
     storageRef.current = storage;
+    void loadInitialEvents(storage);
 
-    const loadEvents = async () => {
-      const loaded = await storage.getEvents();
-
-      // 转换为 UI 使用的 Event 格式
-      const converted: Event[] = loaded.map((e: StorageEvent) => ({
-        id: e.id,
-        timestamp: new Date(e.createdAt).getTime(),
-        content: e.content,
-        tags: new Set<string>(e.type ? [e.type] : []),
-      }));
-
-      // 反转为升序 [最旧, ..., 最新]
-      setEvents([...converted].reverse());
-    };
-
-    loadEvents();
-
-    // 监听变更（本地和远程）
     const unsubscribe = storage.onRemoteChange(() => {
-      loadEvents();
+      shouldStickToBottomRef.current = isNearBottom();
+      void refreshLatestEvents(storage);
     });
 
-    // 如果已登录，连接到远程同步
     if (isLoggedIn && currentUser) {
       setSyncStatus('syncing');
       const runtimeHost = typeof window !== 'undefined' ? window.location.hostname : 'localhost';
@@ -75,17 +166,8 @@ export function ChatPage() {
     return () => {
       unsubscribe();
       storage.stopSync();
-      // 注意：不调用 storage.close()，因为 EventStorage 是共享的单例
-      // 其他组件（如 TimeBlockService）可能还在使用它
     };
-  }, [currentUser, isLoggedIn]);
-
-  // 滚动到底部（最新事件在底部）
-  useEffect(() => {
-    if (events.length > 0) {
-      listEndRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
-    }
-  }, [events]);
+  }, [currentUser, isLoggedIn, isNearBottom, loadInitialEvents, refreshLatestEvents]);
 
   // 处理发送消息
   const handleSend = useCallback(async (content: string) => {
@@ -94,23 +176,15 @@ export function ChatPage() {
 
     // 使用 EventStorage 保存到 PouchDB
     if (storageRef.current) {
+      shouldStickToBottomRef.current = true;
       await storageRef.current.addEvent({
         id: crypto.randomUUID(),
         content: trimmed,
         createdAt: new Date().toISOString(),
       });
-
-      // 刷新事件列表
-      const loaded = await storageRef.current.getEvents();
-      const converted: Event[] = loaded.map((e: StorageEvent) => ({
-        id: e.id,
-        timestamp: new Date(e.createdAt).getTime(),
-        content: e.content,
-        tags: new Set<string>(e.type ? [e.type] : []),
-      }));
-      setEvents([...converted].reverse());
+      await refreshLatestEvents(storageRef.current);
     }
-  }, []);
+  }, [refreshLatestEvents]);
 
   // 格式化时间
   const formatTime = (timestamp: number) => {
@@ -183,7 +257,7 @@ export function ChatPage() {
           </Badge>
         </div>
         <Badge variant="secondary" className="text-xs">
-          {events.length} 条事件
+          {events.length}{hasMore ? '+' : ''} 条事件
         </Badge>
       </div>
 
@@ -191,8 +265,17 @@ export function ChatPage() {
       <TimeBlockWidget />
 
       {/* 事件列表 */}
-      <div className="flex-1 overflow-auto p-3 sm:p-6" data-testid="event-list">
-        {events.length === 0 ? (
+      <div
+        ref={listContainerRef}
+        className="flex-1 overflow-auto p-3 sm:p-6"
+        data-testid="event-list"
+        onScroll={handleListScroll}
+      >
+        {isInitialLoading ? (
+          <div className="flex flex-col items-center justify-center h-full text-center">
+            <p className="text-sm text-muted-foreground">加载中...</p>
+          </div>
+        ) : events.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full text-center">
             <div className="w-12 h-12 sm:w-16 sm:h-16 rounded-full bg-muted flex items-center justify-center mb-3 sm:mb-4">
               <span className="text-2xl sm:text-3xl">📝</span>
@@ -204,6 +287,13 @@ export function ChatPage() {
           </div>
         ) : (
           <div className="space-y-4 sm:space-y-6">
+            {loadingOlder && (
+              <div className="flex justify-center">
+                <span className="text-xs text-muted-foreground" data-testid="event-list-loading-more">
+                  加载更多...
+                </span>
+              </div>
+            )}
             {Array.from(groupedEvents.entries()).map(([date, dateEvents]) => (
               <div key={date}>
                 <div className="flex items-center justify-center mb-3 sm:mb-4">

--- a/src/components/Chat/chat-event-pagination.ts
+++ b/src/components/Chat/chat-event-pagination.ts
@@ -1,0 +1,60 @@
+import type { Event as StorageEvent } from '@/lib/storage/event-storage';
+import type { Event as UiEvent } from '@/lib/types/event';
+
+function parseTimestamp(createdAt: string): number {
+  const parsed = Date.parse(createdAt);
+  return Number.isNaN(parsed) ? Date.now() : parsed;
+}
+
+function sortByTimeAsc(events: UiEvent[]): UiEvent[] {
+  return [...events].sort((a, b) => {
+    if (a.timestamp !== b.timestamp) {
+      return a.timestamp - b.timestamp;
+    }
+    return a.id.localeCompare(b.id);
+  });
+}
+
+export function toUiEvent(event: StorageEvent): UiEvent {
+  return {
+    id: event.id,
+    timestamp: parseTimestamp(event.createdAt),
+    content: event.content,
+    tags: new Set<string>(event.type ? [event.type] : []),
+  };
+}
+
+/**
+ * Storage 层按时间倒序返回，UI 层统一使用升序（旧 -> 新）。
+ */
+export function normalizeStorageEventsAscending(events: StorageEvent[]): UiEvent[] {
+  return events.map((event) => toUiEvent(event)).reverse();
+}
+
+/**
+ * 将更早历史 prepend 到已加载列表，按 ID 去重并保持升序。
+ */
+export function prependOlderEventsAscending(existing: UiEvent[], older: UiEvent[]): UiEvent[] {
+  const byId = new Map<string, UiEvent>();
+  for (const event of older) {
+    byId.set(event.id, event);
+  }
+  for (const event of existing) {
+    byId.set(event.id, byId.get(event.id) ?? event);
+  }
+  return sortByTimeAsc(Array.from(byId.values()));
+}
+
+/**
+ * 将最新事件批次并入已加载列表，按 ID 去重并保持升序。
+ */
+export function mergeLatestEventsAscending(existing: UiEvent[], latest: UiEvent[]): UiEvent[] {
+  const byId = new Map<string, UiEvent>();
+  for (const event of existing) {
+    byId.set(event.id, event);
+  }
+  for (const event of latest) {
+    byId.set(event.id, event);
+  }
+  return sortByTimeAsc(Array.from(byId.values()));
+}

--- a/src/lib/storage/event-storage.ts
+++ b/src/lib/storage/event-storage.ts
@@ -20,6 +20,22 @@ export interface Event {
   metadata?: Record<string, unknown>;
 }
 
+export interface EventPageCursor {
+  createdAt: string;
+  id: string;
+}
+
+export interface EventPageOptions {
+  limit?: number;
+  cursor?: EventPageCursor | null;
+}
+
+export interface EventPageResult {
+  events: Event[];
+  nextCursor: EventPageCursor | null;
+  hasMore: boolean;
+}
+
 /**
  * 内部事件文档接口（包含 PouchDB 字段）
  */
@@ -27,6 +43,18 @@ interface EventDoc extends Event {
   _id: string;
   _rev?: string;
 }
+
+const BY_CREATED_AT_MAP = `function(doc) {
+  if (doc._id && doc._id.startsWith('event:')) {
+    emit([doc.createdAt, doc._id], null);
+  }
+}`;
+
+const BY_ID_MAP = `function(doc) {
+  if (doc._id && doc._id.startsWith('event:')) {
+    emit(doc._id, doc);
+  }
+}`;
 
 // 单例缓存
 const storageInstances: Map<string, EventStorage> = new Map();
@@ -109,31 +137,47 @@ export class EventStorage {
   private async initializeDesignDoc(): Promise<void> {
     if (this.initialized) return;
 
-    try {
-      await (this.db as unknown as { put(doc: unknown): Promise<unknown> }).put({
-        _id: '_design/events',
-        views: {
-          by_created_at: {
-            map: `function(doc) {
-              if (doc._id && doc._id.startsWith('event:')) {
-                emit(doc.createdAt, doc);
-              }
-            }`,
-          },
-          by_id: {
-            map: `function(doc) {
-              if (doc._id && doc._id.startsWith('event:')) {
-                emit(doc._id, doc);
-              }
-            }`,
-          },
+    const designDoc = {
+      _id: '_design/events',
+      views: {
+        by_created_at: {
+          map: BY_CREATED_AT_MAP,
         },
-      });
+        by_id: {
+          map: BY_ID_MAP,
+        },
+      },
+    };
+
+    try {
+      await (this.db as unknown as { put(doc: unknown): Promise<unknown> }).put(designDoc);
       this.initialized = true;
     } catch (error: unknown) {
-      // 409 表示文档已存在，这是正常情况
       if (error && typeof error === 'object' && 'status' in error && (error as { status: number }).status === 409) {
-        this.initialized = true;
+        try {
+          const existingDoc = await this.db.get<{
+            _rev: string;
+            views?: {
+              by_created_at?: { map?: string };
+              by_id?: { map?: string };
+            };
+          }>('_design/events');
+
+          const hasLatestMap =
+            existingDoc.views?.by_created_at?.map === BY_CREATED_AT_MAP &&
+            existingDoc.views?.by_id?.map === BY_ID_MAP;
+
+          if (!hasLatestMap) {
+            await (this.db as unknown as { put(doc: unknown): Promise<unknown> }).put({
+              ...designDoc,
+              _rev: existingDoc._rev,
+            });
+          }
+
+          this.initialized = true;
+        } catch (updateError) {
+          console.warn('更新设计文档失败:', updateError);
+        }
       } else {
         console.warn('创建设计文档失败:', error);
       }
@@ -174,14 +218,50 @@ export class EventStorage {
       descending: true,
     });
 
-    return result.rows
-      .filter((row) => row.doc)
-      .map((row) => {
-        const doc = row.doc!;
-        // 移除内部字段
-        const { _id, _rev, _conflicts, ...event } = doc;
-        return event as Event;
-      });
+    return result.rows.filter((row) => row.doc).map((row) => this.toEvent(row.doc!));
+  }
+
+  /**
+   * 分页获取事件（按时间倒序，最新在前）
+   */
+  async getEventsPage(options: EventPageOptions = {}): Promise<EventPageResult> {
+    await this.initializeDesignDoc();
+
+    const limit = Math.max(1, options.limit ?? 50);
+    const queryOptions: Record<string, unknown> = {
+      include_docs: true,
+      descending: true,
+      limit: limit + 1,
+    };
+
+    if (options.cursor) {
+      queryOptions.startkey = [options.cursor.createdAt, `event:${options.cursor.id}`];
+      queryOptions.skip = 1;
+    }
+
+    const result = await this.db.query<EventDoc>(
+      'events/by_created_at',
+      queryOptions as Parameters<typeof this.db.query<EventDoc>>[1]
+    );
+
+    const docs = result.rows.filter((row) => row.doc).map((row) => row.doc!);
+    const hasMore = docs.length > limit;
+    const pageDocs = hasMore ? docs.slice(0, limit) : docs;
+    const events = pageDocs.map((doc) => this.toEvent(doc));
+
+    const lastEvent = events[events.length - 1];
+    const nextCursor = hasMore && lastEvent
+      ? {
+          createdAt: lastEvent.createdAt,
+          id: lastEvent.id,
+        }
+      : null;
+
+    return {
+      events,
+      nextCursor,
+      hasMore,
+    };
   }
 
   /**
@@ -364,5 +444,13 @@ export class EventStorage {
       paused: false,
       error: null,
     };
+  }
+
+  private toEvent(doc: EventDoc): Event {
+    const event = { ...doc } as Record<string, unknown>;
+    delete event._id;
+    delete event._rev;
+    delete event._conflicts;
+    return event as unknown as Event;
   }
 }

--- a/tests/storage/event-storage.test.ts
+++ b/tests/storage/event-storage.test.ts
@@ -194,4 +194,54 @@ describe('EventStorage', () => {
       expect(parsed.target).toBe('button');
     });
   });
+
+  describe('getEventsPage', () => {
+    it('应该按分页返回最近事件并提供下一页游标', async () => {
+      const base = new Date('2024-01-01T10:00:00.000Z').getTime();
+
+      for (let i = 0; i < 5; i++) {
+        await storage.addEvent({
+          id: `page-${i + 1}`,
+          content: `事件 ${i + 1}`,
+          createdAt: new Date(base + i * 1000).toISOString(),
+        });
+      }
+
+      const firstPage = await storage.getEventsPage({ limit: 2 });
+
+      expect(firstPage.events.map((event) => event.id)).toEqual(['page-5', 'page-4']);
+      expect(firstPage.hasMore).toBe(true);
+      expect(firstPage.nextCursor).toEqual({
+        createdAt: new Date(base + 3 * 1000).toISOString(),
+        id: 'page-4',
+      });
+    });
+
+    it('应该根据游标继续加载更早事件且不重复', async () => {
+      const base = new Date('2024-01-01T10:00:00.000Z').getTime();
+
+      for (let i = 0; i < 5; i++) {
+        await storage.addEvent({
+          id: `cursor-${i + 1}`,
+          content: `事件 ${i + 1}`,
+          createdAt: new Date(base + i * 1000).toISOString(),
+        });
+      }
+
+      const firstPage = await storage.getEventsPage({ limit: 2 });
+      const secondPage = await storage.getEventsPage({
+        limit: 2,
+        cursor: firstPage.nextCursor!,
+      });
+      const thirdPage = await storage.getEventsPage({
+        limit: 2,
+        cursor: secondPage.nextCursor!,
+      });
+
+      expect(secondPage.events.map((event) => event.id)).toEqual(['cursor-3', 'cursor-2']);
+      expect(thirdPage.events.map((event) => event.id)).toEqual(['cursor-1']);
+      expect(thirdPage.hasMore).toBe(false);
+      expect(thirdPage.nextCursor).toBeNull();
+    });
+  });
 });

--- a/tests/unit/chat/chat-event-pagination.test.ts
+++ b/tests/unit/chat/chat-event-pagination.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import type { Event as StorageEvent } from '@/lib/storage/event-storage';
+import type { Event as UiEvent } from '@/lib/types/event';
+import {
+  normalizeStorageEventsAscending,
+  prependOlderEventsAscending,
+  mergeLatestEventsAscending,
+} from '@/components/Chat/chat-event-pagination';
+
+function createStorageEvent(id: string, createdAt: string, content?: string): StorageEvent {
+  return {
+    id,
+    createdAt,
+    content: content ?? id,
+  };
+}
+
+function createUiEvent(id: string, timestamp: number, content?: string): UiEvent {
+  return {
+    id,
+    timestamp,
+    content: content ?? id,
+    tags: new Set<string>(),
+  };
+}
+
+describe('chat-event-pagination', () => {
+  it('should normalize storage events from desc to asc order', () => {
+    const descEvents: StorageEvent[] = [
+      createStorageEvent('3', '2024-01-01T10:00:02.000Z'),
+      createStorageEvent('2', '2024-01-01T10:00:01.000Z'),
+      createStorageEvent('1', '2024-01-01T10:00:00.000Z'),
+    ];
+
+    const ascEvents = normalizeStorageEventsAscending(descEvents);
+    expect(ascEvents.map((event) => event.id)).toEqual(['1', '2', '3']);
+  });
+
+  it('should prepend older events and remove duplicates by id', () => {
+    const older: UiEvent[] = [
+      createUiEvent('1', 1_000),
+      createUiEvent('2', 2_000),
+      createUiEvent('3', 3_000),
+    ];
+    const existing: UiEvent[] = [
+      createUiEvent('3', 3_000),
+      createUiEvent('4', 4_000),
+    ];
+
+    const merged = prependOlderEventsAscending(existing, older);
+    expect(merged.map((event) => event.id)).toEqual(['1', '2', '3', '4']);
+  });
+
+  it('should merge latest events and keep ascending order', () => {
+    const existing: UiEvent[] = [
+      createUiEvent('1', 1_000, 'old-1'),
+      createUiEvent('2', 2_000, 'old-2'),
+    ];
+    const latest: UiEvent[] = [
+      createUiEvent('2', 2_000, 'new-2'),
+      createUiEvent('3', 3_000, 'new-3'),
+    ];
+
+    const merged = mergeLatestEventsAscending(existing, latest);
+    expect(merged.map((event) => event.id)).toEqual(['1', '2', '3']);
+    expect(merged.find((event) => event.id === '2')?.content).toBe('new-2');
+  });
+});


### PR DESCRIPTION
## Linked Issue
Closes #65

已更新：以下为“无乱码重写版”说明。

## 当前实现状态
- 方案选择：**方案 B（存储分页 + 顶部无限滚动）**
- 分支：`feature/issue-65-eventlog-lazy-loading`
- 提交：`cee9b09`

## 已完成的主要变更
1. `EventStorage` 新增 `getEventsPage({ limit, cursor })` 分页读取能力。
2. 分页游标采用 `createdAt + id`，`by_created_at` 视图升级为复合 key，降低跨页重复/漏读风险。
3. `ChatPage` 首屏仅加载最近 50 条，滚动到顶部自动加载更早历史数据。
4. 历史页加载时使用“滚动高度差修正”，避免视口跳屏。
5. 本地发送与远程同步均走“最新页刷新 + 去重合并”路径。

## 已验证
- `bun test tests/storage/event-storage.test.ts` ✅
- `bun test tests/unit/chat/chat-event-pagination.test.ts` ✅
- `bun test tests/integration/chat-event-storage.test.ts` ✅
- `bun run build` ✅

## 请重点审查
- 游标稳定性（同时间戳场景）
- 跨页无重复、无漏读
- 顶部触发加载时视口是否稳定
- 新消息并入后顺序与可见性