### PR TITLE
docs: 版本治理方案（SemVer + Beta + Hash）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,35 @@ jobs:
           $short = $env:GITHUB_SHA.Substring(0, 7)
           "HASH=$short" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
+      - name: Resolve app version (解析应用版本)
+        id: app_version
+        shell: powershell
+        run: |
+          $refName = "${{ github.ref_name }}"
+          $appVersion = ""
+
+          if ($refName.StartsWith("release/")) {
+            $appVersion = $refName.Substring("release/".Length)
+          } elseif ($refName.StartsWith("build/")) {
+            $appVersion = $refName.Substring("build/".Length)
+          }
+
+          if (-not $appVersion) {
+            $packageVersion = (Get-Content -Path "package.json" -Raw | ConvertFrom-Json).version
+            $appVersion = [string]$packageVersion
+          }
+
+          if ($appVersion.StartsWith("v")) {
+            $appVersion = $appVersion.Substring(1)
+          }
+
+          if (-not $appVersion) {
+            throw "Cannot resolve app version from tag or package.json."
+          }
+
+          "APP_VERSION=$appVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          Write-Host "Resolved app version: $appVersion"
+
       - name: Install dependencies
         run: bun install
 
@@ -144,6 +173,8 @@ jobs:
         run: bun tauri build --bundles 'nsis'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VITE_APP_VERSION: ${{ steps.app_version.outputs.APP_VERSION }}
+          VITE_BUILD_HASH: ${{ steps.hash.outputs.HASH }}
 
       - name: Build Windows MSI installer (可选 MSI，失败不阻断)
         id: build_msi
@@ -151,6 +182,8 @@ jobs:
         run: bun tauri build --bundles 'msi'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VITE_APP_VERSION: ${{ steps.app_version.outputs.APP_VERSION }}
+          VITE_BUILD_HASH: ${{ steps.hash.outputs.HASH }}
 
       - name: Warn MSI optional failure (提示 MSI 可选失败)
         if: ${{ steps.build_msi.outcome != 'success' }}
@@ -299,6 +332,35 @@ jobs:
           $short = $env:GITHUB_SHA.Substring(0, 7)
           "HASH=$short" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
+      - name: Resolve app version (解析应用版本)
+        id: app_version
+        shell: powershell
+        run: |
+          $refName = "${{ github.ref_name }}"
+          $appVersion = ""
+
+          if ($refName.StartsWith("release/")) {
+            $appVersion = $refName.Substring("release/".Length)
+          } elseif ($refName.StartsWith("build/")) {
+            $appVersion = $refName.Substring("build/".Length)
+          }
+
+          if (-not $appVersion) {
+            $packageVersion = (Get-Content -Path "package.json" -Raw | ConvertFrom-Json).version
+            $appVersion = [string]$packageVersion
+          }
+
+          if ($appVersion.StartsWith("v")) {
+            $appVersion = $appVersion.Substring(1)
+          }
+
+          if (-not $appVersion) {
+            throw "Cannot resolve app version from tag or package.json."
+          }
+
+          "APP_VERSION=$appVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          Write-Host "Resolved app version: $appVersion"
+
       - name: Install dependencies
         run: bun install
 
@@ -328,6 +390,8 @@ jobs:
         run: bun tauri android build --ci --apk --split-per-abi -t aarch64 i686
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VITE_APP_VERSION: ${{ steps.app_version.outputs.APP_VERSION }}
+          VITE_BUILD_HASH: ${{ steps.hash.outputs.HASH }}
           HTTP_PROXY: http://127.0.0.1:7890
           HTTPS_PROXY: http://127.0.0.1:7890
           ALL_PROXY: http://127.0.0.1:7890
@@ -450,18 +514,90 @@ jobs:
         run: |
           set -euo pipefail
           version="${GITHUB_REF_NAME#release/}"
-          if [[ "$version" =~ (preview|alpha|beta|rc) ]]; then
+          short_hash="${GITHUB_SHA::7}"
+          lower_version="$(echo "$version" | tr '[:upper:]' '[:lower:]')"
+          channel=""
+          if [[ "$lower_version" == *"-alpha."* ]]; then
+            channel="Alpha"
+          elif [[ "$lower_version" == *"-beta."* ]]; then
+            channel="Beta"
+          elif [[ "$lower_version" == *"-rc."* ]]; then
+            channel="RC"
+          elif [[ "$lower_version" == *"-preview."* ]]; then
+            channel="Preview"
+          fi
+
+          if [[ -n "$channel" ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
-            echo "title=Preview $version" >> "$GITHUB_OUTPUT"
+            echo "title=$channel $version" >> "$GITHUB_OUTPUT"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
             echo "title=Release $version" >> "$GITHUB_OUTPUT"
           fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "short_hash=$short_hash" >> "$GITHUB_OUTPUT"
+
+      - name: Normalize release artifact names (统一发布产物命名)
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob globstar
+
+          version="${{ steps.meta.outputs.version }}"
+          short_hash="${{ steps.meta.outputs.short_hash }}"
+          source_dir="release-files"
+          output_dir="release-assets"
+          mkdir -p "$output_dir"
+
+          exe_files=("$source_dir"/**/*.exe)
+          if (( ${#exe_files[@]} == 0 )); then
+            echo "::error::Missing Windows EXE artifact."
+            exit 1
+          fi
+          cp "${exe_files[0]}" "$output_dir/ExoMind-${version}-${short_hash}-windows-x64-setup.exe"
+
+          msi_files=("$source_dir"/**/*.msi)
+          if (( ${#msi_files[@]} > 0 )); then
+            cp "${msi_files[0]}" "$output_dir/ExoMind-${version}-${short_hash}-windows-x64-installer.msi"
+          fi
+
+          apk_files=("$source_dir"/**/*signed.apk)
+          if (( ${#apk_files[@]} == 0 )); then
+            apk_files=("$source_dir"/**/*.apk)
+          fi
+
+          arm64_apk=""
+          x86_apk=""
+          for apk in "${apk_files[@]}"; do
+            file_name="$(basename "$apk" | tr '[:upper:]' '[:lower:]')"
+            if [[ -z "$arm64_apk" && ( "$file_name" == *"arm64"* || "$file_name" == *"aarch64"* || "$file_name" == *"arm64-v8a"* ) ]]; then
+              arm64_apk="$apk"
+              continue
+            fi
+            if [[ -z "$x86_apk" && ( "$file_name" == *"i686"* || "$file_name" == *"x86"* ) && "$file_name" != *"x86_64"* ]]; then
+              x86_apk="$apk"
+            fi
+          done
+
+          if [[ -z "$arm64_apk" ]]; then
+            echo "::error::Missing Android arm64 APK artifact."
+            exit 1
+          fi
+          if [[ -z "$x86_apk" ]]; then
+            echo "::error::Missing Android x86 APK artifact."
+            exit 1
+          fi
+
+          cp "$arm64_apk" "$output_dir/ExoMind-${version}-${short_hash}-android-arm64.apk"
+          cp "$x86_apk" "$output_dir/ExoMind-${version}-${short_hash}-android-x86.apk"
+
+      - name: List Normalized Files
+        run: ls -la release-assets/
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          files: release-files/**
+          files: release-assets/**
           # 从 tag 名称提取版本号 (去掉 release/ 前缀)
           tag_name: ${{ github.ref_name }}
           name: ${{ steps.meta.outputs.title }}

--- a/docs/plans/2026-02-19-semver-beta-versioning-proposal.md
+++ b/docs/plans/2026-02-19-semver-beta-versioning-proposal.md
@@ -74,15 +74,15 @@
 
 引入统一命名模板：
 
-- Windows EXE: `ExoMind-v<version>-<pre>-<hash>-x64-setup.exe`
-- Windows MSI（若启用）: `ExoMind-v<version>-<pre>-<hash>-x64-installer.msi`
+- Windows EXE: `ExoMind-v<version>-<pre>-<hash>-windows-x64-setup.exe`
+- Windows MSI（若启用）: `ExoMind-v<version>-<pre>-<hash>-windows-x64-installer.msi`
 - Android APK（arm64）: `ExoMind-v<version>-<pre>-<hash>-android-arm64.apk`
 - Android APK（x86）: `ExoMind-v<version>-<pre>-<hash>-android-x86.apk`
 
 示例：
 
-- `ExoMind-v0.2.1-beta.1-dbce231-x64-setup.exe`
-- `ExoMind-v0.2.1-beta.1-dbce231-x64-installer.msi`
+- `ExoMind-v0.2.1-beta.1-dbce231-windows-x64-setup.exe`
+- `ExoMind-v0.2.1-beta.1-dbce231-windows-x64-installer.msi`
 - `ExoMind-v0.2.1-beta.1-dbce231-android-arm64.apk`
 - `ExoMind-v0.2.1-beta.1-dbce231-android-x86.apk`
 
@@ -90,6 +90,7 @@
 
 - 该模板中的 `<pre>` 指 pre-release identifier（预发布标识），例如 `beta.1`。
 - 该模板中的 `<hash>` 指 git short hash（提交短哈希），例如 `dbce231`。
+- `windows` 前缀显式标注 OS（操作系统）维度，和 `android` 保持并列结构，可读性更高。
 
 ### 4.5 应用内版本展示（In-App Version Display / 应用内展示）
 
@@ -115,8 +116,9 @@
 
 1. `release/v0.2.1-beta.1`（发布标签）
 2. `Beta v0.2.1-beta.1`（发布标题）
-3. `ExoMind-v0.2.1-beta.1-dbce231-android-arm64.apk`（发布产物）
-4. `App Version: 0.2.1-beta.1` + `Build Hash: dbce231`（应用内展示）
+3. `ExoMind-v0.2.1-beta.1-dbce231-windows-x64-setup.exe`（发布产物，Windows）
+4. `ExoMind-v0.2.1-beta.1-dbce231-android-arm64.apk`（发布产物，Android）
+5. `App Version: 0.2.1-beta.1` + `Build Hash: dbce231`（应用内展示）
 
 ## 5. 实施边界（Scope / 范围）
 

--- a/docs/plans/2026-02-19-semver-beta-versioning-proposal.md
+++ b/docs/plans/2026-02-19-semver-beta-versioning-proposal.md
@@ -52,18 +52,22 @@
 
 ### 4.2 标签规则（Tag Convention / 标签规范）
 
-继续沿用现有路径前缀，最小改动：
+继续沿用现有路径前缀，按已确认决策执行：
 
-- 构建标签（仅构建）：`build/v0.2.1-beta.<n>-data-<sha7>`
-- 发布标签（构建 + GitHub Release）：`release/v0.2.1-beta.<n>-data-<sha7>`
+- 发布标签（构建 + GitHub Release）：`release/v0.2.1-beta.<n>`
+- 不在标签中携带 `data` 或 `hash`
 
 示例：
 
-- `release/v0.2.1-beta.1-data-dbce231`
+- `release/v0.2.1-beta.1`
+
+说明：
+
+- `hash（构建哈希）` 通过构建产物命名与应用内展示体现，不进入 tag。
 
 ### 4.3 Release 标题策略（Release Title / 发布标题）
 
-- 当版本包含 `beta` 时，标题显示为：`Beta v0.2.1-beta.1-data-dbce231`
+- 当版本包含 `beta` 时，标题显示为：`Beta v0.2.1-beta.1`
 - 正式版（无 pre-release 标识）显示：`Release v0.2.1`
 
 ### 4.4 产物命名策略（Artifact Naming / 产物命名）
@@ -71,13 +75,21 @@
 引入统一命名模板：
 
 - Windows EXE: `ExoMind-v<version>-<pre>-<hash>-x64-setup.exe`
+- Windows MSI（若启用）: `ExoMind-v<version>-<pre>-<hash>-x64-installer.msi`
 - Android APK（arm64）: `ExoMind-v<version>-<pre>-<hash>-android-arm64.apk`
 - Android APK（x86）: `ExoMind-v<version>-<pre>-<hash>-android-x86.apk`
 
 示例：
 
 - `ExoMind-v0.2.1-beta.1-dbce231-x64-setup.exe`
+- `ExoMind-v0.2.1-beta.1-dbce231-x64-installer.msi`
 - `ExoMind-v0.2.1-beta.1-dbce231-android-arm64.apk`
+- `ExoMind-v0.2.1-beta.1-dbce231-android-x86.apk`
+
+说明：
+
+- 该模板中的 `<pre>` 指 pre-release identifier（预发布标识），例如 `beta.1`。
+- 该模板中的 `<hash>` 指 git short hash（提交短哈希），例如 `dbce231`。
 
 ### 4.5 应用内版本展示（In-App Version Display / 应用内展示）
 
@@ -91,6 +103,21 @@
 - `version`：Tauri API `getVersion()`（桌面）+ `VITE_APP_VERSION`（Web/回退）
 - `hash`：CI 注入 `VITE_BUILD_HASH`
 
+### 4.6 业界常见做法（Common Practice / 常见规范）
+
+为避免语义混乱，采用以下通用实践：
+
+1. tag 使用可比较的 SemVer 版本语义：`vX.Y.Z-beta.N`，不混入提交哈希。
+2. hash 放在产物名、应用内“关于页”、Release Notes（发布说明）中，用于可追溯。
+3. GitHub `prerelease` 由版本字符串中的 `beta/alpha/rc` 与发布属性共同体现。
+
+样例对照：
+
+1. `release/v0.2.1-beta.1`（发布标签）
+2. `Beta v0.2.1-beta.1`（发布标题）
+3. `ExoMind-v0.2.1-beta.1-dbce231-android-arm64.apk`（发布产物）
+4. `App Version: 0.2.1-beta.1` + `Build Hash: dbce231`（应用内展示）
+
 ## 5. 实施边界（Scope / 范围）
 
 ### 5.1 本 PR（方案评审 PR）包含
@@ -103,14 +130,14 @@
 2. release 标题文案由 `Preview` 改为 `Beta`
 3. 产物重命名逻辑
 4. 设置页版本/哈希展示
-5. 真实 CI 验证（build/release tag）
+5. 真实 CI 验证（release tag）
 
 ## 6. 验收标准（Acceptance Criteria / 验收标准）
 
 审批后实施时满足以下标准：
 
 1. 三处代码版本一致为 `0.2.1`
-2. 使用 `release/v0.2.1-beta.1-data-<sha7>` 触发后，Release 被标记为 `prerelease = true`
+2. 使用 `release/v0.2.1-beta.1` 触发后，Release 被标记为 `prerelease = true`
 3. Release 标题为 `Beta ...`（不再使用 `Preview ...`）
 4. Windows 与 Android 发布产物文件名包含 `version + beta序号 + hash`
 5. 应用设置页可看到 `App Version` 与 `Build Hash`
@@ -127,9 +154,10 @@
 - 任何一步失败可回滚到“保持现有产物命名，仅先统一版本与 beta 标题”
 - 保证主干构建不被阻断
 
-## 8. 待审批决策（Pending Decisions / 待你审批）
+## 8. 已确认决策（Approved Decisions / 已确认）
 
-请确认以下两点后进入实现：
+以下决策已由评审确认：
 
-1. 是否采用 `release/v0.2.1-beta.<n>-data-<sha7>` 作为唯一预发布标签格式。
-2. 产物命名是否采用 `ExoMind-v<version>-<pre>-<hash>-<platform>` 的统一模板。
+1. 发布标签采用：`release/v0.2.1-beta.1`（不带 `data`、不带 `hash`）。
+2. 应用显示采用：`App Version = 0.2.1-beta.1`，`Build Hash = dbce231`。
+3. 产物文件名采用统一模板并包含 hash：`ExoMind-v<version>-<pre>-<hash>-<platform>`。

--- a/docs/plans/2026-02-19-semver-beta-versioning-proposal.md
+++ b/docs/plans/2026-02-19-semver-beta-versioning-proposal.md
@@ -1,0 +1,135 @@
+﻿# ExoMind 版本治理方案（SemVer + Beta + Hash）
+
+## 1. 背景（Background / 背景）
+
+当前仓库已经进入 `0.2.1` 的预发布节奏，但代码内与发布链路的版本语义存在不一致，影响：
+
+1. 用户对版本认知不一致（代码显示 `0.2.0`，Release tag 显示 `0.2.1-preview*`）。
+2. 产物命名无法快速定位构建来源（是否同一提交、同一预发布序号）。
+3. 应用内缺少“版本 + 构建哈希（build hash）”的可视信息，不利于问题排查与回溯。
+
+## 2. 现状（Current State / 现状）
+
+### 2.1 代码内版本
+
+- `package.json` 当前 `version = 0.2.0`
+- `src-tauri/tauri.conf.json` 当前 `version = 0.2.0`
+- `src-tauri/Cargo.toml` 当前 `version = 0.2.0`
+
+### 2.2 发布标签与预发布
+
+- 已使用标签：`release/v0.2.1-preview*-data-<sha7>`
+- 当前 workflow 会把包含 `preview|alpha|beta|rc` 的版本判定为 `prerelease = true`
+- Release 标题仍按 `Preview ...` 文案展示
+
+### 2.3 产物命名
+
+- Windows 产物中出现 `ExoMind_0.2.0_x64-setup.exe`（与 tag 语义不一致）
+- Android 产物命名偏技术细节（如 `app-arm64-release-unsigned-signed.apk`），不够面向发布管理
+
+## 3. 目标（Goals / 目标）
+
+根据需求，目标统一为：
+
+1. 将 `preview` 命名切换为 `beta`。
+2. 统一代码版本到目标稳定版：`0.2.1`。
+3. 预发布命名使用 `0.2.1-beta.1`（后续递增 `beta.2`、`beta.3`）。
+4. 产物命名与应用内展示同时具备：
+   - `version（版本号）`
+   - `channel/pre-release（预发布渠道）`
+   - `build hash（构建哈希）`
+
+## 4. 方案（Proposed Solution / 解决方案）
+
+### 4.1 版本源统一（Single Source of Truth / 单一事实源）
+
+- 将三处版本统一改为：`0.2.1`
+  - `package.json`
+  - `src-tauri/tauri.conf.json`
+  - `src-tauri/Cargo.toml`
+
+说明：`0.2.1` 代表目标稳定版本；`beta.N` 通过标签与发布元信息表达，不直接写死在代码版本字段。
+
+### 4.2 标签规则（Tag Convention / 标签规范）
+
+继续沿用现有路径前缀，最小改动：
+
+- 构建标签（仅构建）：`build/v0.2.1-beta.<n>-data-<sha7>`
+- 发布标签（构建 + GitHub Release）：`release/v0.2.1-beta.<n>-data-<sha7>`
+
+示例：
+
+- `release/v0.2.1-beta.1-data-dbce231`
+
+### 4.3 Release 标题策略（Release Title / 发布标题）
+
+- 当版本包含 `beta` 时，标题显示为：`Beta v0.2.1-beta.1-data-dbce231`
+- 正式版（无 pre-release 标识）显示：`Release v0.2.1`
+
+### 4.4 产物命名策略（Artifact Naming / 产物命名）
+
+引入统一命名模板：
+
+- Windows EXE: `ExoMind-v<version>-<pre>-<hash>-x64-setup.exe`
+- Android APK（arm64）: `ExoMind-v<version>-<pre>-<hash>-android-arm64.apk`
+- Android APK（x86）: `ExoMind-v<version>-<pre>-<hash>-android-x86.apk`
+
+示例：
+
+- `ExoMind-v0.2.1-beta.1-dbce231-x64-setup.exe`
+- `ExoMind-v0.2.1-beta.1-dbce231-android-arm64.apk`
+
+### 4.5 应用内版本展示（In-App Version Display / 应用内展示）
+
+在“设置（Settings）/ 关于（About）”区域新增或补充两项：
+
+1. `App Version（应用版本）`：`0.2.1-beta.1`
+2. `Build Hash（构建哈希）`：`dbce231`
+
+建议数据来源：
+
+- `version`：Tauri API `getVersion()`（桌面）+ `VITE_APP_VERSION`（Web/回退）
+- `hash`：CI 注入 `VITE_BUILD_HASH`
+
+## 5. 实施边界（Scope / 范围）
+
+### 5.1 本 PR（方案评审 PR）包含
+
+- 仅文档化现状与方案，不改业务代码，不改 CI 逻辑。
+
+### 5.2 审批后实施 PR 包含
+
+1. 版本字段统一到 `0.2.1`
+2. release 标题文案由 `Preview` 改为 `Beta`
+3. 产物重命名逻辑
+4. 设置页版本/哈希展示
+5. 真实 CI 验证（build/release tag）
+
+## 6. 验收标准（Acceptance Criteria / 验收标准）
+
+审批后实施时满足以下标准：
+
+1. 三处代码版本一致为 `0.2.1`
+2. 使用 `release/v0.2.1-beta.1-data-<sha7>` 触发后，Release 被标记为 `prerelease = true`
+3. Release 标题为 `Beta ...`（不再使用 `Preview ...`）
+4. Windows 与 Android 发布产物文件名包含 `version + beta序号 + hash`
+5. 应用设置页可看到 `App Version` 与 `Build Hash`
+
+## 7. 风险与回滚（Risk & Rollback / 风险与回滚）
+
+### 7.1 风险
+
+- 产物重命名若处理不当，可能导致 release 上传路径不匹配。
+- 应用内版本展示若仅依赖 Tauri API，Web 模式可能缺字段。
+
+### 7.2 回滚
+
+- 任何一步失败可回滚到“保持现有产物命名，仅先统一版本与 beta 标题”
+- 保证主干构建不被阻断
+
+## 8. 待审批决策（Pending Decisions / 待你审批）
+
+请确认以下两点后进入实现：
+
+1. 是否采用 `release/v0.2.1-beta.<n>-data-<sha7>` 作为唯一预发布标签格式。
+2. 产物命名是否采用 `ExoMind-v<version>-<pre>-<hash>-<platform>` 的统一模板。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "exomind",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exomind"
-version = "0.2.0"
+version = "0.2.1"
 description = "ExoMind - A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ExoMind",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.exomind.app",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/Settings/SettingsPage.tsx
+++ b/src/components/Settings/SettingsPage.tsx
@@ -10,6 +10,7 @@ import {
   resolveSyncServerUrl,
   setSyncServerUrlOverride,
 } from '@/config/port-env';
+import { resolveVersionBuildInfo } from '@/config/version-build-info';
 import {
   getThemePreference,
   setThemePreference,
@@ -25,6 +26,7 @@ function buildBackupFileName(): string {
 
 export function SettingsPage() {
   const envMap = import.meta.env as Record<string, string | undefined>;
+  const versionBuildInfo = resolveVersionBuildInfo(envMap, '0.2.1');
   const autoSyncServerUrl = resolveSyncServerUrl(envMap, {
     syncServerOverride: null,
   });
@@ -168,6 +170,14 @@ export function SettingsPage() {
       <p className="text-muted-foreground">
         配置局域网同步地址与事件日志导入导出
       </p>
+      <div className="space-y-1 max-w-sm text-sm">
+        <p>
+          <span className="font-medium">App Version（应用版本）:</span> {versionBuildInfo.appVersion}
+        </p>
+        <p>
+          <span className="font-medium">Build Hash（构建哈希）:</span> {versionBuildInfo.buildHash}
+        </p>
+      </div>
 
       <div className="space-y-2 max-w-sm">
         <Label htmlFor="theme-preference">主题</Label>

--- a/src/config/version-build-info.ts
+++ b/src/config/version-build-info.ts
@@ -1,0 +1,32 @@
+export type VersionEnvMap = Record<string, string | undefined>;
+
+export type VersionBuildInfo = {
+  appVersion: string;
+  buildHash: string;
+};
+
+const SHORT_HASH_LENGTH = 7; // git short hash（短哈希）长度
+const BUILD_HASH_PATTERN = /^[0-9a-fA-F]{7,40}$/; // 允许 7~40 位十六进制哈希
+
+export function resolveAppVersion(envMap: VersionEnvMap, baseVersion: string): string {
+  const appVersion = envMap.VITE_APP_VERSION?.trim();
+  if (appVersion) {
+    return appVersion;
+  }
+  return baseVersion;
+}
+
+export function resolveBuildHash(rawHash?: string): string {
+  const normalizedHash = rawHash?.trim();
+  if (!normalizedHash || !BUILD_HASH_PATTERN.test(normalizedHash)) {
+    return 'dev'; // dev 表示本地开发态（development fallback）
+  }
+  return normalizedHash.toLowerCase().slice(0, SHORT_HASH_LENGTH);
+}
+
+export function resolveVersionBuildInfo(envMap: VersionEnvMap, baseVersion: string): VersionBuildInfo {
+  return {
+    appVersion: resolveAppVersion(envMap, baseVersion),
+    buildHash: resolveBuildHash(envMap.VITE_BUILD_HASH),
+  };
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,6 +4,11 @@
 declare module 'remark-obsidian';
 declare module 'rehype-katex';
 
+interface ImportMetaEnv {
+  readonly VITE_APP_VERSION?: string; // App Version（应用版本）
+  readonly VITE_BUILD_HASH?: string; // Build Hash（构建哈希）
+}
+
 interface Window {
   __TAURI__: {
     [key: string]: unknown;

--- a/tests/config/version-build-info.test.ts
+++ b/tests/config/version-build-info.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveAppVersion,
+  resolveBuildHash,
+  resolveVersionBuildInfo,
+} from '@/config/version-build-info';
+
+describe('version build info resolver', () => {
+  it('prefers VITE_APP_VERSION when present（优先使用 VITE_APP_VERSION）', () => {
+    const version = resolveAppVersion(
+      {
+        VITE_APP_VERSION: '0.2.1-beta.1',
+      },
+      '0.2.1'
+    );
+
+    expect(version).toBe('0.2.1-beta.1');
+  });
+
+  it('falls back to base version when app version env is missing（缺失时回退基础版本）', () => {
+    const version = resolveAppVersion({}, '0.2.1');
+
+    expect(version).toBe('0.2.1');
+  });
+
+  it('uses dev when build hash env is invalid（非法 hash 回退 dev）', () => {
+    expect(resolveBuildHash(undefined)).toBe('dev');
+    expect(resolveBuildHash('')).toBe('dev');
+    expect(resolveBuildHash('abc')).toBe('dev');
+  });
+
+  it('normalizes build hash to short lowercase（hash 归一化为小写短哈希）', () => {
+    expect(resolveBuildHash('DBCE231ABC')).toBe('dbce231');
+    expect(resolveBuildHash('dbce231')).toBe('dbce231');
+  });
+
+  it('resolves complete app version and build hash（组合解析版本与哈希）', () => {
+    const info = resolveVersionBuildInfo(
+      {
+        VITE_APP_VERSION: '0.2.1-beta.1',
+        VITE_BUILD_HASH: 'DBCE23189',
+      },
+      '0.2.1'
+    );
+
+    expect(info.appVersion).toBe('0.2.1-beta.1');
+    expect(info.buildHash).toBe('dbce231');
+  });
+});
+


### PR DESCRIPTION
﻿## 背景
当前版本治理存在“代码版本、发布标签、产物命名、应用展示”四处不一致的问题，导致发布识别与问题回溯成本偏高。

## 现状（Current State / 现状）
1. 代码版本仍为 `0.2.0`：
   - `package.json`
   - `src-tauri/tauri.conf.json`
   - `src-tauri/Cargo.toml`
2. 发布标签历史存在 `0.2.1-preview*` 以及带 `data/hash` 的命名。
3. Release 标题文案历史使用 `Preview ...`。
4. 产物命名未统一体现 `version + pre-release + hash`。
5. 应用内未统一展示 `App Version（应用版本）` 与 `Build Hash（构建哈希）`。

## 已确认方案（Approved Solution / 已确认）
1. 发布标签：`release/v0.2.1-beta.1`（不带 `data`，不带 `hash`）。
2. 三处代码版本统一到：`0.2.1`。
3. 应用显示：
   - `App Version = 0.2.1-beta.1`
   - `Build Hash = dbce231`（示例）
4. 产物文件名统一包含 `version + pre-release + hash`，并显式包含平台维度（`windows` / `android`）。

## 产物命名模板与样例（Artifact Naming / 命名样例）
命名模板：`ExoMind-v<version>-<pre>-<hash>-<platform>`

样例：
- `ExoMind-v0.2.1-beta.1-dbce231-windows-x64-setup.exe`
- `ExoMind-v0.2.1-beta.1-dbce231-windows-x64-installer.msi`
- `ExoMind-v0.2.1-beta.1-dbce231-android-arm64.apk`
- `ExoMind-v0.2.1-beta.1-dbce231-android-x86.apk`

说明：
- `<pre>` = pre-release identifier（预发布标识），如 `beta.1`
- `<hash>` = git short hash（提交短哈希），如 `dbce231`
- `windows` 前缀显式标注 OS（操作系统）维度，和 `android` 保持并列结构。

## 本 PR 范围（方案评审）
- 仅更新方案文档：`docs/plans/2026-02-19-semver-beta-versioning-proposal.md`
- 不做实现代码改动，不改 CI 行为。

## 审批后实施项（Implementation After Approval）
1. 版本字段统一到 `0.2.1`
2. release 标题由 `Preview` 改为 `Beta`
3. 产物重命名逻辑落地（含 Windows / Android）
4. 设置页版本与哈希展示落地
5. 真实 release workflow 验证并给出证据
