### PR TITLE
fix(eventlog): unify tauri runtime eventlog source to pouchdb (issue #144)

### DIFF
--- a/src/lib/environment/bootstrap.ts
+++ b/src/lib/environment/bootstrap.ts
@@ -1,5 +1,4 @@
 import { VolcanoEngineASRAdapter } from '../adapters/asr/volcano-engine-asr';
-import { TauriEventLogStorageAdapter } from '../adapters/tauri-eventlog-storage';
 import { WebEventLogStorageAdapter } from '../adapters/web-eventlog-storage';
 import { WebStorageAdapter } from '../adapters/web-storage';
 import type { IASRPort } from './interfaces/asr.port';
@@ -53,7 +52,8 @@ export function createRuntimeBootstrap(options: RuntimeBootstrapOptions = {}): R
       runtime,
       asr,
       storage: new TauriStorageAdapter(),
-      eventlog: new TauriEventLogStorageAdapter(),
+      // 临时统一到 PouchDB，避免 Tauri 原生 EventLog 与 UI 读取源分裂（#144）
+      eventlog: new WebEventLogStorageAdapter(),
     };
   }
 

--- a/tests/unit/environment/bootstrap.test.ts
+++ b/tests/unit/environment/bootstrap.test.ts
@@ -15,14 +15,14 @@ describe('environment bootstrap', () => {
     expect(result.eventlog.constructor.name).toBe('WebEventLogStorageAdapter');
   });
 
-  it('createRuntimeBootstrap should build tauri storage adapter for tauri runtime', () => {
+  it('createRuntimeBootstrap should use pouchdb eventlog adapter for tauri runtime', () => {
     const webResult = createRuntimeBootstrap({ runtime: 'web' });
     const tauriResult = createRuntimeBootstrap({ runtime: 'tauri' });
 
     expect(tauriResult.runtime).toBe('tauri');
     expect(tauriResult.storage.constructor.name).toBe('TauriStorageAdapter');
     expect(tauriResult.storage.constructor.name).not.toBe(webResult.storage.constructor.name);
-    expect(tauriResult.eventlog.constructor.name).toBe('TauriEventLogStorageAdapter');
-    expect(tauriResult.eventlog.constructor.name).not.toBe(webResult.eventlog.constructor.name);
+    expect(tauriResult.eventlog.constructor.name).toBe('WebEventLogStorageAdapter');
+    expect(tauriResult.eventlog.constructor.name).toBe(webResult.eventlog.constructor.name);
   });
 });


### PR DESCRIPTION
Summary
- Unify Tauri runtime EventLog source to PouchDB in runtime bootstrap.
- This removes write/read source split on Android where UI reads from PouchDB but Tauri adapter wrote to native JSON.

Changes
- src/lib/environment/bootstrap.ts
  - tauri runtime eventlog adapter: TauriEventLogStorageAdapter -> WebEventLogStorageAdapter.
- tests/unit/environment/bootstrap.test.ts
  - update tauri runtime expectation to WebEventLogStorageAdapter.

Validation
- Unit test: tests/unit/environment/bootstrap.test.ts
- Regression unit tests for EventLog service and contract.
- Manual checks on desktop/emulator were recorded in issue comments.

Fixes #144
