### PR TITLE
feat(v0.3.0): 新 UI 暗色模式适配

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,4 +96,14 @@ packages/mcp/events_*/
 events_*/
 
 # 配置文件不同步
-pencil/.claude/settings.local.jsonagent.test.local.state.json
+pencil/.claude/settings.local.json
+
+# Agent 本地状态
+agent.test.local.state.json
+
+# 临时截图和备份
+dark-mode-*.png
+*-backup.md
+
+# 测试输出
+vitest-output.txt

--- a/.gitignore
+++ b/.gitignore
@@ -96,4 +96,4 @@ packages/mcp/events_*/
 events_*/
 
 # 配置文件不同步
-pencil/.claude/settings.local.json
+pencil/.claude/settings.local.jsonagent.test.local.state.json

--- a/src/App.css
+++ b/src/App.css
@@ -14,7 +14,7 @@ html, body {
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  background: #f8fafc;
+  background: hsl(var(--background));
 }
 
 .app-container {
@@ -23,7 +23,7 @@ body {
   height: 100%;
   width: 100%;
   overflow: hidden;
-  background: #f8fafc;
+  background: hsl(var(--background));
 }
 
 /* 滚动条美化 */
@@ -43,4 +43,12 @@ body {
 
 ::-webkit-scrollbar-thumb:hover {
   background: rgba(0, 0, 0, 0.25);
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.25);
 }

--- a/src/components/Chat/DevicePanel.css
+++ b/src/components/Chat/DevicePanel.css
@@ -23,6 +23,10 @@
   color: #1e293b;
 }
 
+.dark .device-panel-header h2 {
+  color: #FAFAF9;
+}
+
 .device-section {
   padding-bottom: 0.5rem;
   flex-shrink: 0;
@@ -34,6 +38,10 @@
   color: #94a3b8;
   margin: 0 0 0.25rem 0;
   padding: 0 1rem;
+}
+
+.dark .device-section h3 {
+  color: #78716C;
 }
 
 .device-list {
@@ -57,8 +65,16 @@
   background-color: #f1f5f9;
 }
 
+.dark .device-item:hover {
+  background-color: #292524;
+}
+
 .device-item.selected {
   background-color: #e0f2fe;
+}
+
+.dark .device-item.selected {
+  background-color: #1C1917;
 }
 
 .device-icon {
@@ -71,6 +87,10 @@
   justify-content: center;
   background-color: #f1f5f9;
   border-radius: 50%;
+}
+
+.dark .device-icon {
+  background-color: #292524;
 }
 
 .device-info {
@@ -90,9 +110,17 @@
   text-overflow: ellipsis;
 }
 
+.dark .device-name {
+  color: #FAFAF9;
+}
+
 .device-ip {
   font-size: 0.75rem;
   color: #94a3b8;
+}
+
+.dark .device-ip {
+  color: #A8A29E;
 }
 
 .selected-indicator {
@@ -106,6 +134,10 @@
   color: #94a3b8;
   margin: 0;
   padding: 1rem;
+}
+
+.dark .empty-message {
+  color: #78716C;
 }
 
 /* ========== 移动端布局 (< 768px) ========== */

--- a/src/components/Chat/DevicePanel.css
+++ b/src/components/Chat/DevicePanel.css
@@ -20,11 +20,7 @@
   margin: 0;
   font-size: 1.25rem;
   font-weight: 600;
-  color: #1e293b;
-}
-
-.dark .device-panel-header h2 {
-  color: #FAFAF9;
+  color: hsl(var(--text-primary));
 }
 
 .device-section {
@@ -35,13 +31,9 @@
 .device-section h3 {
   font-size: 0.75rem;
   font-weight: 500;
-  color: #94a3b8;
+  color: hsl(var(--text-muted));
   margin: 0 0 0.25rem 0;
   padding: 0 1rem;
-}
-
-.dark .device-section h3 {
-  color: #78716C;
 }
 
 .device-list {
@@ -62,19 +54,11 @@
 }
 
 .device-item:hover {
-  background-color: #f1f5f9;
-}
-
-.dark .device-item:hover {
-  background-color: #292524;
+  background-color: hsl(var(--border-card));
 }
 
 .device-item.selected {
-  background-color: #e0f2fe;
-}
-
-.dark .device-item.selected {
-  background-color: #1C1917;
+  background-color: hsl(var(--bg-card));
 }
 
 .device-icon {
@@ -85,12 +69,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: #f1f5f9;
+  background-color: hsl(var(--border-card));
   border-radius: 50%;
-}
-
-.dark .device-icon {
-  background-color: #292524;
 }
 
 .device-info {
@@ -104,23 +84,15 @@
 .device-name {
   font-size: 0.9375rem;
   font-weight: 500;
-  color: #1e293b;
+  color: hsl(var(--text-primary));
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.dark .device-name {
-  color: #FAFAF9;
-}
-
 .device-ip {
   font-size: 0.75rem;
-  color: #94a3b8;
-}
-
-.dark .device-ip {
-  color: #A8A29E;
+  color: hsl(var(--text-muted));
 }
 
 .selected-indicator {
@@ -131,13 +103,9 @@
 
 .empty-message {
   font-size: 0.875rem;
-  color: #94a3b8;
+  color: hsl(var(--text-muted));
   margin: 0;
   padding: 1rem;
-}
-
-.dark .empty-message {
-  color: #78716C;
 }
 
 /* ========== 移动端布局 (< 768px) ========== */

--- a/src/components/Chat/MessageInput.tsx
+++ b/src/components/Chat/MessageInput.tsx
@@ -15,28 +15,14 @@ export function MessageInput({ onSend }: MessageInputProps) {
   };
 
   return (
-    <div style={{
-      display: 'flex',
-      padding: '16px',
-      borderTop: '1px solid hsl(var(--border-card, 0 0% 15%))',
-      backgroundColor: 'hsl(var(--background, 0 0% 4%))',
-    }}>
+    <div className="flex p-4 border-t border-border-card bg-background">
       <input
         type="text"
         placeholder="输入消息..."
         value={value}
         onChange={(e) => setValue(e.target.value)}
         onKeyDown={handleKeyDown}
-        style={{
-          flex: 1,
-          padding: '12px 16px',
-          borderRadius: '20px',
-          border: '1px solid hsl(var(--border-card, 0 0% 15%))',
-          outline: 'none',
-          fontSize: '14px',
-          backgroundColor: 'hsl(var(--bg-card, 0 0% 10%))',
-          color: 'hsl(var(--text-primary, 0 0% 100%))',
-        }}
+        className="flex-1 px-4 py-3 rounded-[20px] border border-border-card bg-card text-primary text-sm outline-none"
       />
     </div>
   );

--- a/src/components/Chat/MessageInput.tsx
+++ b/src/components/Chat/MessageInput.tsx
@@ -18,8 +18,8 @@ export function MessageInput({ onSend }: MessageInputProps) {
     <div style={{
       display: 'flex',
       padding: '16px',
-      borderTop: '1px solid #e5e5ea',
-      backgroundColor: '#fff',
+      borderTop: '1px solid hsl(var(--border-card, 0 0% 15%))',
+      backgroundColor: 'hsl(var(--background, 0 0% 4%))',
     }}>
       <input
         type="text"
@@ -31,9 +31,11 @@ export function MessageInput({ onSend }: MessageInputProps) {
           flex: 1,
           padding: '12px 16px',
           borderRadius: '20px',
-          border: '1px solid #e5e5ea',
+          border: '1px solid hsl(var(--border-card, 0 0% 15%))',
           outline: 'none',
           fontSize: '14px',
+          backgroundColor: 'hsl(var(--bg-card, 0 0% 10%))',
+          color: 'hsl(var(--text-primary, 0 0% 100%))',
         }}
       />
     </div>

--- a/src/components/Chat/MessageList.tsx
+++ b/src/components/Chat/MessageList.tsx
@@ -59,8 +59,8 @@ export function MessageList({
               marginLeft: isSent ? 'auto' : '8px',
               padding: '12px 16px',
               borderRadius: isSent ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-              backgroundColor: isSent ? '#007aff' : '#e5e5ea',
-              color: isSent ? '#fff' : '#000',
+              backgroundColor: isSent ? '#C75B3A' : 'hsl(var(--bg-card, 229 84% 5%))',
+              color: isSent ? '#fff' : 'hsl(var(--text-primary, 0 0% 100%))',
             }}
           >
             <div

--- a/src/components/Chat/MessageList.tsx
+++ b/src/components/Chat/MessageList.tsx
@@ -59,8 +59,8 @@ export function MessageList({
               marginLeft: isSent ? 'auto' : '8px',
               padding: '12px 16px',
               borderRadius: isSent ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
-              backgroundColor: isSent ? '#C75B3A' : 'hsl(var(--bg-card, 229 84% 5%))',
-              color: isSent ? '#fff' : 'hsl(var(--text-primary, 0 0% 100%))',
+              backgroundColor: isSent ? 'hsl(var(--brand-accent))' : 'hsl(var(--bg-card))',
+              color: isSent ? '#FAFAF9' : 'hsl(var(--text-primary))',
             }}
           >
             <div

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg dark:rounded-2xl dark:border-[#FFFFFF15] dark:bg-[rgba(28,25,23,0.85)] dark:shadow-[0_8px_32px_rgba(0,0,0,0.25)]",
         className
       )}
       {...props}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -10,7 +10,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-[#C75B3A] dark:data-[state=checked]:bg-[#C75B3A] data-[state=unchecked]:bg-[#E7E5E4] dark:data-[state=unchecked]:bg-[#FFFFFF1A]",
       className
     )}
     {...props}
@@ -18,7 +18,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+        "pointer-events-none block h-4 w-4 rounded-full bg-[#FAFAFA] dark:bg-[#0A0A0A] shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
       )}
     />
   </SwitchPrimitives.Root>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -10,7 +10,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-[#C75B3A] dark:data-[state=checked]:bg-[#C75B3A] data-[state=unchecked]:bg-[#E7E5E4] dark:data-[state=unchecked]:bg-[#FFFFFF1A]",
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-brand-accent data-[state=unchecked]:bg-[#E7E5E4] dark:data-[state=unchecked]:bg-white/10",
       className
     )}
     {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -43,6 +43,10 @@
     --border-subtle: 30 10% 91%;
     --brand-accent: 14 76% 66%;
     --brand-gradient: 14 76% 66%, 14 68% 53%, 14 64% 48%;
+
+    /* UserCard 渐变背景和阴影 */
+    --user-card-bg: radial-gradient(circle at 15% 0%, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 60%), linear-gradient(145deg, #E8866F 0%, #D4664A 50%, #C75B3A 100%);
+    --user-card-shadow: 0 8px 24px -4px rgba(199,91,58,0.19), 0 20px 40px -8px rgba(199,91,58,0.13), 0 3px 8px rgba(255,255,255,0.31);
   }
 
   .dark {
@@ -84,6 +88,10 @@
     --border-subtle: 20 5% 12%;      /* #211F1E Stone-850 approx */
     --brand-accent: 14 56% 50%;      /* #C75B3A */
     --brand-gradient: 14 56% 50%, 14 60% 42%, 14 65% 35%;
+
+    /* UserCard 渐变背景和阴影 - 暗色 */
+    --user-card-bg: radial-gradient(circle at 15% 0%, rgba(255,255,255,0.08) 0%, rgba(255,255,255,0) 50%), linear-gradient(145deg, #8B3A25 0%, #6B2E1E 50%, #4A1F14 100%);
+    --user-card-shadow: 0 8px 24px -4px rgba(199,91,58,0.12), 0 20px 40px -8px rgba(199,91,58,0.08);
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -73,17 +73,17 @@
     --warning: 38 92% 55%;
     --warning-foreground: 222.2 84% 4.9%;
 
-    /* 语义化颜色变量 - 深色模式 */
-    --text-primary: 270 31% 94%;
-    --text-strong: 270 30% 88%;
-    --text-secondary: 270 25% 68%;
-    --text-muted: 270 20% 55%;
-    --bg-card: 270 30% 18%;
-    --bg-surface: 270 25% 14%;
-    --border-card: 270 30% 25%;
-    --border-subtle: 270 25% 20%;
-    --brand-accent: 271 81% 76%;
-    --brand-gradient: 271 81% 76%, 271 75% 65%, 271 70% 55%;
+    /* 语义化颜色变量 - 深色模式 (Stone warm tone) */
+    --text-primary: 60 9% 98%;       /* #FAFAF9 Stone-50 */
+    --text-strong: 20 6% 90%;        /* #E7E5E4 Stone-200 */
+    --text-secondary: 24 5% 64%;     /* #A8A29E Stone-400 */
+    --text-muted: 25 5% 45%;         /* #78716C Stone-500 */
+    --bg-card: 24 10% 10%;           /* #1C1917 Stone-900 */
+    --bg-surface: 20 14% 4%;         /* #0C0A09 Stone-950 */
+    --border-card: 12 6% 15%;        /* #292524 Stone-800 */
+    --border-subtle: 20 5% 12%;      /* #211F1E Stone-850 approx */
+    --brand-accent: 14 56% 50%;      /* #C75B3A */
+    --brand-gradient: 14 56% 50%, 14 60% 42%, 14 65% 35%;
   }
 }
 

--- a/src/routes-new.tsx
+++ b/src/routes-new.tsx
@@ -16,13 +16,13 @@ function NewLayout() {
   ];
 
   return (
-    <div className="min-h-[100dvh] bg-[#ECE6E1] md:p-6">
-      <div className="relative mx-auto h-[100dvh] w-full max-w-[393px] overflow-hidden bg-[#FAF7F5] md:h-[852px] md:rounded-[40px] md:border md:border-[#E6DFD8] md:shadow-[0_24px_60px_-28px_rgba(0,0,0,0.35)]">
+    <div className="min-h-[100dvh] bg-[#ECE6E1] dark:bg-[#0C0A09] md:p-6">
+      <div className="relative mx-auto h-[100dvh] w-full max-w-[393px] overflow-hidden bg-[#FAF7F5] dark:bg-[#0C0A09] md:h-[852px] md:rounded-[40px] md:border md:border-[#E6DFD8] md:dark:border-[#292524] md:shadow-[0_24px_60px_-28px_rgba(0,0,0,0.35)]">
         <main className="absolute inset-x-0 top-0 bottom-[calc(env(safe-area-inset-bottom,0px)+60px)] overflow-y-auto">
           <Outlet />
         </main>
 
-        <nav className="absolute inset-x-0 bottom-0 z-40 border-t border-[#E4DED7] bg-[#FAF7F5]/95 backdrop-blur">
+        <nav className="absolute inset-x-0 bottom-0 z-40 border-t border-[#E4DED7] dark:border-[#292524] bg-[#FAF7F5]/95 dark:bg-[#0C0A09]/95 backdrop-blur">
           <div className="flex items-center justify-around px-6 pb-[calc(env(safe-area-inset-bottom,0px)+12px)] pt-2">
             {navItems.map((item) => {
               const Icon = item.icon;
@@ -33,7 +33,7 @@ function NewLayout() {
                   to={item.path}
                   className={cn(
                     'flex min-w-20 flex-col items-center gap-1 rounded-xl px-3 py-1 text-[11px] transition-colors',
-                    active ? 'text-[#C75B3A] font-semibold' : 'text-stone-400'
+                    active ? 'text-[#C75B3A] dark:text-[#E8734E] font-semibold' : 'text-stone-400 dark:text-[#57534E]'
                   )}
                 >
                   <Icon size={20} />

--- a/src/ui/new/components/NewFocusTimerWidget.tsx
+++ b/src/ui/new/components/NewFocusTimerWidget.tsx
@@ -394,7 +394,7 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
 
             <div
               id="new-focus-config-panel"
-              className={`relative flex w-full flex-col gap-3 rounded-[24px] border border-[#FFFFFF80] dark:border-[#FFFFFF15] bg-[linear-gradient(180deg,rgba(255,255,255,0.64)_0%,rgba(255,255,255,0.36)_100%)] dark:bg-[#1C1917] px-[18px] py-4 backdrop-blur-[24px] ${glassCardShadowClass()}`}
+              className={`relative flex w-full flex-col gap-3 rounded-[24px] border border-[#FFFFFF80] dark:border-[#FFFFFF15] bg-[linear-gradient(180deg,rgba(255,255,255,0.64)_0%,rgba(255,255,255,0.36)_100%)] dark:[background-color:rgba(28,25,23,0.5)] dark:bg-[linear-gradient(180deg,rgba(28,25,23,0.25)_0%,rgba(28,25,23,0)_100%)] px-[18px] py-4 backdrop-blur-[24px] ${glassCardShadowClass()}`}
             >
               <div className="flex items-center gap-[10px]">
                 <button
@@ -534,7 +534,7 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
             />
             <div
               data-testid="new-focus-running-task-card"
-              className={`absolute left-4 right-4 top-4 flex h-[169px] flex-col gap-3 rounded-[24px] border border-[#FFFFFF80] dark:border-[#FFFFFF15] bg-[linear-gradient(180deg,rgba(255,255,255,0.64)_0%,rgba(255,255,255,0.36)_100%)] dark:bg-[#1C1917] px-5 py-4 backdrop-blur-[24px] ${glassCardShadowClass()}`}
+              className={`absolute left-4 right-4 top-4 flex h-[169px] flex-col gap-3 rounded-[24px] border border-[#FFFFFF80] dark:border-[#FFFFFF15] bg-[linear-gradient(180deg,rgba(255,255,255,0.64)_0%,rgba(255,255,255,0.36)_100%)] dark:[background-color:rgba(28,25,23,0.5)] dark:bg-[linear-gradient(180deg,rgba(28,25,23,0.25)_0%,rgba(28,25,23,0)_100%)] px-5 py-4 backdrop-blur-[24px] ${glassCardShadowClass()}`}
             >
               <div className="flex min-w-0 items-center gap-3">
                 <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[#FEF0ED] dark:bg-[#2A1510] text-[#C75B3A] dark:text-[#E8734E]">

--- a/src/ui/new/components/NewFocusTimerWidget.tsx
+++ b/src/ui/new/components/NewFocusTimerWidget.tsx
@@ -573,7 +573,7 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
                   data-testid="new-focus-end-button"
                   aria-label="结束（End）"
                   onClick={handleOpenEndDialog}
-                  className="h-11 w-11 rounded-[12px] bg-[#FDECEB] dark:bg-[#2A1510] p-0 text-[#C75B3A] dark:text-[#E8734E] hover:bg-[#F8DED9] dark:hover:bg-[#3D1F15]"
+                  className="h-11 w-11 rounded-[12px] bg-[#FDECEB] dark:bg-[#C75B3A] p-0 text-[#C75B3A] dark:text-[#FAFAF9] hover:bg-[#F8DED9] dark:hover:bg-[#B24D2F]"
                 >
                   <Square size={18} />
                 </Button>

--- a/src/ui/new/components/NewFocusTimerWidget.tsx
+++ b/src/ui/new/components/NewFocusTimerWidget.tsx
@@ -595,7 +595,7 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
             value={feedback}
             onChange={(event) => setFeedback(event.target.value)}
             placeholder="记录本次专注的反馈..."
-            className="min-h-[96px] resize-none"
+            className="min-h-[96px] resize-none dark:bg-[rgba(255,255,255,0.06)] dark:border-[#FFFFFF15] dark:text-[#FAFAF9] dark:placeholder:text-[#78716C]"
           />
           <DialogFooter>
             <Button
@@ -604,6 +604,7 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
               onClick={() => {
                 void handleConfirmEnd();
               }}
+              className="dark:rounded-[10px] dark:bg-[#C75B3A] dark:text-white dark:hover:bg-[#B24D2F]"
             >
               确认结束
             </Button>

--- a/src/ui/new/components/NewFocusTimerWidget.tsx
+++ b/src/ui/new/components/NewFocusTimerWidget.tsx
@@ -515,7 +515,7 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
                 onClick={() => {
                   void handleStart();
                 }}
-                className="h-10 w-full rounded-[12px] bg-[#C75B3A] text-[14px] font-medium hover:bg-[#B24D2F] dark:bg-[#C75B3A] dark:hover:bg-[#B24D2F]"
+                className="h-10 w-full rounded-[12px] bg-[#C75B3A] text-[14px] font-medium text-white hover:bg-[#B24D2F] dark:bg-[#C75B3A] dark:hover:bg-[#B24D2F]"
               >
                 <Play size={16} className="mr-2" />
                 开始

--- a/src/ui/new/components/NewFocusTimerWidget.tsx
+++ b/src/ui/new/components/NewFocusTimerWidget.tsx
@@ -367,7 +367,7 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
               aria-expanded="false"
               aria-controls="new-focus-config-panel"
               aria-label="展开专注配置（Expand focus configuration）"
-              className={`absolute left-4 right-4 top-4 flex h-[68px] items-center justify-between rounded-[24px] border border-[#FFFFFF80] dark:border-[#FFFFFF15] bg-[linear-gradient(180deg,rgba(255,255,255,0.64)_0%,rgba(255,255,255,0.36)_100%)] dark:bg-[#1C1917] px-5 py-[18px] text-left backdrop-blur-[24px] ${glassCardShadowClass()}`}
+              className={`absolute left-4 right-4 top-4 flex h-[68px] items-center justify-between rounded-[24px] border border-[#FFFFFF80] dark:border-[#FFFFFF15] bg-[linear-gradient(180deg,rgba(255,255,255,0.64)_0%,rgba(255,255,255,0.36)_100%)] dark:[background-color:rgba(28,25,23,0.5)] dark:bg-[linear-gradient(180deg,rgba(28,25,23,0.25)_0%,rgba(28,25,23,0)_100%)] px-5 py-[18px] text-left backdrop-blur-[24px] ${glassCardShadowClass()}`}
             >
               <div className="mr-3 flex min-w-0 items-center gap-3">
                 <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[#FEF0ED] dark:bg-[#2A1510] text-[#C75B3A] dark:text-[#E8734E]">
@@ -378,7 +378,7 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
                   <p className="truncate text-[12px] leading-[1.4] text-[#78716C]">配置时间块、开始倒计时</p>
                 </div>
               </div>
-              <ChevronRight size={20} className="shrink-0 text-[#C75B3A]" />
+              <ChevronRight size={20} className="shrink-0 text-[#C75B3A] dark:text-[#E8734E]" />
             </button>
           </div>
         </section>

--- a/src/ui/new/components/NewFocusTimerWidget.tsx
+++ b/src/ui/new/components/NewFocusTimerWidget.tsx
@@ -39,10 +39,9 @@ export interface NewFocusTimerWidgetHandle {
 function formatClock(ms: number): string {
   const safe = Math.max(0, Math.floor(ms));
   const totalSeconds = Math.floor(safe / 1000);
-  const hours = Math.floor(totalSeconds / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
-  return `${hours}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+  return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
 }
 
 function glassCardShadowClass(): string {

--- a/src/ui/new/components/NewFocusTimerWidget.tsx
+++ b/src/ui/new/components/NewFocusTimerWidget.tsx
@@ -351,12 +351,12 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
   );
 
   return (
-    <div className="bg-[#FAF7F5]" data-testid="new-focus-timer-widget">
+    <div className="bg-[#FAF7F5] dark:bg-[#0C0A09]" data-testid="new-focus-timer-widget">
       {uiState === 'idle' && (
         <section className="safe-area-pt-plus">
           <div className="relative mx-auto h-[104px] w-full max-w-[390px]" data-testid="new-focus-state-idle">
             <div
-              className="absolute left-1/2 top-[18px] h-[74px] w-[calc(100%-40px)] max-w-[353px] -translate-x-1/2 rounded-[22px] bg-gradient-to-br from-[#EDADA0] via-[#E08E7A] to-[#D4785F] blur-[8px]"
+              className="absolute left-1/2 top-[18px] h-[74px] w-[calc(100%-40px)] max-w-[353px] -translate-x-1/2 rounded-[22px] bg-gradient-to-br from-[#EDADA0] via-[#E08E7A] to-[#D4785F] dark:from-[#8B3A25] dark:via-[#6B2E1E] dark:to-[#4A1F14] blur-[8px]"
               aria-hidden
             />
 
@@ -367,14 +367,14 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
               aria-expanded="false"
               aria-controls="new-focus-config-panel"
               aria-label="展开专注配置（Expand focus configuration）"
-              className={`absolute left-4 right-4 top-4 flex h-[68px] items-center justify-between rounded-[24px] border border-[#FFFFFF80] bg-[linear-gradient(180deg,rgba(255,255,255,0.64)_0%,rgba(255,255,255,0.36)_100%)] px-5 py-[18px] text-left backdrop-blur-[24px] ${glassCardShadowClass()}`}
+              className={`absolute left-4 right-4 top-4 flex h-[68px] items-center justify-between rounded-[24px] border border-[#FFFFFF80] dark:border-[#FFFFFF15] bg-[linear-gradient(180deg,rgba(255,255,255,0.64)_0%,rgba(255,255,255,0.36)_100%)] dark:bg-[#1C1917] px-5 py-[18px] text-left backdrop-blur-[24px] ${glassCardShadowClass()}`}
             >
               <div className="mr-3 flex min-w-0 items-center gap-3">
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[#FEF0ED] text-[#C75B3A]">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[#FEF0ED] dark:bg-[#2A1510] text-[#C75B3A] dark:text-[#E8734E]">
                   <Target size={20} />
                 </div>
                 <div className="min-w-0">
-                  <p className="truncate text-[16px] font-semibold leading-[1.4] text-[#1C1917]">点击设置专注任务</p>
+                  <p className="truncate text-[16px] font-semibold leading-[1.4] text-[#1C1917] dark:text-[#FAFAF9]">点击设置专注任务</p>
                   <p className="truncate text-[12px] leading-[1.4] text-[#78716C]">配置时间块、开始倒计时</p>
                 </div>
               </div>
@@ -388,13 +388,13 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
         <section className="safe-area-pt-plus">
           <div className="relative mx-auto w-full max-w-[390px] px-4 pb-3 pt-4" data-testid="new-focus-state-config">
             <div
-              className="absolute inset-x-4 bottom-[10px] top-[14px] rounded-[22px] bg-gradient-to-br from-[#EDADA0] via-[#E08E7A] to-[#D4785F] blur-[8px]"
+              className="absolute inset-x-4 bottom-[10px] top-[14px] rounded-[22px] bg-gradient-to-br from-[#EDADA0] via-[#E08E7A] to-[#D4785F] dark:from-[#8B3A25] dark:via-[#6B2E1E] dark:to-[#4A1F14] blur-[8px]"
               aria-hidden
             />
 
             <div
               id="new-focus-config-panel"
-              className={`relative flex w-full flex-col gap-3 rounded-[24px] border border-[#FFFFFF80] bg-[linear-gradient(180deg,rgba(255,255,255,0.64)_0%,rgba(255,255,255,0.36)_100%)] px-[18px] py-4 backdrop-blur-[24px] ${glassCardShadowClass()}`}
+              className={`relative flex w-full flex-col gap-3 rounded-[24px] border border-[#FFFFFF80] dark:border-[#FFFFFF15] bg-[linear-gradient(180deg,rgba(255,255,255,0.64)_0%,rgba(255,255,255,0.36)_100%)] dark:bg-[#1C1917] px-[18px] py-4 backdrop-blur-[24px] ${glassCardShadowClass()}`}
             >
               <div className="flex items-center gap-[10px]">
                 <button
@@ -404,7 +404,7 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
                   aria-controls="new-focus-config-panel"
                   aria-label="收起专注配置（Collapse focus configuration）"
                   onClick={handleCollapseToIdle}
-                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[#FEF0ED] text-[#C75B3A] transition-transform active:scale-95"
+                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[#FEF0ED] dark:bg-[#2A1510] text-[#C75B3A] dark:text-[#E8734E] transition-transform active:scale-95"
                 >
                   <Target size={20} />
                 </button>
@@ -414,20 +414,20 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
                   value={taskNameDraft}
                   onChange={(event) => setTaskNameDraft(event.target.value)}
                   placeholder="输入任务名称..."
-                  className="h-9 border-[#E7E5E4]/80 bg-white/60 text-sm"
+                  className="h-9 border-[#E7E5E4]/80 dark:border-[#FFFFFF20] bg-white/60 dark:bg-[#FFFFFF10] text-sm dark:text-[#FAFAF9]"
                 />
               </div>
 
-              <div className="h-px w-full bg-[#D4785F30]" />
+              <div className="h-px w-full bg-[#D4785F30] dark:bg-[#D4785F20]" />
 
               <div className="flex items-center justify-between">
-                <span className="text-[12px] font-medium text-[#57534E]">计时模式</span>
+                <span className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">计时模式</span>
                 <div className="flex items-center gap-1">
                   <button
                     type="button"
                     data-testid="new-focus-mode-countup"
                     onClick={() => setTimerMode('countup')}
-                    className={`rounded-[8px] px-[10px] py-[6px] text-[12px] ${timerMode === 'countup' ? 'bg-white/90 text-[#1C1917]' : 'bg-transparent text-[#A8A29E]'}`}
+                    className={`rounded-[8px] px-[10px] py-[6px] text-[12px] ${timerMode === 'countup' ? 'bg-white/90 dark:bg-[#FFFFFF20] text-[#1C1917] dark:text-[#FAFAF9]' : 'bg-transparent text-[#A8A29E]'}`}
                   >
                     正计时
                   </button>
@@ -435,7 +435,7 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
                     type="button"
                     data-testid="new-focus-mode-countdown"
                     onClick={() => setTimerMode('countdown')}
-                    className={`rounded-[8px] px-[10px] py-[6px] text-[12px] ${timerMode === 'countdown' ? 'bg-white/90 text-[#1C1917]' : 'bg-transparent text-[#A8A29E]'}`}
+                    className={`rounded-[8px] px-[10px] py-[6px] text-[12px] ${timerMode === 'countdown' ? 'bg-white/90 dark:bg-[#FFFFFF20] text-[#1C1917] dark:text-[#FAFAF9]' : 'bg-transparent text-[#A8A29E]'}`}
                   >
                     倒计时
                   </button>
@@ -444,7 +444,7 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
 
               {timerMode === 'countdown' && (
                 <div className="flex items-center justify-between">
-                  <span className="text-[12px] font-medium text-[#57534E]">倒计时时长</span>
+                  <span className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">倒计时时长</span>
                   <div className="flex items-center gap-[6px]">
                     <button
                       type="button"
@@ -452,7 +452,7 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
                       onClick={handleOpenCustomDurationEditor}
                       className={`flex items-center rounded-[8px] text-[12px] ${
                         isCustomDurationEditing || isCustomDurationSelected
-                          ? 'bg-white/90 font-semibold text-[#C75B3A]'
+                          ? 'bg-white/90 dark:bg-[#FFFFFF20] font-semibold text-[#C75B3A]'
                           : 'bg-transparent text-[#C75B3A]'
                       } ${
                         isCustomDurationEditing ? 'h-8 w-8 justify-center p-0' : 'gap-1 px-[8px] py-[6px]'
@@ -485,7 +485,7 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
                         }}
                         aria-label="自定义倒计时分钟（Custom countdown minutes）"
                         placeholder="分钟"
-                        className="h-8 w-[72px] border-[#FFFFFF60] bg-white/90 px-2 text-[12px] font-medium text-[#1C1917]"
+                        className="h-8 w-[72px] border-[#FFFFFF60] bg-white/90 dark:bg-[#FFFFFF20] px-2 text-[12px] font-medium text-[#1C1917] dark:text-[#FAFAF9]"
                       />
                     )}
 

--- a/src/ui/new/components/NewFocusTimerWidget.tsx
+++ b/src/ui/new/components/NewFocusTimerWidget.tsx
@@ -499,7 +499,7 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
                           setCountdownMinutes(minutes);
                         }}
                         className={`rounded-[8px] px-[10px] py-[6px] text-[12px] ${
-                          countdownMinutes === minutes ? 'border border-[#FFFFFF60] bg-white/90 font-semibold text-[#1C1917]' : 'bg-transparent text-[#78716C]'
+                          countdownMinutes === minutes ? 'border border-[#FFFFFF60] bg-white/90 dark:bg-[#FFFFFF20] font-semibold text-[#1C1917] dark:text-[#FAFAF9]' : 'bg-transparent text-[#78716C]'
                         }`}
                       >
                         {minutes}m
@@ -515,7 +515,7 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
                 onClick={() => {
                   void handleStart();
                 }}
-                className="h-10 w-full rounded-[12px] bg-[#C75B3A] text-[14px] font-medium hover:bg-[#B24D2F]"
+                className="h-10 w-full rounded-[12px] bg-[#C75B3A] text-[14px] font-medium hover:bg-[#B24D2F] dark:bg-[#C75B3A] dark:hover:bg-[#B24D2F]"
               >
                 <Play size={16} className="mr-2" />
                 开始
@@ -529,20 +529,20 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
         <section className="safe-area-pt-plus" data-testid="new-focus-state-running">
           <div className="relative mx-auto h-[200px] w-full max-w-[390px]">
             <div
-              className="absolute left-1/2 top-[20px] h-[163px] w-[calc(100%-40px)] max-w-[353px] -translate-x-1/2 rounded-[22px] bg-gradient-to-br from-[#EDADA0] via-[#E08E7A] to-[#D4785F] blur-[8px]"
+              className="absolute left-1/2 top-[20px] h-[163px] w-[calc(100%-40px)] max-w-[353px] -translate-x-1/2 rounded-[22px] bg-gradient-to-br from-[#EDADA0] via-[#E08E7A] to-[#D4785F] dark:from-[#8B3A25] dark:via-[#6B2E1E] dark:to-[#4A1F14] blur-[8px]"
               aria-hidden
             />
             <div
               data-testid="new-focus-running-task-card"
-              className={`absolute left-4 right-4 top-4 flex h-[169px] flex-col gap-3 rounded-[24px] border border-[#FFFFFF80] bg-[linear-gradient(180deg,rgba(255,255,255,0.64)_0%,rgba(255,255,255,0.36)_100%)] px-5 py-4 backdrop-blur-[24px] ${glassCardShadowClass()}`}
+              className={`absolute left-4 right-4 top-4 flex h-[169px] flex-col gap-3 rounded-[24px] border border-[#FFFFFF80] dark:border-[#FFFFFF15] bg-[linear-gradient(180deg,rgba(255,255,255,0.64)_0%,rgba(255,255,255,0.36)_100%)] dark:bg-[#1C1917] px-5 py-4 backdrop-blur-[24px] ${glassCardShadowClass()}`}
             >
               <div className="flex min-w-0 items-center gap-3">
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[#FEF0ED] text-[#C75B3A]">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[#FEF0ED] dark:bg-[#2A1510] text-[#C75B3A] dark:text-[#E8734E]">
                   <Target size={20} />
                 </div>
-                <p className="truncate text-[20px] font-semibold leading-[1.4] text-[#1C1917]">{taskName || '未命名任务'}</p>
+                <p className="truncate text-[20px] font-semibold leading-[1.4] text-[#1C1917] dark:text-[#FAFAF9]">{taskName || '未命名任务'}</p>
               </div>
-              <div className="h-px w-full bg-[#D4785F30]" />
+              <div className="h-px w-full bg-[#D4785F30] dark:bg-[#D4785F20]" />
               <div className="flex items-center justify-between px-1 pt-1">
                 <Button
                   type="button"
@@ -554,14 +554,14 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
                   className={
                     isPaused
                       ? 'h-11 w-11 rounded-[12px] bg-[#16A34A] p-0 text-white hover:bg-[#15803D]'
-                      : 'h-11 w-11 rounded-[12px] bg-[#EDECE9] p-0 text-[#1C1917] hover:bg-[#E5E3DF]'
+                      : 'h-11 w-11 rounded-[12px] bg-[#EDECE9] dark:bg-[#292524] p-0 text-[#1C1917] dark:text-[#FAFAF9] hover:bg-[#E5E3DF] dark:hover:bg-[#3D3835]'
                   }
                 >
                   {isPaused ? <Play size={18} /> : <Pause size={18} />}
                 </Button>
                 <span
                   className={`font-mono text-[40px] font-normal leading-[1.1] tracking-[2px] ${
-                    isCountdownWarning ? 'text-[#C75B3A]' : 'text-[#1C1917]'
+                    isCountdownWarning ? 'text-[#C75B3A]' : 'text-[#1C1917] dark:text-[#FAFAF9]'
                   }`}
                   data-testid="new-focus-running-clock"
                 >
@@ -574,7 +574,7 @@ export const NewFocusTimerWidget = forwardRef<NewFocusTimerWidgetHandle>(functio
                   data-testid="new-focus-end-button"
                   aria-label="结束（End）"
                   onClick={handleOpenEndDialog}
-                  className="h-11 w-11 rounded-[12px] bg-[#FDECEB] p-0 text-[#C75B3A] hover:bg-[#F8DED9]"
+                  className="h-11 w-11 rounded-[12px] bg-[#FDECEB] dark:bg-[#2A1510] p-0 text-[#C75B3A] dark:text-[#E8734E] hover:bg-[#F8DED9] dark:hover:bg-[#3D1F15]"
                 >
                   <Square size={18} />
                 </Button>

--- a/src/ui/new/components/NewNowInputRow.tsx
+++ b/src/ui/new/components/NewNowInputRow.tsx
@@ -93,12 +93,12 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
   }), []);
 
   return (
-    <div className="mb-2 shrink-0 border-t border-[#E7E5E4] bg-[#FAF7F5]" data-testid="new-now-input-row">
+    <div className="mb-2 shrink-0 border-t border-[#E7E5E4] bg-[#FAF7F5] dark:border-[#292524] dark:bg-[#0C0A09]" data-testid="new-now-input-row">
       <div className="px-4 py-2">
         <div className="flex items-center gap-2">
           <button
             type="button"
-            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#EDECE9] text-stone-500"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#EDECE9] text-stone-500 dark:bg-[#292524] dark:text-[#A8A29E]"
             aria-label="附件"
             data-testid="new-now-attachment-button"
           >
@@ -116,13 +116,13 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
               onKeyDown={handleKeyDown}
               placeholder={placeholder}
               rows={1}
-              className="min-h-[44px] rounded-3xl border-[#E7E5E4] bg-white px-4 py-2 pr-10 text-sm text-stone-700 placeholder:text-stone-400"
+              className="min-h-[44px] rounded-3xl border-[#E7E5E4] bg-white px-4 py-2 pr-10 text-sm text-stone-700 placeholder:text-stone-400 dark:border-[#292524] dark:bg-[#1C1917] dark:text-[#FAFAF9] dark:placeholder:text-[#57534E]"
               data-testid="new-now-input-textarea"
             />
             <button
               type="button"
               onClick={handlePasteFromClipboard}
-              className="absolute right-[7px] top-1/2 flex h-[30px] w-[30px] -translate-y-1/2 items-center justify-center rounded-[15px] text-stone-400"
+              className="absolute right-[7px] top-1/2 flex h-[30px] w-[30px] -translate-y-1/2 items-center justify-center rounded-[15px] text-stone-400 dark:text-[#78716C]"
               aria-label="剪贴板"
               data-testid="new-now-input-inline-button"
             >

--- a/src/ui/new/components/UserCard.tsx
+++ b/src/ui/new/components/UserCard.tsx
@@ -1,33 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Users, LogOut, LogIn, UserPlus } from 'lucide-react';
 import { useSyncStore } from '@/ui/stores/sync-store';
-import {
-  getThemePreference,
-  resolveThemePreference,
-  subscribeThemePreferenceChanges,
-  subscribeSystemThemeChanges,
-} from '@/config/theme';
 import { SwitchAccountSheet } from './SwitchAccountSheet';
 
 export function UserCard() {
   const { isLoggedIn, currentUser, logout } = useSyncStore();
   const [sheetOpen, setSheetOpen] = useState(false);
   const [sheetMode, setSheetMode] = useState<'switch' | 'login' | 'register'>('login');
-
-  const [isDark, setIsDark] = useState(() => {
-    const pref = getThemePreference();
-    return resolveThemePreference(pref) === 'dark';
-  });
-
-  useEffect(() => {
-    function update() {
-      const pref = getThemePreference();
-      setIsDark(resolveThemePreference(pref) === 'dark');
-    }
-    const unsub1 = subscribeThemePreferenceChanges(update);
-    const unsub2 = subscribeSystemThemeChanges(update);
-    return () => { unsub1(); unsub2(); };
-  }, []);
 
   function openSheet(mode: 'switch' | 'login' | 'register') {
     setSheetMode(mode);
@@ -40,21 +19,15 @@ export function UserCard() {
 
   return (
     <>
+      {/*
+        UserCard 使用 CSS 自定义属性实现暗色模式，而非 JS 条件判断。
+        复杂渐变和阴影无法用 Tailwind dark: 前缀表达，因此通过 CSS 变量在 index.css 中定义。
+      */}
       <div
-        className="relative overflow-hidden"
+        className="user-card relative overflow-hidden rounded-[20px] p-5 border border-white/[0.19] dark:border-white/[0.15] backdrop-blur-[20px]"
         style={{
-          borderRadius: 20,
-          padding: 20,
-          border: isDark
-            ? '1px solid rgba(255,255,255,0.15)'
-            : '1px solid rgba(255,255,255,0.19)',
-          background: isDark
-            ? 'radial-gradient(circle at 15% 0%, rgba(255,255,255,0.08) 0%, rgba(255,255,255,0) 50%), linear-gradient(145deg, #8B3A25 0%, #6B2E1E 50%, #4A1F14 100%)'
-            : 'radial-gradient(circle at 15% 0%, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 60%), linear-gradient(145deg, #E8866F 0%, #D4664A 50%, #C75B3A 100%)',
-          boxShadow: isDark
-            ? '0 8px 24px -4px rgba(199,91,58,0.12), 0 20px 40px -8px rgba(199,91,58,0.08)'
-            : '0 8px 24px -4px rgba(199,91,58,0.19), 0 20px 40px -8px rgba(199,91,58,0.13), 0 3px 8px rgba(255,255,255,0.31)',
-          backdropFilter: 'blur(20px)',
+          background: 'var(--user-card-bg)',
+          boxShadow: 'var(--user-card-shadow)',
         }}
       >
         {/* Profile Top */}

--- a/src/ui/new/components/UserCard.tsx
+++ b/src/ui/new/components/UserCard.tsx
@@ -1,12 +1,33 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Users, LogOut, LogIn, UserPlus } from 'lucide-react';
 import { useSyncStore } from '@/ui/stores/sync-store';
+import {
+  getThemePreference,
+  resolveThemePreference,
+  subscribeThemePreferenceChanges,
+  subscribeSystemThemeChanges,
+} from '@/config/theme';
 import { SwitchAccountSheet } from './SwitchAccountSheet';
 
 export function UserCard() {
   const { isLoggedIn, currentUser, logout } = useSyncStore();
   const [sheetOpen, setSheetOpen] = useState(false);
   const [sheetMode, setSheetMode] = useState<'switch' | 'login' | 'register'>('login');
+
+  const [isDark, setIsDark] = useState(() => {
+    const pref = getThemePreference();
+    return resolveThemePreference(pref) === 'dark';
+  });
+
+  useEffect(() => {
+    function update() {
+      const pref = getThemePreference();
+      setIsDark(resolveThemePreference(pref) === 'dark');
+    }
+    const unsub1 = subscribeThemePreferenceChanges(update);
+    const unsub2 = subscribeSystemThemeChanges(update);
+    return () => { unsub1(); unsub2(); };
+  }, []);
 
   function openSheet(mode: 'switch' | 'login' | 'register') {
     setSheetMode(mode);
@@ -24,11 +45,15 @@ export function UserCard() {
         style={{
           borderRadius: 20,
           padding: 20,
-          border: '1px solid rgba(255,255,255,0.19)',
-          background:
-            'radial-gradient(circle at 15% 0%, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 60%), linear-gradient(145deg, #E8866F 0%, #D4664A 50%, #C75B3A 100%)',
-          boxShadow:
-            '0 8px 24px -4px rgba(199,91,58,0.19), 0 20px 40px -8px rgba(199,91,58,0.13), 0 3px 8px rgba(255,255,255,0.31)',
+          border: isDark
+            ? '1px solid rgba(255,255,255,0.15)'
+            : '1px solid rgba(255,255,255,0.19)',
+          background: isDark
+            ? 'radial-gradient(circle at 15% 0%, rgba(255,255,255,0.08) 0%, rgba(255,255,255,0) 50%), linear-gradient(145deg, #8B3A25 0%, #6B2E1E 50%, #4A1F14 100%)'
+            : 'radial-gradient(circle at 15% 0%, rgba(255,255,255,0.25) 0%, rgba(255,255,255,0) 60%), linear-gradient(145deg, #E8866F 0%, #D4664A 50%, #C75B3A 100%)',
+          boxShadow: isDark
+            ? '0 8px 24px -4px rgba(199,91,58,0.12), 0 20px 40px -8px rgba(199,91,58,0.08)'
+            : '0 8px 24px -4px rgba(199,91,58,0.19), 0 20px 40px -8px rgba(199,91,58,0.13), 0 3px 8px rgba(255,255,255,0.31)',
           backdropFilter: 'blur(20px)',
         }}
       >

--- a/src/ui/new/pages/NewSettingsPage.tsx
+++ b/src/ui/new/pages/NewSettingsPage.tsx
@@ -86,11 +86,11 @@ function SettingRow({
     <Wrapper
       type={onClick ? 'button' : undefined}
       onClick={onClick}
-      className={`flex w-full items-center justify-between px-4 py-[14px] ${onClick ? 'active:bg-stone-50' : ''} ${className}`}
+      className={`flex w-full items-center justify-between px-4 py-[14px] ${onClick ? 'active:bg-stone-50 dark:active:bg-stone-800' : ''} ${className}`}
     >
       <div className="flex items-center gap-3">
         {icon}
-        <span className="text-sm text-[#1C1917]">{label}</span>
+        <span className="text-sm text-[#1C1917] dark:text-[#FAFAF9]">{label}</span>
       </div>
       {right}
     </Wrapper>
@@ -100,14 +100,14 @@ function SettingRow({
 function Divider() {
   return (
     <div className="px-4">
-      <div className="h-px bg-[#F0ECE8]" />
+      <div className="h-px bg-[#F0ECE8] dark:bg-[#292524]" />
     </div>
   );
 }
 
 function SectionCard({ children }: { children: React.ReactNode }) {
   return (
-    <div className="overflow-hidden rounded-2xl border border-[#F0ECE8] bg-white">
+    <div className="overflow-hidden rounded-2xl border border-[#F0ECE8] bg-white dark:border-[#292524] dark:bg-[#1C1917]">
       {children}
     </div>
   );
@@ -291,7 +291,7 @@ export function NewSettingsPage() {
   })();
 
   return (
-    <div className="min-h-full bg-[#FAF7F5]">
+    <div className="min-h-full bg-[#FAF7F5] dark:bg-[#0C0A09]">
       {/* Hidden file input for import */}
       <input
         ref={fileInputRef}
@@ -303,7 +303,7 @@ export function NewSettingsPage() {
 
       {/* Header */}
       <header className="flex items-center justify-center px-6 py-3">
-        <h1 className="text-lg font-semibold leading-[1.5] text-[#1C1917]">设置</h1>
+        <h1 className="text-lg font-semibold leading-[1.5] text-[#1C1917] dark:text-[#FAFAF9]">设置</h1>
       </header>
 
       {/* Settings Content */}
@@ -319,13 +319,13 @@ export function NewSettingsPage() {
             <div className="flex items-center justify-between px-4 py-[14px]">
               <div className="flex items-center gap-3">
                 <MoonStar className="h-[18px] w-[18px] text-[#78716C]" />
-                <span className="text-sm text-[#1C1917]">主题</span>
+                <span className="text-sm text-[#1C1917] dark:text-[#FAFAF9]">主题</span>
               </div>
               <div
                 id="theme-preference-new"
                 role="group"
                 aria-label="主题"
-                className="flex items-center rounded-[10px] bg-[#F5F0ED] p-[3px]"
+                className="flex items-center rounded-[10px] bg-[#F5F0ED] p-[3px] dark:bg-[#292524]"
               >
                 <button
                   type="button"
@@ -335,7 +335,7 @@ export function NewSettingsPage() {
                   disabled={loading}
                   className={`flex items-center gap-1 rounded-[8px] px-2.5 py-1.5 text-xs transition-colors disabled:cursor-not-allowed ${
                     themePreference === 'system'
-                      ? 'bg-white font-medium text-[#1C1917] shadow-[0_1px_3px_rgba(0,0,0,0.08)]'
+                      ? 'bg-white font-medium text-[#1C1917] shadow-[0_1px_3px_rgba(0,0,0,0.08)] dark:bg-[#44403C] dark:text-[#FAFAF9]'
                       : 'text-[#A8A29E]'
                   }`}
                 >
@@ -350,7 +350,7 @@ export function NewSettingsPage() {
                   disabled={loading}
                   className={`flex items-center gap-1 rounded-[8px] px-2.5 py-1.5 text-xs transition-colors disabled:cursor-not-allowed ${
                     themePreference === 'light'
-                      ? 'bg-white font-medium text-[#1C1917] shadow-[0_1px_3px_rgba(0,0,0,0.08)]'
+                      ? 'bg-white font-medium text-[#1C1917] shadow-[0_1px_3px_rgba(0,0,0,0.08)] dark:bg-[#44403C] dark:text-[#FAFAF9]'
                       : 'text-[#A8A29E]'
                   }`}
                 >
@@ -365,7 +365,7 @@ export function NewSettingsPage() {
                   disabled={loading}
                   className={`flex items-center gap-1 rounded-[8px] px-2.5 py-1.5 text-xs transition-colors disabled:cursor-not-allowed ${
                     themePreference === 'dark'
-                      ? 'bg-white font-medium text-[#1C1917] shadow-[0_1px_3px_rgba(0,0,0,0.08)]'
+                      ? 'bg-white font-medium text-[#1C1917] shadow-[0_1px_3px_rgba(0,0,0,0.08)] dark:bg-[#44403C] dark:text-[#FAFAF9]'
                       : 'text-[#A8A29E]'
                   }`}
                 >
@@ -388,7 +388,7 @@ export function NewSettingsPage() {
               right={
                 <div className="flex items-center gap-1">
                   <span className="text-sm text-[#A8A29E]">{countdownEndModeLabel}</span>
-                  <ChevronRight className="h-4 w-4 text-[#D6D3D1]" />
+                  <ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />
                 </div>
               }
             />
@@ -400,7 +400,7 @@ export function NewSettingsPage() {
               right={
                 <div className="flex items-center gap-1">
                   <span className="text-sm text-[#A8A29E]">{currentSoundLabel}</span>
-                  <ChevronRight className="h-4 w-4 text-[#D6D3D1]" />
+                  <ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />
                 </div>
               }
             />
@@ -418,7 +418,7 @@ export function NewSettingsPage() {
               right={
                 <div className="flex items-center gap-1">
                   <span className="text-sm text-[#A8A29E]">{syncHost}</span>
-                  <ChevronRight className="h-4 w-4 text-[#D6D3D1]" />
+                  <ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />
                 </div>
               }
             />
@@ -433,14 +433,14 @@ export function NewSettingsPage() {
               icon={<Download className="h-[18px] w-[18px] text-[#78716C]" />}
               label="导出备份"
               onClick={handleExportBackup}
-              right={<ChevronRight className="h-4 w-4 text-[#D6D3D1]" />}
+              right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
             />
             <Divider />
             <SettingRow
               icon={<Upload className="h-[18px] w-[18px] text-[#78716C]" />}
               label="导入数据"
               onClick={handleImportBackup}
-              right={<ChevronRight className="h-4 w-4 text-[#D6D3D1]" />}
+              right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
             />
           </SectionCard>
         </section>
@@ -469,42 +469,42 @@ export function NewSettingsPage() {
                   icon={<Undo2 className="h-[18px] w-[18px] text-[#78716C]" />}
                   label="返回旧 UI"
                   onClick={handleSwitchToOldUI}
-                  right={<ChevronRight className="h-4 w-4 text-[#D6D3D1]" />}
+                  right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
                 />
                 <Divider />
                 <SettingRow
                   icon={<Mic className="h-[18px] w-[18px] text-[#78716C]" />}
                   label="语音测试页面"
                   onClick={() => navigate({ to: '/asr-test' })}
-                  right={<ChevronRight className="h-4 w-4 text-[#D6D3D1]" />}
+                  right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
                 />
                 <Divider />
                 <SettingRow
                   icon={<Bot className="h-[18px] w-[18px] text-[#78716C]" />}
                   label="MOSS 调试"
                   onClick={() => navigate({ to: '/moss-test' })}
-                  right={<ChevronRight className="h-4 w-4 text-[#D6D3D1]" />}
+                  right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
                 />
                 <Divider />
                 <SettingRow
                   icon={<Speech className="h-[18px] w-[18px] text-[#78716C]" />}
                   label="ASR 语音识别"
                   onClick={() => navigate({ to: '/asr-test' })}
-                  right={<ChevronRight className="h-4 w-4 text-[#D6D3D1]" />}
+                  right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
                 />
                 <Divider />
                 <SettingRow
                   icon={<Users className="h-[18px] w-[18px] text-[#78716C]" />}
                   label="多用户管理"
                   onClick={() => navigate({ to: '/user-manage' })}
-                  right={<ChevronRight className="h-4 w-4 text-[#D6D3D1]" />}
+                  right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
                 />
                 <Divider />
                 <SettingRow
                   icon={<House className="h-[18px] w-[18px] text-[#78716C]" />}
                   label="旧首页"
                   onClick={() => { setUIMode('old'); window.location.pathname = '/'; }}
-                  right={<ChevronRight className="h-4 w-4 text-[#D6D3D1]" />}
+                  right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
                 />
               </>
             )}
@@ -530,7 +530,7 @@ export function NewSettingsPage() {
             <div className="px-4 pb-[14px] pt-[14px]">
               <div className="flex items-center gap-3">
                 <Heart className="h-[18px] w-[18px] text-[#78716C]" />
-                <span className="text-sm text-[#1C1917]">开发者</span>
+                <span className="text-sm text-[#1C1917] dark:text-[#FAFAF9]">开发者</span>
               </div>
               <p className="mt-1 pl-[30px] text-xs leading-[1.4] text-[#A8A29E]">
                 ExoMind — 个人生命成长助手，探索生命与认知的本质。
@@ -563,10 +563,10 @@ export function NewSettingsPage() {
             <button
               type="button"
               onClick={() => handleCountdownEndModeChange('hard')}
-              className="flex w-full items-center justify-between rounded-xl border border-[#F0ECE8] px-4 py-3 text-left text-sm hover:bg-[#FAF7F5]"
+              className="flex w-full items-center justify-between rounded-xl border border-[#F0ECE8] px-4 py-3 text-left text-sm hover:bg-[#FAF7F5] dark:border-[#292524] dark:hover:bg-[#1C1917]"
             >
               <div>
-                <div className="font-medium text-[#1C1917]">硬停止</div>
+                <div className="font-medium text-[#1C1917] dark:text-[#FAFAF9]">硬停止</div>
                 <div className="mt-0.5 text-xs text-[#A8A29E]">倒计时结束后立即停止</div>
               </div>
               {timerPreferences.countdownEndMode === 'hard' && <Check className="h-4 w-4 text-[#C75B3A]" />}
@@ -574,10 +574,10 @@ export function NewSettingsPage() {
             <button
               type="button"
               onClick={() => handleCountdownEndModeChange('soft')}
-              className="flex w-full items-center justify-between rounded-xl border border-[#F0ECE8] px-4 py-3 text-left text-sm hover:bg-[#FAF7F5]"
+              className="flex w-full items-center justify-between rounded-xl border border-[#F0ECE8] px-4 py-3 text-left text-sm hover:bg-[#FAF7F5] dark:border-[#292524] dark:hover:bg-[#1C1917]"
             >
               <div>
-                <div className="font-medium text-[#1C1917]">柔和提醒</div>
+                <div className="font-medium text-[#1C1917] dark:text-[#FAFAF9]">柔和提醒</div>
                 <div className="mt-0.5 text-xs text-[#A8A29E]">倒计时结束后继续计时并提醒</div>
               </div>
               {timerPreferences.countdownEndMode === 'soft' && <Check className="h-4 w-4 text-[#C75B3A]" />}
@@ -597,7 +597,7 @@ export function NewSettingsPage() {
             <button
               type="button"
               onClick={() => handleSoundPresetChange('off')}
-              className="flex w-full items-center justify-between rounded-xl border border-[#F0ECE8] px-4 py-3 text-left text-sm hover:bg-[#FAF7F5]"
+              className="flex w-full items-center justify-between rounded-xl border border-[#F0ECE8] px-4 py-3 text-left text-sm hover:bg-[#FAF7F5] dark:border-[#292524] dark:hover:bg-[#1C1917]"
             >
               <span className="text-[#1C1917]">关闭提示音</span>
               {!timerPreferences.countdownEndSoundEnabled && <Check className="h-4 w-4 text-[#C75B3A]" />}
@@ -611,7 +611,7 @@ export function NewSettingsPage() {
                   key={preset.id}
                   type="button"
                   onClick={() => handleSoundPresetChange(preset.id)}
-                  className="flex w-full items-center justify-between rounded-xl border border-[#F0ECE8] px-4 py-3 text-left text-sm hover:bg-[#FAF7F5]"
+                  className="flex w-full items-center justify-between rounded-xl border border-[#F0ECE8] px-4 py-3 text-left text-sm hover:bg-[#FAF7F5] dark:border-[#292524] dark:hover:bg-[#1C1917]"
                 >
                   <span className="text-[#1C1917]">{preset.label}</span>
                   {selected && <Check className="h-4 w-4 text-[#C75B3A]" />}
@@ -635,7 +635,7 @@ export function NewSettingsPage() {
               value={syncServerUrl}
               onChange={(e) => setSyncServerUrl(e.target.value)}
               placeholder="https://example.com"
-              className="w-full rounded-xl border border-[#F0ECE8] bg-white px-4 py-3 text-sm text-[#1C1917] outline-none placeholder:text-[#D6D3D1] focus:border-[#C75B3A] focus:ring-1 focus:ring-[#C75B3A]"
+              className="w-full rounded-xl border border-[#F0ECE8] bg-white px-4 py-3 text-sm text-[#1C1917] outline-none placeholder:text-[#D6D3D1] focus:border-[#C75B3A] focus:ring-1 focus:ring-[#C75B3A] dark:border-[#292524] dark:bg-[#1C1917] dark:text-[#FAFAF9] dark:placeholder:text-[#57534E]"
             />
             {errorMessage && (
               <p className="text-xs text-red-500">{errorMessage}</p>
@@ -644,7 +644,7 @@ export function NewSettingsPage() {
               <button
                 type="button"
                 onClick={() => setSyncDialogOpen(false)}
-                className="flex-1 rounded-xl border border-[#F0ECE8] px-4 py-2.5 text-sm font-medium text-[#78716C] hover:bg-[#FAF7F5]"
+                className="flex-1 rounded-xl border border-[#F0ECE8] px-4 py-2.5 text-sm font-medium text-[#78716C] hover:bg-[#FAF7F5] dark:border-[#292524] dark:text-[#A8A29E] dark:hover:bg-[#1C1917]"
               >
                 取消
               </button>

--- a/src/ui/new/pages/NewSettingsPage.tsx
+++ b/src/ui/new/pages/NewSettingsPage.tsx
@@ -599,7 +599,7 @@ export function NewSettingsPage() {
               onClick={() => handleSoundPresetChange('off')}
               className="flex w-full items-center justify-between rounded-xl border border-[#F0ECE8] px-4 py-3 text-left text-sm hover:bg-[#FAF7F5] dark:border-[#292524] dark:hover:bg-[#1C1917]"
             >
-              <span className="text-[#1C1917]">关闭提示音</span>
+              <span className="text-[#1C1917] dark:text-[#FAFAF9]">关闭提示音</span>
               {!timerPreferences.countdownEndSoundEnabled && <Check className="h-4 w-4 text-[#C75B3A]" />}
             </button>
 
@@ -613,7 +613,7 @@ export function NewSettingsPage() {
                   onClick={() => handleSoundPresetChange(preset.id)}
                   className="flex w-full items-center justify-between rounded-xl border border-[#F0ECE8] px-4 py-3 text-left text-sm hover:bg-[#FAF7F5] dark:border-[#292524] dark:hover:bg-[#1C1917]"
                 >
-                  <span className="text-[#1C1917]">{preset.label}</span>
+                  <span className="text-[#1C1917] dark:text-[#FAFAF9]">{preset.label}</span>
                   {selected && <Check className="h-4 w-4 text-[#C75B3A]" />}
                 </button>
               );

--- a/tests/unit/settings/new-settings-timer-card.issue182.test.tsx
+++ b/tests/unit/settings/new-settings-timer-card.issue182.test.tsx
@@ -28,6 +28,9 @@ vi.mock('@/config/port-env', () => ({
 vi.mock('@/config/theme', () => ({
   getThemePreference: () => 'system',
   setThemePreference: mocks.setThemePreference,
+  resolveThemePreference: (pref: string) => pref === 'system' ? 'light' : pref,
+  subscribeThemePreferenceChanges: () => () => {},
+  subscribeSystemThemeChanges: () => () => {},
 }));
 
 vi.mock('@/config/developer-mode', () => ({

--- a/tests/unit/settings/ui-transition.test.tsx
+++ b/tests/unit/settings/ui-transition.test.tsx
@@ -1,5 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
+
+vi.mock('@/config/theme', () => ({
+  getThemePreference: () => 'system',
+  setThemePreference: vi.fn(),
+  resolveThemePreference: (pref: string) => pref === 'system' ? 'light' : pref,
+  subscribeThemePreferenceChanges: () => () => {},
+  subscribeSystemThemeChanges: () => () => {},
+}));
+
 import { SettingsPage } from '@/components/Settings/SettingsPage';
 import { NewSettingsPage } from '@/ui/new/pages/NewSettingsPage';
 

--- a/tests/unit/ui/dark-mode-variables.test.ts
+++ b/tests/unit/ui/dark-mode-variables.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { applyThemePreference } from '@/config/theme';
+
+describe('dark mode CSS variables', () => {
+  beforeEach(() => {
+    document.documentElement.classList.remove('dark');
+    document.documentElement.style.cssText = '';
+  });
+
+  afterEach(() => {
+    document.documentElement.classList.remove('dark');
+    document.documentElement.style.cssText = '';
+  });
+
+  it('applies dark class to html element', () => {
+    const resolved = applyThemePreference('dark');
+    expect(resolved).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('semantic variables use Stone palette hue in dark mode (not purple 270)', () => {
+    const cssPath = path.resolve('src/index.css');
+    const content = fs.readFileSync(cssPath, 'utf-8');
+
+    // Extract the .dark block
+    const darkBlockMatch = content.match(/\.dark\s*\{([\s\S]*?)\}/);
+    expect(darkBlockMatch).not.toBeNull();
+    const darkBlock = darkBlockMatch![1];
+
+    // Verify NO semantic variable uses purple hue 270
+    const semanticVars = [
+      '--text-primary',
+      '--text-strong',
+      '--text-secondary',
+      '--text-muted',
+      '--bg-card',
+      '--bg-surface',
+      '--border-card',
+      '--border-subtle',
+      '--brand-accent',
+    ];
+
+    for (const varName of semanticVars) {
+      const varMatch = darkBlock.match(new RegExp(`${varName.replace('-', '\\-')}:\\s*([^;]+);`));
+      if (varMatch) {
+        const value = varMatch[1].trim();
+        // Must NOT start with 270 or 271 (purple hue)
+        expect(value).not.toMatch(/^27[01]\s/);
+      }
+    }
+
+    // Verify Stone palette hues are used (hues in range 0-60, warm tones)
+    const textPrimaryMatch = darkBlock.match(/--text-primary:\s*(\d+)/);
+    expect(textPrimaryMatch).not.toBeNull();
+    const textPrimaryHue = parseInt(textPrimaryMatch![1]);
+    expect(textPrimaryHue).toBeLessThanOrEqual(60);
+
+    const bgCardMatch = darkBlock.match(/--bg-card:\s*(\d+)/);
+    expect(bgCardMatch).not.toBeNull();
+    const bgCardHue = parseInt(bgCardMatch![1]);
+    expect(bgCardHue).toBeLessThanOrEqual(30);
+
+    const brandAccentMatch = darkBlock.match(/--brand-accent:\s*(\d+)/);
+    expect(brandAccentMatch).not.toBeNull();
+    const brandAccentHue = parseInt(brandAccentMatch![1]);
+    expect(brandAccentHue).toBeLessThanOrEqual(20);
+  });
+});

--- a/tests/unit/ui/new-dark-mode-palette.issue179.test.ts
+++ b/tests/unit/ui/new-dark-mode-palette.issue179.test.ts
@@ -1,0 +1,26 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('new ui dark mode palette issue-179（新UI暗色配色）', () => {
+  const newLayoutSource = readFileSync(path.resolve('src/routes-new.tsx'), 'utf-8');
+  const focusWidgetSource = readFileSync(path.resolve('src/ui/new/components/NewFocusTimerWidget.tsx'), 'utf-8');
+  const switchSource = readFileSync(path.resolve('src/components/ui/switch.tsx'), 'utf-8');
+
+  it('applies dark nav shell tokens on NewLayout（NewLayout 应有暗色外壳与底栏）', () => {
+    expect(newLayoutSource).toContain('dark:bg-[#0C0A09]');
+    expect(newLayoutSource).toContain('dark:border-[#292524]');
+    expect(newLayoutSource).toContain('dark:bg-[#0C0A09]/95');
+  });
+
+  it('applies pencil dark glass tokens on idle focus card（Idle 卡片应匹配 Pencil 暗色玻璃层）', () => {
+    expect(focusWidgetSource).toContain('dark:[background-color:rgba(28,25,23,0.5)]');
+    expect(focusWidgetSource).toContain('dark:bg-[linear-gradient(180deg,rgba(28,25,23,0.25)_0%,rgba(28,25,23,0)_100%)]');
+  });
+
+  it('applies dark switch tokens from settings pencil（Switch 应匹配设置页暗色令牌）', () => {
+    expect(switchSource).toContain('data-[state=checked]:bg-[#C75B3A]');
+    expect(switchSource).toContain('dark:data-[state=unchecked]:bg-[#FFFFFF1A]');
+    expect(switchSource).toContain('dark:bg-[#0A0A0A]');
+  });
+});

--- a/tests/unit/ui/new-dark-mode-palette.issue179.test.ts
+++ b/tests/unit/ui/new-dark-mode-palette.issue179.test.ts
@@ -19,8 +19,8 @@ describe('new ui dark mode palette issue-179（新UI暗色配色）', () => {
   });
 
   it('applies dark switch tokens from settings pencil（Switch 应匹配设置页暗色令牌）', () => {
-    expect(switchSource).toContain('data-[state=checked]:bg-[#C75B3A]');
-    expect(switchSource).toContain('dark:data-[state=unchecked]:bg-[#FFFFFF1A]');
+    expect(switchSource).toContain('data-[state=checked]:bg-brand-accent');
+    expect(switchSource).toContain('dark:data-[state=unchecked]:bg-white/10');
     expect(switchSource).toContain('dark:bg-[#0A0A0A]');
   });
 });

--- a/tests/unit/ui/new-now-chat-container.issue175.test.ts
+++ b/tests/unit/ui/new-now-chat-container.issue175.test.ts
@@ -7,7 +7,7 @@ describe('new now chat container issue-175 structure', () => {
   const source = readFileSync(chatPagePath, 'utf-8');
 
   it('uses flat full-width container for new-mobile variant instead of rounded card shell', () => {
-    expect(source).toContain('flex h-full min-h-0 flex-col bg-[#FAF7F5]');
+    expect(source).toContain('flex h-full min-h-0 flex-col bg-surface');
     expect(source).not.toContain('rounded-[24px] border border-[#F0ECE8] bg-[#FAF7F5]');
   });
 });

--- a/tests/unit/ui/new-now-input-row.issue175-pencil-align.test.ts
+++ b/tests/unit/ui/new-now-input-row.issue175-pencil-align.test.ts
@@ -12,7 +12,7 @@ describe('NewNowInputRow issue-175 pencil align', () => {
   });
 
   it('does not apply safe-area bottom padding on row wrapper', () => {
-    expect(source).toContain('className="mb-2 shrink-0 border-t border-[#E7E5E4] bg-[#FAF7F5]"');
+    expect(source).toContain('mb-2 shrink-0 border-t border-[#E7E5E4] bg-[#FAF7F5]');
     expect(source).not.toContain('safe-area-pb shrink-0');
   });
 });


### PR DESCRIPTION
## feat(v0.3.0): 新 UI 暗色模式适配

Closes #179

### 目标
完成新 UI 暗色模式适配，保证可读性、层级、对比度与主题一致性。

### 设计参考
基于 Pencil 设计稿中的 Dark Mode 页面：
- Focus Timer Screen - Dark Mode
- Event Log - Dark Mode
- Focus Start Dialog - Dark Mode
- Settings Screen - Dark Mode

### 实现方案
- 统一使用 CSS 变量 + Tailwind 语义化 token
- 将硬编码颜色替换为 dark-aware 的 CSS 变量
- 暗色色板采用 Stone 暖色调（与设计稿一致）

### 颜色体系（Stone Dark Palette）
| Token | 暗色值 | 用途 |
|-------|--------|------|
| background | `#0C0A09` | 页面背景 |
| card | `#1C1917` | 卡片背景 |
| border | `#292524` | 边框 |
| text-primary | `#FAFAF9` | 主文字 |
| text-secondary | `#A8A29E` | 次要文字 |
| text-muted | `#78716C` | 弱化文字 |
| brand-accent | `#C75B3A` | 品牌强调色 |

### 涉及文件
- `src/index.css` - 暗色 CSS 变量修正
- `src/App.css` - 硬编码颜色修复
- `src/ui/new/components/NewNowInputRow.tsx`
- `src/ui/new/components/NewFocusTimerWidget.tsx`
- `src/ui/new/components/UserCard.tsx`
- `src/ui/new/pages/NewSettingsPage.tsx`
- `src/components/Chat/ChatPage.tsx`
- `src/components/Chat/DevicePanel.css`
- `src/components/Chat/MessageList.tsx`
- `src/components/Chat/MessageInput.tsx`

### 验收标准
- [ ] 无文字对比不足（可读性通过）
- [ ] 交互状态（hover/active/disabled）在暗色下可识别
- [ ] 设置切换后无闪烁、无主题错乱
- [ ] 构建和相关测试通过
