### PR TITLE
fix: fallback uuid for browsers without crypto.randomUUID (issue #149)

### DIFF
--- a/src/lib/services/eventlog.service.ts
+++ b/src/lib/services/eventlog.service.ts
@@ -13,6 +13,7 @@ import { ExoMindEnvironment } from '../environment/environment';
 import type { IEventLogPort } from '../environment/interfaces/eventlog.port';
 import type { Event, NoteContent, Tag, EventData } from '../types/event';
 import { WebEventLogStorageAdapter } from '../adapters/web-eventlog-storage';
+import { createUuidV4 } from '../utils/uuid';
 import {
   createBackupPayload,
   parseBackupPayload,
@@ -65,7 +66,7 @@ export class EventLogServiceImpl implements EventLogService {
 
   async addEvent(content: NoteContent, tags?: Set<Tag>): Promise<Event> {
     const eventData: EventData = {
-      id: crypto.randomUUID(),
+      id: createUuidV4(),
       timestamp: Date.now(),
       content,
       tags: tags ? Array.from(tags) : [NOTE_TAG],

--- a/src/lib/utils/uuid.ts
+++ b/src/lib/utils/uuid.ts
@@ -1,0 +1,32 @@
+/**
+ * Create UUID v4 with progressive fallback.
+ * 生成 UUID v4，按能力逐级回退，兼容缺少 `crypto.randomUUID` 的浏览器。
+ */
+export function createUuidV4(): string {
+  const runtimeCrypto = globalThis.crypto;
+
+  if (runtimeCrypto && typeof runtimeCrypto.randomUUID === 'function') {
+    return runtimeCrypto.randomUUID();
+  }
+
+  if (runtimeCrypto && typeof runtimeCrypto.getRandomValues === 'function') {
+    const bytes = new Uint8Array(16);
+    runtimeCrypto.getRandomValues(bytes);
+
+    // RFC 4122 v4: version + variant bits.
+    // RFC 4122 v4：设置版本号与变体位。
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+    const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
+
+  // Last fallback for legacy runtime; not cryptographically secure.
+  // 末级兜底（旧环境），不具备密码学安全性。
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (char) => {
+    const randomNibble = Math.floor(Math.random() * 16);
+    const value = char === 'x' ? randomNibble : (randomNibble & 0x3) | 0x8;
+    return value.toString(16);
+  });
+}

--- a/tests/unit/eventlog/eventlog-port-contract.test.ts
+++ b/tests/unit/eventlog/eventlog-port-contract.test.ts
@@ -1,8 +1,22 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { EventData } from '@/lib/types/event';
 import { EventLogServiceImpl } from '@/lib/services/eventlog.service';
 
+const originalCrypto = globalThis.crypto;
+
+function replaceGlobalCrypto(value: Crypto | undefined): void {
+  Object.defineProperty(globalThis, 'crypto', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
 describe('EventLogService port contract', () => {
+  afterEach(() => {
+    replaceGlobalCrypto(originalCrypto);
+  });
+
   it('uses injected eventlog port for read/write instead of direct storage dependency', async () => {
     const port = {
       listEvents: vi.fn<() => Promise<EventData[]>>().mockResolvedValue([]),
@@ -18,5 +32,29 @@ describe('EventLogService port contract', () => {
 
     expect(port.listEvents).toHaveBeenCalled();
     expect(port.appendEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps addEvent working when crypto.randomUUID is unavailable', async () => {
+    const port = {
+      listEvents: vi.fn<() => Promise<EventData[]>>().mockResolvedValue([]),
+      appendEvent: vi.fn<(_: EventData) => Promise<void>>().mockResolvedValue(undefined),
+      getEvent: vi.fn<(_: string) => Promise<EventData | null>>().mockResolvedValue(null),
+      clearEvents: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    };
+
+    const getRandomValues = vi.fn((array: Uint8Array) => {
+      array.set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+      return array;
+    });
+
+    replaceGlobalCrypto({ getRandomValues } as unknown as Crypto);
+
+    const service = new EventLogServiceImpl({ port });
+    await service.addEvent('fallback path');
+
+    expect(port.appendEvent).toHaveBeenCalledTimes(1);
+    const [event] = port.appendEvent.mock.calls[0] as [EventData];
+    expect(event.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    expect(getRandomValues).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- Replace direct `crypto.randomUUID()` call in EventLog send path with `createUuidV4()`.
- Add a progressive UUID fallback chain:
  - `crypto.randomUUID()`
  - `crypto.getRandomValues()` (RFC 4122 v4)
  - `Math.random()` fallback for legacy runtimes
- Add a regression test for environments where `crypto.randomUUID` is unavailable.

## Root Cause
In some browser/runtime combinations (notably Linux Firefox / Android Edge on non-localhost HTTP), `crypto.randomUUID` may be missing. This throws `TypeError: crypto.randomUUID is not a function` in the send flow and prevents event append.

## Files Changed
| File | Change |
| --- | --- |
| `src/lib/services/eventlog.service.ts` | Use `createUuidV4()` for event IDs |
| `src/lib/utils/uuid.ts` | Add UUID v4 fallback helper |
| `tests/unit/eventlog/eventlog-port-contract.test.ts` | Add regression test for missing `randomUUID` |

## Verification
```bash
bun test tests/unit/eventlog/eventlog-port-contract.test.ts
bun test tests/unit/eventlog/service-pouchdb-backend.test.ts
bun test tests/unit/eventlog/format.test.ts
bun run build
```

Closes #149