### PR TITLE
ci(release): signed Android AAB/APK, Windows EXE artifacts, and v0.2.0 preview flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - 'build/**'      # 构建触发：只构建，不发布
       - 'release/**'     # 发布触发：构建 + GitHub Release
 
+permissions:
+  contents: write
+
 env:
   RUST_TOOLCHAIN: stable
 
@@ -37,12 +40,18 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Build Windows
-        run: bun tauri build --bundles msi
+      - name: Build Windows installers (构建 Windows 安装包)
+        run: bun tauri build --bundles nsis,msi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload Artifact
+      - name: Upload Windows EXE Artifact (上传 EXE)
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-exe-${{ steps.hash.outputs.HASH }}
+          path: src-tauri/target/release/bundle/nsis/
+
+      - name: Upload Windows MSI Artifact (上传 MSI)
         uses: actions/upload-artifact@v4
         with:
           name: windows-msi-${{ steps.hash.outputs.HASH }}
@@ -89,32 +98,120 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Android AAB (release channel)
-        run: bun tauri android build
+      - name: Build Android AAB (release channel / 商店包)
+        run: bun tauri android build --ci --aab
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Android APK (sideload channel, split by ABI)
-        run: bun tauri android build --debug --apk --split-per-abi
+      - name: Build Android APK (release split-per-abi / 侧载包)
+        run: bun tauri android build --ci --apk --split-per-abi -t aarch64 i686
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Validate Android app name/icon/artifact size
+      - name: Validate Android app name/icon/artifact size (门禁校验)
         run: bun run check:android:meta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload Android AAB Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: android-aab-${{ steps.hash.outputs.HASH }}
-          path: src-tauri/gen/android/app/build/outputs/bundle/
+      - name: Prepare Android signing keystore (准备签名密钥库)
+        shell: bash
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ANDROID_KEYSTORE_BASE64:-}" ]; then
+            echo "Missing secret: ANDROID_KEYSTORE_BASE64"
+            exit 1
+          fi
+          KEYSTORE_PATH="$RUNNER_TEMP/android-release.jks"
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$KEYSTORE_PATH"
+          echo "ANDROID_KEYSTORE_PATH=$KEYSTORE_PATH" >> "$GITHUB_ENV"
 
-      - name: Upload Android APK Artifact
+      - name: Sign Android release artifacts (签名 APK/AAB)
+        shell: bash
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          for required in ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_ALIAS ANDROID_KEY_PASSWORD; do
+            if [ -z "${!required:-}" ]; then
+              echo "Missing secret: ${required}"
+              exit 1
+            fi
+          done
+
+          BUILD_TOOLS_DIR="$(ls -d "$ANDROID_HOME"/build-tools/* | sort -V | tail -n 1)"
+          APKSIGNER="$BUILD_TOOLS_DIR/apksigner"
+          ZIPALIGN="$BUILD_TOOLS_DIR/zipalign"
+
+          if [ ! -x "$APKSIGNER" ] || [ ! -x "$ZIPALIGN" ]; then
+            echo "apksigner/zipalign not found under $BUILD_TOOLS_DIR"
+            exit 1
+          fi
+
+          SIGNED_APK_DIR="src-tauri/gen/android/app/build/outputs/apk-signed"
+          SIGNED_AAB_DIR="src-tauri/gen/android/app/build/outputs/bundle-signed"
+          mkdir -p "$SIGNED_APK_DIR" "$SIGNED_AAB_DIR"
+
+          mapfile -t APK_FILES < <(find src-tauri/gen/android/app/build/outputs/apk -type f -name "*release*.apk" ! -name "*-signed.apk")
+          if [ "${#APK_FILES[@]}" -eq 0 ]; then
+            echo "No release APK files found."
+            exit 1
+          fi
+
+          for apk in "${APK_FILES[@]}"; do
+            base_name="$(basename "$apk" .apk)"
+            aligned_apk="$RUNNER_TEMP/${base_name}-aligned.apk"
+            signed_apk="$SIGNED_APK_DIR/${base_name}-signed.apk"
+
+            "$ZIPALIGN" -p -f 4 "$apk" "$aligned_apk"
+            "$APKSIGNER" sign \
+              --ks "$ANDROID_KEYSTORE_PATH" \
+              --ks-pass "pass:$ANDROID_KEYSTORE_PASSWORD" \
+              --ks-key-alias "$ANDROID_KEY_ALIAS" \
+              --key-pass "pass:$ANDROID_KEY_PASSWORD" \
+              --out "$signed_apk" \
+              "$aligned_apk"
+
+            "$APKSIGNER" verify --verbose "$signed_apk"
+            echo "Signed APK: $signed_apk"
+          done
+
+          mapfile -t AAB_FILES < <(find src-tauri/gen/android/app/build/outputs/bundle -type f -name "*.aab")
+          if [ "${#AAB_FILES[@]}" -eq 0 ]; then
+            echo "No AAB files found."
+            exit 1
+          fi
+
+          for aab in "${AAB_FILES[@]}"; do
+            base_name="$(basename "$aab" .aab)"
+            signed_aab="$SIGNED_AAB_DIR/${base_name}-signed.aab"
+
+            jarsigner \
+              -keystore "$ANDROID_KEYSTORE_PATH" \
+              -storepass "$ANDROID_KEYSTORE_PASSWORD" \
+              -keypass "$ANDROID_KEY_PASSWORD" \
+              -signedjar "$signed_aab" \
+              "$aab" \
+              "$ANDROID_KEY_ALIAS"
+
+            jarsigner -verify -verbose "$signed_aab" > /dev/null
+            echo "Signed AAB: $signed_aab"
+          done
+
+      - name: Upload Android signed AAB Artifact (上传已签名 AAB)
         uses: actions/upload-artifact@v4
         with:
-          name: android-apk-${{ steps.hash.outputs.HASH }}
-          path: src-tauri/gen/android/app/build/outputs/apk/
+          name: android-aab-signed-${{ steps.hash.outputs.HASH }}
+          path: src-tauri/gen/android/app/build/outputs/bundle-signed/
+
+      - name: Upload Android signed APK Artifact (上传已签名 APK)
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk-signed-${{ steps.hash.outputs.HASH }}
+          path: src-tauri/gen/android/app/build/outputs/apk-signed/
 
   create-release:
     needs: [build-windows, build-android]
@@ -131,15 +228,29 @@ jobs:
       - name: List Files
         run: ls -la release-files/
 
+      - name: Resolve release metadata (解析发布元信息)
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#release/}"
+          if [[ "$version" =~ (preview|alpha|beta|rc) ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "title=Preview $version" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "title=Release $version" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           files: release-files/**
           # 从 tag 名称提取版本号 (去掉 release/ 前缀)
           tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
+          name: ${{ steps.meta.outputs.title }}
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,8 +1,8 @@
 # ExoMind 构建指南
 
 > ExoMind 项目构建和 CI/CD 流程说明
-> 版本: v1.0
-> 更新日期: 2026-02-04
+> 版本: v1.1
+> 更新日期: 2026-02-18
 
 ---
 
@@ -144,7 +144,7 @@ $env:ANDROID_SDK_ROOT = "D:\Android\Sdk"
 | Tag 模式 | 触发 | 产出 |
 |----------|------|------|
 | `build/**` | 推送到 build tag | 构建产物 (Artifact) |
-| `release/**` | 推送 release tag | 构建产物 + GitHub Release |
+| `release/**` | 推送 release tag | 构建产物 + GitHub Release（支持 preview 预发布） |
 
 #### Tag 命名规范
 
@@ -154,11 +154,15 @@ build/v{主}.{次}.{修订}-{commit_hash}
 
 # 发布 Tag（构建 + Release）
 release/v{主}.{次}.{修订}
+
+# 预览发布 Tag（构建 + Pre-Release）
+release/v{主}.{次}.{修订}-preview
 ```
 
 示例：
-- `build/v0.1.0-alpha-eef7afc` - v0.1.0 开发构建（commit: eef7afc）
-- `release/v0.1.0` - v0.1.0 正式发布
+- `build/v0.2.0-alpha-eef7afc` - v0.2.0 开发构建（commit: eef7afc）
+- `release/v0.2.0` - v0.2.0 正式发布
+- `release/v0.2.0-preview` - v0.2.0 预览发布（GitHub Pre-release）
 
 #### 触发构建
 
@@ -169,23 +173,42 @@ git commit -m "feat: 新功能"
 git push origin feature/xxx
 
 # 2. 创建并推送 build tag
-git tag build/v0.1.0-alpha-$(git rev-parse --short=7 HEAD)
-git push origin build/v0.1.0-alpha-xxxxxxx
+git tag build/v0.2.0-alpha-$(git rev-parse --short=7 HEAD)
+git push origin build/v0.2.0-alpha-xxxxxxx
 
 # 3. 等待构建完成，下载 Artifacts
 # 查看构建状态: https://github.com/exomind-team/exomind/actions
 
 # 4. 如需正式发布，创建 release tag
-git tag release/v0.1.0
-git push origin release/v0.1.0
+git tag release/v0.2.0
+git push origin release/v0.2.0
+
+# 5. 如需预览发布，创建 preview tag
+git tag release/v0.2.0-preview
+git push origin release/v0.2.0-preview
 ```
+
+#### Android 签名 Secrets（GitHub Actions）
+
+在仓库 `Settings -> Secrets and variables -> Actions` 配置以下 secrets：
+
+| Secret 名称 | 说明 |
+|------------|------|
+| `ANDROID_KEYSTORE_BASE64` | JKS 文件的 Base64 内容（`base64 -w 0 your-key.jks`） |
+| `ANDROID_KEYSTORE_PASSWORD` | keystore 密码 |
+| `ANDROID_KEY_ALIAS` | 密钥别名（alias） |
+| `ANDROID_KEY_PASSWORD` | key 密码 |
 
 #### 构建产物
 
 | 平台 | Job | 产物 | Artifact 名称 |
 |------|-----|------|---------------|
 | Windows | build-windows | MSI 安装包 | `windows-msi-<hash>` |
-| Android | build-android | Debug APK | `android-apk-<hash>` |
+| Windows | build-windows | EXE 安装包（NSIS） | `windows-exe-<hash>` |
+| Android | build-android | 已签名 AAB（release） | `android-aab-signed-<hash>` |
+| Android | build-android | 已签名 APK（release, split ABI） | `android-apk-signed-<hash>` |
+
+> Android APK 默认输出 `aarch64 (arm64-v8a)` 与 `x86 (i686)` 两个 ABI，可直接侧载安装。
 
 #### 下载构建产物
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -190,7 +190,8 @@ git push origin release/v0.2.0-preview
 
 #### Android 签名 Secrets（GitHub Actions）
 
-在仓库 `Settings -> Secrets and variables -> Actions` 配置以下 secrets：
+在仓库 `Settings -> Secrets and variables -> Actions` 配置以下 secrets。
+说明：`build/**` 与 `release/**` 两类 tag 流程都会执行 Android 签名步骤，因此都要求这些 secrets 已配置。
 
 | Secret 名称 | 说明 |
 |------------|------|
@@ -205,8 +206,8 @@ git push origin release/v0.2.0-preview
 |------|-----|------|---------------|
 | Windows | build-windows | MSI 安装包 | `windows-msi-<hash>` |
 | Windows | build-windows | EXE 安装包（NSIS） | `windows-exe-<hash>` |
-| Android | build-android | 已签名 AAB（release） | `android-aab-signed-<hash>` |
-| Android | build-android | 已签名 APK（release, split ABI） | `android-apk-signed-<hash>` |
+| Android | build-android | 已签名 AAB（build/release） | `android-aab-signed-<hash>` |
+| Android | build-android | 已签名 APK（build/release, split ABI） | `android-apk-signed-<hash>` |
 
 > Android APK 默认输出 `aarch64 (arm64-v8a)` 与 `x86 (i686)` 两个 ABI，可直接侧载安装。
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "exomind",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exomind"
-version = "0.1.0"
+version = "0.2.0"
 description = "ExoMind - A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ExoMind",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.exomind.app",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## What Changed（做了什么变更）
- Updated `.github/workflows/release.yml` to strengthen release CI/CD（持续集成/持续交付）:
  - Windows build now produces both `NSIS .exe` and `MSI` installers, and uploads them as separate artifacts.
  - Android build now produces:
    - Release `AAB` for store distribution
    - Release `APK` split per ABI for sideload, targeting `aarch64` and `i686` (x86)
  - Added Android signing pipeline for release artifacts:
    - Decode keystore from `ANDROID_KEYSTORE_BASE64`
    - Sign APK via `zipalign + apksigner`
    - Sign AAB via `jarsigner`
    - Verify signatures during CI
  - Added release metadata resolution so tags containing `preview/alpha/beta/rc` are published as GitHub `prerelease`.
- Updated `BUILD.md` with:
  - New artifact outputs (`windows-exe-*`, `windows-msi-*`, `android-aab-signed-*`, `android-apk-signed-*`)
  - Android signing secrets documentation
  - `release/v0.2.0-preview` usage example
- Bumped app version from `0.1.0` to `0.2.0` in:
  - `package.json`
  - `src-tauri/Cargo.toml`
  - `src-tauri/tauri.conf.json`

## Why（为什么这样做）
This PR is driven by the release requirements from issue #139 and the current task context:
- Ensure GitHub Actions can produce installable artifacts for both desktop and Android in one release flow.
- Provide signed Android release artifacts suitable for actual distribution.
- Support a `v0.2.0` preview release process through tag-driven prerelease publishing.
- Align artifact strategy with both store channel (AAB) and direct download/sideload channel (APK split by ABI).

## Important Implementation Details（关键实现细节）
- Android signing requires these GitHub Actions secrets:
  - `ANDROID_KEYSTORE_BASE64`
  - `ANDROID_KEYSTORE_PASSWORD`
  - `ANDROID_KEY_ALIAS`
  - `ANDROID_KEY_PASSWORD`
- Release naming behavior is now tag-sensitive:
  - `release/v0.2.0-preview` => GitHub prerelease
  - regular `release/vX.Y.Z` => normal release
- Signed Android outputs are separated into dedicated directories before upload:
  - `src-tauri/gen/android/app/build/outputs/apk-signed/`
  - `src-tauri/gen/android/app/build/outputs/bundle-signed/`

This PR was written using [Vibe Kanban](https://vibekanban.com)