### PR TITLE
fix(ci): make Windows tauri bundle args PowerShell-safe (Vibe Kanban)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
         run: bun install
 
       - name: Build Windows installers (构建 Windows 安装包)
-        run: bun tauri build --bundles nsis,msi
+        run: bun tauri build --bundles 'nsis,msi'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
﻿## 变更内容 / What changed
- 修复 Windows 构建命令：`bun tauri build --bundles nsis,msi` -> `bun tauri build --bundles ''nsis,msi''`

## 原因 / Why
- 在 PowerShell 中未加引号的 `nsis,msi` 被解释成数组，最终传入 tauri CLI 变成非法值 `"nsis msi"`，导致 `build-windows` 失败。

## 实现细节 / Implementation details
- 仅改动 `release.yml` 一行命令参数，最小变更，不影响 Android 构建与签名流程。

This PR was written using [Vibe Kanban](https://vibekanban.com)
