### PR TITLE
feat(ui): dark mode theme preference

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,22 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Exomind</title>
+    <script>
+      (function () {
+        try {
+          var preference = localStorage.getItem("exomind:themePreference") || "system";
+          var prefersDark =
+            preference === "dark" ||
+            (preference === "system" &&
+              window.matchMedia &&
+              window.matchMedia("(prefers-color-scheme: dark)").matches);
+          var root = document.documentElement;
+          if (prefersDark) root.classList.add("dark");
+          else root.classList.remove("dark");
+          root.style.colorScheme = prefersDark ? "dark" : "light";
+        } catch (e) {}
+      })();
+    </script>
   </head>
 
   <body>

--- a/pm/issue-40-dark-mode-plan.md
+++ b/pm/issue-40-dark-mode-plan.md
@@ -1,0 +1,73 @@
+# Issue #40 暗色模式：实施计划
+
+## 背景 / 需求
+
+- Issue：exomind-team/exomind#40（暗色模式）
+- 诉求：支持 Chrome 手机版等无法通过浏览器扩展强制暗色的场景，应用自身提供暗色模式切换能力。
+
+## 现状调研结论
+
+- Tailwind 已配置 `darkMode: ["class"]`（`tailwind.config.js`），并且 `src/index.css` 已定义 `.dark { ... }` 下的 CSS 变量。
+- 目前缺少“把 `.dark` class 应用到根节点（`<html>`/`document.documentElement`）”的机制，也没有 UI 入口与持久化策略。
+
+## 目标与验收标准
+
+### 目标
+
+1. 在 Web UI 中提供“主题/外观”设置：`system` / `light` / `dark`。
+2. 主题选择持久化（刷新后仍生效）。
+3. 在 `system` 模式下跟随系统 `prefers-color-scheme`（至少启动时正确；理想情况下系统切换时也能即时跟随）。
+4. 尽量避免启动瞬间“闪白/闪黑”（FOUC）。
+
+### 验收标准（可手工验证）
+
+1. 打开 `/settings`，切换为 `dark` 后整个页面立刻变暗（含背景、文字、卡片等）。
+2. 刷新页面仍保持 `dark`。
+3. 切换为 `light` 后立刻恢复浅色并能持久化。
+4. 切换为 `system`：当系统为暗色时页面为暗色；系统为浅色时页面为浅色。
+
+## 方案设计
+
+### 数据模型（localStorage）
+
+- Key：`exomind:themePreference`
+- Value：`system` | `light` | `dark`
+- 默认：`system`
+
+### 技术实现（最小侵入）
+
+1. 新增主题模块 `src/config/theme.ts`
+   - `getThemePreference()`：读取并校验 localStorage（无效值回退 `system`）。
+   - `setThemePreference(pref)`：写入 localStorage，并 `dispatchEvent` 通知运行中页面更新。
+   - `applyThemePreference(pref)`：把最终主题映射为是否添加 `.dark`，并设置 `document.documentElement.style.colorScheme`。
+2. 启动前应用主题（避免 FOUC）
+   - 在 `index.html` 的 `<head>` 注入一段极小的自执行脚本：读取 localStorage + `matchMedia`，在 React 启动前给 `<html>` 加/删 `.dark`。
+3. 运行时同步
+   - 新增 `ThemeController`（React 组件，`return null`）：负责初次 `apply`、监听 `themePreference` 变更事件、在 `system` 模式下监听 `matchMedia` 变化。
+   - 在 `src/App.tsx` 中挂载该组件，确保路由切换不影响。
+4. 设置页 UI
+   - 在 `src/components/Settings/SettingsPage.tsx` 添加“主题”下拉选择（system/light/dark），调用 `setThemePreference` 并即时生效。
+
+## 测试计划
+
+### 单测（Vitest）
+
+- 新增 `tests/unit/ui/theme-preference.test.ts`
+  - `getThemePreference` 默认值与非法值回退。
+  - `applyThemePreference('dark')` 会给 `document.documentElement` 添加 `.dark`，并设置 `colorScheme` 为 `dark`。
+  - `applyThemePreference('light')` 会移除 `.dark`，并设置 `colorScheme` 为 `light`。
+  - `system` 模式下会使用 `matchMedia('(prefers-color-scheme: dark)')` 的结果。
+
+## 验证命令（本地）
+
+1. 安装依赖：`bun install`
+2. 单测：`bun run test tests/unit/ui/theme-preference.test.ts`
+3. 构建（合并前要求）：`bun run build`
+4. 手工验证：`bun run dev` → 打开 `http://localhost:<port>/settings` 切换主题并刷新验证持久化。
+
+## 交付物
+
+- 代码变更（主题模块 + UI + 启动脚本 + 单测）。
+- Issue 评论：说明方案与验收链路（与本计划一致）。
+- Draft PR：base=`dev`，在 PR 描述中给出验证方式与相关命令。
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,15 @@
 import { RouterProvider } from "@tanstack/react-router";
 import { router } from "@/routes";
+import { ThemeController } from "@/components/ThemeController";
 import "./App.css";
 
 function App() {
-  return <RouterProvider router={router} />;
+  return (
+    <>
+      <ThemeController />
+      <RouterProvider router={router} />
+    </>
+  );
 }
 
 export default App;

--- a/src/components/Chat/ChatPage.tsx
+++ b/src/components/Chat/ChatPage.tsx
@@ -218,6 +218,8 @@ export function ChatPage() {
   // 获取事件图标
   const getEventIcon = (event: Event) => {
     if (event.tags.has('block_start')) return '🔷';
+    if (event.tags.has('block_pause')) return '⏸️';
+    if (event.tags.has('block_resume')) return '▶️';
     if (event.tags.has('block_end')) return '🔴';
     if (event.tags.has('block_feedback')) return '📝';
     return '📝';
@@ -228,6 +230,12 @@ export function ChatPage() {
     if (event.tags.has('block_start')) {
       return 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-100 rounded-br-md';
     }
+    if (event.tags.has('block_pause')) {
+      return 'bg-yellow-100 text-yellow-900 dark:bg-yellow-950 dark:text-yellow-100 rounded-br-md';
+    }
+    if (event.tags.has('block_resume')) {
+      return 'bg-green-100 text-green-900 dark:bg-green-950 dark:text-green-100 rounded-br-md';
+    }
     if (event.tags.has('block_end')) {
       return 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-100 rounded-br-md';
     }
@@ -237,6 +245,8 @@ export function ChatPage() {
   // 获取事件前缀
   const getEventPrefix = (event: Event) => {
     if (event.tags.has('block_start')) return '🔷';
+    if (event.tags.has('block_pause')) return '⏸️';
+    if (event.tags.has('block_resume')) return '▶️';
     if (event.tags.has('block_end')) return '🔴';
     if (event.tags.has('block_feedback')) return '📝';
     return null;

--- a/src/components/Chat/ChatPage.tsx
+++ b/src/components/Chat/ChatPage.tsx
@@ -225,8 +225,12 @@ export function ChatPage() {
 
   // 获取事件背景色
   const getEventBgColor = (event: Event) => {
-    if (event.tags.has('block_start')) return 'bg-blue-100 text-blue-800 rounded-br-md';
-    if (event.tags.has('block_end')) return 'bg-red-100 text-red-800 rounded-br-md';
+    if (event.tags.has('block_start')) {
+      return 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-100 rounded-br-md';
+    }
+    if (event.tags.has('block_end')) {
+      return 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-100 rounded-br-md';
+    }
     return 'bg-muted rounded-bl-md';
   };
 

--- a/src/components/Chat/ChatPage.tsx
+++ b/src/components/Chat/ChatPage.tsx
@@ -218,6 +218,8 @@ export function ChatPage() {
   // 获取事件图标
   const getEventIcon = (event: Event) => {
     if (event.tags.has('block_start')) return '🔷';
+    if (event.tags.has('block_pause')) return '⏸️';
+    if (event.tags.has('block_resume')) return '▶️';
     if (event.tags.has('block_end')) return '🔴';
     if (event.tags.has('block_feedback')) return '📝';
     return '📝';
@@ -226,6 +228,8 @@ export function ChatPage() {
   // 获取事件背景色
   const getEventBgColor = (event: Event) => {
     if (event.tags.has('block_start')) return 'bg-blue-100 text-blue-800 rounded-br-md';
+    if (event.tags.has('block_pause')) return 'bg-yellow-100 text-yellow-900 rounded-br-md';
+    if (event.tags.has('block_resume')) return 'bg-green-100 text-green-900 rounded-br-md';
     if (event.tags.has('block_end')) return 'bg-red-100 text-red-800 rounded-br-md';
     return 'bg-muted rounded-bl-md';
   };
@@ -233,6 +237,8 @@ export function ChatPage() {
   // 获取事件前缀
   const getEventPrefix = (event: Event) => {
     if (event.tags.has('block_start')) return '🔷';
+    if (event.tags.has('block_pause')) return '⏸️';
+    if (event.tags.has('block_resume')) return '▶️';
     if (event.tags.has('block_end')) return '🔴';
     if (event.tags.has('block_feedback')) return '📝';
     return null;

--- a/src/components/Settings/SettingsPage.tsx
+++ b/src/components/Settings/SettingsPage.tsx
@@ -9,6 +9,11 @@ import {
   resolveSyncServerUrl,
   setSyncServerUrlOverride,
 } from '@/config/port-env';
+import {
+  getThemePreference,
+  setThemePreference,
+  type ThemePreference,
+} from '@/config/theme';
 
 type ImportStrategy = 'merge' | 'overwrite';
 
@@ -24,6 +29,7 @@ export function SettingsPage() {
   });
   const [syncServerUrl, setSyncServerUrl] = useState(() => getSyncServerUrlOverride() || autoSyncServerUrl);
   const [savedSyncServerUrl, setSavedSyncServerUrl] = useState<string | null>(() => getSyncServerUrlOverride());
+  const [themePreference, setThemePreferenceState] = useState<ThemePreference>(() => getThemePreference());
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [importStrategy, setImportStrategy] = useState<ImportStrategy>('merge');
   const [statusMessage, setStatusMessage] = useState('');
@@ -145,6 +151,28 @@ export function SettingsPage() {
         配置局域网同步地址与事件日志导入导出
       </p>
 
+      <div className="space-y-2 max-w-sm">
+        <Label htmlFor="theme-preference">主题</Label>
+        <select
+          id="theme-preference"
+          className="w-full rounded-md border bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          value={themePreference}
+          disabled={loading}
+          onChange={(event) => {
+            const nextPreference = event.target.value as ThemePreference;
+            setThemePreference(nextPreference);
+            setThemePreferenceState(nextPreference);
+          }}
+        >
+          <option value="system">system（跟随系统）</option>
+          <option value="light">light（浅色）</option>
+          <option value="dark">dark（暗色）</option>
+        </select>
+        <p className="text-xs text-muted-foreground">
+          暗色模式对 Chrome 手机版等无法使用扩展的环境更友好。
+        </p>
+      </div>
+
       <div className="space-y-2 max-w-xl">
         <Label htmlFor="sync-server-url">同步服务器地址</Label>
         <Input
@@ -181,7 +209,7 @@ export function SettingsPage() {
         <Label htmlFor="import-strategy">导入策略</Label>
         <select
           id="import-strategy"
-          className="w-full rounded-md border px-3 py-2 text-sm"
+          className="w-full rounded-md border bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           value={importStrategy}
           onChange={(e) => setImportStrategy(e.target.value as ImportStrategy)}
           disabled={loading}

--- a/src/components/ThemeController.tsx
+++ b/src/components/ThemeController.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import type { ThemePreference } from '@/config/theme';
+import {
+  applyThemePreference,
+  getThemePreference,
+  subscribeSystemThemeChanges,
+  subscribeThemePreferenceChanges,
+} from '@/config/theme';
+
+function syncSystemTheme(preference: ThemePreference): () => void {
+  if (preference !== 'system') {
+    return () => {};
+  }
+
+  return subscribeSystemThemeChanges(() => {
+    applyThemePreference('system');
+  });
+}
+
+export function ThemeController() {
+  useEffect(() => {
+    let preference = getThemePreference();
+    applyThemePreference(preference);
+
+    let unsubscribeSystem = syncSystemTheme(preference);
+    const unsubscribePreference = subscribeThemePreferenceChanges((nextPreference) => {
+      preference = nextPreference;
+      applyThemePreference(preference);
+      unsubscribeSystem();
+      unsubscribeSystem = syncSystemTheme(preference);
+    });
+
+    return () => {
+      unsubscribePreference();
+      unsubscribeSystem();
+    };
+  }, []);
+
+  return null;
+}
+

--- a/src/components/VoiceInputButton.tsx
+++ b/src/components/VoiceInputButton.tsx
@@ -511,6 +511,12 @@ export function VoiceInputButton({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [enableShortcut, handleClick, state.state, releaseRecordingResources]);
 
+  const formatCssVarColor = (triplet: string, alpha: number): string | null => {
+    const parts = triplet.trim().split(/\s+/);
+    if (parts.length < 3) return null;
+    return `hsla(${parts[0]}, ${parts[1]}, ${parts[2]}, ${alpha})`;
+  };
+
   // 音量波形动画
   useEffect(() => {
     if (!showWaveform || state.state !== 'recording' || !canvasRef.current) {
@@ -532,6 +538,10 @@ export function VoiceInputButton({
     const centerX = canvas.width / 2;
     const centerY = canvas.height / 2;
     const baseRadius = (size / 2) - 8;
+    const rootStyle = getComputedStyle(document.documentElement);
+    const destructiveTriplet = rootStyle.getPropertyValue('--destructive');
+    const destructive0 = formatCssVarColor(destructiveTriplet, 0.9) ?? '#ff6b6b';
+    const destructive1 = formatCssVarColor(destructiveTriplet, 0.6) ?? '#ee5a5a';
 
     const draw = () => {
       animationFrameId = requestAnimationFrame(draw);
@@ -555,8 +565,8 @@ export function VoiceInputButton({
         const y2 = centerY + Math.sin(angle) * (baseRadius + barHeight);
 
         const gradient = ctx.createLinearGradient(x1, y1, x2, y2);
-        gradient.addColorStop(0, '#ff6b6b');
-        gradient.addColorStop(1, '#ee5a5a');
+        gradient.addColorStop(0, destructive0);
+        gradient.addColorStop(1, destructive1);
 
         ctx.beginPath();
         ctx.moveTo(x1, y1);
@@ -605,26 +615,30 @@ export function VoiceInputButton({
     switch (state.state) {
       case 'recording':
         return {
-          background: 'linear-gradient(135deg, #ff6b6b 0%, #ee5a5a 100%)',
-          shadow: '0 0 20px rgba(255, 107, 107, 0.6)',
+          background:
+            'linear-gradient(135deg, hsl(var(--destructive)) 0%, hsl(var(--destructive) / 0.85) 100%)',
+          shadow: '0 0 20px hsl(var(--destructive) / 0.6)',
           icon: '🎤',
         };
       case 'recognizing':
         return {
-          background: 'linear-gradient(135deg, #4dabf7 0%, #339af0 100%)',
-          shadow: '0 0 20px rgba(77, 171, 247, 0.6)',
+          background:
+            'linear-gradient(135deg, hsl(var(--brand)) 0%, hsl(var(--brand) / 0.85) 100%)',
+          shadow: '0 0 20px hsl(var(--brand) / 0.6)',
           icon: '⏳',
         };
       case 'completed':
         return {
-          background: 'linear-gradient(135deg, #51cf66 0%, #40c057 100%)',
-          shadow: '0 0 20px rgba(81, 207, 102, 0.6)',
+          background:
+            'linear-gradient(135deg, hsl(var(--success)) 0%, hsl(var(--success) / 0.85) 100%)',
+          shadow: '0 0 20px hsl(var(--success) / 0.6)',
           icon: '✓',
         };
       default:
         return {
-          background: 'linear-gradient(135deg, #868e96 0%, #6c757d 100%)',
-          shadow: '0 4px 12px rgba(108, 117, 125, 0.3)',
+          background:
+            'linear-gradient(135deg, hsl(var(--muted)) 0%, hsl(var(--secondary)) 100%)',
+          shadow: '0 4px 12px hsl(var(--ring) / 0.2)',
           icon: '🎤',
         };
     }
@@ -667,8 +681,12 @@ export function VoiceInputButton({
           transform: 'translateX(-50%)',
           fontSize: 12,
           fontWeight: 500,
-          color: state.state === 'recording' ? '#ff6b6b' :
-                 state.state === 'recognizing' ? '#4dabf7' : '#51cf66',
+          color:
+            state.state === 'recording'
+              ? 'hsl(var(--destructive))'
+              : state.state === 'recognizing'
+                ? 'hsl(var(--brand))'
+                : 'hsl(var(--success))',
           whiteSpace: 'nowrap',
         }}>
           {state.state === 'recording' ? formatTime(state.duration) :
@@ -740,7 +758,7 @@ export function VoiceInputButton({
             width: 8,
             height: 8,
             borderRadius: '50%',
-            background: '#fff',
+            background: 'hsl(var(--foreground))',
             animation: 'blink 1s ease-in-out infinite',
           }}>
             <style>{`
@@ -768,7 +786,7 @@ export function VoiceInputButton({
           left: '50%',
           transform: 'translateX(-50%)',
           fontSize: 10,
-          color: '#adb5bd',
+          color: 'hsl(var(--muted-foreground))',
           whiteSpace: 'nowrap',
         }}>
           按 [空格] 开始/停止
@@ -784,8 +802,9 @@ export function VoiceInputButton({
             height: buttonSize,
             borderRadius: '50%',
             border: 'none',
-            background: 'linear-gradient(135deg, #ffa500 0%, #ff8c00 100%)',
-            boxShadow: '0 4px 12px rgba(255, 140, 0, 0.4)',
+            background:
+              'linear-gradient(135deg, hsl(var(--warning)) 0%, hsl(var(--warning) / 0.85) 100%)',
+            boxShadow: '0 4px 12px hsl(var(--warning) / 0.4)',
             cursor: 'pointer',
             display: 'flex',
             alignItems: 'center',
@@ -807,7 +826,7 @@ export function VoiceInputButton({
           left: '50%',
           transform: 'translateX(-50%)',
           fontSize: 10,
-          color: '#ffa500',
+          color: 'hsl(var(--warning))',
           whiteSpace: 'nowrap',
         }}>
           {permissionState === 'unavailable' ? '不支持' : '需要权限'}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -11,6 +11,8 @@ const buttonVariants = cva(
       variant: {
         default:
           "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        brand:
+          "bg-brand text-brand-foreground shadow hover:bg-brand/90",
         destructive:
           "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
         outline:

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -1,0 +1,117 @@
+export const THEME_PREFERENCE_STORAGE_KEY = 'exomind:themePreference';
+export const THEME_PREFERENCE_CHANGED_EVENT = 'exomind:theme-preference-changed';
+
+export type ThemePreference = 'system' | 'light' | 'dark';
+export type ResolvedTheme = 'light' | 'dark';
+
+const VALID_PREFERENCES: ThemePreference[] = ['system', 'light', 'dark'];
+const MEDIA_QUERY = '(prefers-color-scheme: dark)';
+
+function isThemePreference(value: unknown): value is ThemePreference {
+  return typeof value === 'string' && VALID_PREFERENCES.includes(value as ThemePreference);
+}
+
+export function getThemePreference(): ThemePreference {
+  if (typeof window === 'undefined') {
+    return 'system';
+  }
+
+  try {
+    const stored = window.localStorage.getItem(THEME_PREFERENCE_STORAGE_KEY);
+    if (!stored) {
+      return 'system';
+    }
+
+    return isThemePreference(stored) ? stored : 'system';
+  } catch {
+    return 'system';
+  }
+}
+
+export function setThemePreference(preference: ThemePreference): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(THEME_PREFERENCE_STORAGE_KEY, preference);
+    window.dispatchEvent(
+      new CustomEvent(THEME_PREFERENCE_CHANGED_EVENT, {
+        detail: { value: preference },
+      })
+    );
+  } catch {
+    // ignore localStorage write errors
+  }
+}
+
+export function resolveThemePreference(preference: ThemePreference): ResolvedTheme {
+  if (preference === 'dark') return 'dark';
+  if (preference === 'light') return 'light';
+
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return 'light';
+  }
+
+  try {
+    return window.matchMedia(MEDIA_QUERY).matches ? 'dark' : 'light';
+  } catch {
+    return 'light';
+  }
+}
+
+export function applyThemePreference(preference: ThemePreference): ResolvedTheme {
+  if (typeof document === 'undefined') {
+    return resolveThemePreference(preference);
+  }
+
+  const resolved = resolveThemePreference(preference);
+  const root = document.documentElement;
+  root.classList.toggle('dark', resolved === 'dark');
+  root.style.colorScheme = resolved;
+  return resolved;
+}
+
+export function subscribeThemePreferenceChanges(
+  listener: (preference: ThemePreference) => void
+): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const handler = (event: Event) => {
+    const detail = (event as CustomEvent<{ value?: unknown }>).detail;
+    if (detail && isThemePreference(detail.value)) {
+      listener(detail.value);
+    } else {
+      listener(getThemePreference());
+    }
+  };
+
+  window.addEventListener(THEME_PREFERENCE_CHANGED_EVENT, handler);
+  return () => window.removeEventListener(THEME_PREFERENCE_CHANGED_EVENT, handler);
+}
+
+export function subscribeSystemThemeChanges(listener: (theme: ResolvedTheme) => void): () => void {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return () => {};
+  }
+
+  let mql: MediaQueryList;
+  try {
+    mql = window.matchMedia(MEDIA_QUERY);
+  } catch {
+    return () => {};
+  }
+
+  const handler = () => listener(mql.matches ? 'dark' : 'light');
+
+  if (typeof mql.addEventListener === 'function') {
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }
+
+  mql.addListener(handler);
+  return () => mql.removeListener(handler);
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -40,8 +40,8 @@
     --card-foreground: 210 40% 98%;
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: var(--brand);
+    --primary-foreground: 210 40% 98%;
     --secondary: 217.2 32.6% 17.5%;
     --secondary-foreground: 210 40% 98%;
     --muted: 217.2 32.6% 17.5%;

--- a/src/index.css
+++ b/src/index.css
@@ -24,6 +24,13 @@
     --input: 214.3 31.8% 91.4%;
     --ring: 222.2 84% 4.9%;
     --radius: 0.5rem;
+
+    --brand: 221 83% 53%;
+    --brand-foreground: 210 40% 98%;
+    --success: 142 71% 45%;
+    --success-foreground: 210 40% 98%;
+    --warning: 38 92% 50%;
+    --warning-foreground: 222.2 84% 4.9%;
   }
 
   .dark {
@@ -46,6 +53,13 @@
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
     --ring: 212.7 26.8% 83.9%;
+
+    --brand: 217 91% 60%;
+    --brand-foreground: 222.2 84% 4.9%;
+    --success: 142 70% 50%;
+    --success-foreground: 222.2 84% 4.9%;
+    --warning: 38 92% 55%;
+    --warning-foreground: 222.2 84% 4.9%;
   }
 }
 

--- a/src/lib/services/timeblock.service.ts
+++ b/src/lib/services/timeblock.service.ts
@@ -84,7 +84,7 @@ export class TimeBlockServiceImpl implements TimeBlockService {
       : 0;
 
     // 创建开始事件
-    await this.addBlockEvent(startId, name, 'block_start');
+    await this.addBlockEvent(name, 'block_start');
 
     // 保存进行中的时间块
     const activeBlock: ActiveBlockData = {
@@ -108,7 +108,7 @@ export class TimeBlockServiceImpl implements TimeBlockService {
 
   async pauseBlock(): Promise<void> {
     const data = await this.env.storage.read<ActiveBlockData>(ACTIVE_BLOCK_KEY);
-    if (!data) return;
+    if (!data || data.paused) return;
 
     const now = Date.now();
     const normalized = this.normalizeActiveBlock(data, now);
@@ -120,6 +120,9 @@ export class TimeBlockServiceImpl implements TimeBlockService {
     };
 
     await this.env.storage.write(ACTIVE_BLOCK_KEY, pausedBlock);
+
+    // 记录暂停事件
+    await this.addBlockEvent(`${normalized.name} 暂停`, 'block_pause');
     this.notifyChange(pausedBlock);
   }
 
@@ -136,6 +139,9 @@ export class TimeBlockServiceImpl implements TimeBlockService {
     };
 
     await this.env.storage.write(ACTIVE_BLOCK_KEY, resumedBlock);
+
+    // 记录继续事件
+    await this.addBlockEvent(`${data.name} 继续`, 'block_resume');
     this.notifyChange(resumedBlock);
   }
 
@@ -147,7 +153,7 @@ export class TimeBlockServiceImpl implements TimeBlockService {
     const endId = crypto.randomUUID();
 
     // 创建结束事件（通过 EventStorage，与 ChatPage 保持一致）
-    await this.addBlockEvent(endId, `${activeData.name} 完成`, 'block_end');
+    await this.addBlockEvent(`${activeData.name} 完成`, 'block_end');
 
     // 身心反馈作为独立事件添加到事件日志（通过 EventStorage）
     if (feedback) {
@@ -214,9 +220,8 @@ export class TimeBlockServiceImpl implements TimeBlockService {
 
   /** 添加时间块事件（通过 EventStorage，与 ChatPage 保持一致） */
   private async addBlockEvent(
-    _eventId: string,
     content: string,
-    tag: 'block_start' | 'block_end',
+    tag: 'block_start' | 'block_end' | 'block_pause' | 'block_resume',
   ): Promise<void> {
     // 使用 EventStorage 保存事件，与 ChatPage 保持一致
     const storage = getEventStorage();

--- a/src/lib/services/timeblock.service.ts
+++ b/src/lib/services/timeblock.service.ts
@@ -77,6 +77,16 @@ export class TimeBlockServiceImpl implements TimeBlockService {
   }
 
   async startBlock(name: string, config: TimerConfig): Promise<ActiveBlockData> {
+    // 不允许在已有活跃块（运行中/已暂停）时开启新块
+    const existing = await this.env.storage.read<ActiveBlockData>(ACTIVE_BLOCK_KEY);
+    if (existing) {
+      const normalized = this.normalizeActiveBlock(existing);
+      if (this.shouldPersistNormalized(existing, normalized)) {
+        await this.env.storage.write(ACTIVE_BLOCK_KEY, normalized);
+      }
+      return normalized;
+    }
+
     const startId = crypto.randomUUID();
     const now = Date.now();
     const initialElapsed = config.mode === 'countdown'

--- a/src/lib/types/event.ts
+++ b/src/lib/types/event.ts
@@ -14,6 +14,8 @@ export type Tag = string;
 export const SYSTEM_TAGS = {
   BLOCK_START: 'block_start' as Tag,
   BLOCK_END: 'block_end' as Tag,
+  BLOCK_PAUSE: 'block_pause' as Tag,
+  BLOCK_RESUME: 'block_resume' as Tag,
   BLOCK_FEEDBACK: 'block_feedback' as Tag,
   NOTE: 'note' as Tag,
 } as const;

--- a/src/pages/ASRTestPage.tsx
+++ b/src/pages/ASRTestPage.tsx
@@ -5,6 +5,9 @@
 
 import { useEffect, useRef, useState } from 'react';
 import type { ASRResult } from '../lib/ports/asr-port';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
 
 // 获取 SpeechRecognition 构造函数
 const getSpeechRecognition = () => {
@@ -146,146 +149,99 @@ export function ASRTestPage() {
   }, []);
 
   return (
-    <div style={{
-      padding: '24px',
-      maxWidth: '600px',
-      margin: '0 auto',
-      fontFamily: 'system-ui, sans-serif',
-    }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '20px' }}>
-        <h1 style={{ margin: 0, fontSize: '24px' }}>语音识别测试</h1>
-      </div>
+    <div className="p-6 max-w-2xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">语音识别测试</h1>
 
-      {/* 状态显示 */}
-      <div style={{
-        padding: '12px',
-        background: status === 'success' ? '#dcfce7' :
-                    status === 'error' ? '#fee2e2' :
-                    status === 'recording' ? '#fee2e2' :
-                    '#f3f4f6',
-        borderRadius: '8px',
-        marginBottom: '16px',
-        textAlign: 'center',
-      }}>
-        {status === 'idle' && '点击"开始录音"'}
+      <div
+        className={cn(
+          "rounded-lg border p-3 text-center text-sm",
+          status === 'success'
+            ? "border-success/30 bg-success/10"
+            : status === 'error'
+              ? "border-destructive/30 bg-destructive/10"
+              : status === 'recording'
+                ? "border-brand/30 bg-brand/10"
+                : "bg-muted"
+        )}
+      >
+        {status === 'idle' && '点击“开始录音”'}
         {status === 'ready' && '✓ 准备就绪'}
         {status === 'recording' && '🔴 录音中...请说话'}
         {status === 'success' && '✓ 识别完成'}
         {status === 'error' && '✗ 出错了'}
       </div>
 
-      {/* 控制按钮 */}
-      <div style={{ display: 'flex', gap: '12px', marginBottom: '16px' }}>
+      <div className="flex gap-3">
         {!apiAvailable ? (
-          <button
-            disabled
-            style={{
-              flex: 1,
-              padding: '16px',
-              fontSize: '18px',
-              background: '#9ca3af',
-              color: 'white',
-              border: 'none',
-              borderRadius: '8px',
-              cursor: 'not-allowed',
-            }}
-          >
+          <Button type="button" disabled className="flex-1 h-auto py-4 text-lg">
             浏览器不支持语音识别
-          </button>
+          </Button>
         ) : status === 'success' || status === 'error' ? (
-          <button
-            onClick={reset}
-            style={{
-              flex: 1,
-              padding: '16px',
-              fontSize: '18px',
-              background: '#3b82f6',
-              color: 'white',
-              border: 'none',
-              borderRadius: '8px',
-              cursor: 'pointer',
-            }}
-          >
+          <Button type="button" variant="brand" onClick={reset} className="flex-1 h-auto py-4 text-lg">
             🔄 重新开始
-          </button>
-        ) : (
-          <button
+          </Button>
+        ) : status === 'recording' ? (
+          <Button
+            type="button"
+            variant="destructive"
             onClick={toggleRecording}
-            style={{
-              flex: 1,
-              padding: '16px',
-              fontSize: '18px',
-              background: status === 'recording' ? '#ef4444' : '#3b82f6',
-              color: 'white',
-              border: 'none',
-              borderRadius: '8px',
-              cursor: 'pointer',
-            }}
+            className="flex-1 h-auto py-4 text-lg"
           >
-            {status === 'recording' ? '⏹ 点击停止' : '🎤 点击开始录音'}
-          </button>
+            ⏹ 点击停止
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            variant="brand"
+            onClick={toggleRecording}
+            className="flex-1 h-auto py-4 text-lg"
+          >
+            🎤 点击开始录音
+          </Button>
         )}
       </div>
 
-      {/* 识别结果 */}
       {result && (
-        <div style={{
-          padding: '16px',
-          background: '#f0fdf4',
-          borderRadius: '8px',
-          marginTop: '16px',
-        }}>
-          <h3 style={{ margin: '0 0 8px 0' }}>识别结果：</h3>
-          <p style={{ margin: 0, fontSize: '18px' }}>{result.text}</p>
-          <p style={{ margin: '8px 0 0 0', fontSize: '12px', color: '#666' }}>
-            置信度: {(result.confidence * 100).toFixed(1)}% | 语言: {result.lang}
-          </p>
-        </div>
+        <Card className="shadow-sm border-success/30 bg-success/10">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm text-success">识别结果</CardTitle>
+          </CardHeader>
+          <CardContent className="pt-0 space-y-2">
+            <p className="text-lg">{result.text}</p>
+            <p className="text-xs text-muted-foreground">
+              置信度: {(result.confidence * 100).toFixed(1)}% | 语言: {result.lang}
+            </p>
+          </CardContent>
+        </Card>
       )}
 
-      {/* 错误信息 */}
       {error && (
-        <div style={{
-          padding: '12px',
-          background: '#fef2f2',
-          borderRadius: '8px',
-          marginTop: '16px',
-          color: '#dc2626',
-        }}>
-          错误: {error}
-        </div>
+        <Card className="shadow-sm border-destructive/30 bg-destructive/10">
+          <CardContent className="p-4 text-sm text-destructive">
+            错误: {error}
+          </CardContent>
+        </Card>
       )}
 
-      {/* 日志 */}
-      <div style={{
-        padding: '12px',
-        background: '#1f2937',
-        borderRadius: '8px',
-        marginTop: '16px',
-        fontFamily: 'monospace',
-        fontSize: '12px',
-        color: '#10b981',
-      }}>
-        <div style={{ marginBottom: '8px', color: '#9ca3af' }}>运行日志：</div>
-        {logs.map((log, i) => (
-          <div key={i} style={{ marginBottom: '4px' }}>{log}</div>
-        ))}
-        {logs.length === 0 && <span style={{ color: '#4b5563' }}>暂无日志</span>}
-      </div>
+      <Card className="shadow-sm">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm">运行日志</CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0 font-mono text-xs text-brand space-y-1">
+          {logs.map((log, i) => (
+            <div key={i}>{log}</div>
+          ))}
+          {logs.length === 0 && <span className="text-muted-foreground">暂无日志</span>}
+        </CardContent>
+      </Card>
 
-      {/* API 状态 */}
-      <div style={{
-        marginTop: '24px',
-        padding: '12px',
-        background: '#f0f9ff',
-        borderRadius: '8px',
-        fontSize: '12px',
-        color: '#0369a1',
-      }}>
-        <strong>Web Speech API 状态：</strong>
-        <br />
-        {apiAvailable ? '✓ 浏览器支持语音识别' : '✗ 浏览器不支持语音识别（请使用 Chrome/Edge/Safari）'}
-      </div>
+      <Card className="shadow-sm border-brand/20 bg-brand/10">
+        <CardContent className="p-4 text-xs text-brand">
+          <span className="font-semibold">Web Speech API 状态：</span>
+          <br />
+          {apiAvailable ? '✓ 浏览器支持语音识别' : '✗ 浏览器不支持语音识别（请使用 Chrome/Edge/Safari）'}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/pages/MOSSASRTestPage.tsx
+++ b/src/pages/MOSSASRTestPage.tsx
@@ -16,6 +16,12 @@ import { MOSSASRAdapter, MOSSASRResult } from '../lib/adapters/asr/moss-asr';
 import { VoiceInputButton } from '../components/VoiceInputButton';
 import type { ASRResult } from '../lib/environment/interfaces/asr.port';
 import { getEventLogService } from '@/lib/services';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
 
 // 录音状态
 type RecordingState = 'idle' | 'recording';
@@ -392,429 +398,288 @@ export function MOSSASRTestPage() {
   const voiceButtonAdapterConfig = apiKey ? { apiKey } : undefined;
 
   return (
-    <div style={{ padding: '24px', maxWidth: '700px', margin: '0 auto' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '20px' }}>
-        <h1 style={{ margin: 0, fontSize: '24px' }}>MOSS 语音识别测试</h1>
-      </div>
+    <div className="p-6 max-w-3xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">MOSS 语音识别测试</h1>
 
-      {/* API Key 配置卡片 */}
-      <div style={{
-        padding: '16px',
-        background: '#f8fafc',
-        borderRadius: '12px',
-        marginBottom: '16px',
-        border: '1px solid #e2e8f0',
-      }}>
-        <div style={{ marginBottom: '12px' }}>
-          <strong style={{ fontSize: '14px' }}>MOSS API Key 配置</strong>
-          <p style={{ fontSize: '12px', color: '#666', marginTop: '4px' }}>
-            申请地址: <a href="https://studio.mosi.cn/" target="_blank" style={{ color: '#3b82f6' }}>https://studio.mosi.cn/</a>
+      <Card className="shadow-sm">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm">MOSS API Key 配置</CardTitle>
+          <p className="text-xs text-muted-foreground">
+            申请地址:{' '}
+            <a
+              href="https://studio.mosi.cn/"
+              target="_blank"
+              rel="noreferrer"
+              className="text-brand underline underline-offset-4"
+            >
+              https://studio.mosi.cn/
+            </a>
           </p>
-        </div>
+        </CardHeader>
+        <CardContent className="pt-0 space-y-2">
+          <div className="space-y-1">
+            <Label htmlFor="moss-api-key">API Key</Label>
+            <div className="flex gap-2">
+              <Input
+                id="moss-api-key"
+                type="password"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder="sk-xxxxxxxxxxxxxxxxxxxxxxxx"
+                className="font-mono"
+              />
+              <Button type="button" variant="brand" onClick={handleSaveApiKey}>
+                保存
+              </Button>
+            </div>
+          </div>
 
-        <div style={{ display: 'flex', gap: '8px' }}>
-          <input
-            type="password"
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-            placeholder="sk-xxxxxxxxxxxxxxxxxxxxxxxx"
-            style={{
-              flex: 1,
-              padding: '10px 12px',
-              border: '1px solid #d1d5db',
-              borderRadius: '8px',
-              fontSize: '14px',
-              fontFamily: 'monospace',
-            }}
-          />
-          <button
-            onClick={handleSaveApiKey}
-            style={{
-              padding: '10px 16px',
-              background: '#3b82f6',
-              color: 'white',
-              border: 'none',
-              borderRadius: '8px',
-              cursor: 'pointer',
-              fontSize: '14px',
-            }}
-          >
-            保存
-          </button>
-        </div>
+          <div className="text-xs text-muted-foreground">
+            {apiKey ? '✓ 已配置' : '✗ 未配置'}
+            {apiKey && ` (${apiKey.slice(0, 4)}...${apiKey.slice(-4)})`}
+          </div>
+        </CardContent>
+      </Card>
 
-        <div style={{ marginTop: '8px', fontSize: '11px', color: '#666' }}>
-          {apiKey ? '✓ 已配置' : '✗ 未配置'}
-          {apiKey && ` (${apiKey.slice(0, 4)}...${apiKey.slice(-4)})`}
-        </div>
-      </div>
+      <Card
+        className={cn(
+          "shadow-sm",
+          isAvailable ? "border-success/30 bg-success/10" : "border-destructive/30 bg-destructive/10"
+        )}
+      >
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="text-sm">MOSS Transcribe-Diarize</CardTitle>
+            <span
+              className={cn(
+                "rounded-md px-2 py-0.5 text-xs font-semibold",
+                isAvailable
+                  ? "bg-success text-success-foreground"
+                  : "bg-destructive text-destructive-foreground"
+              )}
+            >
+              {isAvailable ? '就绪' : '未配置'}
+            </span>
+          </div>
+          <p className="mt-2 text-xs text-muted-foreground">
+            {isAvailable ? '直接调用 MOSS HTTP API，无需后端服务' : '请在上方配置 API Key'}
+          </p>
+        </CardHeader>
+      </Card>
 
-      {/* 状态卡片 */}
-      <div style={{
-        padding: '16px',
-        background: isAvailable ? '#dcfce7' : '#fee2e2',
-        borderRadius: '12px',
-        marginBottom: '16px',
-        fontSize: '13px',
-      }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <strong>MOSS Transcribe-Diarize</strong>
-          <span style={{
-            padding: '2px 8px',
-            borderRadius: '4px',
-            background: isAvailable ? '#22c55e' : '#ef4444',
-            color: 'white',
-            fontSize: '11px',
-          }}>
-            {isAvailable ? '就绪' : '未配置'}
-          </span>
-        </div>
-        <div style={{ marginTop: '8px', color: '#666' }}>
-          {isAvailable ? '直接调用 MOSS HTTP API，无需后端服务' : '请在上方配置 API Key'}
-        </div>
-      </div>
-
-      {/* 录音方式切换 */}
       {recordingState === 'idle' && (
-        <div style={{
-          padding: '12px',
-          background: '#f8fafc',
-          borderRadius: '8px',
-          marginBottom: '16px',
-          border: '1px solid #e2e8f0',
-        }}>
-          <div style={{ marginBottom: '8px', fontSize: '12px', fontWeight: '500' }}>
-            录音方式
-          </div>
-          <div style={{ display: 'flex', gap: '8px' }}>
-            <button
-              onClick={() => setRecordingMethod('scriptProcessor')}
-              disabled={!isAvailable}
-              style={{
-                flex: 1,
-                padding: '8px 12px',
-                fontSize: '12px',
-                background: recordingMethod === 'scriptProcessor' ? '#3b82f6' : '#e5e7eb',
-                color: recordingMethod === 'scriptProcessor' ? 'white' : '#374151',
-                border: 'none',
-                borderRadius: '6px',
-                cursor: isAvailable ? 'pointer' : 'not-allowed',
-              }}
-            >
-              ScriptProcessor
-              <br />
-              <small style={{ opacity: 0.8 }}>WAV，~100KB/3秒</small>
-            </button>
-            <button
-              onClick={() => setRecordingMethod('mediaRecorder')}
-              disabled={!isAvailable}
-              style={{
-                flex: 1,
-                padding: '8px 12px',
-                fontSize: '12px',
-                background: recordingMethod === 'mediaRecorder' ? '#3b82f6' : '#e5e7eb',
-                color: recordingMethod === 'mediaRecorder' ? 'white' : '#374151',
-                border: 'none',
-                borderRadius: '6px',
-                cursor: isAvailable ? 'pointer' : 'not-allowed',
-              }}
-            >
-              MediaRecorder
-              <br />
-              <small style={{ opacity: 0.8 }}>WebM，~40KB/3秒</small>
-            </button>
-          </div>
-        </div>
+        <Card className="shadow-sm">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm">录音方式</CardTitle>
+          </CardHeader>
+          <CardContent className="pt-0">
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                onClick={() => setRecordingMethod('scriptProcessor')}
+                disabled={!isAvailable}
+                variant={recordingMethod === 'scriptProcessor' ? 'brand' : 'outline'}
+                className="flex-1 h-auto py-2 px-3 flex-col items-start gap-0"
+              >
+                <span className="text-sm">ScriptProcessor</span>
+                <span className="text-xs opacity-80">WAV，~100KB/3秒</span>
+              </Button>
+              <Button
+                type="button"
+                onClick={() => setRecordingMethod('mediaRecorder')}
+                disabled={!isAvailable}
+                variant={recordingMethod === 'mediaRecorder' ? 'brand' : 'outline'}
+                className="flex-1 h-auto py-2 px-3 flex-col items-start gap-0"
+              >
+                <span className="text-sm">MediaRecorder</span>
+                <span className="text-xs opacity-80">WebM，~40KB/3秒</span>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
       )}
 
-      {/* 连接状态 */}
-      <div style={{
-        padding: '12px',
-        background: '#f8fafc',
-        borderRadius: '8px',
-        marginBottom: '16px',
-        fontSize: '12px',
-        border: '1px solid #e2e8f0',
-      }}>
-        <strong>状态：</strong> {connectionStatus}
-      </div>
+      <Card className="shadow-sm">
+        <CardContent className="p-4 text-sm">
+          <span className="font-semibold">状态：</span> {connectionStatus}
+        </CardContent>
+      </Card>
 
-      {/* 录音状态 */}
-      <div style={{
-        padding: '24px',
-        background: recordingState === 'recording' ? '#fee2e2' :
-                    result ? '#dcfce7' : '#f3f4f6',
-        borderRadius: '12px',
-        marginBottom: '16px',
-        textAlign: 'center',
-      }}>
-        <div style={{ fontSize: '18px', marginBottom: '8px', fontWeight: '500' }}>
-          {recordingState === 'recording' ? '🔴 录音中...' :
-           result ? '✓ 识别完成' : '🎤 点击开始录音'}
+      <div
+        className={cn(
+          "rounded-xl border p-6 text-center",
+          recordingState === 'recording'
+            ? "border-destructive/30 bg-destructive/10"
+            : result
+              ? "border-success/30 bg-success/10"
+              : "bg-muted"
+        )}
+      >
+        <div className="text-lg font-medium mb-2">
+          {recordingState === 'recording' ? '🔴 录音中...' : result ? '✓ 识别完成' : '🎤 点击开始录音'}
         </div>
         {recordingState === 'recording' && (
-          <div style={{ fontSize: '40px', fontWeight: 'bold', fontFamily: 'monospace', color: '#dc2626' }}>
+          <div className="font-mono text-4xl font-bold text-destructive">
             {duration.toFixed(1)}s
           </div>
         )}
       </div>
 
-      {/* 控制按钮 */}
-      <div style={{ display: 'flex', gap: '12px', marginBottom: '16px' }}>
+      <div className="flex gap-3">
         {recordingState === 'idle' && !result && (
-          <button
+          <Button
+            type="button"
             onClick={handleStart}
             disabled={!isAvailable}
-            style={{
-              flex: 1,
-              padding: '24px',
-              fontSize: '18px',
-              background: isAvailable ? '#3b82f6' : '#9ca3af',
-              color: 'white',
-              border: 'none',
-              borderRadius: '12px',
-              cursor: isAvailable ? 'pointer' : 'not-allowed',
-            }}
+            variant="brand"
+            className="flex-1 h-auto py-6 text-lg"
           >
             🎤 开始录音
-          </button>
+          </Button>
         )}
 
         {recordingState === 'recording' && (
-          <button
+          <Button
+            type="button"
             onClick={handleStop}
-            style={{
-              flex: 1,
-              padding: '24px',
-              fontSize: '18px',
-              background: '#ef4444',
-              color: 'white',
-              border: 'none',
-              borderRadius: '12px',
-              cursor: 'pointer',
-            }}
+            variant="destructive"
+            className="flex-1 h-auto py-6 text-lg"
           >
             ⏹ 停止并识别
-          </button>
+          </Button>
         )}
 
         {result && (
-          <button
+          <Button
+            type="button"
             onClick={handleReset}
-            style={{
-              flex: 1,
-              padding: '24px',
-              fontSize: '18px',
-              background: '#10b981',
-              color: 'white',
-              border: 'none',
-              borderRadius: '12px',
-              cursor: 'pointer',
-            }}
+            variant="brand"
+            className="flex-1 h-auto py-6 text-lg"
           >
             🔄 重新录音
-          </button>
+          </Button>
         )}
       </div>
 
-      {/* VoiceInputButton 语音输入区域 */}
-      <div style={{
-        padding: '20px',
-        background: '#f8fafc',
-        borderRadius: '12px',
-        marginBottom: '16px',
-        border: '1px solid #e2e8f0',
-      }}>
-        <h3 style={{ margin: '0 0 16px 0', fontSize: '14px', color: '#374151' }}>
-          🎤 语音输入
-        </h3>
+      <Card className="shadow-sm">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm">🎤 语音输入</CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0 space-y-4">
+          <div className="flex flex-col sm:flex-row sm:items-start gap-6">
+            <div className="shrink-0 self-center sm:self-start">
+              <VoiceInputButton
+                adapterConfig={voiceButtonAdapterConfig}
+                onResult={handleVoiceResult}
+                onError={(err) => addLogEntry(`❌ ${err}`)}
+                onStateChange={(state) => {
+                  if (state === 'recording') {
+                    addLogEntry('🎤 开始录音');
+                  } else if (state === 'recognizing') {
+                    addLogEntry('⏳ 识别中...');
+                  } else if (state === 'completed') {
+                    addLogEntry('✅ 识别完成');
+                  }
+                }}
+                showWaveform={true}
+                showTimer={true}
+                enableShortcut={true}
+                size={72}
+              />
+            </div>
 
-        <div style={{ display: 'flex', alignItems: 'center', gap: '24px' }}>
-          {/* 语音输入按钮 */}
-          <VoiceInputButton
-            adapterConfig={voiceButtonAdapterConfig}
-            onResult={handleVoiceResult}
-            onError={(err) => addLogEntry(`❌ ${err}`)}
-            onStateChange={(state) => {
-              if (state === 'recording') {
-                addLogEntry('🎤 开始录音');
-              } else if (state === 'recognizing') {
-                addLogEntry('⏳ 识别中...');
-              } else if (state === 'completed') {
-                addLogEntry('✅ 识别完成');
-              }
-            }}
-            showWaveform={true}
-            showTimer={true}
-            enableShortcut={true}
-            size={72}
-          />
-
-          {/* 语音输入框 */}
-          <div style={{ flex: 1 }}>
-            <textarea
-              value={inputText}
-              onChange={(e) => setInputText(e.target.value)}
-              placeholder="点击上方麦克风按钮开始语音输入..."
-              style={{
-                width: '100%',
-                minHeight: '80px',
-                padding: '12px',
-                border: '1px solid #d1d5db',
-                borderRadius: '8px',
-                fontSize: '14px',
-                resize: 'vertical',
-                fontFamily: 'inherit',
-              }}
-            />
-            {inputText && (
-              <div style={{ marginTop: '8px', display: 'flex', gap: '8px' }}>
-                <button
-                  onClick={() => navigator.clipboard.writeText(inputText)}
-                  style={{
-                    padding: '6px 12px',
-                    fontSize: '12px',
-                    background: '#f3f4f6',
-                    border: '1px solid #d1d5db',
-                    borderRadius: '6px',
-                    cursor: 'pointer',
-                  }}
-                >
-                  复制
-                </button>
-                <button
-                  onClick={() => setInputText('')}
-                  style={{
-                    padding: '6px 12px',
-                    fontSize: '12px',
-                    background: '#f3f4f6',
-                    border: '1px solid #d1d5db',
-                    borderRadius: '6px',
-                    cursor: 'pointer',
-                  }}
-                >
-                  清空
-                </button>
-              </div>
-            )}
+            <div className="flex-1 space-y-2">
+              <Textarea
+                value={inputText}
+                onChange={(e) => setInputText(e.target.value)}
+                placeholder="点击上方麦克风按钮开始语音输入..."
+                className="min-h-20 resize-y"
+              />
+              {inputText && (
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => navigator.clipboard.writeText(inputText)}
+                  >
+                    复制
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setInputText('')}
+                  >
+                    清空
+                  </Button>
+                </div>
+              )}
+            </div>
           </div>
-        </div>
 
-        <div style={{
-          marginTop: '12px',
-          padding: '12px',
-          background: '#fef3c7',
-          borderRadius: '8px',
-          fontSize: '12px',
-          color: '#92400e',
-        }}>
-          <strong>快捷键提示：</strong>
-          <ul style={{ margin: '8px 0 0 0', paddingLeft: '20px' }}>
-            <li>[空格键] 开始/停止录音</li>
-            <li>[Esc] 取消录音</li>
-          </ul>
-        </div>
-      </div>
+          <div className="rounded-lg border border-warning/30 bg-warning/10 p-3 text-xs text-warning">
+            <strong className="text-warning">快捷键提示：</strong>
+            <ul className="mt-2 list-disc pl-5">
+              <li>[空格键] 开始/停止录音</li>
+              <li>[Esc] 取消录音</li>
+            </ul>
+          </div>
+        </CardContent>
+      </Card>
 
-      {/* 原有的识别结果（仅显示，不使用） */}
       {result && (
-        <div style={{
-          padding: '20px',
-          background: '#f0fdf4',
-          borderRadius: '12px',
-          marginTop: '16px',
-          border: '1px solid #86efac',
-        }}>
-          <h3 style={{ margin: '0 0 12px 0', fontSize: '14px', color: '#166534' }}>
-            识别结果
-          </h3>
-          <p style={{ margin: 0, fontSize: '20px', fontWeight: '500' }}>
-            {result.text || '（无识别结果）'}
-          </p>
-          <div style={{ marginTop: '12px', fontSize: '12px', color: '#666' }}>
-            {result.confidence && `置信度: ${(result.confidence * 100).toFixed(1)}%`}
-            {result.duration && ` | 时长: ${(result.duration / 1000).toFixed(2)}秒`}
-            {result.lang && ` | 语言: ${result.lang}`}
-          </div>
-          {audioUrl && (
-            <a
-              href={audioUrl}
-              download={`moss-recording-${Date.now()}.wav`}
-              style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: '6px',
-                marginTop: '12px',
-                padding: '8px 12px',
-                background: '#3b82f6',
-                color: 'white',
-                borderRadius: '6px',
-                textDecoration: 'none',
-                fontSize: '12px',
-              }}
-            >
-              ⬇️ 下载录音文件
-            </a>
-          )}
-        </div>
+        <Card className="shadow-sm border-success/30 bg-success/10">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm text-success">识别结果</CardTitle>
+          </CardHeader>
+          <CardContent className="pt-0 space-y-2">
+            <p className="text-lg font-medium">{result.text || '（无识别结果）'}</p>
+            <div className="text-xs text-muted-foreground">
+              {result.confidence && `置信度: ${(result.confidence * 100).toFixed(1)}%`}
+              {result.duration && ` | 时长: ${(result.duration / 1000).toFixed(2)}秒`}
+              {result.lang && ` | 语言: ${result.lang}`}
+            </div>
+            {audioUrl && (
+              <Button type="button" asChild variant="brand" size="sm" className="w-fit">
+                <a href={audioUrl} download={`moss-recording-${Date.now()}.wav`}>
+                  ⬇️ 下载录音文件
+                </a>
+              </Button>
+            )}
+          </CardContent>
+        </Card>
       )}
 
-      {/* 日志面板 */}
-      <div style={{
-        padding: '16px',
-        background: '#1e293b',
-        borderRadius: '12px',
-        marginTop: '20px',
-        fontFamily: 'monospace',
-        fontSize: '12px',
-        color: '#22d3ee',
-      }}>
-        <div style={{ marginBottom: '12px', color: '#94a3b8', fontSize: '11px' }}>
-          📋 运行日志
-          <button
-            onClick={() => setLogs([])}
-            style={{
-              marginLeft: '8px',
-              padding: '2px 6px',
-              fontSize: '10px',
-              background: '#334155',
-              color: '#94a3b8',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: 'pointer',
-            }}
-          >
+      <Card className="shadow-sm">
+        <CardHeader className="pb-3 flex-row items-center justify-between space-y-0">
+          <CardTitle className="text-sm">📋 运行日志</CardTitle>
+          <Button type="button" variant="outline" size="sm" onClick={() => setLogs([])}>
             清空
-          </button>
-        </div>
-        {logs.map((log, i) => (
-          <div key={i} style={{ marginBottom: '8px', lineHeight: '1.5' }}>
-            <span style={{ color: '#64748b' }}>[{log.time}]</span>{' '}
-            <span>{log.message}</span>
-            {log.duration !== undefined && (
-              <span style={{ color: '#94a3b8', marginLeft: 8 }}>
-                ({log.duration.toFixed(1)}秒)
-              </span>
-            )}
-            {log.text && (
-              <div style={{
-                marginTop: 4,
-                padding: '8px 12px',
-                background: 'rgba(81, 207, 102, 0.2)',
-                borderRadius: '6px',
-                borderLeft: '3px solid #51cf66',
-                fontSize: '13px',
-                color: '#fff',
-              }}>
-                {log.text}
-              </div>
-            )}
-          </div>
-        ))}
-        {logs.length === 0 && (
-          <div style={{ color: '#475569' }}>暂无日志</div>
-        )}
-      </div>
+          </Button>
+        </CardHeader>
+        <CardContent className="pt-0 font-mono text-xs space-y-2">
+          {logs.map((log, i) => (
+            <div key={i} className="leading-relaxed">
+              <span className="text-muted-foreground">[{log.time}]</span>{' '}
+              <span className="text-foreground">{log.message}</span>
+              {log.duration !== undefined && (
+                <span className="text-muted-foreground ml-2">
+                  ({log.duration.toFixed(1)}秒)
+                </span>
+              )}
+              {log.text && (
+                <div className="mt-1 rounded-md border-l-4 border-success bg-success/10 px-3 py-2 text-sm text-foreground">
+                  {log.text}
+                </div>
+              )}
+            </div>
+          ))}
+          {logs.length === 0 && (
+            <div className="text-muted-foreground">暂无日志</div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/pages/VoiceChatPage.tsx
+++ b/src/pages/VoiceChatPage.tsx
@@ -14,6 +14,9 @@ import { useEffect, useState } from 'react';
 import { getVoiceChatService, setASRAdapterType, ASRAdapterType } from '../lib/services/voice-chat.service';
 import type { ASRResult } from '../lib/environment/interfaces/asr.port';
 import { resolveAsrServerUrl } from '@/config/port-env';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
 
 export function VoiceChatPage() {
   const service = getVoiceChatService();
@@ -116,228 +119,158 @@ export function VoiceChatPage() {
   };
 
   return (
-    <div style={{ padding: '24px', maxWidth: '700px', margin: '0 auto' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '20px' }}>
-        <h1 style={{ margin: 0, fontSize: '24px' }}>语音聊天</h1>
-      </div>
+    <div className="p-6 max-w-3xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">语音聊天</h1>
 
-      {/* ASR 状态卡片 */}
-      <div style={{
-        padding: '16px',
-        background: isAvailable ? '#dcfce7' : '#fee2e2',
-        borderRadius: '12px',
-        marginBottom: '16px',
-        fontSize: '13px',
-      }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' }}>
-          <strong>火山引擎 ASR 适配器</strong>
-          <span style={{
-            padding: '2px 8px',
-            borderRadius: '4px',
-            background: isAvailable ? '#22c55e' : '#ef4444',
-            color: 'white',
-            fontSize: '11px',
-          }}>
-            {isAvailable ? '就绪' : '不可用'}
-          </span>
-        </div>
-
-        <div style={{ display: 'flex', gap: '8px', marginTop: '12px' }}>
-          <button
-            onClick={() => handleSwitchAdapter('http')}
-            style={{
-              flex: 1,
-              padding: '8px',
-              fontSize: '12px',
-              background: adapterType === 'http' ? '#3b82f6' : '#e5e7eb',
-              color: adapterType === 'http' ? 'white' : '#374151',
-              border: 'none',
-              borderRadius: '6px',
-              cursor: 'pointer',
-            }}
-          >
-            HTTP 模式
-            <br />
-            <small>需要 Bun 后端</small>
-          </button>
-          <button
-            onClick={() => handleSwitchAdapter('websocket')}
-            style={{
-              flex: 1,
-              padding: '8px',
-              fontSize: '12px',
-              background: adapterType === 'websocket' ? '#3b82f6' : '#e5e7eb',
-              color: adapterType === 'websocket' ? 'white' : '#374151',
-              border: 'none',
-              borderRadius: '6px',
-              cursor: 'pointer',
-            }}
-          >
-            WebSocket 模式
-            <br />
-            <small>浏览器直接连接</small>
-          </button>
-        </div>
-
-        {adapterType === 'websocket' && (
-          <div style={{ marginTop: '8px', padding: '8px', background: '#fef3c7', borderRadius: '6px', fontSize: '11px' }}>
-            ⚠️ 注意：WebSocket 模式需要浏览器支持自定义认证头部，可能无法正常工作
+      <Card className={cn(
+        "shadow-sm",
+        isAvailable ? "border-success/30 bg-success/10" : "border-destructive/30 bg-destructive/10"
+      )}>
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="text-sm">火山引擎 ASR 适配器</CardTitle>
+            <span
+              className={cn(
+                "rounded-md px-2 py-0.5 text-xs font-semibold",
+                isAvailable
+                  ? "bg-success text-success-foreground"
+                  : "bg-destructive text-destructive-foreground"
+              )}
+            >
+              {isAvailable ? '就绪' : '不可用'}
+            </span>
           </div>
+          {!isAvailable && (
+            <div className="text-xs text-muted-foreground whitespace-pre-line mt-2">
+              【启动 Bun 后端服务】{'\n'}  bun run src/backend/server.ts{'\n\n'}
+              【配置环境变量】{'\n'}  VITE_VOLCANO_APP_KEY=xxx{'\n'}  VITE_VOLCANO_ACCESS_KEY=xxx{'\n'}  VITE_ASR_SERVER_URL={defaultAsrServerUrl}
+            </div>
+          )}
+        </CardHeader>
+        <CardContent className="pt-0">
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant={adapterType === 'http' ? 'brand' : 'outline'}
+              onClick={() => handleSwitchAdapter('http')}
+              className="flex-1 h-auto py-2 px-3 flex-col items-start gap-0"
+            >
+              <span className="text-sm">HTTP 模式</span>
+              <span className="text-xs opacity-80">需要 Bun 后端</span>
+            </Button>
+            <Button
+              type="button"
+              variant={adapterType === 'websocket' ? 'brand' : 'outline'}
+              onClick={() => handleSwitchAdapter('websocket')}
+              className="flex-1 h-auto py-2 px-3 flex-col items-start gap-0"
+            >
+              <span className="text-sm">WebSocket 模式</span>
+              <span className="text-xs opacity-80">浏览器直接连接</span>
+            </Button>
+          </div>
+
+          {adapterType === 'websocket' && (
+            <div className="mt-3 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning">
+              ⚠️ 注意：WebSocket 模式需要浏览器支持自定义认证头部，可能无法正常工作
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="shadow-sm">
+        <CardContent className="p-4 text-sm">
+          <span className="font-semibold">状态：</span> {connectionStatus}
+        </CardContent>
+      </Card>
+
+      <div
+        className={cn(
+          "rounded-xl border p-4 flex items-center justify-between",
+          result
+            ? "border-success/30 bg-success/10"
+            : isRecording
+              ? "border-destructive/30 bg-destructive/10"
+              : "bg-muted"
         )}
-      </div>
-
-      {/* 连接状态 */}
-      <div style={{
-        padding: '12px',
-        background: '#f8fafc',
-        borderRadius: '8px',
-        marginBottom: '16px',
-        fontSize: '12px',
-        border: '1px solid #e2e8f0',
-      }}>
-        <strong>状态：</strong> {connectionStatus}
-      </div>
-
-      {/* 状态栏 */}
-      <div style={{
-        padding: '16px',
-        background: result ? '#dcfce7' :
-                    isRecording ? '#fee2e2' :
-                    '#f3f4f6',
-        borderRadius: '12px',
-        marginBottom: '16px',
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-      }}>
-        <span style={{ fontSize: '14px', fontWeight: '500' }}>
-          {isRecording ? '🔴 录音中' :
-           result ? '✓ 识别完成' : '🎤 点击开始录音'}
+      >
+        <span className="text-sm font-medium">
+          {isRecording ? '🔴 录音中' : result ? '✓ 识别完成' : '🎤 点击开始录音'}
         </span>
         {isRecording && (
-          <span style={{ fontSize: '28px', fontWeight: 'bold', fontFamily: 'monospace' }}>
+          <span className="font-mono text-3xl font-bold">
             {formatDuration(duration)}
           </span>
         )}
       </div>
 
-      {/* 控制按钮 */}
-      <div style={{ display: 'flex', gap: '12px', marginBottom: '16px' }}>
+      <div className="flex gap-3">
         {!isRecording && !result ? (
-          <button
+          <Button
+            type="button"
+            variant="brand"
             onClick={handleStart}
             disabled={!isAvailable}
-            style={{
-              flex: 1,
-              padding: '24px',
-              fontSize: '18px',
-              background: isAvailable ? '#3b82f6' : '#9ca3af',
-              color: 'white',
-              border: 'none',
-              borderRadius: '12px',
-              cursor: isAvailable ? 'pointer' : 'not-allowed',
-            }}
+            className="flex-1 h-auto py-6 text-lg flex-col items-center gap-1"
           >
-            🎤 开始录音
-            <br />
-            <small style={{ fontSize: '12px', opacity: 0.9 }}>
+            <span>🎤 开始录音</span>
+            <span className="text-xs opacity-80">
               {adapterType === 'http' ? '自动 3 秒识别' : '手动控制'}
-            </small>
-          </button>
+            </span>
+          </Button>
         ) : isRecording ? (
-          <button
+          <Button
+            type="button"
+            variant="destructive"
             onClick={handleStop}
-            style={{
-              flex: 1,
-              padding: '24px',
-              fontSize: '18px',
-              background: '#ef4444',
-              color: 'white',
-              border: 'none',
-              borderRadius: '12px',
-              cursor: 'pointer',
-            }}
+            className="flex-1 h-auto py-6 text-lg"
           >
             ⏹ 停止并识别
-          </button>
+          </Button>
         ) : (
-          <button
+          <Button
+            type="button"
+            variant="brand"
             onClick={handleReset}
-            style={{
-              flex: 1,
-              padding: '24px',
-              fontSize: '18px',
-              background: '#10b981',
-              color: 'white',
-              border: 'none',
-              borderRadius: '12px',
-              cursor: 'pointer',
-            }}
+            className="flex-1 h-auto py-6 text-lg"
           >
             🔄 重新录音
-          </button>
+          </Button>
         )}
       </div>
 
-      {/* 识别结果 */}
       {result && (
-        <div style={{
-          padding: '20px',
-          background: '#f0fdf4',
-          borderRadius: '12px',
-          marginTop: '16px',
-          border: '1px solid #86efac',
-        }}>
-          <h3 style={{ margin: '0 0 12px 0', fontSize: '14px', color: '#166534' }}>
-            ✓ 识别结果
-          </h3>
-          <p style={{ margin: 0, fontSize: '20px', fontWeight: '500' }}>
-            {result.text || '（无识别结果）'}
-          </p>
-          <div style={{ marginTop: '12px', fontSize: '12px', color: '#666' }}>
-            置信度: {(result.confidence * 100).toFixed(1)}%
-            {result.duration && ` | 音频时长: ${result.duration}ms`}
-          </div>
-        </div>
+        <Card className="shadow-sm border-success/30 bg-success/10">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm text-success">✓ 识别结果</CardTitle>
+          </CardHeader>
+          <CardContent className="pt-0 space-y-2">
+            <p className="text-lg font-medium">{result.text || '（无识别结果）'}</p>
+            <div className="text-xs text-muted-foreground">
+              置信度: {(result.confidence * 100).toFixed(1)}%
+              {result.duration && ` | 音频时长: ${result.duration}ms`}
+            </div>
+          </CardContent>
+        </Card>
       )}
 
-      {/* 日志面板 */}
-      <div style={{
-        padding: '16px',
-        background: '#1e293b',
-        borderRadius: '12px',
-        marginTop: '20px',
-        fontFamily: 'monospace',
-        fontSize: '12px',
-        color: '#22d3ee',
-      }}>
-        <div style={{ marginBottom: '12px', color: '#94a3b8', fontSize: '11px' }}>
-          📋 运行日志
-          <button
-            onClick={() => setLogs([])}
-            style={{
-              marginLeft: '8px',
-              padding: '2px 6px',
-              fontSize: '10px',
-              background: '#334155',
-              color: '#94a3b8',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: 'pointer',
-            }}
-          >
+      <Card className="shadow-sm">
+        <CardHeader className="pb-3 flex-row items-center justify-between space-y-0">
+          <CardTitle className="text-sm">📋 运行日志</CardTitle>
+          <Button type="button" variant="outline" size="sm" onClick={() => setLogs([])}>
             清空
-          </button>
-        </div>
-        {logs.map((log, i) => (
-          <div key={i} style={{ marginBottom: '4px', lineHeight: '1.5' }}>
-            {log}
-          </div>
-        ))}
-        {logs.length === 0 && (
-          <div style={{ color: '#475569' }}>暂无日志，点击开始录音后显示</div>
-        )}
-      </div>
+          </Button>
+        </CardHeader>
+        <CardContent className="pt-0 font-mono text-xs text-brand space-y-1">
+          {logs.map((log, i) => (
+            <div key={i} className="leading-relaxed">
+              {log}
+            </div>
+          ))}
+          {logs.length === 0 && (
+            <div className="text-muted-foreground">暂无日志，点击开始录音后显示</div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,8 +1,8 @@
 import { createRootRoute, createRouter, createRoute, Outlet, useLocation } from "@tanstack/react-router";
 import { Link } from "@tanstack/react-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
-import { X, Settings, Mic, MicVocal, ClipboardList, Menu, Home, Users } from "lucide-react";
+import { X, Settings, Mic, MicVocal, ClipboardList, Menu, Home, Users, Sun, Moon, SunMoon } from "lucide-react";
 import { ChatPage } from "@/components/Chat/ChatPage";
 import { SettingsPage } from "@/components/Settings/SettingsPage";
 import { ASRTestPage } from "@/pages/ASRTestPage";
@@ -11,6 +11,12 @@ import { MOSSASRTestPage } from "@/pages/MOSSASRTestPage";
 import { HomePage } from "@/components/Home/HomePage";
 import { UserManagePage } from "@/ui/pages/UserManagePage";
 import { SyncTestPage } from "@/ui/pages/SyncTestPage";
+import {
+  getThemePreference,
+  setThemePreference,
+  subscribeThemePreferenceChanges,
+  type ThemePreference,
+} from "@/config/theme";
 
 const sidebarItems = [
   { title: "首页", path: "/", icon: Home },
@@ -24,6 +30,39 @@ const sidebarItems = [
 
 function Sidebar({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
   const location = useLocation();
+  const [themePreference, setThemePreferenceState] = useState<ThemePreference>(() => getThemePreference());
+
+  useEffect(() => {
+    return subscribeThemePreferenceChanges((preference) => {
+      setThemePreferenceState(preference);
+    });
+  }, []);
+
+  const handleToggleTheme = () => {
+    const nextPreference: ThemePreference =
+      themePreference === 'light' ? 'dark' : themePreference === 'dark' ? 'system' : 'light';
+    setThemePreference(nextPreference);
+    setThemePreferenceState(nextPreference);
+  };
+
+  const renderThemeIcon = () => {
+    const iconClassName = "w-5 h-5";
+    if (themePreference === 'light') {
+      return <Sun className={iconClassName} aria-hidden="true" />;
+    }
+    if (themePreference === 'dark') {
+      return <Moon className={iconClassName} aria-hidden="true" />;
+    }
+
+    return (
+      <span className="relative inline-flex" aria-hidden="true">
+        <SunMoon className={iconClassName} />
+        <span className="absolute -bottom-0.5 -right-0.5 rounded bg-background px-0.5 text-[9px] leading-none text-muted-foreground border">
+          A
+        </span>
+      </span>
+    );
+  };
 
   return (
     <>
@@ -41,14 +80,26 @@ function Sidebar({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) 
         )}
         data-testid="device-panel"
       >
-        <div className="p-4 border-b flex items-center justify-between">
+        <div className="p-4 border-b flex items-center justify-between gap-2">
           <h1 className="text-xl font-bold">ExoMind</h1>
-          <button
-            onClick={onClose}
-            className="lg:hidden p-2 hover:bg-accent rounded-md"
-          >
-            <X size={20} />
-          </button>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={handleToggleTheme}
+              className="p-2 hover:bg-accent rounded-md"
+              aria-label="切换主题（浅色/深色/跟随系统）"
+              title="切换主题：浅 → 深 → 系统"
+            >
+              {renderThemeIcon()}
+            </button>
+            <button
+              onClick={onClose}
+              className="lg:hidden p-2 hover:bg-accent rounded-md"
+              aria-label="关闭侧边栏"
+            >
+              <X size={20} />
+            </button>
+          </div>
         </div>
         <nav className="flex-1 p-4 space-y-1">
           {sidebarItems.map((item) => {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -42,6 +42,18 @@ export default {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        brand: {
+          DEFAULT: "hsl(var(--brand) / <alpha-value>)",
+          foreground: "hsl(var(--brand-foreground) / <alpha-value>)",
+        },
+        success: {
+          DEFAULT: "hsl(var(--success) / <alpha-value>)",
+          foreground: "hsl(var(--success-foreground) / <alpha-value>)",
+        },
+        warning: {
+          DEFAULT: "hsl(var(--warning) / <alpha-value>)",
+          foreground: "hsl(var(--warning-foreground) / <alpha-value>)",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",

--- a/tests/unit/services/timeblock.service.test.ts
+++ b/tests/unit/services/timeblock.service.test.ts
@@ -146,4 +146,36 @@ describe('TimeBlockServiceImpl', () => {
     expect(paused?.elapsed).toBeGreaterThanOrEqual(3000);
     expect(stillPaused?.elapsed).toBe(paused?.elapsed);
   });
+
+  it('writes block_pause and block_resume events when pausing and resuming', async () => {
+    const env = createMemoryEnv();
+    const service = new TimeBlockServiceImpl(env as never);
+
+    await service.startBlock('pause-resume', { mode: 'countup' });
+    await service.pauseBlock();
+    await service.resumeBlock();
+
+    const types = addEventMock.mock.calls.map(([event]) => (event as { type?: string }).type);
+    expect(types).toEqual(expect.arrayContaining(['block_start', 'block_pause', 'block_resume']));
+    expect(addEventMock).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'block_pause',
+      content: expect.stringContaining('pause-resume'),
+    }));
+    expect(addEventMock).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'block_resume',
+      content: expect.stringContaining('pause-resume'),
+    }));
+  });
+
+  it('does not write duplicate pause events when pausing an already paused block', async () => {
+    const env = createMemoryEnv();
+    const service = new TimeBlockServiceImpl(env as never);
+
+    await service.startBlock('idempotent-pause', { mode: 'countup' });
+    await service.pauseBlock();
+    await service.pauseBlock();
+
+    const pauseCalls = addEventMock.mock.calls.filter(([event]) => (event as { type?: string }).type === 'block_pause');
+    expect(pauseCalls).toHaveLength(1);
+  });
 });

--- a/tests/unit/services/timeblock.service.test.ts
+++ b/tests/unit/services/timeblock.service.test.ts
@@ -178,4 +178,20 @@ describe('TimeBlockServiceImpl', () => {
     const pauseCalls = addEventMock.mock.calls.filter(([event]) => (event as { type?: string }).type === 'block_pause');
     expect(pauseCalls).toHaveLength(1);
   });
+
+  it('does not start a new block when an active block exists', async () => {
+    const env = createMemoryEnv();
+    const service = new TimeBlockServiceImpl(env as never);
+
+    const first = await service.startBlock('first', { mode: 'countup' });
+    await service.pauseBlock();
+
+    const second = await service.startBlock('second', { mode: 'countup' });
+
+    expect(second.startId).toBe(first.startId);
+    expect(second.name).toBe(first.name);
+
+    const startCalls = addEventMock.mock.calls.filter(([event]) => (event as { type?: string }).type === 'block_start');
+    expect(startCalls).toHaveLength(1);
+  });
 });

--- a/tests/unit/ui/button-variants.test.ts
+++ b/tests/unit/ui/button-variants.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { buttonVariants } from '@/components/ui/button';
+
+describe('button variants', () => {
+  it('should include brand variant classes', () => {
+    const className = buttonVariants({ variant: 'brand' });
+    expect(className).toContain('bg-brand');
+    expect(className).toContain('text-brand-foreground');
+  });
+});
+

--- a/tests/unit/ui/css-variables.test.ts
+++ b/tests/unit/ui/css-variables.test.ts
@@ -22,6 +22,9 @@ describe('CSS variables', () => {
     expect(content).toContain('--background');
     expect(content).toContain('--foreground');
     expect(content).toContain('--primary');
+    expect(content).toContain('--brand');
+    expect(content).toContain('--success');
+    expect(content).toContain('--warning');
     expect(content).toContain('--radius');
   });
 
@@ -30,6 +33,9 @@ describe('CSS variables', () => {
     expect(content).toContain('.dark');
     expect(content).toContain('--background:');
     expect(content).toContain('--foreground:');
+    expect(content).toContain('--brand:');
+    expect(content).toContain('--success:');
+    expect(content).toContain('--warning:');
   });
 
   it('should apply border-base and body styles', () => {

--- a/tests/unit/ui/theme-preference.test.ts
+++ b/tests/unit/ui/theme-preference.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  applyThemePreference,
+  getThemePreference,
+  resolveThemePreference,
+  setThemePreference,
+  subscribeThemePreferenceChanges,
+} from '@/config/theme';
+
+describe('theme preference', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.classList.remove('dark');
+    document.documentElement.style.colorScheme = '';
+  });
+
+  it('defaults to system when not set', () => {
+    expect(getThemePreference()).toBe('system');
+  });
+
+  it('falls back to system for invalid stored values', () => {
+    window.localStorage.setItem('exomind:themePreference', 'nope');
+    expect(getThemePreference()).toBe('system');
+  });
+
+  it('persists preference and notifies subscribers', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeThemePreferenceChanges(listener);
+
+    setThemePreference('dark');
+    expect(window.localStorage.getItem('exomind:themePreference')).toBe('dark');
+    expect(listener).toHaveBeenCalledWith('dark');
+
+    unsubscribe();
+  });
+
+  it('applies dark preference via html.dark and colorScheme', () => {
+    expect(applyThemePreference('dark')).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.style.colorScheme).toBe('dark');
+  });
+
+  it('applies light preference via html.dark removal and colorScheme', () => {
+    document.documentElement.classList.add('dark');
+
+    expect(applyThemePreference('light')).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(document.documentElement.style.colorScheme).toBe('light');
+  });
+
+  it('resolves system theme using matchMedia', () => {
+    const originalMatchMedia = window.matchMedia;
+
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes('prefers-color-scheme') ? true : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    expect(resolveThemePreference('system')).toBe('dark');
+    expect(applyThemePreference('system')).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+
+    window.matchMedia = originalMatchMedia;
+  });
+});
+


### PR DESCRIPTION
Fixes #40.

## What
- Adds a theme preference (`system`/`light`/`dark`) persisted in localStorage (`exomind:themePreference`).
- Applies `.dark` on `<html>` (Tailwind `darkMode: class`) and sets `color-scheme` for native controls.
- Bootstraps theme in `index.html` to reduce initial flash.
- Adds a controller component to keep runtime/theme changes in sync.
- Adds a global theme toggle button in the sidebar header (cycles `light -> dark -> system`).
- Introduces semantic theme colors (`brand`/`success`/`warning`) and updates voice pages + voice input button to use theme-controlled colors.
- Ensures event bubbles that used fixed Tailwind palette colors have explicit dark variants.
- Merges Issue #76 (pause/resume events) so the new `block_pause`/`block_resume` events render with correct colors in dark mode.

## Bubble color variants
`src/components/Chat/ChatPage.tsx` currently maps tags to bubble styles:
- `block_start`: `bg-blue-100 text-blue-800` + `dark:bg-blue-950 dark:text-blue-100`
- `block_pause`: `bg-yellow-100 text-yellow-900` + `dark:bg-yellow-950 dark:text-yellow-100`
- `block_resume`: `bg-green-100 text-green-900` + `dark:bg-green-950 dark:text-green-100`
- `block_end`: `bg-red-100 text-red-800` + `dark:bg-red-950 dark:text-red-100`
- default: `bg-muted` (CSS-variable based, auto theme)

## Verify
- `bun install`
- `bun run test tests/unit/services/timeblock.service.test.ts`
- `bun run test tests/unit/ui/theme-preference.test.ts tests/unit/ui/css-variables.test.ts tests/unit/ui/button-variants.test.ts`
- `bun run build`
- `bun run dev`
  - Use sidebar header theme toggle (Sun/Moon/Auto) or `/settings` theme selector, then refresh to confirm persistence.
  - In Event Log, start a timeblock, then pause/resume/end it; verify bubbles are blue/yellow/green/red and switch to dark variants in dark mode.