### PR TITLE
fix(android): 修复 Android release cleartext 注入脚本中的 Kotlin 注释语法

### DIFF
--- a/Scripts/dev/tauri-wrapper.ps1
+++ b/Scripts/dev/tauri-wrapper.ps1
@@ -134,7 +134,7 @@ function Ensure-AndroidReleaseCleartextTraffic {
   $updated = [regex]::Replace(
     $content,
     'getByName\("release"\)\s*\{',
-    "getByName(`"release`") {`r`n            # LAN debug first（局域网调试优先）: allow HTTP sync in release for now`r`n            $targetLine",
+    "getByName(`"release`") {`r`n            // LAN debug first（局域网调试优先）: allow HTTP sync in release for now`r`n            $targetLine",
     1
   )
 


### PR DESCRIPTION
## 变更内容\n- 将 Scripts/dev/tauri-wrapper.ps1 中注入到 uild.gradle.kts 的注释从 # 改为 //。\n\n## 变更原因\n- elease/v0.2.1-beta.10 在 Build Android APK only 失败。\n- 失败日志显示 uild.gradle.kts 第 40 行出现 Kotlin DSL 语法错误：# LAN ...。\n\n## 实现细节\n- 仅修复注释前缀，不改动 cleartext 注入逻辑和已有功能。\n- 本地已执行：un vitest run tests/unit/scripts/tauri-wrapper.test.ts。\n\nThis PR was written using [Vibe Kanban](https://vibekanban.com)