### PR TITLE
fix(ci): 修复 CI 中 tauri-wrapper 的 PowerShell 5.1 UTF8NoBOM 兼容问题

### DIFF
--- a/Scripts/dev/tauri-wrapper.ps1
+++ b/Scripts/dev/tauri-wrapper.ps1
@@ -4,6 +4,25 @@ $TauriArgs = @($args)
 
 $ErrorActionPreference = "Stop"
 
+function Write-TextUtf8NoBom {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [Parameter(Mandatory = $true)]
+    [string]$Content
+  )
+
+  # PowerShell 5.1 does not support UTF8NoBOM in Set-Content.
+  #（PowerShell 5.1 不支持 Set-Content 的 UTF8NoBOM）
+  if ($PSVersionTable.PSVersion.Major -ge 6) {
+    Set-Content -LiteralPath $Path -Value $Content -Encoding UTF8NoBOM
+    return
+  }
+
+  $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+  [System.IO.File]::WriteAllText($Path, $Content, $utf8NoBom)
+}
+
 function Ensure-CargoFromRustup {
   # Guard: if cargo already available, keep existing behavior.
   #（若 PATH 已有 cargo，保持原行为）
@@ -120,7 +139,7 @@ function Ensure-AndroidReleaseCleartextTraffic {
   )
 
   if ($updated -ne $content) {
-    Set-Content -LiteralPath $BuildGradlePath -Value $updated -Encoding UTF8NoBOM
+    Write-TextUtf8NoBom -Path $BuildGradlePath -Content $updated
     Write-Host "[tauri-wrapper] Enabled release cleartext traffic in Android build.gradle.kts"
   }
 }


### PR DESCRIPTION
## 变更内容\n- 在 Scripts/dev/tauri-wrapper.ps1 增加 Write-TextUtf8NoBom 辅助函数。\n- Ensure-AndroidReleaseCleartextTraffic 写回 uild.gradle.kts 时改为调用该函数。\n\n## 变更原因\n- elease/v0.2.1-beta.9 的 Build & Release 在 Init Android 步骤失败。\n- 失败原因为 Windows PowerShell 5.1 不支持 Set-Content -Encoding UTF8NoBOM，导致 tauri wrapper 在 CI 中报错退出。\n\n## 实现细节\n- PowerShell >= 6 仍使用 Set-Content -Encoding UTF8NoBOM。\n- PowerShell 5.1 回退为 .NET UTF8Encoding(False) + File.WriteAllText，保持 UTF-8 无 BOM 输出。\n- 本地已执行：\n  - un vitest run tests/unit/scripts/tauri-wrapper.test.ts\n  - PowerShell 脚本语法检查通过\n\nThis PR was written using [Vibe Kanban](https://vibekanban.com)