### PR TITLE
fix(tauri): 修复桌面端 tauri-wrapper 在缺少 cargo shim 时启动失败 (Vibe Kanban)

### DIFF
--- a/Scripts/dev/tauri-wrapper.ps1
+++ b/Scripts/dev/tauri-wrapper.ps1
@@ -4,6 +4,48 @@ $TauriArgs = @($args)
 
 $ErrorActionPreference = "Stop"
 
+function Ensure-CargoFromRustup {
+  # Guard: if cargo already available, keep existing behavior.
+  #（若 PATH 已有 cargo，保持原行为）
+  if (Get-Command cargo -ErrorAction SilentlyContinue) {
+    return
+  }
+
+  $rustupCommand = Get-Command rustup -ErrorAction SilentlyContinue
+  if (-not $rustupCommand) {
+    return
+  }
+
+  $cargoPath = ""
+  try {
+    $cargoPath = (& $rustupCommand.Source which cargo 2>$null | Select-Object -First 1)
+  } catch {
+    return
+  }
+
+  if ([string]::IsNullOrWhiteSpace($cargoPath)) {
+    return
+  }
+
+  $cargoPath = $cargoPath.Trim()
+  if (-not (Test-Path -LiteralPath $cargoPath)) {
+    return
+  }
+
+  $cargoBinDir = Split-Path -Parent $cargoPath
+  if ([string]::IsNullOrWhiteSpace($cargoBinDir)) {
+    return
+  }
+
+  $pathEntries = @($env:PATH -split ';')
+  if ($pathEntries -contains $cargoBinDir) {
+    return
+  }
+
+  $env:PATH = "$cargoBinDir;$env:PATH"
+  Write-Host "[tauri-wrapper] Added cargo path from rustup: $cargoBinDir"
+}
+
 function Ensure-AndroidManifestPermissions {
   param(
     [Parameter(Mandatory = $true)]
@@ -58,6 +100,10 @@ $manifestPath = [System.IO.Path]::GetFullPath($manifestPath)
 
 # Patch before command for existing Android project (已有工程先补权限)
 Ensure-AndroidManifestPermissions -ManifestPath $manifestPath
+
+# Ensure cargo is resolvable even when rustup shim is partial.
+#（兼容仅安装 rustup、但 PATH 缺少 cargo 代理的环境）
+Ensure-CargoFromRustup
 
 # Run tauri CLI (执行 tauri 命令)
 if ($TauriArgs -and $TauriArgs.Count -gt 0) {

--- a/tests/unit/scripts/tauri-wrapper.test.ts
+++ b/tests/unit/scripts/tauri-wrapper.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const POWERSHELL_PATH = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+
+const describeWindowsOnly = process.platform === 'win32' ? describe : describe.skip;
+
+describeWindowsOnly('tauri-wrapper', () => {
+  it('resolves cargo via rustup when cargo is missing in PATH（PATH 缺少 cargo 时可通过 rustup 补齐）', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'tauri-wrapper-test-'));
+    const fakeBinDir = join(tempDir, 'bin');
+    const fakeCargoDir = join(tempDir, 'cargo');
+    const fakeTauriCmd = join(fakeBinDir, 'tauri.cmd');
+    const fakeRustupCmd = join(fakeBinDir, 'rustup.cmd');
+    const fakeCargoCmd = join(fakeCargoDir, 'cargo.cmd');
+    const wrapperPath = join(process.cwd(), 'Scripts', 'dev', 'tauri-wrapper.ps1');
+
+    try {
+      spawnSync('cmd.exe', ['/c', 'mkdir', fakeBinDir], { stdio: 'ignore' });
+      spawnSync('cmd.exe', ['/c', 'mkdir', fakeCargoDir], { stdio: 'ignore' });
+
+      writeFileSync(
+        fakeTauriCmd,
+        [
+          '@echo off',
+          'cargo --version >nul 2>&1',
+          'if errorlevel 1 exit /b 99',
+          'exit /b 0',
+          '',
+        ].join('\r\n'),
+        'utf8',
+      );
+
+      writeFileSync(
+        fakeCargoCmd,
+        [
+          '@echo off',
+          'echo cargo 0.0.0-test',
+          'exit /b 0',
+          '',
+        ].join('\r\n'),
+        'utf8',
+      );
+
+      const cargoPathForCmd = fakeCargoCmd.replaceAll('/', '\\');
+      writeFileSync(
+        fakeRustupCmd,
+        [
+          '@echo off',
+          'if /I "%1"=="which" if /I "%2"=="cargo" (',
+          `  echo ${cargoPathForCmd}`,
+          '  exit /b 0',
+          ')',
+          'exit /b 1',
+          '',
+        ].join('\r\n'),
+        'utf8',
+      );
+
+      const result = spawnSync(
+        POWERSHELL_PATH,
+        ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', wrapperPath, 'info'],
+        {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PATH: fakeBinDir,
+          },
+        },
+      );
+
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## 背景
- 对应任务：issue #162「电脑端加了录音权限后启动失败」。
- 问题现象：`bun run tauri dev` 进入 `Scripts/dev/tauri-wrapper.ps1` 后，报错 `cargo metadata ... program not found`，导致桌面端启动失败。

## 本次改动
- 在 `Scripts/dev/tauri-wrapper.ps1` 新增 `Ensure-CargoFromRustup`（通过 rustup 兜底解析 cargo 路径）逻辑：
  - 先检查 `cargo` 是否已可用；
  - 若不可用，则调用 `rustup which cargo` 获取 cargo 绝对路径；
  - 校验路径存在后将其目录前置到当前进程 `PATH`；
  - 输出一条 wrapper 日志，便于定位环境问题。
- 在 wrapper 主流程中，执行 tauri 命令前调用该兜底逻辑，保证 `cargo metadata` 可执行。
- 新增单元测试 `tests/unit/scripts/tauri-wrapper.test.ts`：
  - 模拟 `PATH` 中缺少 `cargo` 但可通过 `rustup which cargo` 找到路径的场景；
  - 验证 wrapper 能成功恢复并继续执行（回归覆盖 issue #162 链路）。

## 为什么这样改
- 根因不是 Tauri 本身，而是部分 Windows 环境存在「仅有 rustup、缺少 cargo shim（代理）」的 PATH 状态。
- 录音权限改动引入 wrapper 后，启动链路稳定依赖 `cargo`；若不做兜底，用户会在本地直接遇到启动阻断。
- 该修复仅在 `cargo` 缺失时生效，属于最小侵入改动，不影响已有正常环境。

## 重要实现细节
- 兜底逻辑是“按需触发”：`cargo` 已可用时不会改写 PATH。
- 兜底逻辑只修改当前 wrapper 进程环境变量，不写系统级配置，避免副作用。
- 通过测试覆盖“缺 cargo shim”这一关键边界条件，防止后续回归。

This PR was written using [Vibe Kanban](https://vibekanban.com)