### PR TITLE
fix(build): ensure frontend deps before Android packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "server": "node server/pouchdb-server.js",
     "server:dev": "node --watch server/pouchdb-server.js",
     "test:sync": "vitest run tests/sync/pouch-sync.test.ts",
-    "build": "tsc && vite build",
+    "build": "bun install --frozen-lockfile && tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
     "test": "vitest",


### PR DESCRIPTION
﻿## Summary
- Fix frontend build precondition in clean environments by ensuring dependencies before compile.
- Keep behavior unchanged; this is a build-stability fix.

## Changes
- `package.json`
  - `build`: `tsc && vite build`
  - to: `bun install --frozen-lockfile && tsc && vite build`

## Why
`tauri android build` runs `beforeBuildCommand = bun run build`. On fresh worktrees without installed deps, TypeScript emits massive missing-module errors and blocks packaging. This change makes the build pipeline self-healing for that case.

## Verification
- `bun run build` ✅
- `bun tauri android build --apk --split-per-abi --target x86_64 --ci` ✅
- `adb install -r app-x86_64-release-debugsigned.apk` ✅ (`Success`)

Closes #140
