### PR TITLE
fix(android): 修复 Android 安全区遮挡并加固 GitHub 评论乱码防护

### DIFF
--- a/Scripts/dev/github-comment-lib.ts
+++ b/Scripts/dev/github-comment-lib.ts
@@ -67,31 +67,35 @@ export function resolveMode(requestedMode: string | undefined, commentId: string
   return commentId ? 'append' : 'create';
 }
 
+export function normalizeBodyText(
+  content: string,
+  source: 'input' | 'existing' = 'input',
+): string {
+  const withoutBom = content.startsWith(UTF8_BOM) ? content.slice(1) : content;
+  const sourceLabel = source === 'existing' ? 'Existing comment body' : 'Input body';
+
+  if (withoutBom.includes('\u0000')) {
+    throw new Error(`${sourceLabel} appears to contain NULL bytes. 可能是错误编码（encoding）文件。`);
+  }
+  if (withoutBom.includes('\uFFFD')) {
+    throw new Error(`${sourceLabel} contains replacement characters (�), possible garbled text. 可能已乱码。`);
+  }
+  if (SUSPICIOUS_QUESTION_SEQUENCE.test(withoutBom)) {
+    throw new Error(`${sourceLabel} contains suspicious long "?" sequence, possible garbled text. 检测到疑似乱码。`);
+  }
+
+  return withoutBom;
+}
+
 export function buildAppendedBody(existingBody: string, incomingBody: string): string {
-  const current = existingBody ?? '';
-  const next = incomingBody ?? '';
+  const current = normalizeBodyText(existingBody ?? '', 'existing');
+  const next = normalizeBodyText(incomingBody ?? '', 'input');
 
   if (!current.trim()) {
     return next;
   }
 
   return `${current}\n\n${next}`;
-}
-
-function normalizeBodyText(content: string): string {
-  const withoutBom = content.startsWith(UTF8_BOM) ? content.slice(1) : content;
-
-  if (withoutBom.includes('\u0000')) {
-    throw new Error('Comment body appears to contain NULL bytes. 可能是错误编码（encoding）文件。');
-  }
-  if (withoutBom.includes('\uFFFD')) {
-    throw new Error('Comment body contains replacement characters (�), possible garbled text. 可能已乱码。');
-  }
-  if (SUSPICIOUS_QUESTION_SEQUENCE.test(withoutBom)) {
-    throw new Error('Comment body contains suspicious long "?" sequence, possible garbled text. 检测到疑似乱码。');
-  }
-
-  return withoutBom;
 }
 
 export function readBodyInput(filePath: string | undefined, bodyText: string | undefined): string {
@@ -104,10 +108,10 @@ export function readBodyInput(filePath: string | undefined, bodyText: string | u
 
   if (filePath) {
     const raw = readFileSync(filePath);
-    return normalizeBodyText(raw.toString('utf8'));
+    return normalizeBodyText(raw.toString('utf8'), 'input');
   }
 
-  return normalizeBodyText(bodyText as string);
+  return normalizeBodyText(bodyText as string, 'input');
 }
 
 export function parseRepoFromRemoteUrl(remoteUrl: string): string {

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Exomind</title>
     <script>
       (function () {

--- a/src/components/VoiceMessageInput.tsx
+++ b/src/components/VoiceMessageInput.tsx
@@ -142,55 +142,57 @@ export const VoiceMessageInput = forwardRef<VoiceMessageInputHandle, VoiceMessag
   }), []);
 
   return (
-    <div className="flex items-end gap-2 px-3 py-2 border-t bg-card shrink-0 safe-area-pb">
-      {/* 语音输入按钮 */}
-      <VoiceInputButton
-        ref={voiceButtonRef}
-        onResult={handleVoiceResult}
-        onStateChange={handleStateChange}
-        adapter={adapter}
-        adapterConfig={adapterConfig}
-        showWaveform={showWaveform}
-        showTimer={showTimer}
-        enableShortcut={enableShortcut}
-        size={buttonSize}
-        style={{
-          flexShrink: 0,
-        }}
-      />
+    <div className="safe-area-pb bg-card shrink-0">
+      <div className="flex items-end gap-2 px-3 py-2 border-t">
+        {/* 语音输入按钮 */}
+        <VoiceInputButton
+          ref={voiceButtonRef}
+          onResult={handleVoiceResult}
+          onStateChange={handleStateChange}
+          adapter={adapter}
+          adapterConfig={adapterConfig}
+          showWaveform={showWaveform}
+          showTimer={showTimer}
+          enableShortcut={enableShortcut}
+          size={buttonSize}
+          style={{
+            flexShrink: 0,
+          }}
+        />
 
-      {/* 文本输入框 */}
-      <Textarea
-        ref={textareaRef}
-        value={value}
-        onChange={(e) => {
-          setValue(e.target.value);
-          resizeTextarea(e.target);
-        }}
-        onKeyDown={handleKeyDown}
-        placeholder={placeholder}
-        className={inputClassName}
-        rows={minRows}
-        data-testid="event-input-textarea"
-        data-gramm="false"
-        spellCheck={false}
-        style={{
-          flex: 1,
-          minHeight: '56px',
-        }}
-      />
+        {/* 文本输入框 */}
+        <Textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+            resizeTextarea(e.target);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className={inputClassName}
+          rows={minRows}
+          data-testid="event-input-textarea"
+          data-gramm="false"
+          spellCheck={false}
+          style={{
+            flex: 1,
+            minHeight: '56px',
+          }}
+        />
 
-      {/* 发送按钮 */}
-      <Button
-        onClick={handleSend}
-        disabled={!value.trim()}
-        size="icon"
-        className="shrink-0"
-        type="button"
-        data-testid="event-send-button"
-      >
-        <Send size={18} />
-      </Button>
+        {/* 发送按钮 */}
+        <Button
+          onClick={handleSend}
+          disabled={!value.trim()}
+          size="icon"
+          className="shrink-0"
+          type="button"
+          data-testid="event-send-button"
+        >
+          <Send size={18} />
+        </Button>
+      </div>
     </div>
   );
 });

--- a/src/index.css
+++ b/src/index.css
@@ -71,3 +71,16 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  /* Safe area utilities / 安全区工具类（顶部与底部） */
+  .safe-area-pt {
+    padding-top: constant(safe-area-inset-top);
+    padding-top: env(safe-area-inset-top, 0px);
+  }
+
+  .safe-area-pb {
+    padding-bottom: constant(safe-area-inset-bottom);
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+  }
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -75,7 +75,7 @@ function Sidebar({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) 
       )}
       <aside
         className={cn(
-          "fixed lg:static inset-y-0 left-0 z-50 w-64 bg-card border-r flex flex-col transition-transform duration-300 lg:translate-x-0",
+          "fixed lg:static inset-y-0 left-0 z-50 w-64 bg-card border-r flex flex-col safe-area-pt transition-transform duration-300 lg:translate-x-0",
           isOpen ? "translate-x-0" : "-translate-x-full"
         )}
         data-testid="device-panel"
@@ -139,7 +139,7 @@ function Layout() {
       {/* 主内容区 */}
       <div className="flex-1 flex flex-col min-w-0">
         {/* 顶部栏 - 移动端显示菜单按钮 */}
-        <header className="lg:hidden flex items-center px-4 py-3 border-b bg-card shrink-0">
+        <header className="lg:hidden sticky top-0 z-30 safe-area-pt flex items-center px-4 py-3 border-b bg-card shrink-0">
           <button
             onClick={() => setSidebarOpen(true)}
             className="p-2 hover:bg-accent rounded-md mr-3"

--- a/tests/unit/scripts/github-comment-tool.test.ts
+++ b/tests/unit/scripts/github-comment-tool.test.ts
@@ -73,6 +73,11 @@ describe('github-comment-lib', () => {
     it('returns incoming body when existing body is empty', () => {
       expect(buildAppendedBody('', 'new text')).toBe('new text');
     });
+
+    it('throws when existing body is suspiciously garbled', () => {
+      expect(() => buildAppendedBody('Android ????????????', 'new text'))
+        .toThrow(/garbled|encoding|乱码/i);
+    });
   });
 
   describe('parseRepoFromRemoteUrl', () => {

--- a/tests/unit/ui/mobile-safe-area.issue142.test.ts
+++ b/tests/unit/ui/mobile-safe-area.issue142.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+describe('issue-142 mobile safe area', () => {
+  const htmlPath = path.resolve('index.html');
+  const cssPath = path.resolve('src/index.css');
+  const routesPath = path.resolve('src/routes.tsx');
+
+  it('includes viewport-fit=cover in index.html', () => {
+    const html = fs.readFileSync(htmlPath, 'utf-8');
+    expect(html).toContain('viewport-fit=cover');
+  });
+
+  it('defines safe-area utility classes in src/index.css', () => {
+    const css = fs.readFileSync(cssPath, 'utf-8');
+    expect(css).toContain('.safe-area-pt');
+    expect(css).toContain('.safe-area-pb');
+    expect(css).toContain('env(safe-area-inset-top');
+    expect(css).toContain('env(safe-area-inset-bottom');
+    expect(css).toContain('constant(safe-area-inset-top)');
+    expect(css).toContain('constant(safe-area-inset-bottom)');
+  });
+
+  it('applies safe-area class to mobile header and sidebar', () => {
+    const routesSource = fs.readFileSync(routesPath, 'utf-8');
+    expect(routesSource).toContain('safe-area-pt');
+  });
+});

--- a/tests/unit/ui/mobile-safe-area.issue142.test.ts
+++ b/tests/unit/ui/mobile-safe-area.issue142.test.ts
@@ -6,6 +6,7 @@ describe('issue-142 mobile safe area', () => {
   const htmlPath = path.resolve('index.html');
   const cssPath = path.resolve('src/index.css');
   const routesPath = path.resolve('src/routes.tsx');
+  const voiceInputPath = path.resolve('src/components/VoiceMessageInput.tsx');
 
   it('includes viewport-fit=cover in index.html', () => {
     const html = fs.readFileSync(htmlPath, 'utf-8');
@@ -25,5 +26,12 @@ describe('issue-142 mobile safe area', () => {
   it('applies safe-area class to mobile header and sidebar', () => {
     const routesSource = fs.readFileSync(routesPath, 'utf-8');
     expect(routesSource).toContain('safe-area-pt');
+  });
+
+  it('keeps base vertical spacing when applying bottom safe-area in voice input', () => {
+    const voiceInputSource = fs.readFileSync(voiceInputPath, 'utf-8');
+    // safe-area-pb（底部安全区）应放在外层容器，避免覆盖 py-*（垂直内边距）
+    expect(voiceInputSource).not.toMatch(/className="[^"]*py-[^"]*safe-area-pb[^"]*"/);
+    expect(voiceInputSource).toContain('className="safe-area-pb');
   });
 });


### PR DESCRIPTION
## 变更内容（What changed / 改了什么）
- 修复 Android 页面顶部与系统状态栏重叠问题，恢复左上角菜单可点击。
- 新增并应用 Safe Area（安全区）样式：
  - `index.html`：`viewport` 增加 `viewport-fit=cover`。
  - `src/index.css`：新增 `safe-area-pt` / `safe-area-pb` 工具类（utility classes / 工具类）。
  - `src/routes.tsx`：移动端 `header` 与侧边栏容器应用 `safe-area-pt`，并优化层级（`sticky top-0 z-30` 与侧栏 `z-50`）。
- 加固 GitHub 评论脚本的乱码防护逻辑：
  - `Scripts/dev/github-comment-lib.ts`：在 append（追加）时不仅校验输入正文，也会校验已有评论正文，命中可疑乱码（如长 `?` 序列、replacement character、NULL 字节）会直接阻断，避免二次污染。
- 补充自动化测试：
  - 新增 `tests/unit/ui/mobile-safe-area.issue142.test.ts`。
  - 扩展 `tests/unit/scripts/github-comment-tool.test.ts`。

## 变更原因（Why / 为什么要改）
- 来自 Issue #142：Android 端顶部内容与状态栏重叠，导致左上角菜单触控区域受影响，出现不可点击问题。
- 同时处理评论乱码链路：已有评论可能已出现乱码文本，若继续 append 可能把乱码内容持续写回，需要在工具链侧提前拦截。

## 关键实现细节（Implementation details / 重要实现细节）
- Safe Area 采用 `env(safe-area-inset-*)`，并保留 `constant()` 兼容写法，保证不同 WebView 环境下的稳定性。
- 通过给移动端头部和侧栏统一增加 `safe-area-pt`，并明确层级策略，减少状态栏覆盖与遮罩冲突。
- 评论工具中将正文规范化与异常检测前置到“读入输入正文 + 读取已有正文”两个路径，确保 append/replace 场景都可发现乱码风险。

## 验证（Verification / 验证结果）
- `bunx vitest run tests/unit/ui/mobile-safe-area.issue142.test.ts tests/unit/scripts/github-comment-tool.test.ts` 通过。
- `bun run build` 通过。

This PR was written using [Vibe Kanban](https://vibekanban.com)