### PR TITLE
feat: 剪贴板粘贴功能 + dev 端口自动探测 (Vibe Kanban)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ bun install --cwd server --omit optional
 ### 3) 本地开发（Development / 开发）
 
 ```powershell
-# Web 前端（默认端口 1420）
+# Web 前端（默认尝试 1420，被占用时自动选择空闲端口）
 bun run dev
 
 # PouchDB 同步服务（默认 127.0.0.1:6984）
@@ -69,7 +69,7 @@ bun run server
 ```
 
 ```powershell
-# Tauri 桌面开发
+# Tauri 桌面开发（自动探测空闲端口，无需手动配置）
 bun run tauri dev
 
 # Tauri Android 开发
@@ -134,8 +134,8 @@ Copy-Item .env.example .env
 
 | 变量                     | 默认值        | 说明                        |
 | ------------------------ | ------------- | --------------------------- |
-| `EXOMIND_WEB_PORT`     | `1420`      | Web 开发端口                |
-| `EXOMIND_HMR_PORT`     | `1421`      | HMR 端口                    |
+| `EXOMIND_WEB_PORT`     | 自动探测 | Web 开发端口（默认尝试 1420，被占用自动切换） |
+| `EXOMIND_HMR_PORT`     | WEB+1   | HMR 端口                    |
 | `EXOMIND_POUCHDB_PORT` | `6984`      | 同步服务端口                |
 | `EXOMIND_POUCHDB_HOST` | `127.0.0.1` | 同步服务监听地址            |
 | `EXOMIND_ASR_PORT`     | `1949`      | ASR 服务端口                |
@@ -246,7 +246,7 @@ exomind/
 3. Android 构建失败
    先确认 `JAVA_HOME`、`ANDROID_SDK_ROOT` 与 `bun run tauri android init` 已完成。
 4. 多 worktree 端口冲突
-   为每个 worktree 设独立 `EXOMIND_WEB_PORT/EXOMIND_HMR_PORT/EXOMIND_POUCHDB_PORT/EXOMIND_ASR_PORT`。
+   dev 端口已支持自动探测空闲端口，通常无需手动配置。如需固定端口，可设置 `EXOMIND_WEB_PORT/EXOMIND_HMR_PORT/EXOMIND_POUCHDB_PORT/EXOMIND_ASR_PORT`。
 
 ## License
 

--- a/Scripts/dev/find-free-port.ts
+++ b/Scripts/dev/find-free-port.ts
@@ -1,0 +1,32 @@
+/**
+ * Find a free TCP port and print it to stdout.
+ * Usage: bun Scripts/dev/find-free-port.ts [preferredPort]
+ *
+ * If preferredPort is available, prints it. Otherwise finds a random free port.
+ */
+import { createServer } from "net";
+
+function findFreePort(preferred?: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "EADDRINUSE" && preferred) {
+        // preferred port is taken, find a random one
+        findFreePort().then(resolve, reject);
+      } else {
+        reject(err);
+      }
+    });
+    server.listen(preferred ?? 0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+const raw = process.argv[2] ? Number.parseInt(process.argv[2], 10) : undefined;
+const preferred = raw && raw > 0 && raw <= 65535 ? raw : undefined;
+const port = await findFreePort(preferred);
+process.stdout.write(String(port));

--- a/Scripts/dev/find-free-port.ts
+++ b/Scripts/dev/find-free-port.ts
@@ -3,6 +3,11 @@
  * Usage: bun Scripts/dev/find-free-port.ts [preferredPort]
  *
  * If preferredPort is available, prints it. Otherwise finds a random free port.
+ *
+ * NOTE: There is a small TOCTOU window between this script releasing the port
+ * and Vite binding to it. In the Tauri scenario, if another process claims the
+ * port in that window, the injected devUrl will be stale. This is extremely
+ * unlikely in local dev and mitigated by strictPort when EXOMIND_WEB_PORT is set.
  */
 import { createServer } from "net";
 

--- a/Scripts/dev/tauri-wrapper.ps1
+++ b/Scripts/dev/tauri-wrapper.ps1
@@ -209,6 +209,33 @@ function Ensure-AndroidLauncherIcons {
   }
 }
 
+# Resolve a free dev port for Vite when not explicitly configured.
+# (未显式配置端口时，自动寻找空闲端口)
+function Resolve-FreeDevPort {
+  if ($env:EXOMIND_WEB_PORT) {
+    return
+  }
+
+  $scriptPath = Join-Path $PSScriptRoot "find-free-port.ts"
+  if (-not (Test-Path -LiteralPath $scriptPath)) {
+    return
+  }
+
+  try {
+    $port = (& bun $scriptPath 1420 2>$null).Trim()
+    if ($port -and $port -match '^\d+$') {
+      $env:EXOMIND_WEB_PORT = $port
+      $hmr = [int]$port + 1
+      if ($hmr -le 65535) {
+        $env:EXOMIND_HMR_PORT = "$hmr"
+      }
+      Write-Host "[tauri-wrapper] Dev port resolved: $port (HMR: $hmr)"
+    }
+  } catch {
+    Write-Warning "[tauri-wrapper] Failed to resolve free port: $_"
+  }
+}
+
 $projectRoot = Join-Path $PSScriptRoot "..\..\"
 $projectRoot = [System.IO.Path]::GetFullPath($projectRoot)
 $manifestPath = Join-Path $PSScriptRoot "..\..\src-tauri\gen\android\app\src\main\AndroidManifest.xml"
@@ -224,6 +251,12 @@ Ensure-AndroidReleaseCleartextTraffic -BuildGradlePath $buildGradlePath
 #（兼容仅安装 rustup、但 PATH 缺少 cargo 代理的环境）
 Ensure-CargoFromRustup
 
+# Resolve free dev port for `tauri dev` (为 tauri dev 自动寻找空闲端口)
+$isTauriDev = $TauriArgs -and $TauriArgs.Count -ge 1 -and $TauriArgs[0] -eq "dev"
+if ($isTauriDev) {
+  Resolve-FreeDevPort
+}
+
 # Sync launcher icons before android build/dev/run/init (构建前同步 Android 图标)
 $androidCommandsNeedIconSync = @("build", "dev", "run", "init")
 if ($TauriArgs -and $TauriArgs.Count -ge 2 -and $TauriArgs[0] -eq "android" -and ($androidCommandsNeedIconSync -contains $TauriArgs[1])) {
@@ -232,7 +265,14 @@ if ($TauriArgs -and $TauriArgs.Count -ge 2 -and $TauriArgs[0] -eq "android" -and
 
 # Run tauri CLI (执行 tauri 命令)
 if ($TauriArgs -and $TauriArgs.Count -gt 0) {
-  & tauri @TauriArgs
+  # Inject --config to override devUrl when port differs from default
+  # (端口非默认值时，通过 --config 覆盖 devUrl)
+  if ($isTauriDev -and $env:EXOMIND_WEB_PORT -and $env:EXOMIND_WEB_PORT -ne "1420") {
+    $devUrlOverride = '{"build":{"devUrl":"http://localhost:' + $env:EXOMIND_WEB_PORT + '"}}'
+    & tauri @TauriArgs --config $devUrlOverride
+  } else {
+    & tauri @TauriArgs
+  }
 } else {
   & tauri
 }

--- a/dev.ps1
+++ b/dev.ps1
@@ -16,7 +16,25 @@ function Resolve-Port {
     return $Default
 }
 
-$webPort = Resolve-Port $env:EXOMIND_WEB_PORT 1420
+$webPort = Resolve-Port $env:EXOMIND_WEB_PORT 0
+# If no explicit port, find a free one (未指定端口时自动寻找空闲端口)
+if ($webPort -eq 0) {
+    $findPortScript = Join-Path $PSScriptRoot "Scripts\dev\find-free-port.ts"
+    if (Test-Path -LiteralPath $findPortScript) {
+        try {
+            $freePort = (& bun $findPortScript 1420 2>$null).Trim()
+            if ($freePort -match '^\d+$') {
+                $webPort = [int]$freePort
+            } else {
+                $webPort = 1420
+            }
+        } catch {
+            $webPort = 1420
+        }
+    } else {
+        $webPort = 1420
+    }
+}
 $hmrPort = Resolve-Port $env:EXOMIND_HMR_PORT (if ($webPort -lt 65535) { $webPort + 1 } else { 1421 })
 $pouchdbPort = Resolve-Port $env:EXOMIND_POUCHDB_PORT 6984
 $asrPort = Resolve-Port $env:EXOMIND_ASR_PORT 1949

--- a/src/ui/new/components/NewNowInputRow.tsx
+++ b/src/ui/new/components/NewNowInputRow.tsx
@@ -47,6 +47,30 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
     setValue('');
   }, [onSend, value]);
 
+  const handlePasteFromClipboard = useCallback(async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      if (!text) return;
+      setValue((prev) => {
+        const textarea = textareaRef.current;
+        if (textarea) {
+          const start = textarea.selectionStart;
+          const end = textarea.selectionEnd;
+          const next = prev.slice(0, start) + text + prev.slice(end);
+          // 延迟设置光标位置到粘贴文本之后
+          requestAnimationFrame(() => {
+            textarea.selectionStart = textarea.selectionEnd = start + text.length;
+            textarea.focus();
+          });
+          return next;
+        }
+        return prev + text;
+      });
+    } catch {
+      // 权限被拒绝或不支持，静默忽略
+    }
+  }, []);
+
   const handleKeyDown = useCallback((event: KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === 'Escape') {
       textareaRef.current?.blur();
@@ -96,7 +120,7 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
             />
             <button
               type="button"
-              onClick={() => textareaRef.current?.focus()}
+              onClick={handlePasteFromClipboard}
               className="absolute right-[7px] top-1/2 flex h-[30px] w-[30px] -translate-y-1/2 items-center justify-center rounded-[15px] text-stone-400"
               aria-label="剪贴板"
               data-testid="new-now-input-inline-button"

--- a/src/ui/new/components/NewNowInputRow.tsx
+++ b/src/ui/new/components/NewNowInputRow.tsx
@@ -66,8 +66,9 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
         }
         return prev + text;
       });
-    } catch {
-      // 权限被拒绝或不支持，静默忽略
+    } catch (err) {
+      // 权限被拒绝或不支持
+      console.warn('[clipboard] readText failed:', err);
     }
   }, []);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig(({ mode }) => {
     clearScreen: false,
     server: {
       port: devPorts.web,
-      strictPort: true,
+      strictPort: false,
       host: "0.0.0.0",
       hmr: {
         protocol: "ws",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig(({ mode }) => {
     clearScreen: false,
     server: {
       port: devPorts.web,
-      strictPort: false,
+      strictPort: Boolean(process.env.EXOMIND_WEB_PORT),
       host: "0.0.0.0",
       hmr: {
         protocol: "ws",


### PR DESCRIPTION
## 变更概述

本 PR 包含两个独立功能：剪贴板粘贴按钮的实际功能实现，以及 dev 开发服务器端口自动探测机制。

---

## 1. 剪贴板粘贴功能

### 变更内容

- `src/ui/new/components/NewNowInputRow.tsx`：为剪贴板图标按钮添加 `handlePasteFromClipboard` 处理函数

### 实现细节

- 调用 `navigator.clipboard.readText()` 读取系统剪贴板文本
- 将文本插入到 textarea 当前光标位置（而非简单追加到末尾）
- 粘贴后通过 `requestAnimationFrame` 将光标定位到插入文本之后
- 权限被拒绝或不支持时通过 `console.warn` 记录，不向用户抛出错误

---

## 2. Dev 端口自动探测

### 背景

多 worktree 并行开发时，固定端口 1420 会导致冲突，需要手动配置 `EXOMIND_WEB_PORT`。

### 变更内容

| 文件 | 变更 |
|------|------|
| `Scripts/dev/find-free-port.ts` | 新增：探测空闲 TCP 端口的工具脚本 |
| `vite.config.ts` | `strictPort` 改为仅在显式设置 `EXOMIND_WEB_PORT` 时为 `true` |
| `Scripts/dev/tauri-wrapper.ps1` | 新增 `Resolve-FreeDevPort`，`tauri dev` 前自动探测端口并通过 `--config` 覆盖 `devUrl` |
| `dev.ps1` | 未设置 `EXOMIND_WEB_PORT` 时自动调用 `find-free-port.ts` |
| `README.md` | 更新端口相关说明，反映自动探测行为 |

### 实现细节

- `find-free-port.ts`：优先尝试指定端口（默认 1420），被占用则绑定 `:0` 获取随机空闲端口
- Vite 场景：去掉 `strictPort: true`，端口被占用时自动 fallback
- Tauri 场景：`tauri-wrapper.ps1` 在启动前探测端口，通过 `tauri dev --config '{"build":{"devUrl":"http://localhost:PORT"}}'` 动态覆盖静态配置
- 手动设置 `EXOMIND_WEB_PORT` 时跳过自动探测，保持向后兼容
- 已添加 TOCTOU 风险注释（探测到绑定之间的极小时间窗口）

---

## 测试

- 所有 `tests/config/port-env.test.ts`（15 个测试）通过
- TypeScript 类型检查无错误
- `find-free-port.ts` 手动验证：端口空闲时返回首选端口，被占用时返回随机端口

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*