### PR TITLE
ci(release): fix self-hosted windows rust path and finalize android signed APK pipeline (Vibe Kanban)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,13 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: latest
+      - name: Ensure local Bun is available (确保本机 Bun 可用)
+        shell: pwsh
+        run: |
+          if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
+            throw "Bun is required on self-hosted Windows runner. Please install Bun and add it to PATH."
+          }
+          bun --version
 
       - name: Configure local Android toolchain (配置本地 Android 工具链)
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,8 @@ jobs:
 
       - name: Get short commit hash
         id: hash
-        run: echo "HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+        shell: pwsh
+        run: '"HASH=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_OUTPUT'
 
       - name: Install dependencies
         run: bun install
@@ -58,7 +59,7 @@ jobs:
           path: src-tauri/target/release/bundle/msi/
 
   build-android:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Windows, X64]
     steps:
       - uses: actions/checkout@v4
 
@@ -72,23 +73,36 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+      - name: Configure local Android toolchain (配置本地 Android 工具链)
+        shell: pwsh
+        run: |
+          if (-not $env:JAVA_HOME) {
+            $javaHome = "C:\Program Files\Eclipse Adoptium\jdk-17.0.13.11-hotspot"
+            if (-not (Test-Path $javaHome)) {
+              throw "JAVA_HOME is not set and default path not found: $javaHome"
+            }
+            "JAVA_HOME=$javaHome" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          }
 
-      - name: Setup JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
+          if (-not $env:ANDROID_SDK_ROOT) {
+            $androidSdkRoot = "D:\data\AndroidSDK"
+            if (-not (Test-Path $androidSdkRoot)) {
+              throw "ANDROID_SDK_ROOT is not set and default path not found: $androidSdkRoot"
+            }
+            "ANDROID_SDK_ROOT=$androidSdkRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            "ANDROID_HOME=$androidSdkRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          } elseif (-not $env:ANDROID_HOME) {
+            "ANDROID_HOME=$env:ANDROID_SDK_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          }
 
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+      - name: Ensure Rust Android targets (确保 Rust Android 目标)
+        shell: pwsh
+        run: rustup target add aarch64-linux-android i686-linux-android
 
       - name: Get short commit hash
         id: hash
-        run: echo "HASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+        shell: pwsh
+        run: '"HASH=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_OUTPUT'
 
       - name: Install dependencies
         run: bun install
@@ -98,15 +112,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Android AAB (release channel / 商店包)
-        run: bun tauri android build --ci --aab
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build Android APK (release split-per-abi / 侧载包)
+      - name: Build Android APK only (仅构建 APK，aarch64 + i686)
         run: bun tauri android build --ci --apk --split-per-abi -t aarch64 i686
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Stabilize Kotlin/Gradle on Windows runners (稳定 Windows 上 Kotlin/Gradle 构建)
+          GRADLE_OPTS: -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false
 
       - name: Validate Android app name/icon/artifact size (门禁校验)
         run: bun run check:android:meta
@@ -114,98 +125,87 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare Android signing keystore (准备签名密钥库)
-        shell: bash
+        shell: pwsh
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
-          set -euo pipefail
-          if [ -z "${ANDROID_KEYSTORE_BASE64:-}" ]; then
-            echo "Missing secret: ANDROID_KEYSTORE_BASE64"
-            exit 1
-          fi
-          KEYSTORE_PATH="$RUNNER_TEMP/android-release.jks"
-          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$KEYSTORE_PATH"
-          echo "ANDROID_KEYSTORE_PATH=$KEYSTORE_PATH" >> "$GITHUB_ENV"
+          if (-not $env:ANDROID_KEYSTORE_BASE64) {
+            throw "Missing secret: ANDROID_KEYSTORE_BASE64"
+          }
+          $keystorePath = Join-Path $env:RUNNER_TEMP "android-release.jks"
+          try {
+            $bytes = [Convert]::FromBase64String($env:ANDROID_KEYSTORE_BASE64)
+          } catch {
+            throw "ANDROID_KEYSTORE_BASE64 is not valid Base64."
+          }
+          [IO.File]::WriteAllBytes($keystorePath, $bytes)
+          "ANDROID_KEYSTORE_PATH=$keystorePath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Sign Android release artifacts (签名 APK/AAB)
-        shell: bash
+      - name: Sign Android APK artifacts (签名 APK 产物)
+        shell: pwsh
         env:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
-          set -euo pipefail
-          for required in ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_ALIAS ANDROID_KEY_PASSWORD; do
-            if [ -z "${!required:-}" ]; then
-              echo "Missing secret: ${required}"
-              exit 1
-            fi
-          done
+          foreach ($required in @("ANDROID_KEYSTORE_PATH", "ANDROID_KEYSTORE_PASSWORD", "ANDROID_KEY_ALIAS", "ANDROID_KEY_PASSWORD")) {
+            if (-not (Get-Item -Path "Env:$required" -ErrorAction SilentlyContinue)) {
+              throw "Missing secret: $required"
+            }
+          }
 
-          BUILD_TOOLS_DIR="$(ls -d "$ANDROID_HOME"/build-tools/* | sort -V | tail -n 1)"
-          APKSIGNER="$BUILD_TOOLS_DIR/apksigner"
-          ZIPALIGN="$BUILD_TOOLS_DIR/zipalign"
+          $sdkRoot = if ($env:ANDROID_SDK_ROOT) { $env:ANDROID_SDK_ROOT } elseif ($env:ANDROID_HOME) { $env:ANDROID_HOME } else { $null }
+          if (-not $sdkRoot) {
+            throw "ANDROID_SDK_ROOT or ANDROID_HOME must be set."
+          }
 
-          if [ ! -x "$APKSIGNER" ] || [ ! -x "$ZIPALIGN" ]; then
-            echo "apksigner/zipalign not found under $BUILD_TOOLS_DIR"
-            exit 1
-          fi
+          $buildToolsRoot = Join-Path $sdkRoot "build-tools"
+          $buildToolsDir = Get-ChildItem -Path $buildToolsRoot -Directory | Sort-Object { [Version]$_.Name } | Select-Object -Last 1
+          if (-not $buildToolsDir) {
+            throw "No Android build-tools directory found under $buildToolsRoot"
+          }
 
-          SIGNED_APK_DIR="src-tauri/gen/android/app/build/outputs/apk-signed"
-          SIGNED_AAB_DIR="src-tauri/gen/android/app/build/outputs/bundle-signed"
-          mkdir -p "$SIGNED_APK_DIR" "$SIGNED_AAB_DIR"
+          $zipalign = Join-Path $buildToolsDir.FullName "zipalign.exe"
+          $apksigner = Join-Path $buildToolsDir.FullName "apksigner.bat"
+          if ((-not (Test-Path $zipalign)) -or (-not (Test-Path $apksigner))) {
+            throw "zipalign.exe or apksigner.bat not found under $($buildToolsDir.FullName)"
+          }
 
-          mapfile -t APK_FILES < <(find src-tauri/gen/android/app/build/outputs/apk -type f -name "*release*.apk" ! -name "*-signed.apk")
-          if [ "${#APK_FILES[@]}" -eq 0 ]; then
-            echo "No release APK files found."
-            exit 1
-          fi
+          $signedApkDir = "src-tauri/gen/android/app/build/outputs/apk-signed"
+          New-Item -Path $signedApkDir -ItemType Directory -Force | Out-Null
 
-          for apk in "${APK_FILES[@]}"; do
-            base_name="$(basename "$apk" .apk)"
-            aligned_apk="$RUNNER_TEMP/${base_name}-aligned.apk"
-            signed_apk="$SIGNED_APK_DIR/${base_name}-signed.apk"
+          $apkFiles = Get-ChildItem -Path "src-tauri/gen/android/app/build/outputs/apk" -Recurse -Filter "*release*.apk" | Where-Object { $_.Name -notlike "*-signed.apk" }
+          if (-not $apkFiles -or $apkFiles.Count -eq 0) {
+            throw "No release APK files found."
+          }
 
-            "$ZIPALIGN" -p -f 4 "$apk" "$aligned_apk"
-            "$APKSIGNER" sign \
-              --ks "$ANDROID_KEYSTORE_PATH" \
-              --ks-pass "pass:$ANDROID_KEYSTORE_PASSWORD" \
-              --ks-key-alias "$ANDROID_KEY_ALIAS" \
-              --key-pass "pass:$ANDROID_KEY_PASSWORD" \
-              --out "$signed_apk" \
-              "$aligned_apk"
+          foreach ($apk in $apkFiles) {
+            $baseName = [IO.Path]::GetFileNameWithoutExtension($apk.Name)
+            $alignedApk = Join-Path $env:RUNNER_TEMP "$baseName-aligned.apk"
+            $signedApk = Join-Path $signedApkDir "$baseName-signed.apk"
 
-            "$APKSIGNER" verify --verbose "$signed_apk"
-            echo "Signed APK: $signed_apk"
-          done
+            & $zipalign -p -f 4 $apk.FullName $alignedApk
+            if ($LASTEXITCODE -ne 0) {
+              throw "zipalign failed: $($apk.FullName)"
+            }
 
-          mapfile -t AAB_FILES < <(find src-tauri/gen/android/app/build/outputs/bundle -type f -name "*.aab")
-          if [ "${#AAB_FILES[@]}" -eq 0 ]; then
-            echo "No AAB files found."
-            exit 1
-          fi
+            & $apksigner sign `
+              --ks $env:ANDROID_KEYSTORE_PATH `
+              --ks-pass ("pass:{0}" -f $env:ANDROID_KEYSTORE_PASSWORD) `
+              --ks-key-alias $env:ANDROID_KEY_ALIAS `
+              --key-pass ("pass:{0}" -f $env:ANDROID_KEY_PASSWORD) `
+              --out $signedApk `
+              $alignedApk
+            if ($LASTEXITCODE -ne 0) {
+              throw "apksigner sign failed: $($apk.FullName)"
+            }
 
-          for aab in "${AAB_FILES[@]}"; do
-            base_name="$(basename "$aab" .aab)"
-            signed_aab="$SIGNED_AAB_DIR/${base_name}-signed.aab"
-
-            jarsigner \
-              -keystore "$ANDROID_KEYSTORE_PATH" \
-              -storepass "$ANDROID_KEYSTORE_PASSWORD" \
-              -keypass "$ANDROID_KEY_PASSWORD" \
-              -signedjar "$signed_aab" \
-              "$aab" \
-              "$ANDROID_KEY_ALIAS"
-
-            jarsigner -verify -verbose "$signed_aab" > /dev/null
-            echo "Signed AAB: $signed_aab"
-          done
-
-      - name: Upload Android signed AAB Artifact (上传已签名 AAB)
-        uses: actions/upload-artifact@v4
-        with:
-          name: android-aab-signed-${{ steps.hash.outputs.HASH }}
-          path: src-tauri/gen/android/app/build/outputs/bundle-signed/
+            & $apksigner verify --verbose $signedApk
+            if ($LASTEXITCODE -ne 0) {
+              throw "apksigner verify failed: $signedApk"
+            }
+            Write-Host "Signed APK: $signedApk"
+          }
 
       - name: Upload Android signed APK Artifact (上传已签名 APK)
         uses: actions/upload-artifact@v4
@@ -254,3 +254,4 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,19 @@ jobs:
       - name: Ensure local Bun is available (确保本机 Bun 可用)
         shell: pwsh
         run: |
-          if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
-            throw "Bun is required on self-hosted Windows runner. Please install Bun and add it to PATH."
+          $bunCmd = Get-Command bun -ErrorAction SilentlyContinue
+          if (-not $bunCmd) {
+            Write-Host "Bun not found in PATH, installing via npm (通过 npm 安装 Bun)..."
+            npm install -g bun
+            $npmPrefix = (npm config get prefix).Trim()
+            if ($npmPrefix) {
+              $env:Path = "$npmPrefix;$env:Path"
+              "$npmPrefix" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+            }
+            $bunCmd = Get-Command bun -ErrorAction SilentlyContinue
+          }
+          if (-not $bunCmd) {
+            throw "Bun is unavailable after npm installation. Please ensure bun is installed and on PATH."
           }
           bun --version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build-windows:
-    runs-on: windows-latest
+    runs-on: [self-hosted, Windows, X64]
     steps:
       - uses: actions/checkout@v4
 
@@ -23,10 +23,24 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: latest
+      - name: Ensure local Bun is available (确保本机 Bun 可用)
+        shell: pwsh
+        run: |
+          $bunCmd = Get-Command bun -ErrorAction SilentlyContinue
+          if (-not $bunCmd) {
+            Write-Host "Bun not found in PATH, installing via npm (通过 npm 安装 Bun)..."
+            npm install -g bun
+            $npmPrefix = (npm config get prefix).Trim()
+            if ($npmPrefix) {
+              $env:Path = "$npmPrefix;$env:Path"
+              "$npmPrefix" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+            }
+            $bunCmd = Get-Command bun -ErrorAction SilentlyContinue
+          }
+          if (-not $bunCmd) {
+            throw "Bun is unavailable after npm installation. Please ensure bun is installed and on PATH."
+          }
+          bun --version
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,20 +26,22 @@ jobs:
       - name: Ensure local Bun is available (确保本机 Bun 可用)
         shell: powershell
         run: |
-          $bunCmd = Get-Command bun -ErrorAction SilentlyContinue
-          if (-not $bunCmd) {
-            Write-Host "Bun not found in PATH, installing via npm (通过 npm 安装 Bun)..."
-            npm install -g bun
-            $npmPrefix = (npm config get prefix).Trim()
-            if ($npmPrefix) {
-              $env:Path = "$npmPrefix;$env:Path"
-              "$npmPrefix" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-            }
-            $bunCmd = Get-Command bun -ErrorAction SilentlyContinue
+          Write-Host "Install Bun via npm to enforce native Windows binary (通过 npm 强制使用 Windows 原生 Bun)..."
+          npm install -g bun
+          $npmPrefix = (npm config get prefix).Trim()
+          if (-not $npmPrefix) {
+            throw "npm prefix is empty; cannot locate global bun install path."
           }
+          $env:Path = "$npmPrefix;$env:Path"
+          "$npmPrefix" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          $bunCmd = Get-Command bun -ErrorAction SilentlyContinue
           if (-not $bunCmd) {
             throw "Bun is unavailable after npm installation. Please ensure bun is installed and on PATH."
           }
+          if ($bunCmd.Source -match '(?i)wsl|\\ubuntu\\') {
+            throw "Detected WSL bun path: $($bunCmd.Source). Please use native Windows Bun."
+          }
+          Write-Host "Using Bun from: $($bunCmd.Source)"
           bun --version
 
       - name: Setup Rust
@@ -85,20 +87,22 @@ jobs:
       - name: Ensure local Bun is available (确保本机 Bun 可用)
         shell: powershell
         run: |
-          $bunCmd = Get-Command bun -ErrorAction SilentlyContinue
-          if (-not $bunCmd) {
-            Write-Host "Bun not found in PATH, installing via npm (通过 npm 安装 Bun)..."
-            npm install -g bun
-            $npmPrefix = (npm config get prefix).Trim()
-            if ($npmPrefix) {
-              $env:Path = "$npmPrefix;$env:Path"
-              "$npmPrefix" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-            }
-            $bunCmd = Get-Command bun -ErrorAction SilentlyContinue
+          Write-Host "Install Bun via npm to enforce native Windows binary (通过 npm 强制使用 Windows 原生 Bun)..."
+          npm install -g bun
+          $npmPrefix = (npm config get prefix).Trim()
+          if (-not $npmPrefix) {
+            throw "npm prefix is empty; cannot locate global bun install path."
           }
+          $env:Path = "$npmPrefix;$env:Path"
+          "$npmPrefix" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          $bunCmd = Get-Command bun -ErrorAction SilentlyContinue
           if (-not $bunCmd) {
             throw "Bun is unavailable after npm installation. Please ensure bun is installed and on PATH."
           }
+          if ($bunCmd.Source -match '(?i)wsl|\\ubuntu\\') {
+            throw "Detected WSL bun path: $($bunCmd.Source). Please use native Windows Bun."
+          }
+          Write-Host "Using Bun from: $($bunCmd.Source)"
           bun --version
 
       - name: Configure local Android toolchain (配置本地 Android 工具链)
@@ -121,6 +125,20 @@ jobs:
             "ANDROID_HOME=$androidSdkRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           } elseif (-not $env:ANDROID_HOME) {
             "ANDROID_HOME=$env:ANDROID_SDK_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          }
+
+      - name: Validate Android signing secrets early (提前校验 Android 签名密钥)
+        shell: powershell
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          foreach ($required in @("ANDROID_KEYSTORE_BASE64", "ANDROID_KEYSTORE_PASSWORD", "ANDROID_KEY_ALIAS", "ANDROID_KEY_PASSWORD")) {
+            if (-not (Get-Item -Path "Env:$required" -ErrorAction SilentlyContinue)) {
+              throw "Missing secret: $required"
+            }
           }
 
       - name: Ensure Rust Android targets (确保 Rust Android 目标)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,34 @@ jobs:
           Write-Host "Using Bun from: $($bunCmd.Source)"
           bun --version
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
+      - name: Use local Rust toolchain (使用本机 Rust 工具链，禁止 WSL)
+        shell: powershell
+        run: |
+          $cargoBin = Join-Path $env:USERPROFILE ".cargo\bin"
+          if (Test-Path $cargoBin) {
+            $env:Path = "$cargoBin;$env:Path"
+            "$cargoBin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          }
+
+          $rustupCmd = Get-Command rustup -ErrorAction SilentlyContinue
+          $rustcCmd = Get-Command rustc -ErrorAction SilentlyContinue
+          $cargoCmd = Get-Command cargo -ErrorAction SilentlyContinue
+          if ((-not $rustupCmd) -or (-not $rustcCmd) -or (-not $cargoCmd)) {
+            throw "Rust toolchain not found on self-hosted Windows runner. Please pre-install rustup/cargo/rustc."
+          }
+
+          if (($rustupCmd.Source -match '(?i)wsl|\\ubuntu\\') -or ($rustcCmd.Source -match '(?i)wsl|\\ubuntu\\') -or ($cargoCmd.Source -match '(?i)wsl|\\ubuntu\\')) {
+            throw "Detected Rust command from WSL path. Please use native Windows Rust toolchain."
+          }
+
+          rustup default stable
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to select stable Rust toolchain. Please install stable locally first (例如: rustup toolchain install stable)."
+          }
+
+          rustup show active-toolchain
+          rustc -vV
+          cargo -V
 
       - name: Get short commit hash
         id: hash
@@ -104,6 +128,35 @@ jobs:
           }
           Write-Host "Using Bun from: $($bunCmd.Source)"
           bun --version
+
+      - name: Use local Rust toolchain (使用本机 Rust 工具链，禁止 WSL)
+        shell: powershell
+        run: |
+          $cargoBin = Join-Path $env:USERPROFILE ".cargo\bin"
+          if (Test-Path $cargoBin) {
+            $env:Path = "$cargoBin;$env:Path"
+            "$cargoBin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          }
+
+          $rustupCmd = Get-Command rustup -ErrorAction SilentlyContinue
+          $rustcCmd = Get-Command rustc -ErrorAction SilentlyContinue
+          $cargoCmd = Get-Command cargo -ErrorAction SilentlyContinue
+          if ((-not $rustupCmd) -or (-not $rustcCmd) -or (-not $cargoCmd)) {
+            throw "Rust toolchain not found on self-hosted Windows runner. Please pre-install rustup/cargo/rustc."
+          }
+
+          if (($rustupCmd.Source -match '(?i)wsl|\\ubuntu\\') -or ($rustcCmd.Source -match '(?i)wsl|\\ubuntu\\') -or ($cargoCmd.Source -match '(?i)wsl|\\ubuntu\\')) {
+            throw "Detected Rust command from WSL path. Please use native Windows Rust toolchain."
+          }
+
+          rustup default stable
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to select stable Rust toolchain. Please install stable locally first (例如: rustup toolchain install stable)."
+          }
+
+          rustup show active-toolchain
+          rustc -vV
+          cargo -V
 
       - name: Configure local Android toolchain (配置本地 Android 工具链)
         shell: powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: '20'
 
       - name: Ensure local Bun is available (确保本机 Bun 可用)
-        shell: pwsh
+        shell: powershell
         run: |
           $bunCmd = Get-Command bun -ErrorAction SilentlyContinue
           if (-not $bunCmd) {
@@ -49,7 +49,7 @@ jobs:
 
       - name: Get short commit hash
         id: hash
-        shell: pwsh
+        shell: powershell
         run: '"HASH=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_OUTPUT'
 
       - name: Install dependencies
@@ -83,7 +83,7 @@ jobs:
           node-version: '20'
 
       - name: Ensure local Bun is available (确保本机 Bun 可用)
-        shell: pwsh
+        shell: powershell
         run: |
           $bunCmd = Get-Command bun -ErrorAction SilentlyContinue
           if (-not $bunCmd) {
@@ -102,7 +102,7 @@ jobs:
           bun --version
 
       - name: Configure local Android toolchain (配置本地 Android 工具链)
-        shell: pwsh
+        shell: powershell
         run: |
           if (-not $env:JAVA_HOME) {
             $javaHome = "C:\Program Files\Eclipse Adoptium\jdk-17.0.13.11-hotspot"
@@ -124,12 +124,12 @@ jobs:
           }
 
       - name: Ensure Rust Android targets (确保 Rust Android 目标)
-        shell: pwsh
+        shell: powershell
         run: rustup target add aarch64-linux-android i686-linux-android
 
       - name: Get short commit hash
         id: hash
-        shell: pwsh
+        shell: powershell
         run: '"HASH=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_OUTPUT'
 
       - name: Install dependencies
@@ -153,7 +153,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare Android signing keystore (准备签名密钥库)
-        shell: pwsh
+        shell: powershell
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
@@ -170,7 +170,7 @@ jobs:
           "ANDROID_KEYSTORE_PATH=$keystorePath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Sign Android APK artifacts (签名 APK 产物)
-        shell: pwsh
+        shell: powershell
         env:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
@@ -282,4 +282,3 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/BUILD.md
+++ b/BUILD.md
@@ -195,10 +195,34 @@ git push origin release/v0.2.0-preview
 
 | Secret 名称 | 说明 |
 |------------|------|
-| `ANDROID_KEYSTORE_BASE64` | JKS 文件的 Base64 内容（`base64 -w 0 your-key.jks`） |
+| `ANDROID_KEYSTORE_BASE64` | JKS 文件完整二进制内容的 Base64（单行文本） |
 | `ANDROID_KEYSTORE_PASSWORD` | keystore 密码 |
 | `ANDROID_KEY_ALIAS` | 密钥别名（alias） |
 | `ANDROID_KEY_PASSWORD` | key 密码 |
+
+推荐使用仓库脚本生成并校验（Windows PowerShell）：
+
+```powershell
+.\Scripts\dev\android-signing-secrets.ps1 `
+  -KeystorePath "D:\sign\exomind-release.jks" `
+  -StorePassword "your-store-password" `
+  -KeyAlias "your-alias" `
+  -KeyPassword "your-key-password"
+```
+
+如需脚本直接写入 GitHub Secrets（需已登录 `gh auth login`）：
+
+```powershell
+.\Scripts\dev\android-signing-secrets.ps1 `
+  -KeystorePath "D:\sign\exomind-release.jks" `
+  -StorePassword "your-store-password" `
+  -KeyAlias "your-alias" `
+  -KeyPassword "your-key-password" `
+  -SetGhSecrets `
+  -Repo "exomind-team/exomind"
+```
+
+> 注意：workflow 已在 Android 构建早期增加签名 secrets 预检，缺任何一个都会立即失败并提示具体 secret 名称。
 
 #### 构建产物
 
@@ -206,7 +230,6 @@ git push origin release/v0.2.0-preview
 |------|-----|------|---------------|
 | Windows | build-windows | MSI 安装包 | `windows-msi-<hash>` |
 | Windows | build-windows | EXE 安装包（NSIS） | `windows-exe-<hash>` |
-| Android | build-android | 已签名 AAB（build/release） | `android-aab-signed-<hash>` |
 | Android | build-android | 已签名 APK（build/release, split ABI） | `android-apk-signed-<hash>` |
 
 > Android APK 默认输出 `aarch64 (arm64-v8a)` 与 `x86 (i686)` 两个 ABI，可直接侧载安装。

--- a/Scripts/dev/android-signing-secrets.ps1
+++ b/Scripts/dev/android-signing-secrets.ps1
@@ -1,0 +1,128 @@
+<#
+.SYNOPSIS
+    Prepare and validate Android signing secrets for GitHub Actions.
+
+.DESCRIPTION
+    1) Validate keystore / alias / passwords via keytool.
+    2) Generate ANDROID_KEYSTORE_BASE64 text file.
+    3) Optionally push all Android signing secrets to GitHub repository secrets.
+
+.PARAMETER KeystorePath
+    Path to Android keystore file (.jks / .keystore).
+
+.PARAMETER StorePassword
+    Keystore password (ANDROID_KEYSTORE_PASSWORD).
+
+.PARAMETER KeyAlias
+    Key alias inside keystore (ANDROID_KEY_ALIAS).
+
+.PARAMETER KeyPassword
+    Key password for alias (ANDROID_KEY_PASSWORD).
+
+.PARAMETER OutFile
+    Output file path for Base64 text. Default: ANDROID_KEYSTORE_BASE64.txt
+
+.PARAMETER Repo
+    GitHub repository in owner/name format. Default: exomind-team/exomind
+
+.PARAMETER SetGhSecrets
+    If set, write all 4 secrets to GitHub via gh CLI.
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$KeystorePath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$StorePassword,
+
+    [Parameter(Mandatory = $true)]
+    [string]$KeyAlias,
+
+    [Parameter(Mandatory = $true)]
+    [string]$KeyPassword,
+
+    [string]$OutFile = "ANDROID_KEYSTORE_BASE64.txt",
+    [string]$Repo = "exomind-team/exomind",
+    [switch]$SetGhSecrets
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-KeytoolPath {
+    if ($env:JAVA_HOME) {
+        $candidate = Join-Path $env:JAVA_HOME "bin\keytool.exe"
+        if (Test-Path $candidate) { return $candidate }
+    }
+
+    $defaultJavaHome = "C:\Program Files\Eclipse Adoptium\jdk-17.0.13.11-hotspot"
+    $defaultKeytool = Join-Path $defaultJavaHome "bin\keytool.exe"
+    if (Test-Path $defaultKeytool) { return $defaultKeytool }
+
+    $cmd = Get-Command keytool -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+
+    throw "keytool not found. Please install JDK 17 and set JAVA_HOME."
+}
+
+if (-not (Test-Path -LiteralPath $KeystorePath)) {
+    throw "Keystore file not found: $KeystorePath"
+}
+
+$resolvedKeystore = (Resolve-Path -LiteralPath $KeystorePath).Path
+$keytool = Resolve-KeytoolPath
+
+Write-Host "[1/4] Validate keystore/alias with keytool (校验 keystore/alias)..."
+& $keytool -list `
+    -keystore $resolvedKeystore `
+    -storepass $StorePassword `
+    -alias $KeyAlias `
+    -keypass $KeyPassword `
+    *> $null
+if ($LASTEXITCODE -ne 0) {
+    throw "Keytool validation failed. Check keystore path / alias / passwords."
+}
+Write-Host "OK: keystore and alias are valid."
+
+Write-Host "[2/4] Generate Base64 for ANDROID_KEYSTORE_BASE64 (生成 Base64)..."
+$bytes = [System.IO.File]::ReadAllBytes($resolvedKeystore)
+$base64 = [Convert]::ToBase64String($bytes)
+if ([string]::IsNullOrWhiteSpace($base64)) {
+    throw "Generated Base64 content is empty."
+}
+
+$outPath = (Join-Path (Get-Location) $OutFile)
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($outPath, $base64, $utf8NoBom)
+Write-Host "OK: Base64 file created: $outPath"
+
+Write-Host "[3/4] Verify Base64 roundtrip (校验 Base64 可逆)..."
+$decoded = [Convert]::FromBase64String($base64)
+if ($decoded.Length -ne $bytes.Length) {
+    throw "Base64 roundtrip length mismatch."
+}
+Write-Host "OK: roundtrip check passed. bytes=$($bytes.Length)"
+
+Write-Host "[4/4] Summary (汇总)"
+Write-Host "Repo: $Repo"
+Write-Host "Secret: ANDROID_KEYSTORE_BASE64 -> $outPath"
+Write-Host "Secret: ANDROID_KEYSTORE_PASSWORD -> (provided)"
+Write-Host "Secret: ANDROID_KEY_ALIAS -> $KeyAlias"
+Write-Host "Secret: ANDROID_KEY_PASSWORD -> (provided)"
+
+if ($SetGhSecrets) {
+    $gh = Get-Command gh -ErrorAction SilentlyContinue
+    if (-not $gh) {
+        throw "gh CLI not found. Install GitHub CLI first."
+    }
+
+    Write-Host "Writing secrets to GitHub (写入 GitHub Secrets)..."
+    gh secret set ANDROID_KEYSTORE_BASE64 --repo $Repo --body $base64 | Out-Null
+    gh secret set ANDROID_KEYSTORE_PASSWORD --repo $Repo --body $StorePassword | Out-Null
+    gh secret set ANDROID_KEY_ALIAS --repo $Repo --body $KeyAlias | Out-Null
+    gh secret set ANDROID_KEY_PASSWORD --repo $Repo --body $KeyPassword | Out-Null
+    Write-Host "OK: all Android signing secrets updated."
+} else {
+    Write-Host "Next step (下一步):"
+    Write-Host "  1) Configure the 4 secrets in GitHub Actions."
+    Write-Host "  2) Re-run release tag workflow."
+}

--- a/Scripts/dev/android-signing-secrets.ps1
+++ b/Scripts/dev/android-signing-secrets.ps1
@@ -72,15 +72,27 @@ $resolvedKeystore = (Resolve-Path -LiteralPath $KeystorePath).Path
 $keytool = Resolve-KeytoolPath
 
 Write-Host "[1/4] Validate keystore/alias with keytool (校验 keystore/alias)..."
-& $keytool -list `
-    -keystore $resolvedKeystore `
-    -storepass $StorePassword `
-    -alias $KeyAlias `
-    -keypass $KeyPassword `
-    *> $null
-if ($LASTEXITCODE -ne 0) {
-    throw "Keytool validation failed. Check keystore path / alias / passwords."
+$tmpOut = Join-Path $env:TEMP ("keytool-out-" + [guid]::NewGuid().ToString("N") + ".log")
+$tmpErr = Join-Path $env:TEMP ("keytool-err-" + [guid]::NewGuid().ToString("N") + ".log")
+$keytoolArgs = @(
+    "-list",
+    "-keystore", $resolvedKeystore,
+    "-storepass", $StorePassword,
+    "-alias", $KeyAlias,
+    "-keypass", $KeyPassword
+)
+$proc = Start-Process -FilePath $keytool `
+    -ArgumentList $keytoolArgs `
+    -Wait `
+    -PassThru `
+    -NoNewWindow `
+    -RedirectStandardOutput $tmpOut `
+    -RedirectStandardError $tmpErr
+if ($proc.ExitCode -ne 0) {
+    $errText = if (Test-Path $tmpErr) { Get-Content -Path $tmpErr -Raw } else { "" }
+    throw "Keytool validation failed. Check keystore path / alias / passwords. $errText"
 }
+Remove-Item -Path $tmpOut, $tmpErr -Force -ErrorAction SilentlyContinue
 Write-Host "OK: keystore and alias are valid."
 
 Write-Host "[2/4] Generate Base64 for ANDROID_KEYSTORE_BASE64 (生成 Base64)..."


### PR DESCRIPTION
## 变更内容 / What changed
- 工作流改为在 self-hosted Windows 上强制使用本机 Rust（rustup/rustc/cargo），并阻断 WSL 路径命令。
- Android 签名 secrets 准备脚本改为更稳健的 keytool 校验流程（Start-Process + 显式 ExitCode）。
- 文档补充 Android signing secrets 准备与 build/release 标签要求。

## 变更原因 / Why
- 解决 `build-windows` 在 `Setup Rust` 阶段意外触发 `bash/WSL` 导致失败的问题。
- 保障 Android APK 在 CI 中可稳定签名并产出可下载安装包，打通发布链路最后一公里。

## 关键实现 / Implementation details
- 移除 `dtolnay/rust-toolchain` 对该 runner 的依赖，改为 PowerShell 原生检测与启用 stable toolchain。
- 在 workflow 中提前校验签名 secrets，缺失时快速失败并给出明确错误。
- 产物策略保持：Android 仅输出 x86 + aarch64 signed APK，Windows 输出 EXE/MSI。

This PR was written using [Vibe Kanban](https://vibekanban.com)