### PR TITLE
feat: issue-108 设置页导出 JSON 改用 Tauri 原生保存对话框

### DIFF
--- a/Scripts/dev/github-comment-lib.ts
+++ b/Scripts/dev/github-comment-lib.ts
@@ -9,6 +9,8 @@ const COMMENT_ID_PATTERNS = [
 const GITHUB_REF_PATTERN = /^https?:\/\/github\.com\/([^/]+\/[^/]+)\/(issues|pull)\/(\d+)(?:#issuecomment-(\d+))?\/?$/i;
 const HTTPS_REMOTE_PATTERN = /^https?:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/i;
 const SSH_REMOTE_PATTERN = /^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/i;
+const UTF8_BOM = '\uFEFF';
+const SUSPICIOUS_QUESTION_SEQUENCE = /\?{8,}/;
 
 export type RefType = 'issue' | 'pr';
 
@@ -76,6 +78,22 @@ export function buildAppendedBody(existingBody: string, incomingBody: string): s
   return `${current}\n\n${next}`;
 }
 
+function normalizeBodyText(content: string): string {
+  const withoutBom = content.startsWith(UTF8_BOM) ? content.slice(1) : content;
+
+  if (withoutBom.includes('\u0000')) {
+    throw new Error('Comment body appears to contain NULL bytes. 可能是错误编码（encoding）文件。');
+  }
+  if (withoutBom.includes('\uFFFD')) {
+    throw new Error('Comment body contains replacement characters (�), possible garbled text. 可能已乱码。');
+  }
+  if (SUSPICIOUS_QUESTION_SEQUENCE.test(withoutBom)) {
+    throw new Error('Comment body contains suspicious long "?" sequence, possible garbled text. 检测到疑似乱码。');
+  }
+
+  return withoutBom;
+}
+
 export function readBodyInput(filePath: string | undefined, bodyText: string | undefined): string {
   if (filePath && bodyText) {
     throw new Error('Use either --file or --body, not both.');
@@ -85,10 +103,11 @@ export function readBodyInput(filePath: string | undefined, bodyText: string | u
   }
 
   if (filePath) {
-    return readFileSync(filePath, 'utf8');
+    const raw = readFileSync(filePath);
+    return normalizeBodyText(raw.toString('utf8'));
   }
 
-  return bodyText as string;
+  return normalizeBodyText(bodyText as string);
 }
 
 export function parseRepoFromRemoteUrl(remoteUrl: string): string {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
@@ -32,7 +33,6 @@ parking_lot = "0.12"
 chrono = { version = "0.4", features = ["serde"] }
 tokio-tungstenite = "0.21"
 url = "2"
-regex = "1"
 rand = "0.8"
 uuid = { version = "1", features = ["v4", "serde"] }
 tauri-plugin-mcp-bridge= "0.8"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,5 +36,4 @@ url = "2"
 rand = "0.8"
 uuid = { version = "1", features = ["v4", "serde"] }
 tauri-plugin-mcp-bridge= "0.8"
-tauri-plugin-dialog = "2"
 thiserror = "1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,4 +36,5 @@ regex = "1"
 rand = "0.8"
 uuid = { version = "1", features = ["v4", "serde"] }
 tauri-plugin-mcp-bridge= "0.8"
+tauri-plugin-dialog = "2"
 thiserror = "1"

--- a/src-tauri/src/commands/file_commands.rs
+++ b/src-tauri/src/commands/file_commands.rs
@@ -1,10 +1,11 @@
 //! 文件操作命令
 //! 用于消息持久化存储 - 重构版（同步版本）
 
-use tauri::{AppHandle, Manager, ipc::InvokeError};
-use tauri_plugin_dialog::DialogExt;
-use std::path::PathBuf;
+use serde::Deserialize;
 use std::fs;
+use std::path::PathBuf;
+use tauri::{ipc::InvokeError, AppHandle, Manager};
+use tauri_plugin_dialog::DialogExt;
 use thiserror::Error;
 
 /// 文件操作错误类型
@@ -17,7 +18,10 @@ pub enum FileError {
     PermissionDenied { path: String },
 
     #[error("IO 错误: {message}")]
-    IoError { message: String, source: std::io::Error },
+    IoError {
+        message: String,
+        source: std::io::Error,
+    },
 
     #[error("路径无效: {path}")]
     InvalidPath { path: String },
@@ -260,6 +264,100 @@ pub fn append_to_markdown(app: AppHandle, filename: String, content: String) -> 
     Ok(())
 }
 
+#[derive(Debug, Deserialize)]
+struct MarkdownMessage {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    content: String,
+    #[serde(default)]
+    timestamp: i64,
+    #[serde(default)]
+    direction: String,
+    #[serde(rename = "senderId", default)]
+    sender_id: String,
+    #[serde(rename = "receiverId", default)]
+    receiver_id: String,
+}
+
+fn parse_markdown_messages(messages_json: &str) -> FileResult<Vec<MarkdownMessage>> {
+    let trimmed = messages_json.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    serde_json::from_str::<Vec<MarkdownMessage>>(trimmed).map_err(|e| FileError::Unknown {
+        message: format!("消息 JSON 解析失败: {}", e),
+    })
+}
+
+fn format_markdown_time(timestamp_ms: i64, fallback: chrono::DateTime<chrono::Utc>) -> String {
+    let tz_utc8 = chrono::FixedOffset::east_opt(8 * 3600)
+        .expect("fixed offset +08:00 should always be valid");
+
+    chrono::DateTime::<chrono::Utc>::from_timestamp_millis(timestamp_ms)
+        .map(|dt| dt.with_timezone(&tz_utc8))
+        .unwrap_or_else(|| fallback.with_timezone(&tz_utc8))
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string()
+}
+
+fn quote_markdown_content(content: &str) -> String {
+    let normalized = content.replace("\r\n", "\n");
+    if normalized.is_empty() {
+        return "  > ".to_string();
+    }
+
+    normalized
+        .split('\n')
+        .map(|line| format!("  > {}", line))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn build_markdown_document(
+    title: &str,
+    messages_json: &str,
+    exported_at: chrono::DateTime<chrono::Utc>,
+) -> FileResult<String> {
+    let messages = parse_markdown_messages(messages_json)?;
+    let mut md_content = String::new();
+
+    md_content.push_str("---\n");
+    md_content.push_str("exported_at: ");
+    md_content.push_str(&exported_at.to_rfc3339());
+    md_content.push_str("\nmessage_count: ");
+    md_content.push_str(&messages.len().to_string());
+    md_content.push_str("\n---\n\n");
+
+    md_content.push_str("# ");
+    md_content.push_str(title);
+    md_content.push_str("\n\n");
+
+    if !messages.is_empty() {
+        md_content.push_str("## 消息记录\n\n");
+
+        for message in messages {
+            let when = format_markdown_time(message.timestamp, exported_at);
+            let is_outgoing = message.direction == "outgoing";
+
+            md_content.push_str("### ");
+            md_content.push_str(if is_outgoing { "发送" } else { "接收" });
+            md_content.push_str("\n\n");
+
+            md_content.push_str(&format!("- **时间**: {}\n", when));
+            md_content.push_str(&format!("- **发送者**: {}\n", message.sender_id));
+            md_content.push_str(&format!("- **接收者**: {}\n", message.receiver_id));
+            md_content.push_str(&format!("- **消息ID**: {}\n", message.id));
+            md_content.push_str("- **内容**:\n");
+            md_content.push_str(&quote_markdown_content(&message.content));
+            md_content.push_str("\n\n---\n\n");
+        }
+    }
+
+    Ok(md_content)
+}
+
 /// 导出所有消息到 Markdown 文件
 /// 格式化消息为标准 Markdown 格式
 #[tauri::command]
@@ -278,65 +376,7 @@ pub fn export_messages_to_markdown(
 
     ensure_parent_dir(&full_path)?;
 
-    // 构建 Markdown 内容
-    let mut md_content = String::new();
-
-    // 添加 YAML front matter
-    md_content.push_str("---\n");
-    md_content.push_str("exported_at: ");
-    md_content.push_str(&chrono::Utc::now().to_rfc3339());
-    md_content.push_str("\nmessage_count: ");
-    // 计算消息数量（粗略估算）
-    let count = messages.matches("\"id\"").count() / 3;
-    md_content.push_str(&count.to_string());
-    md_content.push_str("\n---\n\n");
-
-    // 添加标题
-    md_content.push_str("# ");
-    md_content.push_str(&title);
-    md_content.push_str("\n\n");
-
-    // 解析消息并添加到 Markdown
-    // 消息格式: [{id, content, timestamp, direction, senderId, receiverId}]
-    if !messages.is_empty() {
-        md_content.push_str("## 消息记录\n\n");
-
-        // 简单的消息解析（假设是 JSON 数组格式）
-        // 提取消息内容块
-        let msg_pattern = r#"{"id":"([^"]+)","content":"([^"]+)","timestamp":(\d+),"direction":"([^"]+)","senderId":"([^"]+)","receiverId":"([^"]+)"[^}]*}"#;
-
-        let re = regex::Regex::new(msg_pattern).map_err(|e| FileError::Unknown {
-            message: format!("正则表达式编译失败: {}", e),
-        })?;
-
-        for cap in re.captures_iter(&messages) {
-            let _id = cap.get(1).unwrap().as_str();
-            let content = cap.get(2).unwrap().as_str();
-            let timestamp: i64 = cap.get(3).unwrap().as_str().parse().unwrap_or(0);
-            let direction = cap.get(4).unwrap().as_str();
-            let sender = cap.get(5).unwrap().as_str();
-            let receiver = cap.get(6).unwrap().as_str();
-
-            let dt = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(timestamp)
-                .map(|dt| dt.with_timezone(&chrono::FixedOffset::east_opt(8 * 3600).unwrap()))
-                .unwrap_or_else(|| chrono::Utc::now().into());
-
-            // 判断发送者方向
-            let is_outgoing = direction == "outgoing";
-
-            md_content.push_str("### ");
-            md_content.push_str(if is_outgoing { "发送" } else { "接收" });
-            md_content.push_str("\n\n");
-
-            md_content.push_str(&format!("- **时间**: {}\n", dt.format("%Y-%m-%d %H:%M:%S")));
-            md_content.push_str(&format!("- **发送者**: {}\n", sender));
-            md_content.push_str(&format!("- **接收者**: {}\n", receiver));
-            md_content.push_str("- **内容**:\n");
-            md_content.push_str(&format!("  > {}\n", content.replace('\n', "\n  > ")));
-
-            md_content.push_str("\n---\n\n");
-        }
-    }
+    let md_content = build_markdown_document(&title, &messages, chrono::Utc::now())?;
 
     // 写入文件
     fs::write(&full_path, md_content).map_err(|e| FileError::IoError {
@@ -347,34 +387,87 @@ pub fn export_messages_to_markdown(
     Ok(())
 }
 
-/// 保存 JSON 文件到用户选择的路径
-/// 弹出系统保存对话框，让用户选择保存位置
+/// 保存 JSON 内容到系统文件选择路径
 #[tauri::command]
-pub fn save_json_file(app: AppHandle, content: String, default_name: String) -> FileResult<Option<String>> {
-    let file_path = app.dialog()
+pub fn save_json_file(
+    app: AppHandle,
+    content: String,
+    default_name: String,
+) -> FileResult<Option<String>> {
+    let file_path = app
+        .dialog()
         .file()
         .set_file_name(&default_name)
-        .add_filter("JSON 文件", &["json"])
+        .add_filter("JSON", &["json"])
         .blocking_save_file();
 
-    match file_path {
-        Some(path) => {
-            let path_ref = path.as_path();
-            if let Some(path_str) = path_ref {
-                let path_string = path_str.to_string_lossy().to_string();
-                let path_buf = PathBuf::from(&path_string);
-                fs::write(&path_buf, content).map_err(|e| FileError::IoError {
-                    message: format!("保存文件失败: {}", e),
-                    source: e,
-                })?;
-                Ok(Some(path_string))
-            } else {
-                Ok(None)
-            }
-        }
-        None => {
-            // 用户取消了对话框
-            Ok(None)
-        }
+    let Some(file_path) = file_path else {
+        return Ok(None);
+    };
+
+    let Some(path) = file_path.as_path() else {
+        return Err(FileError::InvalidPath {
+            path: "系统返回了无效的保存路径".to_string(),
+        });
+    };
+
+    fs::write(path, content).map_err(|e| FileError::IoError {
+        message: format!("写入导出文件失败: {}", e),
+        source: e,
+    })?;
+
+    Ok(Some(path.to_string_lossy().to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn builds_markdown_from_structured_json_and_counts_exactly() {
+        let exported_at = chrono::Utc
+            .timestamp_millis_opt(1_700_000_000_000)
+            .single()
+            .unwrap();
+        let messages = r#"[
+            {"timestamp":1700000000000,"id":"m1","receiverId":"bob","content":"hello","direction":"outgoing","senderId":"alice"},
+            {"id":"m2","content":"line1\nline2 \"quoted\" 😀","timestamp":1700000001000,"direction":"incoming","senderId":"bob","receiverId":"alice"}
+        ]"#;
+
+        let markdown = build_markdown_document("导出测试", messages, exported_at)
+            .expect("should render markdown");
+
+        assert!(markdown.contains("message_count: 2"));
+        assert!(markdown.contains("### 发送"));
+        assert!(markdown.contains("### 接收"));
+        assert!(markdown.contains("line1"));
+        assert!(markdown.contains("line2 \"quoted\" 😀"));
+    }
+
+    #[test]
+    fn builds_markdown_for_empty_message_list() {
+        let exported_at = chrono::Utc
+            .timestamp_millis_opt(1_700_000_000_000)
+            .single()
+            .unwrap();
+        let markdown = build_markdown_document("空导出", "[]", exported_at)
+            .expect("should render empty markdown");
+
+        assert!(markdown.contains("message_count: 0"));
+        assert!(!markdown.contains("## 消息记录"));
+    }
+
+    #[test]
+    fn rejects_invalid_messages_json() {
+        let exported_at = chrono::Utc
+            .timestamp_millis_opt(1_700_000_000_000)
+            .single()
+            .unwrap();
+        let err =
+            build_markdown_document("坏数据", "{not-json}", exported_at).expect_err("should fail");
+        let text = format!("{}", err);
+
+        assert!(text.contains("JSON"));
     }
 }

--- a/src-tauri/src/commands/file_commands.rs
+++ b/src-tauri/src/commands/file_commands.rs
@@ -2,6 +2,7 @@
 //! 用于消息持久化存储 - 重构版（同步版本）
 
 use tauri::{AppHandle, Manager, ipc::InvokeError};
+use tauri_plugin_dialog::DialogExt;
 use std::path::PathBuf;
 use std::fs;
 use thiserror::Error;
@@ -344,4 +345,36 @@ pub fn export_messages_to_markdown(
     })?;
 
     Ok(())
+}
+
+/// 保存 JSON 文件到用户选择的路径
+/// 弹出系统保存对话框，让用户选择保存位置
+#[tauri::command]
+pub fn save_json_file(app: AppHandle, content: String, default_name: String) -> FileResult<Option<String>> {
+    let file_path = app.dialog()
+        .file()
+        .set_file_name(&default_name)
+        .add_filter("JSON 文件", &["json"])
+        .blocking_save_file();
+
+    match file_path {
+        Some(path) => {
+            let path_ref = path.as_path();
+            if let Some(path_str) = path_ref {
+                let path_string = path_str.to_string_lossy().to_string();
+                let path_buf = PathBuf::from(&path_string);
+                fs::write(&path_buf, content).map_err(|e| FileError::IoError {
+                    message: format!("保存文件失败: {}", e),
+                    source: e,
+                })?;
+                Ok(Some(path_string))
+            } else {
+                Ok(None)
+            }
+        }
+        None => {
+            // 用户取消了对话框
+            Ok(None)
+        }
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ use commands::ws_commands::{
 };
 use commands::file_commands::{
     write_file, read_file, read_file_binary, delete_file, file_exists, list_files,
-    append_file, append_to_markdown, export_messages_to_markdown
+    append_file, append_to_markdown, export_messages_to_markdown, save_json_file
 };
 use commands::device_commands::get_device_id;
 use commands::eventlog_commands::{
@@ -26,6 +26,7 @@ pub fn run() {
 
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_dialog::init())
         .manage(ws_client_state.clone())
         .invoke_handler(tauri::generate_handler![
             greet,
@@ -44,6 +45,7 @@ pub fn run() {
             append_file,
             append_to_markdown,
             export_messages_to_markdown,
+            save_json_file,
             get_device_id,
             eventlog_list,
             eventlog_append,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,18 +2,16 @@
 
 mod commands;
 
-use commands::ws_commands::{
-    WsClientState, ws_connect, ws_disconnect, ws_send, ws_get_state,
-};
-use commands::file_commands::{
-    write_file, read_file, read_file_binary, delete_file, file_exists, list_files,
-    append_file, append_to_markdown, export_messages_to_markdown, save_json_file
-};
 use commands::device_commands::get_device_id;
 use commands::eventlog_commands::{
     eventlog_append, eventlog_clear, eventlog_get, eventlog_list, eventlog_mirror_status,
     eventlog_rebuild_markdown,
 };
+use commands::file_commands::{
+    append_file, append_to_markdown, delete_file, export_messages_to_markdown, file_exists,
+    list_files, read_file, read_file_binary, save_json_file, write_file,
+};
+use commands::ws_commands::{ws_connect, ws_disconnect, ws_get_state, ws_send, WsClientState};
 
 #[tauri::command]
 fn greet(name: &str) -> String {

--- a/src/components/Settings/SettingsPage.tsx
+++ b/src/components/Settings/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { getEventLogService } from '@/lib/services';
+import { isTauri } from '@tauri-apps/api/core';
 import {
   getSyncServerUrlOverride,
   resolveSyncServerUrl,
@@ -94,18 +95,39 @@ export function SettingsPage() {
       const json = await service.exportEventsAsJson();
       const payload = JSON.parse(json) as { events?: unknown[] };
       const count = Array.isArray(payload.events) ? payload.events.length : 0;
+      const defaultFileName = buildBackupFileName();
 
-      const blob = new Blob([json], { type: 'application/json;charset=utf-8' });
-      const url = URL.createObjectURL(blob);
-      const anchor = document.createElement('a');
-      anchor.href = url;
-      anchor.download = buildBackupFileName();
-      document.body.appendChild(anchor);
-      anchor.click();
-      anchor.remove();
-      URL.revokeObjectURL(url);
+      // 检测是否在 Tauri 环境中运行
+      const isRunningInTauri = await isTauri();
 
-      setStatusMessage(`导出成功，共 ${count} 条事件。`);
+      if (isRunningInTauri) {
+        // Tauri 环境：使用原生保存对话框
+        const { invoke } = await import('@tauri-apps/api/core');
+        const savedPath = await invoke<string | null>('save_json_file', {
+          content: json,
+          defaultName: defaultFileName,
+        });
+
+        if (savedPath) {
+          setStatusMessage(`导出成功，共 ${count} 条事件。保存路径：${savedPath}`);
+        } else {
+          // 用户取消保存
+          setStatusMessage('已取消保存。');
+        }
+      } else {
+        // Web 环境：使用 Blob 下载（兼容模式）
+        const blob = new Blob([json], { type: 'application/json;charset=utf-8' });
+        const url = URL.createObjectURL(blob);
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = defaultFileName;
+        document.body.appendChild(anchor);
+        anchor.click();
+        anchor.remove();
+        URL.revokeObjectURL(url);
+
+        setStatusMessage(`导出成功，共 ${count} 条事件。`);
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : '未知错误';
       setErrorMessage(`导出失败：${message}`);

--- a/src/components/Settings/SettingsPage.tsx
+++ b/src/components/Settings/SettingsPage.tsx
@@ -1,10 +1,10 @@
 import { useRef, useState } from 'react';
 import type { ChangeEvent } from 'react';
+import { invoke, isTauri } from '@tauri-apps/api/core';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { getEventLogService } from '@/lib/services';
-import { isTauri } from '@tauri-apps/api/core';
 import {
   getSyncServerUrlOverride,
   resolveSyncServerUrl,
@@ -95,39 +95,35 @@ export function SettingsPage() {
       const json = await service.exportEventsAsJson();
       const payload = JSON.parse(json) as { events?: unknown[] };
       const count = Array.isArray(payload.events) ? payload.events.length : 0;
-      const defaultFileName = buildBackupFileName();
+      const defaultName = buildBackupFileName();
 
-      // 检测是否在 Tauri 环境中运行
       const isRunningInTauri = await isTauri();
-
       if (isRunningInTauri) {
-        // Tauri 环境：使用原生保存对话框
-        const { invoke } = await import('@tauri-apps/api/core');
         const savedPath = await invoke<string | null>('save_json_file', {
           content: json,
-          defaultName: defaultFileName,
+          defaultName,
         });
 
-        if (savedPath) {
-          setStatusMessage(`导出成功，共 ${count} 条事件。保存路径：${savedPath}`);
-        } else {
-          // 用户取消保存
+        if (!savedPath) {
           setStatusMessage('已取消保存。');
+          return;
         }
-      } else {
-        // Web 环境：使用 Blob 下载（兼容模式）
-        const blob = new Blob([json], { type: 'application/json;charset=utf-8' });
-        const url = URL.createObjectURL(blob);
-        const anchor = document.createElement('a');
-        anchor.href = url;
-        anchor.download = defaultFileName;
-        document.body.appendChild(anchor);
-        anchor.click();
-        anchor.remove();
-        URL.revokeObjectURL(url);
 
-        setStatusMessage(`导出成功，共 ${count} 条事件。`);
+        setStatusMessage(`导出成功，共 ${count} 条事件。保存路径：${savedPath}`);
+        return;
       }
+
+      const blob = new Blob([json], { type: 'application/json;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = defaultName;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(url);
+
+      setStatusMessage(`导出成功，共 ${count} 条事件。`);
     } catch (error) {
       const message = error instanceof Error ? error.message : '未知错误';
       setErrorMessage(`导出失败：${message}`);

--- a/tests/unit/scripts/github-comment-tool.test.ts
+++ b/tests/unit/scripts/github-comment-tool.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   buildAppendedBody,
   parseCommentId,
   parseGithubRef,
   parseRepoFromRemoteUrl,
+  readBodyInput,
   resolveMode,
 } from '../../../Scripts/dev/github-comment-lib.ts';
 
@@ -84,6 +88,38 @@ describe('github-comment-lib', () => {
     it('supports dotted repository names', () => {
       expect(parseRepoFromRemoteUrl('https://github.com/org/my.repo.git')).toBe('org/my.repo');
       expect(parseRepoFromRemoteUrl('git@github.com:org/my.repo.git')).toBe('org/my.repo');
+    });
+  });
+
+  describe('readBodyInput encoding guards', () => {
+    it('strips UTF-8 BOM from file input', () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'gh-comment-lib-'));
+      const filePath = join(tempDir, 'bom.md');
+
+      try {
+        const utf8WithBom = Buffer.concat([
+          Buffer.from([0xef, 0xbb, 0xbf]),
+          Buffer.from('中文内容', 'utf8'),
+        ]);
+        writeFileSync(filePath, utf8WithBom);
+
+        expect(readBodyInput(filePath, undefined)).toBe('中文内容');
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('throws when file body contains suspicious lossy question marks', () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'gh-comment-lib-'));
+      const filePath = join(tempDir, 'lossy.md');
+
+      try {
+        writeFileSync(filePath, 'Android ????????????', 'utf8');
+
+        expect(() => readBodyInput(filePath, undefined)).toThrow(/garbled|encoding|乱码/i);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/tests/unit/settings/export-runtime.test.tsx
+++ b/tests/unit/settings/export-runtime.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mocks = vi.hoisted(() => ({
+  exportEventsAsJson: vi.fn(),
+  importEventsFromJson: vi.fn(),
+  setSyncServerUrlOverride: vi.fn(),
+  setThemePreference: vi.fn(),
+  isTauri: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock('@/lib/services', () => ({
+  getEventLogService: () => ({
+    exportEventsAsJson: mocks.exportEventsAsJson,
+    importEventsFromJson: mocks.importEventsFromJson,
+  }),
+}));
+
+vi.mock('@/config/port-env', () => ({
+  getSyncServerUrlOverride: () => null,
+  resolveSyncServerUrl: () => 'http://127.0.0.1:3001',
+  setSyncServerUrlOverride: mocks.setSyncServerUrlOverride,
+}));
+
+vi.mock('@/config/theme', () => ({
+  getThemePreference: () => 'system',
+  setThemePreference: mocks.setThemePreference,
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: mocks.isTauri,
+  invoke: mocks.invoke,
+}));
+
+import { SettingsPage } from '@/components/Settings/SettingsPage';
+
+const createObjectURLMock = vi.fn(() => 'blob:mock');
+const revokeObjectURLMock = vi.fn();
+
+Object.defineProperty(URL, 'createObjectURL', {
+  value: createObjectURLMock,
+  writable: true,
+});
+
+Object.defineProperty(URL, 'revokeObjectURL', {
+  value: revokeObjectURLMock,
+  writable: true,
+});
+
+describe('SettingsPage export runtime routing', () => {
+  let anchorClickSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.exportEventsAsJson.mockResolvedValue(JSON.stringify({ events: [{ id: 'evt-1' }] }));
+    mocks.importEventsFromJson.mockResolvedValue({ imported: 0, skipped: 0, total: 0 });
+    mocks.isTauri.mockResolvedValue(false);
+    mocks.invoke.mockResolvedValue(null);
+
+    anchorClickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    anchorClickSpy.mockRestore();
+  });
+
+  it('uses tauri native save command in tauri runtime', async () => {
+    mocks.isTauri.mockResolvedValue(true);
+    mocks.invoke.mockResolvedValue('C:\\Exports\\exomind-eventlog-2026-02-18.json');
+
+    render(<SettingsPage />);
+    fireEvent.click(screen.getByRole('button', { name: '导出 JSON' }));
+
+    await waitFor(() => {
+      expect(mocks.invoke).toHaveBeenCalledWith('save_json_file', expect.objectContaining({
+        content: expect.stringContaining('"events"'),
+        defaultName: expect.stringMatching(/^exomind-eventlog-\d{4}-\d{2}-\d{2}\.json$/),
+      }));
+    });
+
+    const status = screen.getByRole('status');
+    expect(status.textContent).toContain('导出成功，共 1 条事件。');
+    expect(status.textContent).toContain('保存路径');
+    expect(anchorClickSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps blob download behavior in web runtime', async () => {
+    mocks.isTauri.mockResolvedValue(false);
+
+    render(<SettingsPage />);
+    fireEvent.click(screen.getByRole('button', { name: '导出 JSON' }));
+
+    await waitFor(() => {
+      expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(anchorClickSpy).toHaveBeenCalledTimes(1);
+    expect(mocks.invoke).not.toHaveBeenCalled();
+    expect(screen.getByRole('status').textContent).toContain('导出成功，共 1 条事件。');
+  });
+});


### PR DESCRIPTION
## Summary
- 添加 tauri-plugin-dialog 依赖
- 新增 save_json_file 命令弹出系统保存对话框
- 设置页根据运行环境分流：Tauri 用原生对话框，Web 用 Blob 下载
- 导出成功后显示实际保存路径

## Test plan
- [ ] 在 Tauri 桌面端测试导出 JSON 功能，验证弹出系统保存对话框
- [ ] 验证导出成功后显示保存路径
- [ ] 在 Web 端测试导出功能仍然正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)