### PR TITLE
fix(ui): restore sync test nav entry

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -2,7 +2,7 @@ import { createRootRoute, createRouter, createRoute, Outlet, useLocation } from 
 import { Link } from "@tanstack/react-router";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
-import { X, Settings, Mic, MicVocal, ClipboardList, Menu, Home, Users } from "lucide-react";
+import { X, Settings, Mic, MicVocal, ClipboardList, Menu, Home, Users, RefreshCw } from "lucide-react";
 import { ChatPage } from "@/components/Chat/ChatPage";
 import { SettingsPage } from "@/components/Settings/SettingsPage";
 import { ASRTestPage } from "@/pages/ASRTestPage";
@@ -18,6 +18,7 @@ const sidebarItems = [
   { title: "MOSS测试", path: "/moss-test", icon: Mic },
   { title: "语音聊天", path: "/voice-chat", icon: MicVocal },
   { title: "ASR测试", path: "/asr-test", icon: Mic },
+  { title: "同步测试", path: "/sync-test", icon: RefreshCw },
   { title: "用户管理", path: "/user-manage", icon: Users },
   { title: "设置", path: "/settings", icon: Settings },
 ];
@@ -177,7 +178,6 @@ const userManageRoute = createRoute({
 });
 
 // Sync Test route (/sync-test)
-// 保留兼容入口；不在侧边栏展示
 const syncTestRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: 'sync-test',

--- a/tests/ui/sync-test.test.tsx
+++ b/tests/ui/sync-test.test.tsx
@@ -51,8 +51,12 @@ describe('SyncTestPage 路由注册', () => {
   const routesPath = path.resolve('src/routes.tsx');
   const routesContent = fs.readFileSync(routesPath, 'utf-8');
 
-  it('不应该在侧边栏显示同步测试入口', () => {
-    expect(routesContent).not.toContain('同步测试');
+  it('应该在侧边栏显示同步测试入口', () => {
+    expect(routesContent).toContain('同步测试');
+  });
+
+  it('同步测试应该使用 RefreshCw 图标', () => {
+    expect(routesContent).toContain('RefreshCw');
   });
 
   it('应该注册 /sync-test 路由（兼容旧入口）', () => {


### PR DESCRIPTION
## What
- Restores the `/sync-test` entry in the sidebar navigation (route already existed but was hidden).

## Verify
- `bun install`
- `bun run test tests/ui/sync-test.test.tsx`
- `bun run build`
- Manual: `bun run dev` -> open `/sync-test` from the sidebar.