### PR TITLE
feat(agent-hub): 前端 UI 设计 + 实现 — 全视图 (GH#204)

### DIFF
--- a/docs/plans/2026-02-23-issue-204-agent-hub-implementation-plan.md
+++ b/docs/plans/2026-02-23-issue-204-agent-hub-implementation-plan.md
@@ -1,0 +1,304 @@
+# GH#204 Agent Hub 全视图实现计划（Implementation Plan）
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 基于 `pencil/eventlog-ui-design.pen` 像素级还原 Agent Hub 全视图（拓扑/列表/设备、Agent/Actor 详情、对话流式输出、市场浏览、添加节点弹窗），并完成 mock/real adapter 零上层改动切换。
+
+**Architecture:** 新增 Agent Hub 领域契约（port + types + service），由 `bootstrap.ts` 注入 mock 或 real adapter；页面统一通过 service 取数与交互，不在 UI 写环境分支判断。路由层扩展 `/agents/*` 子路由，保持现有 `New UI` 布局与底部导航模式。
+
+**Tech Stack:** React 18 + TypeScript + TanStack Router + Zustand（若需要）+ Vitest + Playwright + Bun。
+
+---
+
+## 设计稿锚点（Pencil Node IDs）
+
+- `LxbUp`: Agent Hub - 拓扑视图
+- `pVisN`: Agent Hub - 拓扑视图（节点选中态）
+- `Kn7SD`: Agent Hub - 列表视图
+- `hjRST`: Agent Hub - 设备视图
+- `BUKXz`: Agent Hub - 添加节点（含市场）
+- `bSWUQ`: Agent 详情 - 日报Agent
+- `ockaZ`: Actor 详情 - 定时唤醒
+- `Rw8LA`: Agent 对话 - 日报Agent
+- `KWsUv`: 市场 - 浏览
+
+## 任务 1：建立 Agent Hub 领域契约（types + port）
+
+**Files:**
+- Create: `src/lib/types/agent-hub.ts`
+- Modify: `src/lib/types/index.ts`
+- Create: `src/lib/environment/interfaces/agent.port.ts`
+- Test: `tests/unit/agent-hub/agent-types-contract.issue204.test.ts`
+
+**Step 1: 写失败测试（RED）**
+- 新增契约测试，先引用未实现的 `agent-hub` 类型/port，验证字段覆盖三视图 + 详情 + 市场 + 对话。
+
+**Step 2: 运行测试确认失败**
+- Run: `bun vitest tests/unit/agent-hub/agent-types-contract.issue204.test.ts`
+- Expected: FAIL（模块不存在/导出缺失）
+
+**Step 3: 最小实现（GREEN）**
+- 实现最小可用类型：`AgentNode / ActorNode / DeviceViewModel / MarketItem / ChatMessageChunk` 等。
+- 实现 `IAgentPort`（或等价命名）接口声明。
+
+**Step 4: 运行测试确认通过**
+- Run: `bun vitest tests/unit/agent-hub/agent-types-contract.issue204.test.ts`
+- Expected: PASS
+
+**Step 5: Commit**
+- `git add src/lib/types/agent-hub.ts src/lib/types/index.ts src/lib/environment/interfaces/agent.port.ts tests/unit/agent-hub/agent-types-contract.issue204.test.ts`
+- `git commit -m "feat(agent-hub): add domain types and port contract for issue-204"`
+
+## 任务 2：实现 mock fixture + mock adapter + web adapter
+
+**Files:**
+- Create: `src/lib/adapters/mock/fixtures/agent-hub.ts`
+- Create: `src/lib/adapters/mock/agent-mock-adapter.ts`
+- Create: `src/lib/adapters/agent-web-adapter.ts`
+- Test: `tests/unit/adapters/agent-mock-adapter.issue204.test.ts`
+- Test: `tests/unit/adapters/agent-web-adapter.issue204.test.ts`
+
+**Step 1: 写失败测试（RED）**
+- 为 mock adapter 写读取拓扑/列表/设备、详情、市场、对话流式输出行为测试。
+- 为 web adapter 写本地存储读取回退测试。
+
+**Step 2: 运行测试确认失败**
+- Run: `bun vitest tests/unit/adapters/agent-mock-adapter.issue204.test.ts tests/unit/adapters/agent-web-adapter.issue204.test.ts`
+- Expected: FAIL
+
+**Step 3: 最小实现（GREEN）**
+- 按 Pencil 文案与结构落地 fixture。
+- mock adapter 返回深拷贝数据，支持流式 chunk 生成。
+- web adapter 提供真实数据占位（默认空/最小 seed）。
+
+**Step 4: 运行测试确认通过**
+- 同上命令，Expected: PASS
+
+**Step 5: Commit**
+- `git add src/lib/adapters/mock/fixtures/agent-hub.ts src/lib/adapters/mock/agent-mock-adapter.ts src/lib/adapters/agent-web-adapter.ts tests/unit/adapters/agent-mock-adapter.issue204.test.ts tests/unit/adapters/agent-web-adapter.issue204.test.ts`
+- `git commit -m "feat(agent-hub): add mock and web adapters with fixtures for issue-204"`
+
+## 任务 3：bootstrap/environment 注入 agent adapter（mock/real）
+
+**Files:**
+- Modify: `src/lib/environment/bootstrap.ts`
+- Modify: `src/lib/environment/environment.ts`
+- Test: `tests/unit/environment/bootstrap.test.ts`
+
+**Step 1: 写失败测试（RED）**
+- 在 bootstrap 测试先断言 `useMockData=true` 时注入 `AgentMockAdapter`，否则注入 `AgentWebAdapter`。
+
+**Step 2: 运行测试确认失败**
+- Run: `bun vitest tests/unit/environment/bootstrap.test.ts`
+- Expected: FAIL（agent adapter 未注入）
+
+**Step 3: 最小实现（GREEN）**
+- 扩展 `RuntimeBootstrapResult` + `Environment` 暴露 `agent` 能力。
+- 无上层页面分支改动（zero upper-level branching）。
+
+**Step 4: 运行测试确认通过**
+- 同上命令，Expected: PASS
+
+**Step 5: Commit**
+- `git add src/lib/environment/bootstrap.ts src/lib/environment/environment.ts tests/unit/environment/bootstrap.test.ts`
+- `git commit -m "feat(agent-hub): wire agent adapter in bootstrap and environment"`
+
+## 任务 4：Service 层统一（避免页面直接碰 adapter）
+
+**Files:**
+- Create: `src/lib/services/agent-hub.service.ts`
+- Modify: `src/lib/services/index.ts`
+- Test: `tests/unit/services/agent-hub.service.issue204.test.ts`
+
+**Step 1: 写失败测试（RED）**
+- 先写 service 测试，断言页面需要的读取方法与流式方法都通过 `env.agent` 转发。
+
+**Step 2: 运行测试确认失败**
+- Run: `bun vitest tests/unit/services/agent-hub.service.issue204.test.ts`
+- Expected: FAIL
+
+**Step 3: 最小实现（GREEN）**
+- 实现 `getAgentHubService()` 单例与 `AgentHubService` 接口。
+
+**Step 4: 运行测试确认通过**
+- 同上命令，Expected: PASS
+
+**Step 5: Commit**
+- `git add src/lib/services/agent-hub.service.ts src/lib/services/index.ts tests/unit/services/agent-hub.service.issue204.test.ts`
+- `git commit -m "feat(agent-hub): add service facade for zero upper-layer adapter switching"`
+
+## 任务 5：实现主页面 `/agents`（拓扑/列表/设备 + 添加节点弹窗）
+
+**Files:**
+- Modify/Create: `src/ui/new/pages/AgentsPage.tsx`
+- Create: `src/ui/new/pages/agents/components/*`（按需拆分）
+- Test: `tests/unit/ui/agent-hub/agents-page.issue204.test.tsx`
+
+**Step 1: 写失败测试（RED）**
+- 断言视图三态切换、节点选中高亮与弱化、添加节点弹窗打开关闭、进入市场按钮。
+
+**Step 2: 运行测试确认失败**
+- Run: `bun vitest tests/unit/ui/agent-hub/agents-page.issue204.test.tsx`
+- Expected: FAIL
+
+**Step 3: 最小实现（GREEN）**
+- 严格对齐 `LxbUp / pVisN / Kn7SD / hjRST / BUKXz` 的核心尺寸与视觉 token：
+  - 393 宽画布、Header/Toggle、列表分组卡、设备卡、Overlay + Bottom Sheet。
+- 给可测节点补 `data-testid`。
+
+**Step 4: 运行测试确认通过**
+- 同上命令，Expected: PASS
+
+**Step 5: Commit**
+- `git add src/ui/new/pages/AgentsPage.tsx src/ui/new/pages/agents/components tests/unit/ui/agent-hub/agents-page.issue204.test.tsx`
+- `git commit -m "feat(agent-hub): implement topology/list/device views and add-node sheet"`
+
+## 任务 6：实现详情页（Agent + Actor）
+
+**Files:**
+- Create: `src/ui/new/pages/agents/AgentDetailPage.tsx`
+- Create: `src/ui/new/pages/agents/ActorDetailPage.tsx`
+- Test: `tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx`
+
+**Step 1: 写失败测试（RED）**
+- 断言 Hero 卡、分区卡片、CTA（与 Agent 对话）和返回导航。
+
+**Step 2: 运行测试确认失败**
+- Run: `bun vitest tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx`
+- Expected: FAIL
+
+**Step 3: 最小实现（GREEN）**
+- 严格对齐 `bSWUQ / ockaZ` 的版式（卡片圆角、分隔、统计排布、文案层级）。
+
+**Step 4: 运行测试确认通过**
+- 同上命令，Expected: PASS
+
+**Step 5: Commit**
+- `git add src/ui/new/pages/agents/AgentDetailPage.tsx src/ui/new/pages/agents/ActorDetailPage.tsx tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx`
+- `git commit -m "feat(agent-hub): implement agent and actor detail pages"`
+
+## 任务 7：实现对话页（流式输出）+ 市场浏览页
+
+**Files:**
+- Create: `src/ui/new/pages/agents/AgentConversationPage.tsx`
+- Create: `src/ui/new/pages/agents/AgentMarketPage.tsx`
+- Test: `tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx`
+
+**Step 1: 写失败测试（RED）**
+- 对话页：断言消息气泡、输入栏、发送后出现流式 chunk 增量更新。
+- 市场页：断言搜索框、分类 tabs、推荐卡片列表。
+
+**Step 2: 运行测试确认失败**
+- Run: `bun vitest tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx`
+- Expected: FAIL
+
+**Step 3: 最小实现（GREEN）**
+- 按 `Rw8LA / KWsUv` 对齐布局与 token。
+- 通过 service 的 stream API 做 chunk 渐进渲染（非一次性替换）。
+
+**Step 4: 运行测试确认通过**
+- 同上命令，Expected: PASS
+
+**Step 5: Commit**
+- `git add src/ui/new/pages/agents/AgentConversationPage.tsx src/ui/new/pages/agents/AgentMarketPage.tsx tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx`
+- `git commit -m "feat(agent-hub): implement streaming chat and market browse pages"`
+
+## 任务 8：路由接线 + 设置页 mock toggle 验证
+
+**Files:**
+- Modify: `src/routes-new.tsx`
+- Modify (按需): `src/ui/new/pages/NewSettingsPage.tsx`
+- Test: `tests/unit/ui/agent-hub/agent-routing.issue204.test.ts`
+- Test (按需补充): `tests/unit/settings/new-settings-mock-data-toggle.issue204.test.tsx`
+
+**Step 1: 写失败测试（RED）**
+- 断言新增路由：
+  - `/agents`
+  - `/agents/agent/$agentId`
+  - `/agents/actor/$actorId`
+  - `/agents/chat/$agentId`
+  - `/agents/market`
+
+**Step 2: 运行测试确认失败**
+- Run: `bun vitest tests/unit/ui/agent-hub/agent-routing.issue204.test.ts`
+- Expected: FAIL
+
+**Step 3: 最小实现（GREEN）**
+- 完成 route lazy import 与页面接线。
+- 保持“使用测试数据”开关在开发者区可用。
+
+**Step 4: 运行测试确认通过**
+- 同上命令，Expected: PASS
+
+**Step 5: Commit**
+- `git add src/routes-new.tsx src/ui/new/pages/NewSettingsPage.tsx tests/unit/ui/agent-hub/agent-routing.issue204.test.ts tests/unit/settings/new-settings-mock-data-toggle.issue204.test.tsx`
+- `git commit -m "feat(agent-hub): wire routes and keep settings mock-data toggle"`
+
+## 任务 9：Playwright 自动化（issue204 独立端口）
+
+**Files:**
+- Create: `tests/e2e/playwright.issue204.config.ts`
+- Create: `tests/e2e/agent-hub.issue204.test.ts`
+- Modify: `package.json`（新增 `test:e2e:issue204` script）
+
+**Step 1: 写失败 E2E（RED）**
+- 先写测试覆盖：
+  - 三视图切换
+  - 节点选中态
+  - 添加节点弹窗 + 市场入口
+  - 详情跳转
+  - 对话流式输出
+
+**Step 2: 运行确认失败**
+- Run: `bun run test:e2e:issue204`
+- Expected: FAIL
+
+**Step 3: 最小实现修正（GREEN）**
+- 补充稳定 selector/testid 与交互细节，消除 flake。
+
+**Step 4: 运行确认通过**
+- Run: `bun run test:e2e:issue204`
+- Expected: PASS
+
+**Step 5: Commit**
+- `git add tests/e2e/playwright.issue204.config.ts tests/e2e/agent-hub.issue204.test.ts package.json`
+- `git commit -m "test(agent-hub): add issue-204 playwright e2e coverage"`
+
+## 任务 10：全量验证 + PR 进度评论 + 评审评论
+
+**Files:**
+- Create: `docs/pr/issue-204-progress-comment.md`
+- Create: `docs/pr/issue-204-review-comment.md`
+
+**Step 1: 运行验证**
+- `bun vitest tests/unit/agent-hub tests/unit/environment/bootstrap.test.ts tests/unit/settings/new-settings-mock-data-toggle.issue204.test.tsx`
+- `bun run test:e2e:issue204`
+- `bun run build`
+
+**Step 2: 填写 PR 进度评论（证据）**
+- 写入本轮变更、测试命令、关键输出摘要。
+
+**Step 3: 请求并执行评审（review）**
+- 执行代码评审（按严重级别给 findings）。
+- 修复后再次验证并更新评论。
+
+**Step 4: Commit**
+- `git add docs/pr/issue-204-progress-comment.md docs/pr/issue-204-review-comment.md`
+- `git commit -m "docs(agent-hub): add issue-204 progress and review evidence comments"`
+
+## PR / Issue 评论发布流程
+
+1. 若尚无 PR，先创建 draft PR（base: `dev`，head: `vk/5574-gh-204-feat-agen`）。
+2. 先发计划评论：
+   - `bun run gh:comment -- --type issue --number 204 --file docs/pr/issue-204-plan-comment.md`
+   - `bun run gh:comment -- --type pr --number <PR号> --file docs/pr/issue-204-plan-comment.md`
+3. 每个任务完成后更新 PR 进度评论（追加或新建）。
+4. 最终发布评审结论评论（Approve / 需修复项）。
+
+## 完成定义（Definition of Done）
+
+- UI 视觉与布局对齐上述 9 个 Pencil 节点（关键尺寸/间距/圆角/色值/层级）。
+- `mock-data` 开关下，无上层页面改动即可切换 mock/real adapter。
+- 单测 + E2E + build 全通过，并给出命令与结果证据。
+- PR 中包含：计划评论、阶段进度评论、最终评审评论。
+

--- a/docs/pr/issue-204-plan-comment.md
+++ b/docs/pr/issue-204-plan-comment.md
@@ -1,0 +1,57 @@
+# [GH#204] Agent Hub 全视图实施计划（待审批）
+
+## 本次目标
+- 严格对照 `pencil/eventlog-ui-design.pen` 像素级还原：
+  - 拓扑视图（含节点选中态）
+  - 列表视图
+  - 设备视图
+  - Agent 详情页
+  - Actor 详情页
+  - 对话页（流式输出）
+  - 市场浏览页
+  - 添加节点弹窗（含市场入口）
+- 落地 mock 架构：
+  - `src/config/mock-data.ts`（沿用）
+  - `src/lib/adapters/mock/agent-mock-adapter.ts`（新增）
+  - `bootstrap.ts` 根据 flag 注入 mock/real adapter（上层零改动）
+- 全程执行：TDD（先红后绿）+ Playwright 自动化验证 + 分步 commit + PR 评审闭环。
+
+## 设计稿锚点（Pencil Node IDs）
+- `LxbUp` 拓扑
+- `pVisN` 拓扑选中态
+- `Kn7SD` 列表
+- `hjRST` 设备
+- `BUKXz` 添加节点（含市场）
+- `bSWUQ` Agent 详情
+- `ockaZ` Actor 详情
+- `Rw8LA` 对话
+- `KWsUv` 市场
+
+## 执行分解（每步至少 1 个 commit）
+1. 建立 Agent Hub 类型与 Port 契约（先测试后实现）。  
+2. 实现 `agent-mock-adapter` + `agent-web-adapter` + fixtures。  
+3. `bootstrap/environment` 注入 agent adapter（mock/real 切换）。  
+4. 新增 `agent-hub.service.ts`，页面通过 service 访问数据。  
+5. 实现 `/agents` 主页（三视图 + 节点选中态 + 添加节点弹窗）。  
+6. 实现 Agent/Actor 详情页。  
+7. 实现对话流式输出页 + 市场浏览页。  
+8. 路由接线 `/agents/*` 并保留设置页「使用测试数据」开关能力。  
+9. 新增 `tests/e2e/playwright.issue204.config.ts` + `agent-hub.issue204.test.ts`。  
+10. 运行 `vitest + playwright + build`，发布进度评论与最终评审评论。  
+
+## 验收链路
+- 单测：契约、adapter、bootstrap 注入、service、页面结构与交互、路由接线。
+- E2E：视图切换、节点选中、弹窗开关、详情跳转、市场浏览、对话流式输出。
+- 构建：`bun run build` 通过。
+
+## 过程约束
+- 每一阶段完成后立即提交 commit，并推送到当前 PR 分支。
+- PR 评论持续同步：
+  - 计划评论（本条）
+  - 阶段进度评论（含测试证据）
+  - 最终评审评论（Findings + 结论）
+
+## 请求审批
+- 请确认是否按本计划开始实施。  
+- 回复关键字：`批准执行`（如需调整我将先改计划再动代码）。
+

--- a/docs/pr/issue-204-pr-body.md
+++ b/docs/pr/issue-204-pr-body.md
@@ -1,0 +1,42 @@
+# feat(agent-hub): 前端 UI 设计 + 实现 — 全视图 (GH#204)
+
+## 目标
+严格对照 `pencil/eventlog-ui-design.pen` 完成 Agent Hub 全视图 UI 实现，并保持 mock/真实数据适配可切换（上层零改动）。
+
+## 实现内容
+- Agent Hub 三视图：拓扑 / 列表 / 设备
+- Agent 详情页、Actor 详情页
+- 对话页（流式输出）
+- 市场浏览页
+- 添加节点弹窗（含市场入口）
+- mock 架构：
+  - `src/config/mock-data.ts`
+  - `src/lib/adapters/mock/agent-mock-adapter.ts`
+  - `src/lib/adapters/agent-web-adapter.ts`
+  - `src/lib/environment/bootstrap.ts` 根据 flag 注入
+  - `src/lib/services/agent-hub.service.ts` 对上层统一收口
+
+## 关键技术点
+- 拓扑画布使用绝对定位 + SVG 连线，实现节点高亮与非关联节点/边淡化。
+- Settings 开发者区保留「使用测试数据」开关，切换后无需改页面代码。
+- 路由接线：
+  - `/agents`
+  - `/agents/agent/$agentId`
+  - `/agents/actor/$actorId`
+  - `/agents/chat/$agentId`
+  - `/agents/market`
+
+## 测试与验证
+- 单测：
+  - `bun vitest tests/unit/agent-hub tests/unit/adapters/agent-mock-adapter.issue204.test.ts tests/unit/adapters/agent-web-adapter.issue204.test.ts tests/unit/environment/bootstrap.test.ts tests/unit/services/agent-hub.service.issue204.test.ts tests/unit/ui/agent-hub/agents-page.issue204.test.tsx tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx tests/unit/ui/agent-hub/agent-routing.issue204.test.ts`
+- E2E：
+  - `bun run test:e2e:issue204`
+- 构建：
+  - `bun run build`
+
+## 评审结论
+- 详见 PR 评论：
+  - 进度评论：`docs/pr/issue-204-progress-comment.md`
+  - 评审评论：`docs/pr/issue-204-review-comment.md`
+- 结论：Approve
+

--- a/docs/pr/issue-204-progress-comment-r11.md
+++ b/docs/pr/issue-204-progress-comment-r11.md
@@ -1,0 +1,44 @@
+# [GH#204] 进度补充（R11：修复 Agent 无测试数据）
+
+## 问题现象
+- 在设置页切换「使用测试数据」后，Agent 页仍可能继续显示真实/空数据，不会立即切到 mock 数据。
+
+## 根因
+- `getAgentHubService()` 是单例；
+- `AgentHubServiceImpl` 在构造时把 `ExoMindEnvironment.getInstance()` 固定到实例字段；
+- 切换 mock flag 后，后续调用仍读旧 `agent` adapter。
+
+## 修复
+- 文件：`src/lib/services/agent-hub.service.ts`
+- 调整为“每次调用动态读取当前 environment 的 `agent` port”：
+  - 保留依赖注入路径（测试/显式传 env 时不变）
+  - 默认路径不再冻结 adapter 来源，切换 flag 后可生效
+
+## TDD 证据（RED -> GREEN）
+1. 新增失败用例：
+   - `tests/unit/services/agent-hub-service-mock-toggle.issue204.test.ts`
+   - 用例模拟环境从 `webAgentPort` 切到 `mockAgentPort`
+   - 修复前：第二次调用仍命中 web（失败）
+2. 修复后回归通过：
+
+```bash
+bun vitest tests/unit/services/agent-hub-service-mock-toggle.issue204.test.ts tests/unit/services/agent-hub.service.issue204.test.ts
+```
+
+结果：`2 files, 3 tests passed`
+
+## 全链路验证
+```bash
+bun vitest tests/unit/agent-hub tests/unit/adapters/agent-mock-adapter.issue204.test.ts tests/unit/adapters/agent-web-adapter.issue204.test.ts tests/unit/environment/bootstrap.test.ts tests/unit/services/agent-hub.service.issue204.test.ts tests/unit/services/agent-hub-service-mock-toggle.issue204.test.ts tests/unit/ui/agent-hub/agents-page.issue204.test.tsx tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx tests/unit/ui/agent-hub/agent-routing.issue204.test.ts
+bun run test:e2e:issue204
+bun run build
+```
+
+结果：
+- 单测：`10 files, 25 tests passed`
+- E2E：`2 passed`
+- Build：通过（仅既有 non-blocking warning）
+
+## 本轮提交
+- `1cef1a8` fix(agent-hub): refresh adapter source after mock-data toggle
+

--- a/docs/pr/issue-204-progress-comment-r12.md
+++ b/docs/pr/issue-204-progress-comment-r12.md
@@ -1,0 +1,72 @@
+# [GH#204] 进度补充（R12：修复暗色白底 + mock 切换后网络无数据）
+
+## 问题复现
+1. `Agent` 页面在暗色主题下仍显示浅色背景（白底风格）。
+2. 当 `useMockData=false` 先进入 `/agents` 初始化环境后，再在设置页切到 `useMockData=true`，返回 `Agent` 页面仍无 mock 拓扑数据。
+
+## 根因定位
+1. **暗色白底**：`src/ui/new/pages/AgentsPage.tsx` 及详情/对话/市场页面大量容器只写了浅色类（`bg-white / bg-[#FAF7F5]`），缺少 `dark:*`。
+2. **mock 切换不生效**：`ExoMindEnvironment` 是单例，首次初始化后固定 `agent/task adapter`；切换 mock flag 后没有同步刷新 adapter。
+
+## TDD（先红后绿）
+### RED（先写失败测试）
+- 新增：
+  - `tests/unit/environment/environment-mock-data-sync.issue204.test.ts`
+- 更新：
+  - `tests/unit/ui/agent-hub/agents-page.issue204.test.tsx`
+  - `tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx`
+  - `tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx`
+
+红灯命令：
+```bash
+bun vitest tests/unit/environment/environment-mock-data-sync.issue204.test.ts tests/unit/ui/agent-hub/agents-page.issue204.test.tsx tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx
+```
+结果：`4 files failed, 6 tests failed`
+
+### GREEN（最小修复后通过）
+修复点：
+1. `src/lib/environment/environment.ts`
+   - 增加运行时 `mock-data` 同步逻辑；
+   - `getInstance()` 每次返回前检查开关变化，若变化则重建并替换 `task/agent adapter`。
+2. Agent Hub 全链路页面补齐暗色样式：
+   - `src/ui/new/pages/AgentsPage.tsx`
+   - `src/ui/new/pages/agents/AgentDetailPage.tsx`
+   - `src/ui/new/pages/agents/ActorDetailPage.tsx`
+   - `src/ui/new/pages/agents/AgentConversationPage.tsx`
+   - `src/ui/new/pages/agents/AgentMarketPage.tsx`
+
+绿灯命令：
+```bash
+bun vitest tests/unit/environment/environment-mock-data-sync.issue204.test.ts tests/unit/ui/agent-hub/agents-page.issue204.test.tsx tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx
+```
+结果：`4 files passed, 8 tests passed`
+
+## Playwright 自动化回归
+新增 E2E 场景：
+- 文件：`tests/e2e/agent-hub.issue204.test.ts`
+- 用例：`Issue #204 Agent Hub runtime toggle（运行时切换测试数据）`
+- 校验点：
+  1. 先 `useMockData=false` 进入 `/agents`（无拓扑数据）；
+  2. 不刷新页面，去设置页切换 `useMockData=true`；
+  3. 回到 `/agents` 出现 `agent-topology-node-agent-daily`；
+  4. 校验暗色背景计算值 `rgb(12, 10, 9)`。
+
+执行：
+```bash
+bun run test:e2e:issue204
+```
+结果：`3 passed`
+
+## 最终验证
+```bash
+bun vitest tests/unit/agent-hub tests/unit/adapters/agent-mock-adapter.issue204.test.ts tests/unit/adapters/agent-web-adapter.issue204.test.ts tests/unit/environment/bootstrap.test.ts tests/unit/environment/environment-mock-data-sync.issue204.test.ts tests/unit/services/agent-hub.service.issue204.test.ts tests/unit/services/agent-hub-service-mock-toggle.issue204.test.ts tests/unit/ui/agent-hub/agents-page.issue204.test.tsx tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx tests/unit/ui/agent-hub/agent-routing.issue204.test.ts tests/unit/settings/new-settings-mock-data-toggle.issue213.test.tsx
+bun run test:e2e:issue204
+bun run build
+```
+结果：
+- 单测：`12 files, 29 tests passed`
+- E2E：`3 passed`
+- Build：通过（仅既有 warning）
+
+## 本轮提交
+- `e962785` fix(agent-hub): sync mock toggle adapters and dark-mode surfaces

--- a/docs/pr/issue-204-progress-comment-r13.md
+++ b/docs/pr/issue-204-progress-comment-r13.md
@@ -1,0 +1,55 @@
+# [GH#204] 进度补充（R13：处理评审 P1 + Agent 标题字号）
+
+## 本轮目标
+1. 按评审修复 `P1`：`Agent/Actor` 详情空数据时不再永久“加载中”。
+2. 按产品反馈调整：`Agent 网络` 页面标题字号与任务页保持一致。
+
+## 根因与修复
+### 1) 详情空数据永久 loading（P1）
+- 根因：`detail === null` 同时被用于“正在加载”和“已加载但无数据”两种状态，导致无法区分。
+- 修复：
+  - `src/ui/new/pages/agents/AgentDetailPage.tsx`
+  - `src/ui/new/pages/agents/ActorDetailPage.tsx`
+  - 新增 `loading` 状态，分离三种渲染：
+    - `loading`：显示“加载中”
+    - `loaded + null`：显示空态（`未找到 Agent/Actor 详情`）+ 返回入口
+    - `loaded + data`：正常详情页
+
+### 2) Agent 页面标题过大
+- 修复文件：`src/ui/new/pages/AgentsPage.tsx`
+- 标题从 `text-[30px] font-bold` 调整为与任务页一致：`text-lg font-semibold`（并保持暗色样式）。
+
+## TDD 证据（RED -> GREEN）
+### RED（先失败）
+- 新增失败断言：
+  - `tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx`
+    - `renders agent empty state when detail is missing`
+    - `renders actor empty state when detail is missing`
+  - `tests/unit/ui/agent-hub/agents-page.issue204.test.tsx`
+    - `uses task-page sized title`
+
+失败命令：
+```bash
+bun vitest tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
+```
+失败结果：`2 files failed, 3 tests failed`
+
+### GREEN（修复后通过）
+```bash
+bun vitest tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
+```
+通过结果：`2 files, 8 tests passed`
+
+## 回归验证
+```bash
+bun vitest tests/unit/agent-hub tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
+bun run test:e2e:issue204
+bun run build
+```
+结果：
+- 单测：`3 files, 10 tests passed`
+- E2E：`3 passed`
+- Build：通过（仅既有 warning）
+
+## 本轮提交
+- `611593e` fix(agent-hub): handle empty detail states and align header size

--- a/docs/pr/issue-204-progress-comment.md
+++ b/docs/pr/issue-204-progress-comment.md
@@ -1,0 +1,57 @@
+# [GH#204] Agent Hub 实现进度更新（R9-R10）
+
+## R9：Playwright 专项覆盖（RED -> GREEN）
+- 提交：`e16fb3e`
+- 变更：
+  - 新增 `tests/e2e/playwright.issue204.config.ts`（固定 `1420` 端口，`reuseExistingServer: true`）
+  - 新增 `tests/e2e/agent-hub.issue204.test.ts`
+  - 修复列表页到详情页点击（`agent-list-item-agent-daily` 可正确跳转）
+- RED 证据（历史失败）：
+  - `getByTestId('agent-list-item-agent-daily')` 找不到，E2E 失败
+- GREEN 结果：
+  - `bun run test:e2e:issue204` -> `2 passed`
+
+## R10：Pencil 视觉对齐补强（拓扑/列表/设备/详情/对话/市场）
+- 提交：`ee91158`
+- 变更范围：
+  - `src/ui/new/pages/AgentsPage.tsx`
+  - `src/ui/new/pages/agents/AgentDetailPage.tsx`
+  - `src/ui/new/pages/agents/ActorDetailPage.tsx`
+  - `src/ui/new/pages/agents/AgentConversationPage.tsx`
+  - `src/ui/new/pages/agents/AgentMarketPage.tsx`
+  - `tests/unit/ui/agent-hub/*.issue204.test.tsx`
+  - `tests/e2e/agent-hub.issue204.test.ts`
+- 关键对齐点：
+  - 拓扑：绝对定位画布 + SVG 连线 + 选中高亮/非关联淡化
+  - 列表：分类筛选条、前导图标、Chevron、分组计数样式
+  - 设备：总览卡（CPU/MEM/Latency）+ 分组设备卡
+  - 详情/对话/市场：头部结构、信息层级、输入栏/搜索栏、市场卡片作者行
+
+## TDD 与验证证据
+### 1) UI 单测（先红后绿）
+```bash
+bun vitest tests/unit/ui/agent-hub/agents-page.issue204.test.tsx tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx
+```
+结果：`3 files, 6 tests passed`
+
+### 2) issue-204 全链路单测
+```bash
+bun vitest tests/unit/agent-hub tests/unit/adapters/agent-mock-adapter.issue204.test.ts tests/unit/adapters/agent-web-adapter.issue204.test.ts tests/unit/environment/bootstrap.test.ts tests/unit/services/agent-hub.service.issue204.test.ts tests/unit/ui/agent-hub/agents-page.issue204.test.tsx tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx tests/unit/ui/agent-hub/agent-routing.issue204.test.ts
+```
+结果：`9 files, 24 tests passed`
+
+### 3) Playwright issue204 专项
+```bash
+bun run test:e2e:issue204
+```
+结果：`2 passed`
+
+### 4) 构建校验
+```bash
+bun run build
+```
+结果：构建成功（仅保留既有 chunk size / dynamic import 警告，无阻断错误）
+
+## 本轮新增提交（按步骤提交）
+- `ee91158` feat(agent-hub): polish issue-204 full views to match pencil screens
+

--- a/docs/pr/issue-204-review-comment-r12.md
+++ b/docs/pr/issue-204-review-comment-r12.md
@@ -1,0 +1,36 @@
+# [GH#204] R12 评审结果（Agent 暗色 + mock 切换修复）
+
+## Findings（按严重度）
+1. **Critical / Important**：未发现阻塞项。  
+2. **Minor**：未发现需要阻止合并的问题。  
+
+## 评审范围
+- 代码变更：
+  - `src/lib/environment/environment.ts`
+  - `src/ui/new/pages/AgentsPage.tsx`
+  - `src/ui/new/pages/agents/AgentDetailPage.tsx`
+  - `src/ui/new/pages/agents/ActorDetailPage.tsx`
+  - `src/ui/new/pages/agents/AgentConversationPage.tsx`
+  - `src/ui/new/pages/agents/AgentMarketPage.tsx`
+- 测试变更：
+  - `tests/unit/environment/environment-mock-data-sync.issue204.test.ts`
+  - `tests/unit/ui/agent-hub/*.issue204.test.tsx`（暗色样式断言）
+  - `tests/e2e/agent-hub.issue204.test.ts`（新增 runtime toggle 场景）
+
+## 验证证据
+```bash
+bun vitest tests/unit/agent-hub tests/unit/adapters/agent-mock-adapter.issue204.test.ts tests/unit/adapters/agent-web-adapter.issue204.test.ts tests/unit/environment/bootstrap.test.ts tests/unit/environment/environment-mock-data-sync.issue204.test.ts tests/unit/services/agent-hub.service.issue204.test.ts tests/unit/services/agent-hub-service-mock-toggle.issue204.test.ts tests/unit/ui/agent-hub/agents-page.issue204.test.tsx tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx tests/unit/ui/agent-hub/agent-routing.issue204.test.ts tests/unit/settings/new-settings-mock-data-toggle.issue213.test.tsx
+bun run test:e2e:issue204
+bun run build
+```
+
+结果：
+- 单测：`12 files, 29 tests passed`
+- E2E：`3 passed`
+- Build：通过（仅既有 warning）
+
+## 结论
+- 本轮修复满足目标：  
+  1) Agent 页面暗色主题不再白底；  
+  2) 运行中切换 `useMockData` 后，返回 Agent 网络可获取 mock 拓扑数据。  
+- 评审结论：**通过，可继续合并流程**。

--- a/docs/pr/issue-204-review-comment.md
+++ b/docs/pr/issue-204-review-comment.md
@@ -1,0 +1,25 @@
+# [GH#204] 评审结果（Code Review）
+
+## Findings（按严重级别）
+1. 阻断问题（Critical）：未发现。
+2. 重要问题（Important）：未发现。
+3. 一般问题（Minor）：
+   - `bun run build` 仍有仓库既有的 chunk size / 动态导入混用告警（非本次引入，且不阻断构建）。
+
+## 需求核对（Issue #204）
+- 拓扑/列表/设备三视图：已实现并可切换。
+- 拓扑选中态：已实现节点高亮 + 非关联节点/连线淡化。
+- Agent/Actor 详情：已实现并接线 `/agents/agent/$agentId`、`/agents/actor/$actorId`。
+- 对话页（流式输出）：已实现并通过 E2E 验证。
+- 市场浏览：已实现分类切换与卡片列表。
+- 添加节点弹窗：已实现并包含“从市场安装”入口。
+- Mock 架构：`mock-data` 开关 + `bootstrap.ts` mock/real adapter 注入已生效；上层页面通过 service 调用，无 adapter 分支逻辑。
+
+## 自动化验证结果
+- 单测（issue204 相关）：通过（`24/24`）
+- E2E（issue204 专项）：通过（`2/2`）
+- 构建：通过（`bun run build`）
+
+## 结论
+本次实现满足 GH#204 的功能与验证要求，评审通过（Approve）。
+

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:e2e:issue27": "playwright test tests/e2e/eventlog-multi-device-sync.issue27.test.ts --config tests/e2e/playwright.issue27.config.ts",
     "test:e2e:issue120": "playwright test tests/e2e/eventlog.test.ts --config tests/e2e/playwright.issue120.config.ts -g \"issue-120\"",
     "test:e2e:issue213": "playwright test tests/e2e/task-ui.issue213.test.ts --config tests/e2e/playwright.issue213.config.ts",
+    "test:e2e:issue204": "playwright test tests/e2e/agent-hub.issue204.test.ts --config tests/e2e/playwright.issue204.config.ts",
     "test:e2e:report": "playwright test --reporter=html"
   },
   "dependencies": {

--- a/src/lib/adapters/agent-web-adapter.ts
+++ b/src/lib/adapters/agent-web-adapter.ts
@@ -1,0 +1,155 @@
+import type { IAgentPort } from '@/lib/environment/interfaces/agent.port';
+import type {
+  AgentAddNodeOption,
+  AgentConversationChunk,
+  AgentConversationMessage,
+  AgentDetailData,
+  AgentDeviceGroup,
+  AgentHubListSection,
+  AgentHubTopologyData,
+  AgentMarketCategory,
+  AgentMarketItem,
+} from '@/lib/types/agent-hub';
+import { WebStorageAdapter } from './web-storage';
+
+// Storage keys（存储键）
+export const AGENT_WEB_STORAGE_KEYS = {
+  topology: 'agent_hub_topology',
+  listView: 'agent_hub_list_view',
+  deviceView: 'agent_hub_device_view',
+  marketCategories: 'agent_hub_market_categories',
+  marketItems: 'agent_hub_market_items',
+  addNodeOptions: 'agent_hub_add_node_options',
+  agentDetailPrefix: 'agent_hub_agent_detail_',
+  actorDetailPrefix: 'agent_hub_actor_detail_',
+  conversationPrefix: 'agent_hub_conversation_',
+} as const;
+
+const FALLBACK_ADD_NODE_OPTIONS: AgentAddNodeOption[] = [
+  { id: 'input', title: '添加信号输入', description: '新增 RSS / API / 传感器输入', icon: 'rss', tintColor: '#F97316' },
+  { id: 'agent', title: '添加 Agent', description: '基于大模型的智能决策节点', icon: 'brain', tintColor: '#C75B3A' },
+  { id: 'actor', title: '添加 Actor', description: '定时、条件触发的程序执行节点', icon: 'timer', tintColor: '#78716C' },
+  { id: 'output', title: '添加输出节点', description: '消息通知、写库、API 回调等输出', icon: 'send', tintColor: '#2AABEE' },
+  { id: 'market', title: '从市场安装', description: '浏览社区插件并一键接入节点', icon: 'shopping-bag', tintColor: '#8B5CF6' },
+];
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function splitChunks(text: string, size = 10): string[] {
+  const chunks: string[] = [];
+  for (let index = 0; index < text.length; index += size) {
+    chunks.push(text.slice(index, index + size));
+  }
+  return chunks.length > 0 ? chunks : [''];
+}
+
+export class AgentWebAdapter implements IAgentPort {
+  private readonly storage = new WebStorageAdapter();
+
+  private async readOrDefault<T>(key: string, fallback: T): Promise<T> {
+    const value = await this.storage.read<T>(key);
+    if (value === null || value === undefined) return clone(fallback);
+    return clone(value);
+  }
+
+  async getTopology(): Promise<AgentHubTopologyData> {
+    return this.readOrDefault(AGENT_WEB_STORAGE_KEYS.topology, {
+      nodes: [],
+      edges: [],
+      selectedNodeId: null,
+    });
+  }
+
+  async getListView(): Promise<AgentHubListSection[]> {
+    return this.readOrDefault(AGENT_WEB_STORAGE_KEYS.listView, []);
+  }
+
+  async getDeviceView(): Promise<AgentDeviceGroup[]> {
+    return this.readOrDefault(AGENT_WEB_STORAGE_KEYS.deviceView, []);
+  }
+
+  async listAddNodeOptions(): Promise<AgentAddNodeOption[]> {
+    return this.readOrDefault(AGENT_WEB_STORAGE_KEYS.addNodeOptions, FALLBACK_ADD_NODE_OPTIONS);
+  }
+
+  async getAgentDetail(agentId: string): Promise<AgentDetailData | null> {
+    const key = `${AGENT_WEB_STORAGE_KEYS.agentDetailPrefix}${agentId}`;
+    const detail = await this.storage.read<AgentDetailData>(key);
+    return detail ? clone(detail) : null;
+  }
+
+  async getActorDetail(actorId: string): Promise<AgentDetailData | null> {
+    const key = `${AGENT_WEB_STORAGE_KEYS.actorDetailPrefix}${actorId}`;
+    const detail = await this.storage.read<AgentDetailData>(key);
+    return detail ? clone(detail) : null;
+  }
+
+  async listMarketCategories(): Promise<AgentMarketCategory[]> {
+    return this.readOrDefault(AGENT_WEB_STORAGE_KEYS.marketCategories, []);
+  }
+
+  async getMarketItems(params?: { categoryId?: string; query?: string }): Promise<AgentMarketItem[]> {
+    const all = await this.readOrDefault<AgentMarketItem[]>(AGENT_WEB_STORAGE_KEYS.marketItems, []);
+    const categoryId = params?.categoryId?.trim();
+    const query = params?.query?.trim().toLowerCase();
+    const byCategory = !categoryId || categoryId === 'all'
+      ? all
+      : all.filter((item) => item.tags.includes(categoryId));
+    const byQuery = !query
+      ? byCategory
+      : byCategory.filter((item) => {
+        const text = `${item.name} ${item.summary} ${item.tags.join(' ')}`.toLowerCase();
+        return text.includes(query);
+      });
+    return clone(byQuery);
+  }
+
+  async getConversation(agentId: string): Promise<AgentConversationMessage[]> {
+    const key = `${AGENT_WEB_STORAGE_KEYS.conversationPrefix}${agentId}`;
+    return this.readOrDefault(key, []);
+  }
+
+  async *streamConversation(
+    input: { agentId: string; prompt: string }
+  ): AsyncGenerator<AgentConversationChunk, void, void> {
+    const key = `${AGENT_WEB_STORAGE_KEYS.conversationPrefix}${input.agentId}`;
+    const history = await this.getConversation(input.agentId);
+
+    history.push({
+      id: `msg-user-${crypto.randomUUID()}`,
+      role: 'user',
+      content: input.prompt,
+      createdAt: nowIso(),
+    });
+
+    const assistantMessageId = `msg-agent-${crypto.randomUUID()}`;
+    history.push({
+      id: assistantMessageId,
+      role: 'agent',
+      content: '',
+      createdAt: nowIso(),
+    });
+
+    const response = 'web adapter placeholder response';
+    const chunks = splitChunks(response);
+    for (let index = 0; index < chunks.length; index += 1) {
+      const delta = chunks[index];
+      const assistant = history.find((item) => item.id === assistantMessageId);
+      if (assistant) assistant.content += delta;
+      yield {
+        messageId: assistantMessageId,
+        delta,
+        done: index === chunks.length - 1,
+      };
+    }
+
+    await this.storage.write(key, history);
+  }
+}
+

--- a/src/lib/adapters/mock/agent-mock-adapter.ts
+++ b/src/lib/adapters/mock/agent-mock-adapter.ts
@@ -1,0 +1,129 @@
+import type { IAgentPort } from '@/lib/environment/interfaces/agent.port';
+import type {
+  AgentAddNodeOption,
+  AgentConversationChunk,
+  AgentConversationMessage,
+  AgentDetailData,
+  AgentDeviceGroup,
+  AgentHubListSection,
+  AgentHubTopologyData,
+  AgentMarketCategory,
+  AgentMarketItem,
+} from '@/lib/types/agent-hub';
+import { AGENT_HUB_MOCK_FIXTURE, type AgentHubMockFixture } from './fixtures/agent-hub';
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function splitChunks(text: string, size = 8): string[] {
+  const chunks: string[] = [];
+  for (let index = 0; index < text.length; index += size) {
+    chunks.push(text.slice(index, index + size));
+  }
+  return chunks.length > 0 ? chunks : [''];
+}
+
+// Agent mock adapter（测试数据适配器）
+export class AgentMockAdapter implements IAgentPort {
+  private readonly fixture: AgentHubMockFixture;
+  private readonly conversations: Record<string, AgentConversationMessage[]>;
+
+  constructor(fixture: AgentHubMockFixture = AGENT_HUB_MOCK_FIXTURE) {
+    this.fixture = clone(fixture);
+    this.conversations = clone(fixture.conversations);
+  }
+
+  async getTopology(): Promise<AgentHubTopologyData> {
+    return clone(this.fixture.topology);
+  }
+
+  async getListView(): Promise<AgentHubListSection[]> {
+    return clone(this.fixture.listSections);
+  }
+
+  async getDeviceView(): Promise<AgentDeviceGroup[]> {
+    return clone(this.fixture.deviceGroups);
+  }
+
+  async listAddNodeOptions(): Promise<AgentAddNodeOption[]> {
+    return clone(this.fixture.addNodeOptions);
+  }
+
+  async getAgentDetail(agentId: string): Promise<AgentDetailData | null> {
+    return this.fixture.agentDetails[agentId] ? clone(this.fixture.agentDetails[agentId]) : null;
+  }
+
+  async getActorDetail(actorId: string): Promise<AgentDetailData | null> {
+    return this.fixture.actorDetails[actorId] ? clone(this.fixture.actorDetails[actorId]) : null;
+  }
+
+  async listMarketCategories(): Promise<AgentMarketCategory[]> {
+    return clone(this.fixture.marketCategories);
+  }
+
+  async getMarketItems(params?: { categoryId?: string; query?: string }): Promise<AgentMarketItem[]> {
+    const categoryId = params?.categoryId?.trim();
+    const query = params?.query?.trim().toLowerCase();
+    const byCategory = !categoryId || categoryId === 'all'
+      ? this.fixture.marketItems
+      : this.fixture.marketItems.filter((item) => item.tags.includes(categoryId));
+    const byQuery = !query
+      ? byCategory
+      : byCategory.filter((item) => {
+        const text = `${item.name} ${item.summary} ${item.tags.join(' ')}`.toLowerCase();
+        return text.includes(query);
+      });
+    return clone(byQuery);
+  }
+
+  async getConversation(agentId: string): Promise<AgentConversationMessage[]> {
+    const history = this.conversations[agentId] ?? [];
+    return clone(history);
+  }
+
+  async *streamConversation(
+    input: { agentId: string; prompt: string }
+  ): AsyncGenerator<AgentConversationChunk, void, void> {
+    const history = this.conversations[input.agentId] ?? [];
+    if (!this.conversations[input.agentId]) {
+      this.conversations[input.agentId] = history;
+    }
+
+    history.push({
+      id: `msg-user-${crypto.randomUUID()}`,
+      role: 'user',
+      content: input.prompt,
+      createdAt: nowIso(),
+    });
+
+    const assistantMessageId = `msg-agent-${crypto.randomUUID()}`;
+    history.push({
+      id: assistantMessageId,
+      role: 'agent',
+      content: '',
+      createdAt: nowIso(),
+    });
+
+    const response = `已收到：${input.prompt}。我会继续处理并在稍后同步结果。`;
+    const chunks = splitChunks(response);
+
+    for (let index = 0; index < chunks.length; index += 1) {
+      const delta = chunks[index];
+      const target = history.find((item) => item.id === assistantMessageId);
+      if (target) {
+        target.content += delta;
+      }
+      yield {
+        messageId: assistantMessageId,
+        delta,
+        done: index === chunks.length - 1,
+      };
+    }
+  }
+}
+

--- a/src/lib/adapters/mock/fixtures/agent-hub.ts
+++ b/src/lib/adapters/mock/fixtures/agent-hub.ts
@@ -1,0 +1,291 @@
+import type {
+  AgentAddNodeOption,
+  AgentConversationMessage,
+  AgentDetailData,
+  AgentDeviceGroup,
+  AgentHubListSection,
+  AgentHubTopologyData,
+  AgentMarketCategory,
+  AgentMarketItem,
+} from '@/lib/types/agent-hub';
+
+export interface AgentHubMockFixture {
+  topology: AgentHubTopologyData;
+  listSections: AgentHubListSection[];
+  deviceGroups: AgentDeviceGroup[];
+  addNodeOptions: AgentAddNodeOption[];
+  agentDetails: Record<string, AgentDetailData>;
+  actorDetails: Record<string, AgentDetailData>;
+  marketCategories: AgentMarketCategory[];
+  marketItems: AgentMarketItem[];
+  conversations: Record<string, AgentConversationMessage[]>;
+}
+
+export const AGENT_HUB_MOCK_FIXTURE: AgentHubMockFixture = {
+  topology: {
+    nodes: [
+      { id: 'output-telegram', type: 'output', name: 'Telegram', status: 'running', layer: 'top', brandColor: '#2AABEE' },
+      { id: 'output-wechat', type: 'output', name: '微信', status: 'running', layer: 'top', brandColor: '#07C160' },
+      { id: 'output-email', type: 'output', name: '邮件', status: 'idle', layer: 'top', brandColor: '#EA580C' },
+      { id: 'output-feishu', type: 'output', name: '飞书', status: 'idle', layer: 'top', brandColor: '#3370FF' },
+      { id: 'agent-daily', type: 'agent', name: '日报 Agent', status: 'running', layer: 'middle', brandColor: '#C75B3A', subtitle: '运行中' },
+      { id: 'agent-summary', type: 'agent', name: '摘要 Agent', status: 'idle', layer: 'middle', brandColor: '#3B82F6', subtitle: '待机中' },
+      { id: 'actor-timer', type: 'actor', name: '定时唤醒', status: 'running', layer: 'middle', brandColor: '#78716C', subtitle: '22:00 daily' },
+      { id: 'actor-cleaner', type: 'actor', name: '数据清洗', status: 'idle', layer: 'middle', brandColor: '#78716C', subtitle: 'manual' },
+      { id: 'input-rss', type: 'input', name: 'RSS', status: 'running', layer: 'bottom', brandColor: '#F97316' },
+      { id: 'input-wechat', type: 'input', name: '微信群聊', status: 'running', layer: 'bottom', brandColor: '#07C160' },
+      { id: 'input-api', type: 'input', name: 'API', status: 'idle', layer: 'bottom', brandColor: '#8B5CF6' },
+      { id: 'input-cron', type: 'input', name: '定时触发', status: 'running', layer: 'bottom', brandColor: '#0EA5E9' },
+    ],
+    edges: [
+      { id: 'e-rss-daily', fromNodeId: 'input-rss', toNodeId: 'agent-daily', color: '#C75B3A90' },
+      { id: 'e-wechat-daily', fromNodeId: 'input-wechat', toNodeId: 'agent-daily', color: '#C75B3A90' },
+      { id: 'e-wechat-summary', fromNodeId: 'input-wechat', toNodeId: 'agent-summary', color: '#3B82F690' },
+      { id: 'e-api-summary', fromNodeId: 'input-api', toNodeId: 'agent-summary', color: '#3B82F690' },
+      { id: 'e-cron-timer', fromNodeId: 'input-cron', toNodeId: 'actor-timer', color: '#78716C90' },
+      { id: 'e-timer-daily', fromNodeId: 'actor-timer', toNodeId: 'agent-daily', color: '#78716C90' },
+      { id: 'e-daily-telegram', fromNodeId: 'agent-daily', toNodeId: 'output-telegram', color: '#2AABEE90' },
+      { id: 'e-daily-wechat', fromNodeId: 'agent-daily', toNodeId: 'output-wechat', color: '#07C16090' },
+      { id: 'e-summary-email', fromNodeId: 'agent-summary', toNodeId: 'output-email', color: '#EA580C90' },
+      { id: 'e-summary-feishu', fromNodeId: 'agent-summary', toNodeId: 'output-feishu', color: '#3370FF90' },
+    ],
+    selectedNodeId: null,
+  },
+  listSections: [
+    {
+      id: 'section-input',
+      title: '信号输入',
+      count: 4,
+      items: [
+        { id: 'input-rss', type: 'input', name: 'RSS', description: '订阅源输入', status: 'running', icon: 'rss' },
+        { id: 'input-wechat', type: 'input', name: '微信群聊', description: '微信群消息输入', status: 'running', icon: 'message-circle' },
+        { id: 'input-api', type: 'input', name: 'API', description: 'Webhook 输入', status: 'idle', icon: 'webhook' },
+        { id: 'input-cron', type: 'input', name: '定时触发', description: 'Cron 时间触发', status: 'running', icon: 'timer' },
+      ],
+    },
+    {
+      id: 'section-agent',
+      title: 'Agent',
+      count: 2,
+      items: [
+        { id: 'agent-daily', type: 'agent', name: '日报 Agent', description: '运行中 · 2 入 2 出', status: 'running', icon: 'brain', badgeText: '2 入 / 2 出' },
+        { id: 'agent-summary', type: 'agent', name: '摘要 Agent', description: '待机中 · 2 入 2 出', status: 'idle', icon: 'sparkles', badgeText: '2 入 / 2 出' },
+      ],
+    },
+    {
+      id: 'section-actor',
+      title: 'Actor',
+      count: 2,
+      items: [
+        { id: 'actor-timer', type: 'actor', name: '定时唤醒', description: '每天 22:00', status: 'running', icon: 'timer' },
+        { id: 'actor-cleaner', type: 'actor', name: '数据清洗', description: '手动触发', status: 'idle', icon: 'funnel' },
+      ],
+    },
+    {
+      id: 'section-output',
+      title: '输出节点',
+      count: 4,
+      items: [
+        { id: 'output-telegram', type: 'output', name: 'Telegram', description: '通知频道', status: 'running', icon: 'send' },
+        { id: 'output-wechat', type: 'output', name: '微信', description: '企业微信推送', status: 'running', icon: 'message-circle' },
+        { id: 'output-email', type: 'output', name: '邮件', description: 'SMTP 输出', status: 'idle', icon: 'mail' },
+        { id: 'output-feishu', type: 'output', name: '飞书', description: '飞书机器人输出', status: 'idle', icon: 'bird' },
+      ],
+    },
+  ],
+  deviceGroups: [
+    {
+      id: 'group-local',
+      title: '本地设备',
+      summary: '3 台 · 全部在线',
+      cards: [
+        {
+          id: 'device-desktop',
+          name: '主力台式机',
+          type: 'desktop',
+          status: 'online',
+          summary: '在线 · 4 节点运行中',
+          metrics: [
+            { label: 'CPU', value: '42%' },
+            { label: 'MEM', value: '58%' },
+            { label: 'Latency', value: '6ms' },
+          ],
+          tags: [
+            { id: 'tag-daily', label: '日报Agent', color: '#C75B3A' },
+            { id: 'tag-summary', label: '摘要Agent', color: '#3B82F6' },
+            { id: 'tag-monitor', label: '监控Agent', color: '#22C55E' },
+          ],
+          isHost: true,
+        },
+        {
+          id: 'device-laptop',
+          name: '移动笔记本',
+          type: 'laptop',
+          status: 'online',
+          summary: '在线 · 1 节点运行中',
+          metrics: [{ label: 'Battery', value: '71%' }],
+          tags: [{ id: 'tag-sync', label: 'Obsidian 同步', color: '#8B5CF6' }],
+        },
+        {
+          id: 'device-phone',
+          name: 'Android 手机',
+          type: 'phone',
+          status: 'online',
+          summary: '在线 · 2 节点运行中',
+          metrics: [{ label: 'Signal', value: '5G' }],
+          tags: [
+            { id: 'tag-wx', label: '微信输入', color: '#07C160' },
+            { id: 'tag-notify', label: '通知输出', color: '#2AABEE' },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'group-cloud',
+      title: '云服务器',
+      summary: '1 台 · 在线',
+      cards: [
+        {
+          id: 'device-hk-vps',
+          name: '香港 VPS',
+          type: 'server',
+          status: 'online',
+          summary: '在线 · 2 节点 · 3 容器',
+          metrics: [
+            { label: 'CPU', value: '35%' },
+            { label: 'MEM', value: '49%' },
+          ],
+          tags: [
+            { id: 'tag-n8n', label: 'n8n', color: '#0EA5E9' },
+            { id: 'tag-postgres', label: 'postgres', color: '#6366F1' },
+            { id: 'tag-redis', label: 'redis', color: '#EC4899' },
+          ],
+        },
+      ],
+    },
+  ],
+  addNodeOptions: [
+    { id: 'input', title: '添加信号输入', description: '新增 RSS / API / 传感器输入', icon: 'rss', tintColor: '#F97316' },
+    { id: 'agent', title: '添加 Agent', description: '基于大模型的智能决策节点', icon: 'brain', tintColor: '#C75B3A' },
+    { id: 'actor', title: '添加 Actor', description: '定时、条件触发的程序执行节点', icon: 'timer', tintColor: '#78716C' },
+    { id: 'output', title: '添加输出节点', description: '消息通知、写库、API 回调等输出', icon: 'send', tintColor: '#2AABEE' },
+    { id: 'market', title: '从市场安装', description: '浏览社区插件并一键接入节点', icon: 'shopping-bag', tintColor: '#8B5CF6' },
+  ],
+  agentDetails: {
+    'agent-daily': {
+      id: 'agent-daily',
+      type: 'agent',
+      title: '日报 Agent',
+      status: 'running',
+      description: '每天收集输入通道信息并生成日报，支持晚间复盘。',
+      icon: 'newspaper',
+      tintColor: '#C75B3A',
+      stats: [
+        { label: '已执行', value: '421' },
+        { label: '成功率', value: '97.2%' },
+        { label: '输出节点', value: '2' },
+      ],
+      triggerRules: [
+        { key: '触发方式', value: '定时 + 手动' },
+        { key: 'Cron', value: '0 22 * * *', highlight: true },
+        { key: '时区', value: 'Asia/Shanghai' },
+        { key: '下次执行', value: '2026-02-23 22:00' },
+      ],
+      targets: [
+        { id: 'output-telegram', type: 'output', name: 'Telegram', description: '日报通知', status: 'running', icon: 'send' },
+        { id: 'output-wechat', type: 'output', name: '微信', description: '日报推送', status: 'running', icon: 'message-circle' },
+      ],
+      recentLogs: [
+        { id: 'log-1', time: '21:58', title: '收集 RSS 12 条', status: 'running', duration: '1.2s' },
+        { id: 'log-2', time: '21:59', title: '聚合微信群聊 5 条', status: 'running', duration: '0.9s' },
+        { id: 'log-3', time: '22:00', title: '输出日报到 Telegram', status: 'running', duration: '0.5s' },
+      ],
+    },
+  },
+  actorDetails: {
+    'actor-timer': {
+      id: 'actor-timer',
+      type: 'actor',
+      title: '定时唤醒',
+      status: 'running',
+      description: '每天定时触发日报 Agent 自动执行。',
+      icon: 'timer',
+      tintColor: '#78716C',
+      stats: [
+        { label: '已触发', value: '896' },
+        { label: '准时率', value: '99.8%' },
+        { label: '下游节点', value: '1' },
+      ],
+      triggerRules: [
+        { key: '触发方式', value: 'Cron' },
+        { key: 'Cron', value: '0 22 * * *', highlight: true },
+        { key: '时区', value: 'Asia/Shanghai' },
+        { key: '下次执行', value: '2026-02-23 22:00' },
+      ],
+      targets: [
+        { id: 'agent-daily', type: 'agent', name: '日报 Agent', description: '当前目标', status: 'running', icon: 'brain' },
+      ],
+      recentLogs: [
+        { id: 'log-actor-1', time: '22:00', title: '触发日报 Agent', status: 'running', duration: '45ms' },
+        { id: 'log-actor-2', time: '21:00', title: '跳过（维护窗口）', status: 'warning', duration: '15ms' },
+        { id: 'log-actor-3', time: '20:00', title: '触发成功', status: 'running', duration: '48ms' },
+      ],
+    },
+  },
+  marketCategories: [
+    { id: 'all', label: '全部' },
+    { id: 'agent', label: 'Agent' },
+    { id: 'source', label: '数据源' },
+    { id: 'knowledge', label: '知识包' },
+    { id: 'output', label: '输出' },
+  ],
+  marketItems: [
+    {
+      id: 'market-code-review-agent',
+      name: 'Code Review Agent',
+      summary: '自动审查代码变更并生成风险建议，支持 GitHub PR 触发。',
+      icon: 'shield-check',
+      tintColor: '#3B82F6',
+      tags: ['agent', 'github', 'security'],
+      installsText: '1.2k installs',
+      ratingText: '4.9',
+    },
+    {
+      id: 'market-google-calendar-source',
+      name: 'Google Calendar 数据源',
+      summary: '同步日历事件作为信号输入，用于会议准备与时间分析。',
+      icon: 'calendar-days',
+      tintColor: '#EA580C',
+      tags: ['source', 'calendar', 'schedule'],
+      installsText: '860 installs',
+      ratingText: '4.8',
+    },
+    {
+      id: 'market-team-knowledge-pack',
+      name: '团队知识库',
+      summary: '共享代码规范与项目上下文，支持团队协作节点复用。',
+      icon: 'book-open-text',
+      tintColor: '#22C55E',
+      tags: ['knowledge', 'team', 'docs'],
+      installsText: '530 installs',
+      ratingText: '4.7',
+    },
+  ],
+  conversations: {
+    'agent-daily': [
+      {
+        id: 'msg-agent-welcome',
+        role: 'agent',
+        content: '你好！我是日报 Agent。有什么需要我整理的吗？',
+        createdAt: '2026-02-23T09:41:00.000Z',
+      },
+      {
+        id: 'msg-user-1',
+        role: 'user',
+        content: '帮我看看今天收集了哪些信息？',
+        createdAt: '2026-02-23T09:41:30.000Z',
+      },
+    ],
+  },
+};
+

--- a/src/lib/environment/bootstrap.ts
+++ b/src/lib/environment/bootstrap.ts
@@ -1,9 +1,12 @@
 import { getUseMockDataEnabled } from '@/config/mock-data';
+import { AgentWebAdapter } from '@/lib/adapters/agent-web-adapter';
+import { AgentMockAdapter } from '@/lib/adapters/mock/agent-mock-adapter';
 import { TaskMockAdapter } from '@/lib/adapters/mock/task-mock-adapter';
 import { TaskWebAdapter } from '@/lib/adapters/task-web-adapter';
 import { VolcanoEngineASRAdapter } from '../adapters/asr/volcano-engine-asr';
 import { WebEventLogStorageAdapter } from '../adapters/web-eventlog-storage';
 import { WebStorageAdapter } from '../adapters/web-storage';
+import type { IAgentPort } from './interfaces/agent.port';
 import type { IASRPort } from './interfaces/asr.port';
 import type { IEventLogPort } from './interfaces/eventlog.port';
 import type { IStoragePort } from './interfaces/storage.port';
@@ -17,6 +20,7 @@ export interface RuntimeBootstrapResult {
   storage: IStoragePort;
   eventlog: IEventLogPort;
   task: ITaskPort;
+  agent: IAgentPort;
 }
 
 export interface RuntimeBootstrapOptions {
@@ -54,6 +58,7 @@ export function createRuntimeBootstrap(options: RuntimeBootstrapOptions = {}): R
   const asr = new VolcanoEngineASRAdapter();
   const useMockData = options.useMockData ?? getUseMockDataEnabled();
   const task: ITaskPort = useMockData ? new TaskMockAdapter() : new TaskWebAdapter();
+  const agent: IAgentPort = useMockData ? new AgentMockAdapter() : new AgentWebAdapter();
 
   if (runtime === 'tauri') {
     return {
@@ -63,6 +68,7 @@ export function createRuntimeBootstrap(options: RuntimeBootstrapOptions = {}): R
       // 临时统一到 PouchDB，避免 Tauri 原生 EventLog 与 UI 读取源分裂（#144）
       eventlog: new WebEventLogStorageAdapter(),
       task,
+      agent,
     };
   }
 
@@ -72,5 +78,6 @@ export function createRuntimeBootstrap(options: RuntimeBootstrapOptions = {}): R
     storage: new WebStorageAdapter(),
     eventlog: new WebEventLogStorageAdapter(),
     task,
+    agent,
   };
 }

--- a/src/lib/environment/environment.ts
+++ b/src/lib/environment/environment.ts
@@ -12,6 +12,7 @@
  */
 
 import type { IASRPort } from './interfaces/asr.port';
+import type { IAgentPort } from './interfaces/agent.port';
 import type { IEventLogPort } from './interfaces/eventlog.port';
 import type { IStoragePort } from './interfaces/storage.port';
 import type { ITaskPort } from './interfaces/task.port';
@@ -30,6 +31,8 @@ export interface Environment {
   eventlog: IEventLogPort;
   /** 任务能力 */
   task: ITaskPort;
+  /** Agent Hub 能力 */
+  agent: IAgentPort;
   /** 运行时类型 */
   runtime: RuntimeKind;
 }
@@ -42,6 +45,7 @@ export class ExoMindEnvironment implements Environment {
   storage: IStoragePort;
   eventlog: IEventLogPort;
   task: ITaskPort;
+  agent: IAgentPort;
   runtime: RuntimeKind;
 
   private static instance: ExoMindEnvironment | null = null;
@@ -53,6 +57,7 @@ export class ExoMindEnvironment implements Environment {
     this.storage = bootstrap.storage;
     this.eventlog = bootstrap.eventlog;
     this.task = bootstrap.task;
+    this.agent = bootstrap.agent;
     console.log(`[Environment] ExoMindEnvironment 初始化完成: ${this.runtime}`);
   }
 
@@ -82,6 +87,7 @@ export class ExoMindEnvironment implements Environment {
       storage: true,
       eventlog: true,
       task: true,
+      agent: true,
     };
   }
 }

--- a/src/lib/environment/environment.ts
+++ b/src/lib/environment/environment.ts
@@ -17,6 +17,7 @@ import type { IEventLogPort } from './interfaces/eventlog.port';
 import type { IStoragePort } from './interfaces/storage.port';
 import type { ITaskPort } from './interfaces/task.port';
 import { createRuntimeBootstrap, type RuntimeKind } from './bootstrap';
+import { getUseMockDataEnabled } from '@/config/mock-data';
 
 /**
  * Environment 接口
@@ -47,18 +48,37 @@ export class ExoMindEnvironment implements Environment {
   task: ITaskPort;
   agent: IAgentPort;
   runtime: RuntimeKind;
+  private useMockDataEnabled: boolean;
 
   private static instance: ExoMindEnvironment | null = null;
 
   private constructor(runtime?: RuntimeKind) {
-    const bootstrap = createRuntimeBootstrap({ runtime });
+    const useMockDataEnabled = getUseMockDataEnabled();
+    const bootstrap = createRuntimeBootstrap({ runtime, useMockData: useMockDataEnabled });
     this.runtime = bootstrap.runtime;
     this.asr = bootstrap.asr;
     this.storage = bootstrap.storage;
     this.eventlog = bootstrap.eventlog;
     this.task = bootstrap.task;
     this.agent = bootstrap.agent;
+    this.useMockDataEnabled = useMockDataEnabled;
     console.log(`[Environment] ExoMindEnvironment 初始化完成: ${this.runtime}`);
+  }
+
+  // Runtime sync（运行时同步）: 切换 mock-data 开关后，刷新与数据源相关的 adapter。
+  private refreshDataAdaptersIfNeeded(): void {
+    const nextUseMockDataEnabled = getUseMockDataEnabled();
+    if (nextUseMockDataEnabled === this.useMockDataEnabled) {
+      return;
+    }
+
+    const bootstrap = createRuntimeBootstrap({
+      runtime: this.runtime,
+      useMockData: nextUseMockDataEnabled,
+    });
+    this.task = bootstrap.task;
+    this.agent = bootstrap.agent;
+    this.useMockDataEnabled = nextUseMockDataEnabled;
   }
 
   /**
@@ -68,6 +88,7 @@ export class ExoMindEnvironment implements Environment {
     if (!ExoMindEnvironment.instance) {
       ExoMindEnvironment.instance = new ExoMindEnvironment();
     }
+    ExoMindEnvironment.instance.refreshDataAdaptersIfNeeded();
     return ExoMindEnvironment.instance;
   }
 

--- a/src/lib/environment/interfaces/agent.port.ts
+++ b/src/lib/environment/interfaces/agent.port.ts
@@ -1,0 +1,51 @@
+import type {
+  AgentAddNodeOption,
+  AgentConversationChunk,
+  AgentConversationMessage,
+  AgentDetailData,
+  AgentDeviceGroup,
+  AgentHubListSection,
+  AgentHubTopologyData,
+  AgentMarketCategory,
+  AgentMarketItem,
+} from '@/lib/types/agent-hub';
+
+// Runtime keywords（运行时关键词）for contract assertions（契约断言）
+export const AGENT_PORT_KEYWORDS = [
+  'getTopology',
+  'getListView',
+  'getDeviceView',
+  'listAddNodeOptions',
+  'getAgentDetail',
+  'getActorDetail',
+  'listMarketCategories',
+  'getMarketItems',
+  'getConversation',
+  'streamConversation',
+] as const;
+
+export interface AgentMarketQuery {
+  categoryId?: string;
+  query?: string;
+}
+
+export interface StreamAgentConversationInput {
+  agentId: string;
+  prompt: string;
+}
+
+export interface IAgentPort {
+  getTopology(): Promise<AgentHubTopologyData>;
+  getListView(): Promise<AgentHubListSection[]>;
+  getDeviceView(): Promise<AgentDeviceGroup[]>;
+  listAddNodeOptions(): Promise<AgentAddNodeOption[]>;
+  getAgentDetail(agentId: string): Promise<AgentDetailData | null>;
+  getActorDetail(actorId: string): Promise<AgentDetailData | null>;
+  listMarketCategories(): Promise<AgentMarketCategory[]>;
+  getMarketItems(params?: AgentMarketQuery): Promise<AgentMarketItem[]>;
+  getConversation(agentId: string): Promise<AgentConversationMessage[]>;
+  streamConversation(
+    input: StreamAgentConversationInput
+  ): AsyncGenerator<AgentConversationChunk, void, void>;
+}
+

--- a/src/lib/services/agent-hub.service.ts
+++ b/src/lib/services/agent-hub.service.ts
@@ -1,0 +1,92 @@
+import { ExoMindEnvironment } from '@/lib/environment/environment';
+import type { IAgentPort } from '@/lib/environment/interfaces/agent.port';
+import type {
+  AgentAddNodeOption,
+  AgentConversationChunk,
+  AgentConversationMessage,
+  AgentDetailData,
+  AgentDeviceGroup,
+  AgentHubListSection,
+  AgentHubTopologyData,
+  AgentMarketCategory,
+  AgentMarketItem,
+} from '@/lib/types/agent-hub';
+
+type AgentEnvironmentLike = {
+  agent: IAgentPort;
+};
+
+export interface AgentHubService {
+  getTopology(): Promise<AgentHubTopologyData>;
+  getListView(): Promise<AgentHubListSection[]>;
+  getDeviceView(): Promise<AgentDeviceGroup[]>;
+  listAddNodeOptions(): Promise<AgentAddNodeOption[]>;
+  getAgentDetail(agentId: string): Promise<AgentDetailData | null>;
+  getActorDetail(actorId: string): Promise<AgentDetailData | null>;
+  listMarketCategories(): Promise<AgentMarketCategory[]>;
+  getMarketItems(params?: { categoryId?: string; query?: string }): Promise<AgentMarketItem[]>;
+  getConversation(agentId: string): Promise<AgentConversationMessage[]>;
+  streamConversation(
+    input: { agentId: string; prompt: string }
+  ): AsyncGenerator<AgentConversationChunk, void, void>;
+}
+
+export class AgentHubServiceImpl implements AgentHubService {
+  private readonly env: AgentEnvironmentLike;
+
+  constructor(env?: AgentEnvironmentLike) {
+    this.env = env ?? ExoMindEnvironment.getInstance();
+  }
+
+  async getTopology(): Promise<AgentHubTopologyData> {
+    return this.env.agent.getTopology();
+  }
+
+  async getListView(): Promise<AgentHubListSection[]> {
+    return this.env.agent.getListView();
+  }
+
+  async getDeviceView(): Promise<AgentDeviceGroup[]> {
+    return this.env.agent.getDeviceView();
+  }
+
+  async listAddNodeOptions(): Promise<AgentAddNodeOption[]> {
+    return this.env.agent.listAddNodeOptions();
+  }
+
+  async getAgentDetail(agentId: string): Promise<AgentDetailData | null> {
+    return this.env.agent.getAgentDetail(agentId);
+  }
+
+  async getActorDetail(actorId: string): Promise<AgentDetailData | null> {
+    return this.env.agent.getActorDetail(actorId);
+  }
+
+  async listMarketCategories(): Promise<AgentMarketCategory[]> {
+    return this.env.agent.listMarketCategories();
+  }
+
+  async getMarketItems(params?: { categoryId?: string; query?: string }): Promise<AgentMarketItem[]> {
+    return this.env.agent.getMarketItems(params);
+  }
+
+  async getConversation(agentId: string): Promise<AgentConversationMessage[]> {
+    return this.env.agent.getConversation(agentId);
+  }
+
+  streamConversation(
+    input: { agentId: string; prompt: string }
+  ): AsyncGenerator<AgentConversationChunk, void, void> {
+    return this.env.agent.streamConversation(input);
+  }
+}
+
+let agentHubServiceInstance: AgentHubService | null = null;
+
+export function getAgentHubService(): AgentHubService {
+  if (!agentHubServiceInstance) {
+    agentHubServiceInstance = new AgentHubServiceImpl();
+  }
+  return agentHubServiceInstance;
+}
+

--- a/src/lib/services/agent-hub.service.ts
+++ b/src/lib/services/agent-hub.service.ts
@@ -32,52 +32,59 @@ export interface AgentHubService {
 }
 
 export class AgentHubServiceImpl implements AgentHubService {
-  private readonly env: AgentEnvironmentLike;
+  private readonly injectedEnv: AgentEnvironmentLike | null;
 
   constructor(env?: AgentEnvironmentLike) {
-    this.env = env ?? ExoMindEnvironment.getInstance();
+    this.injectedEnv = env ?? null;
+  }
+
+  private getAgentPort(): IAgentPort {
+    if (this.injectedEnv) {
+      return this.injectedEnv.agent;
+    }
+    return ExoMindEnvironment.getInstance().agent;
   }
 
   async getTopology(): Promise<AgentHubTopologyData> {
-    return this.env.agent.getTopology();
+    return this.getAgentPort().getTopology();
   }
 
   async getListView(): Promise<AgentHubListSection[]> {
-    return this.env.agent.getListView();
+    return this.getAgentPort().getListView();
   }
 
   async getDeviceView(): Promise<AgentDeviceGroup[]> {
-    return this.env.agent.getDeviceView();
+    return this.getAgentPort().getDeviceView();
   }
 
   async listAddNodeOptions(): Promise<AgentAddNodeOption[]> {
-    return this.env.agent.listAddNodeOptions();
+    return this.getAgentPort().listAddNodeOptions();
   }
 
   async getAgentDetail(agentId: string): Promise<AgentDetailData | null> {
-    return this.env.agent.getAgentDetail(agentId);
+    return this.getAgentPort().getAgentDetail(agentId);
   }
 
   async getActorDetail(actorId: string): Promise<AgentDetailData | null> {
-    return this.env.agent.getActorDetail(actorId);
+    return this.getAgentPort().getActorDetail(actorId);
   }
 
   async listMarketCategories(): Promise<AgentMarketCategory[]> {
-    return this.env.agent.listMarketCategories();
+    return this.getAgentPort().listMarketCategories();
   }
 
   async getMarketItems(params?: { categoryId?: string; query?: string }): Promise<AgentMarketItem[]> {
-    return this.env.agent.getMarketItems(params);
+    return this.getAgentPort().getMarketItems(params);
   }
 
   async getConversation(agentId: string): Promise<AgentConversationMessage[]> {
-    return this.env.agent.getConversation(agentId);
+    return this.getAgentPort().getConversation(agentId);
   }
 
   streamConversation(
     input: { agentId: string; prompt: string }
   ): AsyncGenerator<AgentConversationChunk, void, void> {
-    return this.env.agent.streamConversation(input);
+    return this.getAgentPort().streamConversation(input);
   }
 }
 
@@ -89,4 +96,3 @@ export function getAgentHubService(): AgentHubService {
   }
   return agentHubServiceInstance;
 }
-

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -11,5 +11,8 @@ export type { TimeBlockService } from './timeblock.service';
 export { TaskServiceImpl, getTaskService } from './task.service';
 export type { TaskService } from './task.service';
 
+export { AgentHubServiceImpl, getAgentHubService } from './agent-hub.service';
+export type { AgentHubService } from './agent-hub.service';
+
 // 重新导出类型（这些类型在 types/event 中定义）
 export type { TimerMode, TimerConfig } from '../types/event';

--- a/src/lib/types/agent-hub.ts
+++ b/src/lib/types/agent-hub.ts
@@ -1,0 +1,156 @@
+// Agent Hub view modes（视图模式）
+export const AGENT_HUB_VIEW_MODES = ['topology', 'list', 'device'] as const;
+export type AgentHubViewMode = (typeof AGENT_HUB_VIEW_MODES)[number];
+
+// Node type（节点类型）and status（运行状态）
+export type AgentHubNodeType = 'input' | 'agent' | 'actor' | 'output';
+export type AgentHubNodeStatus = 'running' | 'idle' | 'warning' | 'offline';
+export type AgentHubNodeLayer = 'top' | 'middle' | 'bottom';
+
+export interface AgentHubNode {
+  id: string;
+  type: AgentHubNodeType;
+  name: string;
+  status: AgentHubNodeStatus;
+  layer: AgentHubNodeLayer;
+  brandColor: string;
+  subtitle?: string;
+}
+
+export interface AgentHubEdge {
+  id: string;
+  fromNodeId: string;
+  toNodeId: string;
+  color: string;
+  highlighted?: boolean;
+}
+
+export interface AgentHubTopologyData {
+  nodes: AgentHubNode[];
+  edges: AgentHubEdge[];
+  selectedNodeId?: string | null;
+}
+
+export interface AgentHubListItem {
+  id: string;
+  type: AgentHubNodeType;
+  name: string;
+  description: string;
+  status: AgentHubNodeStatus;
+  icon: string;
+  badgeText?: string;
+}
+
+export interface AgentHubListSection {
+  id: string;
+  title: string;
+  count: number;
+  items: AgentHubListItem[];
+}
+
+export type AgentHubDeviceStatus = 'online' | 'offline' | 'warning';
+export type AgentHubDeviceType = 'desktop' | 'laptop' | 'phone' | 'server' | 'embedded' | 'wearable';
+
+export interface AgentHubDeviceMetric {
+  label: string;
+  value: string;
+}
+
+export interface AgentHubDeviceNodeTag {
+  id: string;
+  label: string;
+  color: string;
+}
+
+export interface AgentHubDeviceCard {
+  id: string;
+  name: string;
+  type: AgentHubDeviceType;
+  status: AgentHubDeviceStatus;
+  summary: string;
+  metrics: AgentHubDeviceMetric[];
+  tags: AgentHubDeviceNodeTag[];
+  isHost?: boolean;
+}
+
+export interface AgentDeviceGroup {
+  id: string;
+  title: string;
+  summary: string;
+  cards: AgentHubDeviceCard[];
+}
+
+export type AgentAddNodeOptionId = 'input' | 'agent' | 'actor' | 'output' | 'market';
+
+export interface AgentAddNodeOption {
+  id: AgentAddNodeOptionId;
+  title: string;
+  description: string;
+  icon: string;
+  tintColor: string;
+}
+
+export interface AgentDetailStat {
+  label: string;
+  value: string;
+}
+
+export interface AgentDetailKV {
+  key: string;
+  value: string;
+  highlight?: boolean;
+}
+
+export interface AgentDetailTimelineItem {
+  id: string;
+  time: string;
+  title: string;
+  status: AgentHubNodeStatus;
+  duration?: string;
+}
+
+export interface AgentDetailData {
+  id: string;
+  type: 'agent' | 'actor';
+  title: string;
+  status: AgentHubNodeStatus;
+  description: string;
+  icon: string;
+  tintColor: string;
+  stats: AgentDetailStat[];
+  triggerRules: AgentDetailKV[];
+  targets: AgentHubListItem[];
+  recentLogs: AgentDetailTimelineItem[];
+}
+
+export interface AgentMarketCategory {
+  id: string;
+  label: string;
+}
+
+export interface AgentMarketItem {
+  id: string;
+  name: string;
+  summary: string;
+  icon: string;
+  tintColor: string;
+  tags: string[];
+  installsText: string;
+  ratingText: string;
+}
+
+export type AgentConversationRole = 'agent' | 'user';
+
+export interface AgentConversationMessage {
+  id: string;
+  role: AgentConversationRole;
+  content: string;
+  createdAt: string;
+}
+
+export interface AgentConversationChunk {
+  messageId: string;
+  delta: string;
+  done: boolean;
+}
+

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -7,3 +7,6 @@ export * from './event';
 
 // 消息类型定义
 export * from './message';
+
+// Agent Hub 类型定义
+export * from './agent-hub';

--- a/src/routes-new.tsx
+++ b/src/routes-new.tsx
@@ -1,4 +1,4 @@
-import { createRootRoute, createRouter, createRoute, Outlet, Link, useLocation } from '@tanstack/react-router';
+import { createRootRoute, createRouter, createRoute, Outlet, Link, useLocation, useParams } from '@tanstack/react-router';
 import { Suspense, lazy, useEffect, useState } from 'react';
 import { Target, Settings, Bot, SquareCheckBig } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -42,6 +42,26 @@ const MOSSASRTestPage = lazy(async () => {
 const AgentsPage = lazy(async () => {
   const module = await import('@/ui/new/pages/AgentsPage');
   return { default: module.AgentsPage };
+});
+
+const AgentDetailPage = lazy(async () => {
+  const module = await import('@/ui/new/pages/agents/AgentDetailPage');
+  return { default: module.AgentDetailPage };
+});
+
+const ActorDetailPage = lazy(async () => {
+  const module = await import('@/ui/new/pages/agents/ActorDetailPage');
+  return { default: module.ActorDetailPage };
+});
+
+const AgentConversationPage = lazy(async () => {
+  const module = await import('@/ui/new/pages/agents/AgentConversationPage');
+  return { default: module.AgentConversationPage };
+});
+
+const AgentMarketPage = lazy(async () => {
+  const module = await import('@/ui/new/pages/agents/AgentMarketPage');
+  return { default: module.AgentMarketPage };
 });
 
 function PageFallback() {
@@ -219,6 +239,57 @@ const newAgentsRoute = createRoute({
   },
 });
 
+const newAgentDetailRoute = createRoute({
+  getParentRoute: () => newRootRoute,
+  path: '/agents/agent/$agentId',
+  component: function NewAgentDetail() {
+    const { agentId } = useParams({ strict: false }) as { agentId?: string };
+    return (
+      <LazyPage>
+        <AgentDetailPage agentId={agentId} />
+      </LazyPage>
+    );
+  },
+});
+
+const newActorDetailRoute = createRoute({
+  getParentRoute: () => newRootRoute,
+  path: '/agents/actor/$actorId',
+  component: function NewActorDetail() {
+    const { actorId } = useParams({ strict: false }) as { actorId?: string };
+    return (
+      <LazyPage>
+        <ActorDetailPage actorId={actorId} />
+      </LazyPage>
+    );
+  },
+});
+
+const newAgentConversationRoute = createRoute({
+  getParentRoute: () => newRootRoute,
+  path: '/agents/chat/$agentId',
+  component: function NewAgentConversation() {
+    const { agentId } = useParams({ strict: false }) as { agentId?: string };
+    return (
+      <LazyPage>
+        <AgentConversationPage agentId={agentId} />
+      </LazyPage>
+    );
+  },
+});
+
+const newAgentMarketRoute = createRoute({
+  getParentRoute: () => newRootRoute,
+  path: '/agents/market',
+  component: function NewAgentMarket() {
+    return (
+      <LazyPage>
+        <AgentMarketPage />
+      </LazyPage>
+    );
+  },
+});
+
 const newRouteTree = newRootRoute.addChildren([
   newHomeRoute,
   newEventlogRoute,
@@ -229,6 +300,10 @@ const newRouteTree = newRootRoute.addChildren([
   newAsrTestRoute,
   newMossTestRoute,
   newAgentsRoute,
+  newAgentDetailRoute,
+  newActorDetailRoute,
+  newAgentConversationRoute,
+  newAgentMarketRoute,
 ]);
 
 const newUiRouter = createRouter({ routeTree: newRouteTree });

--- a/src/ui/new/pages/AgentsPage.tsx
+++ b/src/ui/new/pages/AgentsPage.tsx
@@ -141,7 +141,13 @@ function TopologyView({
   );
 }
 
-function ListView({ sections }: { sections: AgentHubListSection[] }) {
+function ListView({
+  sections,
+  onItemNavigate,
+}: {
+  sections: AgentHubListSection[];
+  onItemNavigate: (path: string) => void;
+}) {
   return (
     <section data-testid="agent-list-view" className="space-y-4">
       {sections.map((section) => (
@@ -153,13 +159,25 @@ function ListView({ sections }: { sections: AgentHubListSection[] }) {
           <div className="overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white">
             {section.items.map((item, index) => (
               <div key={item.id}>
-                <div className="flex items-center justify-between px-4 py-3">
+                <button
+                  type="button"
+                  data-testid={`agent-list-item-${item.id}`}
+                  onClick={() => {
+                    if (item.type === 'agent') {
+                      onItemNavigate(`/agents/agent/${item.id}`);
+                    }
+                    if (item.type === 'actor') {
+                      onItemNavigate(`/agents/actor/${item.id}`);
+                    }
+                  }}
+                  className="flex w-full items-center justify-between px-4 py-3 text-left"
+                >
                   <div>
                     <p className="text-sm font-medium text-[#1C1917]">{item.name}</p>
                     <p className="text-xs text-[#A8A29E]">{item.description}</p>
                   </div>
                   <span className="text-[11px] text-[#78716C]">{item.status}</span>
-                </div>
+                </button>
                 {index !== section.items.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
               </div>
             ))}
@@ -212,9 +230,11 @@ function DeviceView({ groups }: { groups: AgentDeviceGroup[] }) {
 function AddNodeSheet({
   options,
   onClose,
+  onNavigate,
 }: {
   options: AgentAddNodeOption[];
   onClose: () => void;
+  onNavigate: (path: string) => void;
 }) {
   return (
     <>
@@ -248,6 +268,13 @@ function AddNodeSheet({
             <button
               key={option.id}
               type="button"
+              data-testid={`agent-add-node-option-${option.id}`}
+              onClick={() => {
+                if (option.id === 'market') {
+                  onClose();
+                  onNavigate('/agents/market');
+                }
+              }}
               className="flex w-full items-center justify-between rounded-2xl bg-[#FAF7F5] px-4 py-3 text-left"
             >
               <div>
@@ -295,9 +322,13 @@ export function AgentsPage() {
     };
   }, []);
 
+  const navigateByPath = (path: string) => {
+    window.location.href = path;
+  };
+
   const content = useMemo(() => {
     if (viewMode === 'list') {
-      return <ListView sections={listSections} />;
+      return <ListView sections={listSections} onItemNavigate={navigateByPath} />;
     }
     if (viewMode === 'device') {
       return <DeviceView groups={deviceGroups} />;
@@ -341,8 +372,13 @@ export function AgentsPage() {
         {content}
       </div>
 
-      {sheetOpen && <AddNodeSheet options={addNodeOptions} onClose={() => setSheetOpen(false)} />}
+      {sheetOpen && (
+        <AddNodeSheet
+          options={addNodeOptions}
+          onClose={() => setSheetOpen(false)}
+          onNavigate={navigateByPath}
+        />
+      )}
     </div>
   );
 }
-

--- a/src/ui/new/pages/AgentsPage.tsx
+++ b/src/ui/new/pages/AgentsPage.tsx
@@ -1,20 +1,158 @@
-import { Bot, List, Monitor, Plus, Settings, X } from 'lucide-react';
+import {
+  AlarmClock,
+  Bot,
+  Brain,
+  ChevronRight,
+  Filter,
+  List,
+  Mail,
+  MessageCircle,
+  Monitor,
+  Newspaper,
+  Plus,
+  Rocket,
+  Rss,
+  Send,
+  Settings,
+  Sparkles,
+  TimerReset,
+  Waypoints,
+  Webhook,
+  X,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { getAgentHubService } from '@/lib/services';
 import type {
   AgentAddNodeOption,
   AgentDeviceGroup,
+  AgentHubEdge,
+  AgentHubListItem,
   AgentHubListSection,
   AgentHubNode,
   AgentHubTopologyData,
   AgentHubViewMode,
 } from '@/lib/types/agent-hub';
 
-const VIEW_ITEMS: Array<{ id: AgentHubViewMode; icon: React.ComponentType<{ size?: number }>; label: string }> = [
+const VIEW_ITEMS: Array<{ id: AgentHubViewMode; icon: LucideIcon; label: string }> = [
   { id: 'topology', icon: Bot, label: '拓扑' },
   { id: 'list', icon: List, label: '列表' },
   { id: 'device', icon: Monitor, label: '设备' },
 ];
+
+const LIST_FILTERS = [
+  { id: 'all', label: '全部' },
+  { id: 'input', label: '信号输入' },
+  { id: 'agent', label: 'Agent' },
+  { id: 'actor', label: 'Actor' },
+  { id: 'output', label: '输出' },
+] as const;
+
+type TopologyLayoutItem = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  shape: 'bubble' | 'card' | 'chip';
+};
+
+// Topology layout（拓扑布局）使用设计稿坐标近似值，保持移动端视觉比例。
+const TOPOLOGY_LAYOUT: Record<string, TopologyLayoutItem> = {
+  'output-telegram': { x: 16, y: 42, width: 58, height: 58, shape: 'bubble' },
+  'output-wechat': { x: 104, y: 42, width: 58, height: 58, shape: 'bubble' },
+  'output-email': { x: 192, y: 42, width: 58, height: 58, shape: 'bubble' },
+  'output-feishu': { x: 280, y: 42, width: 58, height: 58, shape: 'bubble' },
+  'agent-daily': { x: 24, y: 230, width: 156, height: 86, shape: 'card' },
+  'agent-summary': { x: 196, y: 246, width: 144, height: 80, shape: 'card' },
+  'actor-timer': { x: 112, y: 338, width: 120, height: 50, shape: 'chip' },
+  'actor-cleaner': { x: 244, y: 338, width: 112, height: 50, shape: 'chip' },
+  'input-rss': { x: 20, y: 490, width: 56, height: 56, shape: 'bubble' },
+  'input-wechat': { x: 108, y: 490, width: 56, height: 56, shape: 'bubble' },
+  'input-api': { x: 196, y: 490, width: 56, height: 56, shape: 'bubble' },
+  'input-cron': { x: 284, y: 490, width: 56, height: 56, shape: 'bubble' },
+};
+
+function normalizeHexColor(color: string): string {
+  return color.length === 9 ? color.slice(0, 7) : color;
+}
+
+function getNodeIcon(node: AgentHubNode): LucideIcon {
+  if (node.id === 'output-telegram') return Send;
+  if (node.id === 'output-wechat') return MessageCircle;
+  if (node.id === 'output-email') return Mail;
+  if (node.id === 'output-feishu') return Rocket;
+  if (node.id === 'agent-daily') return Newspaper;
+  if (node.id === 'agent-summary') return Sparkles;
+  if (node.id === 'actor-timer') return AlarmClock;
+  if (node.id === 'actor-cleaner') return Filter;
+  if (node.id === 'input-rss') return Rss;
+  if (node.id === 'input-wechat') return MessageCircle;
+  if (node.id === 'input-api') return Webhook;
+  return TimerReset;
+}
+
+function getListItemIcon(item: AgentHubListItem): LucideIcon {
+  if (item.id.includes('rss')) return Rss;
+  if (item.id.includes('wechat')) return MessageCircle;
+  if (item.id.includes('api')) return Webhook;
+  if (item.id.includes('timer') || item.id.includes('cron')) return AlarmClock;
+  if (item.type === 'agent' && item.id.includes('summary')) return Sparkles;
+  if (item.type === 'agent') return Brain;
+  if (item.type === 'actor' && item.id.includes('cleaner')) return Filter;
+  if (item.type === 'actor') return AlarmClock;
+  if (item.id.includes('telegram')) return Send;
+  if (item.id.includes('email')) return Mail;
+  if (item.id.includes('feishu')) return Rocket;
+  return Waypoints;
+}
+
+function getAddOptionIcon(optionId: AgentAddNodeOption['id']): LucideIcon {
+  if (optionId === 'input') return Rss;
+  if (optionId === 'agent') return Brain;
+  if (optionId === 'actor') return AlarmClock;
+  if (optionId === 'output') return Send;
+  return Sparkles;
+}
+
+function getDeviceTypeIcon(groupId: string): LucideIcon {
+  if (groupId.includes('cloud')) return Waypoints;
+  return Monitor;
+}
+
+function getNodeCenter(layout: TopologyLayoutItem): { x: number; y: number } {
+  return {
+    x: layout.x + layout.width / 2,
+    y: layout.y + layout.height / 2,
+  };
+}
+
+function getEdgeEndpoints(edge: AgentHubEdge): { from: { x: number; y: number }; to: { x: number; y: number } } | null {
+  const fromLayout = TOPOLOGY_LAYOUT[edge.fromNodeId];
+  const toLayout = TOPOLOGY_LAYOUT[edge.toNodeId];
+  if (!fromLayout || !toLayout) return null;
+
+  const fromCenter = getNodeCenter(fromLayout);
+  const toCenter = getNodeCenter(toLayout);
+
+  const from = {
+    x: fromCenter.x,
+    y: fromCenter.y > toCenter.y ? fromLayout.y : fromLayout.y + fromLayout.height,
+  };
+  const to = {
+    x: toCenter.x,
+    y: toCenter.y > fromCenter.y ? toLayout.y : toLayout.y + toLayout.height,
+  };
+
+  return { from, to };
+}
+
+function buildEdgePath(edge: AgentHubEdge): string | null {
+  const endpoints = getEdgeEndpoints(edge);
+  if (!endpoints) return null;
+  const { from, to } = endpoints;
+  const controlY = (from.y + to.y) / 2;
+  return `M ${from.x} ${from.y} C ${from.x} ${controlY}, ${to.x} ${controlY}, ${to.x} ${to.y}`;
+}
 
 function ViewToggle({
   value,
@@ -50,35 +188,137 @@ function ViewToggle({
   );
 }
 
-function NodeBadge({
+function TopologyNode({
   node,
   selected,
+  muted,
   onSelect,
 }: {
   node: AgentHubNode;
   selected: boolean;
+  muted: boolean;
   onSelect: (nodeId: string) => void;
 }) {
+  const layout = TOPOLOGY_LAYOUT[node.id];
+  if (!layout) return null;
+
+  const Icon = getNodeIcon(node);
+  const baseColor = normalizeHexColor(node.brandColor);
+
+  if (layout.shape === 'bubble') {
+    return (
+      <button
+        type="button"
+        data-testid={`agent-topology-node-${node.id}`}
+        data-muted={muted ? 'true' : 'false'}
+        onClick={(event) => {
+          event.stopPropagation();
+          onSelect(node.id);
+        }}
+        className="absolute flex flex-col items-center"
+        style={{
+          left: layout.x,
+          top: layout.y,
+          width: layout.width,
+          opacity: muted ? 0.32 : 1,
+          transition: 'opacity 160ms ease, transform 160ms ease',
+        }}
+      >
+        <div
+          className={`flex h-10 w-10 items-center justify-center rounded-full border ${
+            selected ? 'ring-2 ring-offset-1' : ''
+          }`}
+          style={{
+            borderColor: `${baseColor}50`,
+            color: baseColor,
+            backgroundColor: `${baseColor}1A`,
+          }}
+        >
+          <Icon size={15} />
+        </div>
+        <span className="mt-1 text-[10px] font-medium text-[#57534E]">{node.name}</span>
+      </button>
+    );
+  }
+
+  if (layout.shape === 'chip') {
+    return (
+      <button
+        type="button"
+        data-testid={`agent-topology-node-${node.id}`}
+        data-muted={muted ? 'true' : 'false'}
+        onClick={(event) => {
+          event.stopPropagation();
+          onSelect(node.id);
+        }}
+        className={`absolute flex items-center gap-2 rounded-xl border px-3 py-2 text-left transition ${
+          selected
+            ? 'border-[#C75B3A] bg-white shadow-[0_8px_20px_-14px_rgba(199,91,58,0.9)]'
+            : 'border-[#E7E5E4] bg-white'
+        }`}
+        style={{
+          left: layout.x,
+          top: layout.y,
+          width: layout.width,
+          minHeight: layout.height,
+          opacity: muted ? 0.35 : 1,
+        }}
+      >
+        <div
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg"
+          style={{ backgroundColor: `${baseColor}18`, color: baseColor }}
+        >
+          <Icon size={13} />
+        </div>
+        <div className="min-w-0">
+          <p className="truncate text-[12px] font-semibold text-[#44403C]">{node.name}</p>
+          <p className="truncate text-[10px] text-[#A8A29E]">{node.subtitle ?? node.status}</p>
+        </div>
+      </button>
+    );
+  }
+
   return (
     <button
       type="button"
       data-testid={`agent-topology-node-${node.id}`}
+      data-muted={muted ? 'true' : 'false'}
       onClick={(event) => {
         event.stopPropagation();
         onSelect(node.id);
       }}
-      className={`flex min-w-[64px] flex-col items-center gap-1 rounded-2xl border px-2 py-2 transition ${
+      className={`absolute rounded-2xl border bg-white px-3 py-3 text-left transition ${
         selected
-          ? 'scale-[1.03] border-[#C75B3A] bg-white shadow-[0_6px_18px_-8px_rgba(199,91,58,0.8)]'
-          : 'border-[#E7E5E4] bg-white'
+          ? 'border-[#C75B3A] shadow-[0_12px_24px_-16px_rgba(199,91,58,0.9)]'
+          : 'border-[#E7E5E4]'
       }`}
-      style={!selected ? { opacity: 1 } : undefined}
+      style={{
+        left: layout.x,
+        top: layout.y,
+        width: layout.width,
+        minHeight: layout.height,
+        opacity: muted ? 0.35 : 1,
+      }}
     >
-      <span
-        className="inline-block h-8 w-8 rounded-full"
-        style={{ backgroundColor: `${node.brandColor}22`, border: `1px solid ${node.brandColor}66` }}
-      />
-      <span className="text-[10px] font-medium text-[#57534E]">{node.name}</span>
+      <div className="flex items-center gap-2">
+        <div
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
+          style={{ backgroundColor: `${baseColor}1F`, color: baseColor }}
+        >
+          <Icon size={15} />
+        </div>
+        <div className="min-w-0">
+          <p className="truncate text-[13px] font-semibold text-[#1C1917]">{node.name}</p>
+          <p className="truncate text-[10px] text-[#A8A29E]">{node.subtitle ?? node.status}</p>
+        </div>
+      </div>
+      <div className="mt-2 flex items-center gap-1 text-[10px] text-[#78716C]">
+        <span
+          className="inline-block h-1.5 w-1.5 rounded-full"
+          style={{ backgroundColor: node.status === 'running' ? '#22C55E' : '#A8A29E' }}
+        />
+        {node.status === 'running' ? '运行中' : '待机中'}
+      </div>
     </button>
   );
 }
@@ -94,36 +334,77 @@ function TopologyView({
   onSelectNode: (nodeId: string) => void;
   onClearSelection: () => void;
 }) {
-  const topNodes = topology.nodes.filter((node) => node.layer === 'top');
-  const middleNodes = topology.nodes.filter((node) => node.layer === 'middle');
-  const bottomNodes = topology.nodes.filter((node) => node.layer === 'bottom');
   const selectedNode = topology.nodes.find((item) => item.id === selectedNodeId) ?? null;
 
+  const selectionState = useMemo(() => {
+    if (!selectedNodeId) {
+      return {
+        highlightedEdgeIds: new Set<string>(),
+        connectedNodeIds: new Set<string>(),
+      };
+    }
+
+    const connectedNodeIds = new Set<string>([selectedNodeId]);
+    const highlightedEdgeIds = new Set<string>();
+
+    topology.edges.forEach((edge) => {
+      if (edge.fromNodeId === selectedNodeId || edge.toNodeId === selectedNodeId) {
+        highlightedEdgeIds.add(edge.id);
+        connectedNodeIds.add(edge.fromNodeId);
+        connectedNodeIds.add(edge.toNodeId);
+      }
+    });
+
+    return { highlightedEdgeIds, connectedNodeIds };
+  }, [selectedNodeId, topology.edges]);
+
   return (
-    <section
-      data-testid="agent-topology-view"
-      className="space-y-3"
-      onClick={onClearSelection}
-    >
-      <div className="rounded-[10px] bg-[#F5F0ED] px-3 py-1 text-[11px] font-semibold text-[#A8A29E]">输出节点</div>
-      <div className="flex flex-wrap gap-2 px-1">
-        {topNodes.map((node) => (
-          <NodeBadge key={node.id} node={node} selected={node.id === selectedNodeId} onSelect={onSelectNode} />
-        ))}
-      </div>
+    <section data-testid="agent-topology-view" className="space-y-3" onClick={onClearSelection}>
+      <div
+        data-testid="agent-topology-canvas"
+        className="relative h-[568px] overflow-hidden rounded-[22px] border border-[#EDE8E3] bg-[#FAF7F5]"
+      >
+        <div className="absolute left-3 top-2 rounded-md bg-[#F5F0ED] px-2 py-1 text-[10px] font-semibold text-[#A8A29E]">输出节点</div>
+        <div className="absolute left-3 top-[205px] rounded-md bg-[#F5F0ED] px-2 py-1 text-[10px] font-semibold text-[#A8A29E]">Agent / Actor</div>
+        <div className="absolute left-3 top-[462px] rounded-md bg-[#F5F0ED] px-2 py-1 text-[10px] font-semibold text-[#A8A29E]">信号输入</div>
 
-      <div className="rounded-[10px] bg-[#F5F0ED] px-3 py-1 text-[11px] font-semibold text-[#A8A29E]">Agent / Actor</div>
-      <div className="flex flex-wrap gap-2 px-1">
-        {middleNodes.map((node) => (
-          <NodeBadge key={node.id} node={node} selected={node.id === selectedNodeId} onSelect={onSelectNode} />
-        ))}
-      </div>
+        <svg className="absolute inset-0 h-full w-full" viewBox="0 0 356 568" fill="none" aria-hidden="true">
+          {topology.edges.map((edge) => {
+            const path = buildEdgePath(edge);
+            if (!path) return null;
 
-      <div className="rounded-[10px] bg-[#F5F0ED] px-3 py-1 text-[11px] font-semibold text-[#A8A29E]">信号输入</div>
-      <div className="flex flex-wrap gap-2 px-1">
-        {bottomNodes.map((node) => (
-          <NodeBadge key={node.id} node={node} selected={node.id === selectedNodeId} onSelect={onSelectNode} />
-        ))}
+            const highlighted = selectionState.highlightedEdgeIds.has(edge.id);
+            const hasSelection = Boolean(selectedNodeId);
+            const baseColor = normalizeHexColor(edge.color);
+            const opacity = hasSelection ? (highlighted ? 1 : 0.18) : 0.45;
+            const strokeWidth = hasSelection ? (highlighted ? 2.5 : 1.1) : 1.5;
+
+            return (
+              <path
+                key={edge.id}
+                data-testid={`agent-topology-edge-${edge.id}`}
+                d={path}
+                stroke={baseColor}
+                strokeWidth={strokeWidth}
+                strokeLinecap="round"
+                opacity={opacity}
+              />
+            );
+          })}
+        </svg>
+
+        {topology.nodes.map((node) => {
+          const muted = Boolean(selectedNodeId) && !selectionState.connectedNodeIds.has(node.id);
+          return (
+            <TopologyNode
+              key={node.id}
+              node={node}
+              selected={selectedNodeId === node.id}
+              muted={muted}
+              onSelect={onSelectNode}
+            />
+          );
+        })}
       </div>
 
       {selectedNode && (
@@ -150,37 +431,67 @@ function ListView({
 }) {
   return (
     <section data-testid="agent-list-view" className="space-y-4">
+      <div className="flex gap-2 overflow-x-auto pb-1">
+        {LIST_FILTERS.map((filterItem, index) => {
+          const active = index === 0;
+          return (
+            <button
+              key={filterItem.id}
+              type="button"
+              data-testid={`agent-list-filter-${filterItem.id}`}
+              className={`shrink-0 rounded-full px-3 py-1.5 text-[12px] ${
+                active ? 'bg-[#C75B3A] text-white' : 'bg-[#F5F0ED] text-[#78716C]'
+              }`}
+            >
+              {filterItem.label}
+            </button>
+          );
+        })}
+      </div>
+
       {sections.map((section) => (
         <article key={section.id} className="space-y-2">
           <div className="flex items-center justify-between">
             <h3 className="text-[13px] font-semibold text-[#78716C]">{section.title}</h3>
-            <span className="rounded-md bg-[#F5F0ED] px-2 py-0.5 text-[11px] text-[#78716C]">{section.count}</span>
+            <span className="rounded-md bg-[#F5F0ED] px-2 py-0.5 text-[11px] text-[#78716C]">{section.count} 个节点</span>
           </div>
           <div className="overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white">
-            {section.items.map((item, index) => (
-              <div key={item.id}>
-                <button
-                  type="button"
-                  data-testid={`agent-list-item-${item.id}`}
-                  onClick={() => {
-                    if (item.type === 'agent') {
-                      onItemNavigate(`/agents/agent/${item.id}`);
-                    }
-                    if (item.type === 'actor') {
-                      onItemNavigate(`/agents/actor/${item.id}`);
-                    }
-                  }}
-                  className="flex w-full items-center justify-between px-4 py-3 text-left"
-                >
-                  <div>
-                    <p className="text-sm font-medium text-[#1C1917]">{item.name}</p>
-                    <p className="text-xs text-[#A8A29E]">{item.description}</p>
-                  </div>
-                  <span className="text-[11px] text-[#78716C]">{item.status}</span>
-                </button>
-                {index !== section.items.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
-              </div>
-            ))}
+            {section.items.map((item, index) => {
+              const Icon = getListItemIcon(item);
+              return (
+                <div key={item.id}>
+                  <button
+                    type="button"
+                    data-testid={`agent-list-item-${item.id}`}
+                    onClick={() => {
+                      if (item.type === 'agent') {
+                        onItemNavigate(`/agents/agent/${item.id}`);
+                      }
+                      if (item.type === 'actor') {
+                        onItemNavigate(`/agents/actor/${item.id}`);
+                      }
+                    }}
+                    className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left"
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#F5F0ED] text-[#78716C]">
+                        <Icon size={16} />
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium text-[#1C1917]">{item.name}</p>
+                        <p className="text-xs text-[#A8A29E]">{item.description}</p>
+                      </div>
+                    </div>
+                    <ChevronRight
+                      data-testid={`agent-list-item-${item.id}-chevron`}
+                      size={14}
+                      className="shrink-0 text-[#D6D3D1]"
+                    />
+                  </button>
+                  {index !== section.items.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
+                </div>
+              );
+            })}
           </div>
         </article>
       ))}
@@ -189,8 +500,44 @@ function ListView({
 }
 
 function DeviceView({ groups }: { groups: AgentDeviceGroup[] }) {
+  const hostCard = groups.flatMap((group) => group.cards).find((card) => card.isHost) ?? groups[0]?.cards[0];
+
   return (
     <section data-testid="agent-device-view" className="space-y-4">
+      {hostCard && (
+        <article
+          data-testid="agent-device-overview-card"
+          className="rounded-2xl border border-[#E7E5E4] bg-white px-4 py-3"
+        >
+          <div className="flex items-start justify-between">
+            <div>
+              <p className="text-sm font-semibold text-[#1C1917]">{hostCard.name}</p>
+              <p className="mt-0.5 text-xs text-[#A8A29E]">{hostCard.summary}</p>
+            </div>
+            <span className="rounded bg-[#C75B3A15] px-2 py-0.5 text-[11px] text-[#C75B3A]">本机</span>
+          </div>
+          <div className="mt-2 grid grid-cols-3 gap-2">
+            {hostCard.metrics.slice(0, 3).map((metric) => (
+              <div key={metric.label} className="rounded-lg bg-[#FAF7F5] px-2 py-1.5 text-center">
+                <p className="text-[10px] text-[#A8A29E]">{metric.label}</p>
+                <p className="text-[12px] font-semibold text-[#1C1917]">{metric.value}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-2 flex flex-wrap gap-1">
+            {hostCard.tags.map((tag) => (
+              <span
+                key={tag.id}
+                className="rounded-md px-2 py-0.5 text-[11px]"
+                style={{ backgroundColor: `${tag.color}22`, color: tag.color }}
+              >
+                {tag.label}
+              </span>
+            ))}
+          </div>
+        </article>
+      )}
+
       {groups.map((group) => (
         <article key={group.id} className="space-y-2">
           <div className="flex items-center gap-2">
@@ -198,28 +545,36 @@ function DeviceView({ groups }: { groups: AgentDeviceGroup[] }) {
             <span className="text-[11px] text-[#A8A29E]">{group.summary}</span>
           </div>
           <div className="space-y-2">
-            {group.cards.map((card) => (
-              <div key={card.id} className="rounded-2xl border border-[#E7E5E4] bg-white px-4 py-3">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="text-sm font-semibold text-[#1C1917]">{card.name}</p>
-                    <p className="text-xs text-[#A8A29E]">{card.summary}</p>
+            {group.cards.map((card) => {
+              const DeviceIcon = getDeviceTypeIcon(group.id);
+              return (
+                <div key={card.id} className="rounded-2xl border border-[#E7E5E4] bg-white px-4 py-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex items-start gap-2">
+                      <div className="mt-0.5 flex h-7 w-7 items-center justify-center rounded-lg bg-[#F5F0ED] text-[#78716C]">
+                        <DeviceIcon size={14} />
+                      </div>
+                      <div>
+                        <p className="text-sm font-semibold text-[#1C1917]">{card.name}</p>
+                        <p className="text-xs text-[#A8A29E]">{card.summary}</p>
+                      </div>
+                    </div>
+                    <ChevronRight size={14} className="text-[#D6D3D1]" />
                   </div>
-                  {card.isHost && <span className="rounded bg-[#C75B3A15] px-2 py-0.5 text-[11px] text-[#C75B3A]">本机</span>}
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {card.tags.map((tag) => (
+                      <span
+                        key={tag.id}
+                        className="rounded-md px-2 py-0.5 text-[11px]"
+                        style={{ backgroundColor: `${tag.color}22`, color: tag.color }}
+                      >
+                        {tag.label}
+                      </span>
+                    ))}
+                  </div>
                 </div>
-                <div className="mt-2 flex flex-wrap gap-1">
-                  {card.tags.map((tag) => (
-                    <span
-                      key={tag.id}
-                      className="rounded-md px-2 py-0.5 text-[11px]"
-                      style={{ backgroundColor: `${tag.color}22`, color: tag.color }}
-                    >
-                      {tag.label}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </article>
       ))}
@@ -247,7 +602,7 @@ function AddNodeSheet({
       />
       <section
         data-testid="agent-add-node-sheet"
-        className="absolute inset-x-0 bottom-0 z-10 rounded-t-[24px] bg-white pb-7"
+        className="absolute inset-x-0 bottom-0 z-10 rounded-t-[24px] bg-white pb-7 shadow-[0_-8px_28px_rgba(0,0,0,0.12)]"
       >
         <div className="flex justify-center pt-2">
           <div className="h-1 w-10 rounded bg-[#D6D3D1]" />
@@ -258,32 +613,43 @@ function AddNodeSheet({
             type="button"
             data-testid="agent-add-node-close"
             onClick={onClose}
-            className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C]"
+            className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#A8A29E]"
           >
             <X size={16} />
           </button>
         </div>
         <div className="space-y-2 px-5">
-          {options.map((option) => (
-            <button
-              key={option.id}
-              type="button"
-              data-testid={`agent-add-node-option-${option.id}`}
-              onClick={() => {
-                if (option.id === 'market') {
-                  onClose();
-                  onNavigate('/agents/market');
-                }
-              }}
-              className="flex w-full items-center justify-between rounded-2xl bg-[#FAF7F5] px-4 py-3 text-left"
-            >
-              <div>
-                <p className="text-sm font-semibold text-[#1C1917]">{option.title}</p>
-                <p className="mt-1 text-xs text-[#78716C]">{option.description}</p>
-              </div>
-              <span className="h-3 w-3 rounded-full" style={{ backgroundColor: option.tintColor }} />
-            </button>
-          ))}
+          {options.map((option) => {
+            const Icon = getAddOptionIcon(option.id);
+            return (
+              <button
+                key={option.id}
+                type="button"
+                data-testid={`agent-add-node-option-${option.id}`}
+                onClick={() => {
+                  if (option.id === 'market') {
+                    onClose();
+                    onNavigate('/agents/market');
+                  }
+                }}
+                className="flex w-full items-center justify-between rounded-2xl bg-[#FAF7F5] px-4 py-3 text-left"
+              >
+                <div className="flex items-center gap-3">
+                  <div
+                    className="flex h-10 w-10 items-center justify-center rounded-xl"
+                    style={{ backgroundColor: `${option.tintColor}20`, color: option.tintColor }}
+                  >
+                    <Icon size={16} />
+                  </div>
+                  <div>
+                    <p className="text-sm font-semibold text-[#1C1917]">{option.title}</p>
+                    <p className="mt-1 text-xs text-[#78716C]">{option.description}</p>
+                  </div>
+                </div>
+                <ChevronRight size={14} className="text-[#D6D3D1]" />
+              </button>
+            );
+          })}
         </div>
       </section>
     </>
@@ -346,7 +712,7 @@ export function AgentsPage() {
   return (
     <div data-testid="agent-hub-page" className="relative min-h-full bg-[#FAF7F5]">
       <header className="flex items-center justify-between px-5 py-3">
-        <h1 className="text-[20px] font-bold leading-[1.5] text-[#1C1917]">Agent 网络</h1>
+        <h1 className="text-[30px] font-bold leading-[1.2] text-[#1C1917]">Agent 网络</h1>
         <div className="flex items-center gap-2">
           <button
             type="button"

--- a/src/ui/new/pages/AgentsPage.tsx
+++ b/src/ui/new/pages/AgentsPage.tsx
@@ -1,11 +1,348 @@
-import { Bot } from 'lucide-react';
+import { Bot, List, Monitor, Plus, Settings, X } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { getAgentHubService } from '@/lib/services';
+import type {
+  AgentAddNodeOption,
+  AgentDeviceGroup,
+  AgentHubListSection,
+  AgentHubNode,
+  AgentHubTopologyData,
+  AgentHubViewMode,
+} from '@/lib/types/agent-hub';
 
-// TODO: 待实现 — 对照设计稿 Agent Hub 拓扑视图（LxbUp）实现
-export function AgentsPage() {
+const VIEW_ITEMS: Array<{ id: AgentHubViewMode; icon: React.ComponentType<{ size?: number }>; label: string }> = [
+  { id: 'topology', icon: Bot, label: '拓扑' },
+  { id: 'list', icon: List, label: '列表' },
+  { id: 'device', icon: Monitor, label: '设备' },
+];
+
+function ViewToggle({
+  value,
+  onChange,
+}: {
+  value: AgentHubViewMode;
+  onChange: (value: AgentHubViewMode) => void;
+}) {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-3 text-[#A8A29E]">
-      <Bot size={40} className="opacity-40" />
-      <span className="text-[14px]">Agent 页面待实现</span>
+    <div className="flex items-center rounded-[10px] bg-[#F5F0ED] p-1">
+      {VIEW_ITEMS.map((item) => {
+        const Icon = item.icon;
+        const active = value === item.id;
+        return (
+          <button
+            key={item.id}
+            type="button"
+            data-testid={`agent-view-toggle-${item.id}`}
+            onClick={() => onChange(item.id)}
+            aria-pressed={active}
+            className={`flex h-7 w-8 items-center justify-center rounded-[8px] transition ${
+              active
+                ? 'bg-white text-[#1C1917] shadow-[0_1px_3px_rgba(0,0,0,0.08)]'
+                : 'text-[#78716C]'
+            }`}
+            title={item.label}
+          >
+            <Icon size={16} />
+          </button>
+        );
+      })}
     </div>
   );
 }
+
+function NodeBadge({
+  node,
+  selected,
+  onSelect,
+}: {
+  node: AgentHubNode;
+  selected: boolean;
+  onSelect: (nodeId: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      data-testid={`agent-topology-node-${node.id}`}
+      onClick={(event) => {
+        event.stopPropagation();
+        onSelect(node.id);
+      }}
+      className={`flex min-w-[64px] flex-col items-center gap-1 rounded-2xl border px-2 py-2 transition ${
+        selected
+          ? 'scale-[1.03] border-[#C75B3A] bg-white shadow-[0_6px_18px_-8px_rgba(199,91,58,0.8)]'
+          : 'border-[#E7E5E4] bg-white'
+      }`}
+      style={!selected ? { opacity: 1 } : undefined}
+    >
+      <span
+        className="inline-block h-8 w-8 rounded-full"
+        style={{ backgroundColor: `${node.brandColor}22`, border: `1px solid ${node.brandColor}66` }}
+      />
+      <span className="text-[10px] font-medium text-[#57534E]">{node.name}</span>
+    </button>
+  );
+}
+
+function TopologyView({
+  topology,
+  selectedNodeId,
+  onSelectNode,
+  onClearSelection,
+}: {
+  topology: AgentHubTopologyData;
+  selectedNodeId: string | null;
+  onSelectNode: (nodeId: string) => void;
+  onClearSelection: () => void;
+}) {
+  const topNodes = topology.nodes.filter((node) => node.layer === 'top');
+  const middleNodes = topology.nodes.filter((node) => node.layer === 'middle');
+  const bottomNodes = topology.nodes.filter((node) => node.layer === 'bottom');
+  const selectedNode = topology.nodes.find((item) => item.id === selectedNodeId) ?? null;
+
+  return (
+    <section
+      data-testid="agent-topology-view"
+      className="space-y-3"
+      onClick={onClearSelection}
+    >
+      <div className="rounded-[10px] bg-[#F5F0ED] px-3 py-1 text-[11px] font-semibold text-[#A8A29E]">输出节点</div>
+      <div className="flex flex-wrap gap-2 px-1">
+        {topNodes.map((node) => (
+          <NodeBadge key={node.id} node={node} selected={node.id === selectedNodeId} onSelect={onSelectNode} />
+        ))}
+      </div>
+
+      <div className="rounded-[10px] bg-[#F5F0ED] px-3 py-1 text-[11px] font-semibold text-[#A8A29E]">Agent / Actor</div>
+      <div className="flex flex-wrap gap-2 px-1">
+        {middleNodes.map((node) => (
+          <NodeBadge key={node.id} node={node} selected={node.id === selectedNodeId} onSelect={onSelectNode} />
+        ))}
+      </div>
+
+      <div className="rounded-[10px] bg-[#F5F0ED] px-3 py-1 text-[11px] font-semibold text-[#A8A29E]">信号输入</div>
+      <div className="flex flex-wrap gap-2 px-1">
+        {bottomNodes.map((node) => (
+          <NodeBadge key={node.id} node={node} selected={node.id === selectedNodeId} onSelect={onSelectNode} />
+        ))}
+      </div>
+
+      {selectedNode && (
+        <div
+          data-testid="agent-topology-node-detail-card"
+          className="rounded-2xl border border-[#E7E5E4] bg-[#1C1917] px-4 py-3 text-white"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <p className="text-sm font-semibold">{selectedNode.name}</p>
+          <p className="mt-1 text-xs text-white/80">状态：{selectedNode.status}</p>
+          <p className="mt-1 text-xs text-white/60">类型：{selectedNode.type}</p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ListView({ sections }: { sections: AgentHubListSection[] }) {
+  return (
+    <section data-testid="agent-list-view" className="space-y-4">
+      {sections.map((section) => (
+        <article key={section.id} className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 className="text-[13px] font-semibold text-[#78716C]">{section.title}</h3>
+            <span className="rounded-md bg-[#F5F0ED] px-2 py-0.5 text-[11px] text-[#78716C]">{section.count}</span>
+          </div>
+          <div className="overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white">
+            {section.items.map((item, index) => (
+              <div key={item.id}>
+                <div className="flex items-center justify-between px-4 py-3">
+                  <div>
+                    <p className="text-sm font-medium text-[#1C1917]">{item.name}</p>
+                    <p className="text-xs text-[#A8A29E]">{item.description}</p>
+                  </div>
+                  <span className="text-[11px] text-[#78716C]">{item.status}</span>
+                </div>
+                {index !== section.items.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
+              </div>
+            ))}
+          </div>
+        </article>
+      ))}
+    </section>
+  );
+}
+
+function DeviceView({ groups }: { groups: AgentDeviceGroup[] }) {
+  return (
+    <section data-testid="agent-device-view" className="space-y-4">
+      {groups.map((group) => (
+        <article key={group.id} className="space-y-2">
+          <div className="flex items-center gap-2">
+            <h3 className="text-[13px] font-semibold text-[#78716C]">{group.title}</h3>
+            <span className="text-[11px] text-[#A8A29E]">{group.summary}</span>
+          </div>
+          <div className="space-y-2">
+            {group.cards.map((card) => (
+              <div key={card.id} className="rounded-2xl border border-[#E7E5E4] bg-white px-4 py-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-[#1C1917]">{card.name}</p>
+                    <p className="text-xs text-[#A8A29E]">{card.summary}</p>
+                  </div>
+                  {card.isHost && <span className="rounded bg-[#C75B3A15] px-2 py-0.5 text-[11px] text-[#C75B3A]">本机</span>}
+                </div>
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {card.tags.map((tag) => (
+                    <span
+                      key={tag.id}
+                      className="rounded-md px-2 py-0.5 text-[11px]"
+                      style={{ backgroundColor: `${tag.color}22`, color: tag.color }}
+                    >
+                      {tag.label}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </article>
+      ))}
+    </section>
+  );
+}
+
+function AddNodeSheet({
+  options,
+  onClose,
+}: {
+  options: AgentAddNodeOption[];
+  onClose: () => void;
+}) {
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="agent-add-node-overlay"
+        aria-label="关闭添加节点弹窗（Close Add Node Sheet）"
+        className="absolute inset-0 bg-black/35"
+        onClick={onClose}
+      />
+      <section
+        data-testid="agent-add-node-sheet"
+        className="absolute inset-x-0 bottom-0 z-10 rounded-t-[24px] bg-white pb-7"
+      >
+        <div className="flex justify-center pt-2">
+          <div className="h-1 w-10 rounded bg-[#D6D3D1]" />
+        </div>
+        <div className="flex items-center justify-between px-5 py-3">
+          <h2 className="text-[18px] font-bold text-[#1C1917]">添加节点</h2>
+          <button
+            type="button"
+            data-testid="agent-add-node-close"
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C]"
+          >
+            <X size={16} />
+          </button>
+        </div>
+        <div className="space-y-2 px-5">
+          {options.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              className="flex w-full items-center justify-between rounded-2xl bg-[#FAF7F5] px-4 py-3 text-left"
+            >
+              <div>
+                <p className="text-sm font-semibold text-[#1C1917]">{option.title}</p>
+                <p className="mt-1 text-xs text-[#78716C]">{option.description}</p>
+              </div>
+              <span className="h-3 w-3 rounded-full" style={{ backgroundColor: option.tintColor }} />
+            </button>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}
+
+export function AgentsPage() {
+  const [viewMode, setViewMode] = useState<AgentHubViewMode>('topology');
+  const [topology, setTopology] = useState<AgentHubTopologyData>({ nodes: [], edges: [], selectedNodeId: null });
+  const [listSections, setListSections] = useState<AgentHubListSection[]>([]);
+  const [deviceGroups, setDeviceGroups] = useState<AgentDeviceGroup[]>([]);
+  const [addNodeOptions, setAddNodeOptions] = useState<AgentAddNodeOption[]>([]);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  useEffect(() => {
+    let disposed = false;
+    const service = getAgentHubService();
+    const load = async () => {
+      const [nextTopology, nextList, nextDevice, nextAddOptions] = await Promise.all([
+        service.getTopology(),
+        service.getListView(),
+        service.getDeviceView(),
+        service.listAddNodeOptions(),
+      ]);
+      if (disposed) return;
+      setTopology(nextTopology);
+      setSelectedNodeId(nextTopology.selectedNodeId ?? null);
+      setListSections(nextList);
+      setDeviceGroups(nextDevice);
+      setAddNodeOptions(nextAddOptions);
+    };
+    void load();
+    return () => {
+      disposed = true;
+    };
+  }, []);
+
+  const content = useMemo(() => {
+    if (viewMode === 'list') {
+      return <ListView sections={listSections} />;
+    }
+    if (viewMode === 'device') {
+      return <DeviceView groups={deviceGroups} />;
+    }
+    return (
+      <TopologyView
+        topology={topology}
+        selectedNodeId={selectedNodeId}
+        onSelectNode={setSelectedNodeId}
+        onClearSelection={() => setSelectedNodeId(null)}
+      />
+    );
+  }, [deviceGroups, listSections, selectedNodeId, topology, viewMode]);
+
+  return (
+    <div data-testid="agent-hub-page" className="relative min-h-full bg-[#FAF7F5]">
+      <header className="flex items-center justify-between px-5 py-3">
+        <h1 className="text-[20px] font-bold leading-[1.5] text-[#1C1917]">Agent 网络</h1>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="flex h-9 w-9 items-center justify-center rounded-[10px] bg-[#F5F0ED] text-[#78716C]"
+            aria-label="拓扑设置（Topology Settings）"
+          >
+            <Settings size={18} />
+          </button>
+          <ViewToggle value={viewMode} onChange={setViewMode} />
+          <button
+            type="button"
+            data-testid="agent-add-node-button"
+            onClick={() => setSheetOpen(true)}
+            className="flex h-9 w-9 items-center justify-center rounded-full bg-[#C75B3A] text-white"
+            aria-label="添加节点（Add Node）"
+          >
+            <Plus size={18} />
+          </button>
+        </div>
+      </header>
+
+      <div className="px-5 pb-[calc(env(safe-area-inset-bottom,0px)+108px)] pt-2">
+        {content}
+      </div>
+
+      {sheetOpen && <AddNodeSheet options={addNodeOptions} onClose={() => setSheetOpen(false)} />}
+    </div>
+  );
+}
+

--- a/src/ui/new/pages/AgentsPage.tsx
+++ b/src/ui/new/pages/AgentsPage.tsx
@@ -712,7 +712,7 @@ export function AgentsPage() {
   return (
     <div data-testid="agent-hub-page" className="relative min-h-full bg-[#FAF7F5] dark:bg-[#0C0A09]">
       <header className="flex items-center justify-between px-5 py-3">
-        <h1 className="text-[30px] font-bold leading-[1.2] text-[#1C1917] dark:text-[#FAFAF9]">Agent 网络</h1>
+        <h1 className="text-lg font-semibold leading-[1.5] text-[#1C1917] dark:text-[#FAFAF9]">Agent 网络</h1>
         <div className="flex items-center gap-2">
           <button
             type="button"

--- a/src/ui/new/pages/AgentsPage.tsx
+++ b/src/ui/new/pages/AgentsPage.tsx
@@ -162,7 +162,7 @@ function ViewToggle({
   onChange: (value: AgentHubViewMode) => void;
 }) {
   return (
-    <div className="flex items-center rounded-[10px] bg-[#F5F0ED] p-1">
+    <div className="flex items-center rounded-[10px] bg-[#F5F0ED] p-1 dark:bg-[#292524]">
       {VIEW_ITEMS.map((item) => {
         const Icon = item.icon;
         const active = value === item.id;
@@ -175,8 +175,8 @@ function ViewToggle({
             aria-pressed={active}
             className={`flex h-7 w-8 items-center justify-center rounded-[8px] transition ${
               active
-                ? 'bg-white text-[#1C1917] shadow-[0_1px_3px_rgba(0,0,0,0.08)]'
-                : 'text-[#78716C]'
+                ? 'bg-white text-[#1C1917] shadow-[0_1px_3px_rgba(0,0,0,0.08)] dark:bg-[#44403C] dark:text-[#FAFAF9]'
+                : 'text-[#78716C] dark:text-[#A8A29E]'
             }`}
             title={item.label}
           >
@@ -226,7 +226,7 @@ function TopologyNode({
       >
         <div
           className={`flex h-10 w-10 items-center justify-center rounded-full border ${
-            selected ? 'ring-2 ring-offset-1' : ''
+            selected ? 'ring-2 ring-offset-1 ring-offset-[#FAF7F5] dark:ring-offset-[#1C1917]' : ''
           }`}
           style={{
             borderColor: `${baseColor}50`,
@@ -236,7 +236,7 @@ function TopologyNode({
         >
           <Icon size={15} />
         </div>
-        <span className="mt-1 text-[10px] font-medium text-[#57534E]">{node.name}</span>
+        <span className="mt-1 text-[10px] font-medium text-[#57534E] dark:text-[#D6D3D1]">{node.name}</span>
       </button>
     );
   }
@@ -253,8 +253,8 @@ function TopologyNode({
         }}
         className={`absolute flex items-center gap-2 rounded-xl border px-3 py-2 text-left transition ${
           selected
-            ? 'border-[#C75B3A] bg-white shadow-[0_8px_20px_-14px_rgba(199,91,58,0.9)]'
-            : 'border-[#E7E5E4] bg-white'
+            ? 'border-[#C75B3A] bg-white shadow-[0_8px_20px_-14px_rgba(199,91,58,0.9)] dark:border-[#E8734E] dark:bg-[#2A2522]'
+            : 'border-[#E7E5E4] bg-white dark:border-[#292524] dark:bg-[#1C1917]'
         }`}
         style={{
           left: layout.x,
@@ -271,8 +271,8 @@ function TopologyNode({
           <Icon size={13} />
         </div>
         <div className="min-w-0">
-          <p className="truncate text-[12px] font-semibold text-[#44403C]">{node.name}</p>
-          <p className="truncate text-[10px] text-[#A8A29E]">{node.subtitle ?? node.status}</p>
+          <p className="truncate text-[12px] font-semibold text-[#44403C] dark:text-[#F5F5F4]">{node.name}</p>
+          <p className="truncate text-[10px] text-[#A8A29E] dark:text-[#78716C]">{node.subtitle ?? node.status}</p>
         </div>
       </button>
     );
@@ -287,10 +287,10 @@ function TopologyNode({
         event.stopPropagation();
         onSelect(node.id);
       }}
-      className={`absolute rounded-2xl border bg-white px-3 py-3 text-left transition ${
+      className={`absolute rounded-2xl border bg-white px-3 py-3 text-left transition dark:bg-[#1C1917] ${
         selected
-          ? 'border-[#C75B3A] shadow-[0_12px_24px_-16px_rgba(199,91,58,0.9)]'
-          : 'border-[#E7E5E4]'
+          ? 'border-[#C75B3A] shadow-[0_12px_24px_-16px_rgba(199,91,58,0.9)] dark:border-[#E8734E]'
+          : 'border-[#E7E5E4] dark:border-[#292524]'
       }`}
       style={{
         left: layout.x,
@@ -308,11 +308,11 @@ function TopologyNode({
           <Icon size={15} />
         </div>
         <div className="min-w-0">
-          <p className="truncate text-[13px] font-semibold text-[#1C1917]">{node.name}</p>
-          <p className="truncate text-[10px] text-[#A8A29E]">{node.subtitle ?? node.status}</p>
+          <p className="truncate text-[13px] font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{node.name}</p>
+          <p className="truncate text-[10px] text-[#A8A29E] dark:text-[#78716C]">{node.subtitle ?? node.status}</p>
         </div>
       </div>
-      <div className="mt-2 flex items-center gap-1 text-[10px] text-[#78716C]">
+      <div className="mt-2 flex items-center gap-1 text-[10px] text-[#78716C] dark:text-[#A8A29E]">
         <span
           className="inline-block h-1.5 w-1.5 rounded-full"
           style={{ backgroundColor: node.status === 'running' ? '#22C55E' : '#A8A29E' }}
@@ -362,11 +362,11 @@ function TopologyView({
     <section data-testid="agent-topology-view" className="space-y-3" onClick={onClearSelection}>
       <div
         data-testid="agent-topology-canvas"
-        className="relative h-[568px] overflow-hidden rounded-[22px] border border-[#EDE8E3] bg-[#FAF7F5]"
+        className="relative h-[568px] overflow-hidden rounded-[22px] border border-[#EDE8E3] bg-[#FAF7F5] dark:border-[#292524] dark:bg-[#1C1917]"
       >
-        <div className="absolute left-3 top-2 rounded-md bg-[#F5F0ED] px-2 py-1 text-[10px] font-semibold text-[#A8A29E]">输出节点</div>
-        <div className="absolute left-3 top-[205px] rounded-md bg-[#F5F0ED] px-2 py-1 text-[10px] font-semibold text-[#A8A29E]">Agent / Actor</div>
-        <div className="absolute left-3 top-[462px] rounded-md bg-[#F5F0ED] px-2 py-1 text-[10px] font-semibold text-[#A8A29E]">信号输入</div>
+        <div className="absolute left-3 top-2 rounded-md bg-[#F5F0ED] px-2 py-1 text-[10px] font-semibold text-[#A8A29E] dark:bg-[#292524] dark:text-[#78716C]">输出节点</div>
+        <div className="absolute left-3 top-[205px] rounded-md bg-[#F5F0ED] px-2 py-1 text-[10px] font-semibold text-[#A8A29E] dark:bg-[#292524] dark:text-[#78716C]">Agent / Actor</div>
+        <div className="absolute left-3 top-[462px] rounded-md bg-[#F5F0ED] px-2 py-1 text-[10px] font-semibold text-[#A8A29E] dark:bg-[#292524] dark:text-[#78716C]">信号输入</div>
 
         <svg className="absolute inset-0 h-full w-full" viewBox="0 0 356 568" fill="none" aria-hidden="true">
           {topology.edges.map((edge) => {
@@ -410,7 +410,7 @@ function TopologyView({
       {selectedNode && (
         <div
           data-testid="agent-topology-node-detail-card"
-          className="rounded-2xl border border-[#E7E5E4] bg-[#1C1917] px-4 py-3 text-white"
+          className="rounded-2xl border border-[#E7E5E4] bg-[#1C1917] px-4 py-3 text-white dark:border-[#44403C] dark:bg-[#0C0A09]"
           onClick={(event) => event.stopPropagation()}
         >
           <p className="text-sm font-semibold">{selectedNode.name}</p>
@@ -440,7 +440,7 @@ function ListView({
               type="button"
               data-testid={`agent-list-filter-${filterItem.id}`}
               className={`shrink-0 rounded-full px-3 py-1.5 text-[12px] ${
-                active ? 'bg-[#C75B3A] text-white' : 'bg-[#F5F0ED] text-[#78716C]'
+                active ? 'bg-[#C75B3A] text-white' : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'
               }`}
             >
               {filterItem.label}
@@ -452,10 +452,10 @@ function ListView({
       {sections.map((section) => (
         <article key={section.id} className="space-y-2">
           <div className="flex items-center justify-between">
-            <h3 className="text-[13px] font-semibold text-[#78716C]">{section.title}</h3>
-            <span className="rounded-md bg-[#F5F0ED] px-2 py-0.5 text-[11px] text-[#78716C]">{section.count} 个节点</span>
+            <h3 className="text-[13px] font-semibold text-[#78716C] dark:text-[#A8A29E]">{section.title}</h3>
+            <span className="rounded-md bg-[#F5F0ED] px-2 py-0.5 text-[11px] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]">{section.count} 个节点</span>
           </div>
-          <div className="overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white">
+          <div className="overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white dark:border-[#292524] dark:bg-[#1C1917]">
             {section.items.map((item, index) => {
               const Icon = getListItemIcon(item);
               return (
@@ -474,21 +474,21 @@ function ListView({
                     className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left"
                   >
                     <div className="flex items-center gap-3">
-                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#F5F0ED] text-[#78716C]">
+                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]">
                         <Icon size={16} />
                       </div>
                       <div>
-                        <p className="text-sm font-medium text-[#1C1917]">{item.name}</p>
-                        <p className="text-xs text-[#A8A29E]">{item.description}</p>
+                        <p className="text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{item.name}</p>
+                        <p className="text-xs text-[#A8A29E] dark:text-[#78716C]">{item.description}</p>
                       </div>
                     </div>
                     <ChevronRight
                       data-testid={`agent-list-item-${item.id}-chevron`}
                       size={14}
-                      className="shrink-0 text-[#D6D3D1]"
+                      className="shrink-0 text-[#D6D3D1] dark:text-[#57534E]"
                     />
                   </button>
-                  {index !== section.items.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
+                  {index !== section.items.length - 1 && <div className="h-px bg-[#F5F0ED] dark:bg-[#292524]" />}
                 </div>
               );
             })}
@@ -507,20 +507,20 @@ function DeviceView({ groups }: { groups: AgentDeviceGroup[] }) {
       {hostCard && (
         <article
           data-testid="agent-device-overview-card"
-          className="rounded-2xl border border-[#E7E5E4] bg-white px-4 py-3"
+          className="rounded-2xl border border-[#E7E5E4] bg-white px-4 py-3 dark:border-[#292524] dark:bg-[#1C1917]"
         >
           <div className="flex items-start justify-between">
             <div>
-              <p className="text-sm font-semibold text-[#1C1917]">{hostCard.name}</p>
-              <p className="mt-0.5 text-xs text-[#A8A29E]">{hostCard.summary}</p>
+              <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{hostCard.name}</p>
+              <p className="mt-0.5 text-xs text-[#A8A29E] dark:text-[#78716C]">{hostCard.summary}</p>
             </div>
             <span className="rounded bg-[#C75B3A15] px-2 py-0.5 text-[11px] text-[#C75B3A]">本机</span>
           </div>
           <div className="mt-2 grid grid-cols-3 gap-2">
             {hostCard.metrics.slice(0, 3).map((metric) => (
-              <div key={metric.label} className="rounded-lg bg-[#FAF7F5] px-2 py-1.5 text-center">
-                <p className="text-[10px] text-[#A8A29E]">{metric.label}</p>
-                <p className="text-[12px] font-semibold text-[#1C1917]">{metric.value}</p>
+              <div key={metric.label} className="rounded-lg bg-[#FAF7F5] px-2 py-1.5 text-center dark:bg-[#292524]">
+                <p className="text-[10px] text-[#A8A29E] dark:text-[#78716C]">{metric.label}</p>
+                <p className="text-[12px] font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{metric.value}</p>
               </div>
             ))}
           </div>
@@ -541,25 +541,25 @@ function DeviceView({ groups }: { groups: AgentDeviceGroup[] }) {
       {groups.map((group) => (
         <article key={group.id} className="space-y-2">
           <div className="flex items-center gap-2">
-            <h3 className="text-[13px] font-semibold text-[#78716C]">{group.title}</h3>
-            <span className="text-[11px] text-[#A8A29E]">{group.summary}</span>
+            <h3 className="text-[13px] font-semibold text-[#78716C] dark:text-[#A8A29E]">{group.title}</h3>
+            <span className="text-[11px] text-[#A8A29E] dark:text-[#78716C]">{group.summary}</span>
           </div>
           <div className="space-y-2">
             {group.cards.map((card) => {
               const DeviceIcon = getDeviceTypeIcon(group.id);
               return (
-                <div key={card.id} className="rounded-2xl border border-[#E7E5E4] bg-white px-4 py-3">
+                <div key={card.id} className="rounded-2xl border border-[#E7E5E4] bg-white px-4 py-3 dark:border-[#292524] dark:bg-[#1C1917]">
                   <div className="flex items-start justify-between gap-3">
                     <div className="flex items-start gap-2">
-                      <div className="mt-0.5 flex h-7 w-7 items-center justify-center rounded-lg bg-[#F5F0ED] text-[#78716C]">
+                      <div className="mt-0.5 flex h-7 w-7 items-center justify-center rounded-lg bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]">
                         <DeviceIcon size={14} />
                       </div>
                       <div>
-                        <p className="text-sm font-semibold text-[#1C1917]">{card.name}</p>
-                        <p className="text-xs text-[#A8A29E]">{card.summary}</p>
+                        <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{card.name}</p>
+                        <p className="text-xs text-[#A8A29E] dark:text-[#78716C]">{card.summary}</p>
                       </div>
                     </div>
-                    <ChevronRight size={14} className="text-[#D6D3D1]" />
+                    <ChevronRight size={14} className="text-[#D6D3D1] dark:text-[#57534E]" />
                   </div>
                   <div className="mt-2 flex flex-wrap gap-1">
                     {card.tags.map((tag) => (
@@ -602,18 +602,18 @@ function AddNodeSheet({
       />
       <section
         data-testid="agent-add-node-sheet"
-        className="absolute inset-x-0 bottom-0 z-10 rounded-t-[24px] bg-white pb-7 shadow-[0_-8px_28px_rgba(0,0,0,0.12)]"
+        className="absolute inset-x-0 bottom-0 z-10 rounded-t-[24px] bg-white pb-7 shadow-[0_-8px_28px_rgba(0,0,0,0.12)] dark:bg-[#1C1917] dark:shadow-[0_-8px_28px_rgba(0,0,0,0.45)]"
       >
         <div className="flex justify-center pt-2">
-          <div className="h-1 w-10 rounded bg-[#D6D3D1]" />
+          <div className="h-1 w-10 rounded bg-[#D6D3D1] dark:bg-[#57534E]" />
         </div>
         <div className="flex items-center justify-between px-5 py-3">
-          <h2 className="text-[18px] font-bold text-[#1C1917]">添加节点</h2>
+          <h2 className="text-[18px] font-bold text-[#1C1917] dark:text-[#FAFAF9]">添加节点</h2>
           <button
             type="button"
             data-testid="agent-add-node-close"
             onClick={onClose}
-            className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#A8A29E]"
+            className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#A8A29E] dark:bg-[#292524] dark:text-[#78716C]"
           >
             <X size={16} />
           </button>
@@ -632,7 +632,7 @@ function AddNodeSheet({
                     onNavigate('/agents/market');
                   }
                 }}
-                className="flex w-full items-center justify-between rounded-2xl bg-[#FAF7F5] px-4 py-3 text-left"
+                className="flex w-full items-center justify-between rounded-2xl bg-[#FAF7F5] px-4 py-3 text-left dark:bg-[#292524]"
               >
                 <div className="flex items-center gap-3">
                   <div
@@ -642,11 +642,11 @@ function AddNodeSheet({
                     <Icon size={16} />
                   </div>
                   <div>
-                    <p className="text-sm font-semibold text-[#1C1917]">{option.title}</p>
-                    <p className="mt-1 text-xs text-[#78716C]">{option.description}</p>
+                    <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{option.title}</p>
+                    <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">{option.description}</p>
                   </div>
                 </div>
-                <ChevronRight size={14} className="text-[#D6D3D1]" />
+                <ChevronRight size={14} className="text-[#D6D3D1] dark:text-[#57534E]" />
               </button>
             );
           })}
@@ -710,13 +710,13 @@ export function AgentsPage() {
   }, [deviceGroups, listSections, selectedNodeId, topology, viewMode]);
 
   return (
-    <div data-testid="agent-hub-page" className="relative min-h-full bg-[#FAF7F5]">
+    <div data-testid="agent-hub-page" className="relative min-h-full bg-[#FAF7F5] dark:bg-[#0C0A09]">
       <header className="flex items-center justify-between px-5 py-3">
-        <h1 className="text-[30px] font-bold leading-[1.2] text-[#1C1917]">Agent 网络</h1>
+        <h1 className="text-[30px] font-bold leading-[1.2] text-[#1C1917] dark:text-[#FAFAF9]">Agent 网络</h1>
         <div className="flex items-center gap-2">
           <button
             type="button"
-            className="flex h-9 w-9 items-center justify-center rounded-[10px] bg-[#F5F0ED] text-[#78716C]"
+            className="flex h-9 w-9 items-center justify-center rounded-[10px] bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
             aria-label="拓扑设置（Topology Settings）"
           >
             <Settings size={18} />

--- a/src/ui/new/pages/agents/ActorDetailPage.tsx
+++ b/src/ui/new/pages/agents/ActorDetailPage.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { getAgentHubService } from '@/lib/services';
+import type { AgentDetailData } from '@/lib/types/agent-hub';
+
+export function ActorDetailPage({ actorId }: { actorId?: string }) {
+  const [detail, setDetail] = useState<AgentDetailData | null>(null);
+
+  useEffect(() => {
+    let disposed = false;
+    const targetId = actorId ?? '';
+    const load = async () => {
+      if (!targetId) return;
+      const response = await getAgentHubService().getActorDetail(targetId);
+      if (!disposed) {
+        setDetail(response);
+      }
+    };
+    void load();
+    return () => {
+      disposed = true;
+    };
+  }, [actorId]);
+
+  if (!detail) {
+    return (
+      <div data-testid="actor-detail-page" className="min-h-full px-5 py-4 text-sm text-[#A8A29E]">
+        Actor 详情加载中...
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="actor-detail-page" className="min-h-full bg-[#FAF7F5] px-5 py-4">
+      <section className="rounded-[18px] border border-[#E7E5E4] bg-white p-4">
+        <p className="text-[18px] font-bold text-[#1C1917]">{detail.title}</p>
+        <p className="mt-2 text-sm text-[#78716C]">{detail.description}</p>
+      </section>
+
+      <section className="mt-4">
+        <h3 className="text-[13px] font-semibold text-[#78716C]">触发规则</h3>
+        <div className="mt-2 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white">
+          {detail.triggerRules.map((item, index) => (
+            <div key={`${item.key}-${item.value}`}>
+              <div className="flex items-center justify-between px-4 py-3">
+                <span className="text-sm text-[#78716C]">{item.key}</span>
+                <span className={`text-sm ${item.highlight ? 'font-semibold text-[#C75B3A]' : 'text-[#1C1917]'}`}>
+                  {item.value}
+                </span>
+              </div>
+              {index !== detail.triggerRules.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-4">
+        <h3 className="text-[13px] font-semibold text-[#78716C]">最近执行</h3>
+        <div className="mt-2 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white">
+          {detail.recentLogs.map((item, index) => (
+            <div key={item.id}>
+              <div className="flex items-center justify-between px-4 py-3">
+                <div>
+                  <p className="text-sm font-medium text-[#1C1917]">{item.title}</p>
+                  <p className="text-xs text-[#A8A29E]">{item.time}</p>
+                </div>
+                <span className="text-xs text-[#78716C]">{item.duration ?? '--'}</span>
+              </div>
+              {index !== detail.recentLogs.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/src/ui/new/pages/agents/ActorDetailPage.tsx
+++ b/src/ui/new/pages/agents/ActorDetailPage.tsx
@@ -24,66 +24,66 @@ export function ActorDetailPage({ actorId }: { actorId?: string }) {
 
   if (!detail) {
     return (
-      <div data-testid="actor-detail-page" className="min-h-full px-5 py-4 text-sm text-[#A8A29E]">
+      <div data-testid="actor-detail-page" className="min-h-full px-5 py-4 text-sm text-[#A8A29E] dark:text-[#78716C]">
         Actor 详情加载中...
       </div>
     );
   }
 
   return (
-    <div data-testid="actor-detail-page" className="min-h-full bg-[#FAF7F5] px-5 py-3">
+    <div data-testid="actor-detail-page" className="min-h-full bg-[#FAF7F5] px-5 py-3 dark:bg-[#0C0A09]">
       <header data-testid="actor-detail-header" className="mb-3 flex items-center justify-between">
         <button
           type="button"
           onClick={() => window.history.back()}
-          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C]"
+          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
           aria-label="返回（Back）"
         >
           <ArrowLeft size={16} />
         </button>
-        <h1 className="text-[17px] font-bold text-[#1C1917]">{detail.title}</h1>
+        <h1 className="text-[17px] font-bold text-[#1C1917] dark:text-[#FAFAF9]">{detail.title}</h1>
         <button
           type="button"
-          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C]"
+          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
           aria-label="更多（More）"
         >
           <MoreHorizontal size={16} />
         </button>
       </header>
 
-      <section className="rounded-[18px] border border-[#E7E5E4] bg-white p-4">
+      <section className="rounded-[18px] border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#78716C20] text-[#78716C]">
             <AlarmClock size={18} />
           </div>
           <div>
-            <p className="text-[16px] font-bold text-[#1C1917]">{detail.title}</p>
+            <p className="text-[16px] font-bold text-[#1C1917] dark:text-[#FAFAF9]">{detail.title}</p>
             <p className="text-xs text-[#22C55E]">● 运行中</p>
           </div>
         </div>
-        <p className="mt-2 text-sm text-[#78716C]">{detail.description}</p>
+        <p className="mt-2 text-sm text-[#78716C] dark:text-[#A8A29E]">{detail.description}</p>
       </section>
 
       <section className="mt-4">
-        <h3 className="text-[13px] font-semibold text-[#78716C]">触发规则</h3>
-        <div className="mt-2 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white">
+        <h3 className="text-[13px] font-semibold text-[#78716C] dark:text-[#A8A29E]">触发规则</h3>
+        <div className="mt-2 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white dark:border-[#292524] dark:bg-[#1C1917]">
           {detail.triggerRules.map((item, index) => (
             <div key={`${item.key}-${item.value}`}>
               <div className="flex items-center justify-between px-4 py-3">
-                <span className="text-sm text-[#78716C]">{item.key}</span>
-                <span className={`text-sm ${item.highlight ? 'font-semibold text-[#C75B3A]' : 'text-[#1C1917]'}`}>
+                <span className="text-sm text-[#78716C] dark:text-[#A8A29E]">{item.key}</span>
+                <span className={`text-sm ${item.highlight ? 'font-semibold text-[#C75B3A]' : 'text-[#1C1917] dark:text-[#FAFAF9]'}`}>
                   {item.value}
                 </span>
               </div>
-              {index !== detail.triggerRules.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
+              {index !== detail.triggerRules.length - 1 && <div className="h-px bg-[#F5F0ED] dark:bg-[#292524]" />}
             </div>
           ))}
         </div>
       </section>
 
       <section className="mt-4">
-        <h3 className="text-[13px] font-semibold text-[#78716C]">最近执行</h3>
-        <div className="mt-2 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white">
+        <h3 className="text-[13px] font-semibold text-[#78716C] dark:text-[#A8A29E]">最近执行</h3>
+        <div className="mt-2 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white dark:border-[#292524] dark:bg-[#1C1917]">
           {detail.recentLogs.map((item, index) => {
             const warning = item.status === 'warning';
             return (
@@ -94,16 +94,16 @@ export function ActorDetailPage({ actorId }: { actorId?: string }) {
                       <TriangleAlert size={12} />
                     </div>
                     <div>
-                      <p className="text-sm font-medium text-[#1C1917]">{item.title}</p>
-                      <p className="text-xs text-[#A8A29E]">{item.time}</p>
+                      <p className="text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{item.title}</p>
+                      <p className="text-xs text-[#A8A29E] dark:text-[#78716C]">{item.time}</p>
                     </div>
                   </div>
-                  <div className="flex items-center gap-1 text-xs text-[#78716C]">
+                  <div className="flex items-center gap-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
                     <Clock3 size={11} />
                     {item.duration ?? '--'}
                   </div>
                 </div>
-                {index !== detail.recentLogs.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
+                {index !== detail.recentLogs.length - 1 && <div className="h-px bg-[#F5F0ED] dark:bg-[#292524]" />}
               </div>
             );
           })}

--- a/src/ui/new/pages/agents/ActorDetailPage.tsx
+++ b/src/ui/new/pages/agents/ActorDetailPage.tsx
@@ -5,15 +5,34 @@ import type { AgentDetailData } from '@/lib/types/agent-hub';
 
 export function ActorDetailPage({ actorId }: { actorId?: string }) {
   const [detail, setDetail] = useState<AgentDetailData | null>(null);
+  const [loading, setLoading] = useState(true);
   const targetId = actorId ?? '';
 
   useEffect(() => {
     let disposed = false;
     const load = async () => {
-      if (!targetId) return;
-      const response = await getAgentHubService().getActorDetail(targetId);
-      if (!disposed) {
-        setDetail(response);
+      if (!targetId) {
+        if (!disposed) {
+          setDetail(null);
+          setLoading(false);
+        }
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const response = await getAgentHubService().getActorDetail(targetId);
+        if (!disposed) {
+          setDetail(response);
+        }
+      } catch {
+        if (!disposed) {
+          setDetail(null);
+        }
+      } finally {
+        if (!disposed) {
+          setLoading(false);
+        }
       }
     };
     void load();
@@ -22,10 +41,31 @@ export function ActorDetailPage({ actorId }: { actorId?: string }) {
     };
   }, [targetId]);
 
-  if (!detail) {
+  if (loading) {
     return (
       <div data-testid="actor-detail-page" className="min-h-full px-5 py-4 text-sm text-[#A8A29E] dark:text-[#78716C]">
         Actor 详情加载中...
+      </div>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <div data-testid="actor-detail-page" className="min-h-full bg-[#FAF7F5] px-5 py-3 dark:bg-[#0C0A09]">
+        <section
+          data-testid="actor-detail-empty-state"
+          className="mt-6 rounded-2xl border border-[#E7E5E4] bg-white px-4 py-6 text-center dark:border-[#292524] dark:bg-[#1C1917]"
+        >
+          <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">未找到 Actor 详情</p>
+          <p className="mt-1 text-xs text-[#A8A29E] dark:text-[#78716C]">该节点可能已删除或尚未配置详情数据。</p>
+          <button
+            type="button"
+            onClick={() => window.history.back()}
+            className="mt-4 rounded-lg bg-[#F5F0ED] px-3 py-2 text-xs font-medium text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
+          >
+            返回上一页
+          </button>
+        </section>
       </div>
     );
   }

--- a/src/ui/new/pages/agents/ActorDetailPage.tsx
+++ b/src/ui/new/pages/agents/ActorDetailPage.tsx
@@ -1,3 +1,4 @@
+import { AlarmClock, ArrowLeft, Clock3, MoreHorizontal, TriangleAlert } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { getAgentHubService } from '@/lib/services';
 import type { AgentDetailData } from '@/lib/types/agent-hub';
@@ -30,9 +31,36 @@ export function ActorDetailPage({ actorId }: { actorId?: string }) {
   }
 
   return (
-    <div data-testid="actor-detail-page" className="min-h-full bg-[#FAF7F5] px-5 py-4">
+    <div data-testid="actor-detail-page" className="min-h-full bg-[#FAF7F5] px-5 py-3">
+      <header data-testid="actor-detail-header" className="mb-3 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => window.history.back()}
+          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C]"
+          aria-label="返回（Back）"
+        >
+          <ArrowLeft size={16} />
+        </button>
+        <h1 className="text-[17px] font-bold text-[#1C1917]">{detail.title}</h1>
+        <button
+          type="button"
+          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C]"
+          aria-label="更多（More）"
+        >
+          <MoreHorizontal size={16} />
+        </button>
+      </header>
+
       <section className="rounded-[18px] border border-[#E7E5E4] bg-white p-4">
-        <p className="text-[18px] font-bold text-[#1C1917]">{detail.title}</p>
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#78716C20] text-[#78716C]">
+            <AlarmClock size={18} />
+          </div>
+          <div>
+            <p className="text-[16px] font-bold text-[#1C1917]">{detail.title}</p>
+            <p className="text-xs text-[#22C55E]">● 运行中</p>
+          </div>
+        </div>
         <p className="mt-2 text-sm text-[#78716C]">{detail.description}</p>
       </section>
 
@@ -56,18 +84,29 @@ export function ActorDetailPage({ actorId }: { actorId?: string }) {
       <section className="mt-4">
         <h3 className="text-[13px] font-semibold text-[#78716C]">最近执行</h3>
         <div className="mt-2 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white">
-          {detail.recentLogs.map((item, index) => (
-            <div key={item.id}>
-              <div className="flex items-center justify-between px-4 py-3">
-                <div>
-                  <p className="text-sm font-medium text-[#1C1917]">{item.title}</p>
-                  <p className="text-xs text-[#A8A29E]">{item.time}</p>
+          {detail.recentLogs.map((item, index) => {
+            const warning = item.status === 'warning';
+            return (
+              <div key={item.id}>
+                <div className="flex items-center justify-between px-4 py-3">
+                  <div className="flex items-start gap-2">
+                    <div className={`mt-0.5 rounded-full p-1 ${warning ? 'bg-[#F973161A] text-[#F97316]' : 'bg-[#22C55E15] text-[#22C55E]'}`}>
+                      <TriangleAlert size={12} />
+                    </div>
+                    <div>
+                      <p className="text-sm font-medium text-[#1C1917]">{item.title}</p>
+                      <p className="text-xs text-[#A8A29E]">{item.time}</p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1 text-xs text-[#78716C]">
+                    <Clock3 size={11} />
+                    {item.duration ?? '--'}
+                  </div>
                 </div>
-                <span className="text-xs text-[#78716C]">{item.duration ?? '--'}</span>
+                {index !== detail.recentLogs.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
               </div>
-              {index !== detail.recentLogs.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
-            </div>
-          ))}
+            );
+          })}
         </div>
       </section>
     </div>

--- a/src/ui/new/pages/agents/ActorDetailPage.tsx
+++ b/src/ui/new/pages/agents/ActorDetailPage.tsx
@@ -4,10 +4,10 @@ import type { AgentDetailData } from '@/lib/types/agent-hub';
 
 export function ActorDetailPage({ actorId }: { actorId?: string }) {
   const [detail, setDetail] = useState<AgentDetailData | null>(null);
+  const targetId = actorId ?? '';
 
   useEffect(() => {
     let disposed = false;
-    const targetId = actorId ?? '';
     const load = async () => {
       if (!targetId) return;
       const response = await getAgentHubService().getActorDetail(targetId);
@@ -19,7 +19,7 @@ export function ActorDetailPage({ actorId }: { actorId?: string }) {
     return () => {
       disposed = true;
     };
-  }, [actorId]);
+  }, [targetId]);
 
   if (!detail) {
     return (
@@ -73,4 +73,3 @@ export function ActorDetailPage({ actorId }: { actorId?: string }) {
     </div>
   );
 }
-

--- a/src/ui/new/pages/agents/AgentConversationPage.tsx
+++ b/src/ui/new/pages/agents/AgentConversationPage.tsx
@@ -75,20 +75,20 @@ export function AgentConversationPage({ agentId }: { agentId?: string }) {
   };
 
   return (
-    <div data-testid="agent-conversation-page" className="min-h-full bg-[#FAF7F5]">
+    <div data-testid="agent-conversation-page" className="min-h-full bg-[#FAF7F5] dark:bg-[#0C0A09]">
       <header data-testid="agent-conversation-header" className="flex items-center justify-between px-4 py-3">
         <button
           type="button"
           onClick={() => window.history.back()}
-          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C]"
+          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
           aria-label="返回（Back）"
         >
           <ArrowLeft size={16} />
         </button>
-        <h1 className="text-[17px] font-bold text-[#1C1917]">日报 Agent</h1>
+        <h1 className="text-[17px] font-bold text-[#1C1917] dark:text-[#FAFAF9]">日报 Agent</h1>
         <button
           type="button"
-          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C]"
+          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
           aria-label="更多（More）"
         >
           <MoreHorizontal size={16} />
@@ -109,13 +109,13 @@ export function AgentConversationPage({ agentId }: { agentId?: string }) {
                 className={`max-w-[80%] rounded-2xl px-4 py-2 text-sm ${
                   isUser
                     ? 'rounded-tr-[6px] bg-[#C75B3A] text-white'
-                    : 'rounded-tl-[6px] border border-[#E7E5E4] bg-white text-[#1C1917]'
+                    : 'rounded-tl-[6px] border border-[#E7E5E4] bg-white text-[#1C1917] dark:border-[#292524] dark:bg-[#1C1917] dark:text-[#FAFAF9]'
                 }`}
               >
                 {message.content}
               </div>
               {isUser && (
-                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C]">
+                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]">
                   <UserRound size={12} />
                 </div>
               )}
@@ -126,13 +126,13 @@ export function AgentConversationPage({ agentId }: { agentId?: string }) {
 
       <div
         data-testid="agent-chat-input-bar"
-        className="fixed bottom-[calc(env(safe-area-inset-bottom,0px)+64px)] left-0 right-0 mx-auto flex w-full max-w-[393px] items-center gap-2 border-t border-[#E7E5E4] bg-[#FAF7F5] px-4 py-3"
+        className="fixed bottom-[calc(env(safe-area-inset-bottom,0px)+64px)] left-0 right-0 mx-auto flex w-full max-w-[393px] items-center gap-2 border-t border-[#E7E5E4] bg-[#FAF7F5] px-4 py-3 dark:border-[#292524] dark:bg-[#0C0A09]"
       >
         <input
           value={inputValue}
           onChange={(event) => setInputValue(event.target.value)}
           placeholder="输入消息..."
-          className="h-9 flex-1 rounded-full border border-[#E7E5E4] bg-white px-4 text-sm text-[#1C1917] outline-none"
+          className="h-9 flex-1 rounded-full border border-[#E7E5E4] bg-white px-4 text-sm text-[#1C1917] outline-none dark:border-[#292524] dark:bg-[#1C1917] dark:text-[#FAFAF9]"
         />
         <button
           type="button"

--- a/src/ui/new/pages/agents/AgentConversationPage.tsx
+++ b/src/ui/new/pages/agents/AgentConversationPage.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react';
+import { getAgentHubService } from '@/lib/services';
+import type { AgentConversationMessage } from '@/lib/types/agent-hub';
+
+function createMessage(id: string, role: 'agent' | 'user', content: string): AgentConversationMessage {
+  return {
+    id,
+    role,
+    content,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+export function AgentConversationPage({ agentId }: { agentId?: string }) {
+  const [messages, setMessages] = useState<AgentConversationMessage[]>([]);
+  const [inputValue, setInputValue] = useState('');
+  const [sending, setSending] = useState(false);
+
+  useEffect(() => {
+    let disposed = false;
+    const targetId = agentId ?? '';
+    const load = async () => {
+      if (!targetId) return;
+      const history = await getAgentHubService().getConversation(targetId);
+      if (!disposed) {
+        setMessages(history);
+      }
+    };
+    void load();
+    return () => {
+      disposed = true;
+    };
+  }, [agentId]);
+
+  const handleSend = async () => {
+    const prompt = inputValue.trim();
+    const targetId = agentId ?? '';
+    if (!prompt || !targetId || sending) return;
+
+    setSending(true);
+    setInputValue('');
+
+    const userMessage = createMessage(`msg-user-${crypto.randomUUID()}`, 'user', prompt);
+    const pendingMessageId = `msg-agent-pending-${crypto.randomUUID()}`;
+    const streamMessage = createMessage(pendingMessageId, 'agent', '');
+    setMessages((prev) => [...prev, userMessage, streamMessage]);
+
+    for await (const chunk of getAgentHubService().streamConversation({ agentId: targetId, prompt })) {
+      setMessages((prev) => {
+        const chunkMessageIndex = prev.findIndex((item) => item.id === chunk.messageId);
+        if (chunkMessageIndex >= 0) {
+          const next = [...prev];
+          next[chunkMessageIndex] = {
+            ...next[chunkMessageIndex],
+            content: `${next[chunkMessageIndex].content}${chunk.delta}`,
+          };
+          return next;
+        }
+
+        const pendingIndex = prev.findIndex((item) => item.id === pendingMessageId);
+        if (pendingIndex >= 0) {
+          const next = [...prev];
+          next[pendingIndex] = {
+            ...next[pendingIndex],
+            id: chunk.messageId,
+            content: `${next[pendingIndex].content}${chunk.delta}`,
+          };
+          return next;
+        }
+
+        return [...prev, createMessage(chunk.messageId, 'agent', chunk.delta)];
+      });
+    }
+    setSending(false);
+  };
+
+  return (
+    <div data-testid="agent-conversation-page" className="min-h-full bg-[#FAF7F5]">
+      <header className="px-5 py-3">
+        <h1 className="text-[17px] font-bold text-[#1C1917]">Agent 对话</h1>
+      </header>
+
+      <div className="space-y-3 px-4 pb-[calc(env(safe-area-inset-bottom,0px)+108px)] pt-2">
+        {messages.map((message) => {
+          const isUser = message.role === 'user';
+          return (
+            <div key={message.id} className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
+              <div
+                className={`max-w-[80%] rounded-2xl px-4 py-2 text-sm ${
+                  isUser
+                    ? 'rounded-tr-[4px] bg-[#C75B3A] text-white'
+                    : 'rounded-tl-[4px] border border-[#E7E5E4] bg-white text-[#1C1917]'
+                }`}
+              >
+                {message.content}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="fixed bottom-[calc(env(safe-area-inset-bottom,0px)+64px)] left-0 right-0 mx-auto flex w-full max-w-[393px] items-center gap-2 px-4">
+        <input
+          value={inputValue}
+          onChange={(event) => setInputValue(event.target.value)}
+          placeholder="输入消息..."
+          className="h-10 flex-1 rounded-full border border-[#E7E5E4] bg-white px-4 text-sm text-[#1C1917] outline-none"
+        />
+        <button
+          type="button"
+          data-testid="agent-chat-send-button"
+          disabled={sending}
+          onClick={() => {
+            void handleSend();
+          }}
+          className="h-10 rounded-full bg-[#C75B3A] px-4 text-sm font-semibold text-white disabled:opacity-60"
+        >
+          发送
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/new/pages/agents/AgentConversationPage.tsx
+++ b/src/ui/new/pages/agents/AgentConversationPage.tsx
@@ -1,3 +1,4 @@
+import { ArrowLeft, Bot, MoreHorizontal, SendHorizontal, UserRound } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { getAgentHubService } from '@/lib/services';
 import type { AgentConversationMessage } from '@/lib/types/agent-hub';
@@ -75,35 +76,63 @@ export function AgentConversationPage({ agentId }: { agentId?: string }) {
 
   return (
     <div data-testid="agent-conversation-page" className="min-h-full bg-[#FAF7F5]">
-      <header className="px-5 py-3">
-        <h1 className="text-[17px] font-bold text-[#1C1917]">Agent 对话</h1>
+      <header data-testid="agent-conversation-header" className="flex items-center justify-between px-4 py-3">
+        <button
+          type="button"
+          onClick={() => window.history.back()}
+          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C]"
+          aria-label="返回（Back）"
+        >
+          <ArrowLeft size={16} />
+        </button>
+        <h1 className="text-[17px] font-bold text-[#1C1917]">日报 Agent</h1>
+        <button
+          type="button"
+          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C]"
+          aria-label="更多（More）"
+        >
+          <MoreHorizontal size={16} />
+        </button>
       </header>
 
       <div className="space-y-3 px-4 pb-[calc(env(safe-area-inset-bottom,0px)+108px)] pt-2">
         {messages.map((message) => {
           const isUser = message.role === 'user';
           return (
-            <div key={message.id} className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
+            <div key={message.id} className={`flex items-end gap-2 ${isUser ? 'justify-end' : 'justify-start'}`}>
+              {!isUser && (
+                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[#C75B3A] text-white">
+                  <Bot size={12} />
+                </div>
+              )}
               <div
                 className={`max-w-[80%] rounded-2xl px-4 py-2 text-sm ${
                   isUser
-                    ? 'rounded-tr-[4px] bg-[#C75B3A] text-white'
-                    : 'rounded-tl-[4px] border border-[#E7E5E4] bg-white text-[#1C1917]'
+                    ? 'rounded-tr-[6px] bg-[#C75B3A] text-white'
+                    : 'rounded-tl-[6px] border border-[#E7E5E4] bg-white text-[#1C1917]'
                 }`}
               >
                 {message.content}
               </div>
+              {isUser && (
+                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C]">
+                  <UserRound size={12} />
+                </div>
+              )}
             </div>
           );
         })}
       </div>
 
-      <div className="fixed bottom-[calc(env(safe-area-inset-bottom,0px)+64px)] left-0 right-0 mx-auto flex w-full max-w-[393px] items-center gap-2 px-4">
+      <div
+        data-testid="agent-chat-input-bar"
+        className="fixed bottom-[calc(env(safe-area-inset-bottom,0px)+64px)] left-0 right-0 mx-auto flex w-full max-w-[393px] items-center gap-2 border-t border-[#E7E5E4] bg-[#FAF7F5] px-4 py-3"
+      >
         <input
           value={inputValue}
           onChange={(event) => setInputValue(event.target.value)}
           placeholder="输入消息..."
-          className="h-10 flex-1 rounded-full border border-[#E7E5E4] bg-white px-4 text-sm text-[#1C1917] outline-none"
+          className="h-9 flex-1 rounded-full border border-[#E7E5E4] bg-white px-4 text-sm text-[#1C1917] outline-none"
         />
         <button
           type="button"
@@ -112,9 +141,10 @@ export function AgentConversationPage({ agentId }: { agentId?: string }) {
           onClick={() => {
             void handleSend();
           }}
-          className="h-10 rounded-full bg-[#C75B3A] px-4 text-sm font-semibold text-white disabled:opacity-60"
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-[#C75B3A] text-white disabled:opacity-60"
+          aria-label="发送（Send）"
         >
-          发送
+          <SendHorizontal size={15} />
         </button>
       </div>
     </div>

--- a/src/ui/new/pages/agents/AgentConversationPage.tsx
+++ b/src/ui/new/pages/agents/AgentConversationPage.tsx
@@ -15,10 +15,10 @@ export function AgentConversationPage({ agentId }: { agentId?: string }) {
   const [messages, setMessages] = useState<AgentConversationMessage[]>([]);
   const [inputValue, setInputValue] = useState('');
   const [sending, setSending] = useState(false);
+  const targetId = agentId ?? '';
 
   useEffect(() => {
     let disposed = false;
-    const targetId = agentId ?? '';
     const load = async () => {
       if (!targetId) return;
       const history = await getAgentHubService().getConversation(targetId);
@@ -30,11 +30,10 @@ export function AgentConversationPage({ agentId }: { agentId?: string }) {
     return () => {
       disposed = true;
     };
-  }, [agentId]);
+  }, [targetId]);
 
   const handleSend = async () => {
     const prompt = inputValue.trim();
-    const targetId = agentId ?? '';
     if (!prompt || !targetId || sending) return;
 
     setSending(true);

--- a/src/ui/new/pages/agents/AgentDetailPage.tsx
+++ b/src/ui/new/pages/agents/AgentDetailPage.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react';
+import { getAgentHubService } from '@/lib/services';
+import type { AgentDetailData } from '@/lib/types/agent-hub';
+
+export function AgentDetailPage({ agentId }: { agentId?: string }) {
+  const [detail, setDetail] = useState<AgentDetailData | null>(null);
+
+  useEffect(() => {
+    let disposed = false;
+    const targetId = agentId ?? '';
+    const load = async () => {
+      if (!targetId) return;
+      const response = await getAgentHubService().getAgentDetail(targetId);
+      if (!disposed) {
+        setDetail(response);
+      }
+    };
+    void load();
+    return () => {
+      disposed = true;
+    };
+  }, [agentId]);
+
+  if (!detail) {
+    return (
+      <div data-testid="agent-detail-page" className="min-h-full px-5 py-4 text-sm text-[#A8A29E]">
+        Agent 详情加载中...
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="agent-detail-page" className="min-h-full bg-[#FAF7F5] px-5 py-4">
+      <section className="rounded-[18px] border border-[#E7E5E4] bg-white p-4">
+        <p className="text-[18px] font-bold text-[#1C1917]">{detail.title}</p>
+        <p className="mt-2 text-sm text-[#78716C]">{detail.description}</p>
+        <div className="mt-3 flex justify-between gap-2">
+          {detail.stats.map((stat) => (
+            <div key={stat.label} className="flex flex-1 flex-col items-center rounded-lg bg-[#FAF7F5] py-2">
+              <span className="text-[11px] text-[#A8A29E]">{stat.label}</span>
+              <span className="text-sm font-semibold text-[#1C1917]">{stat.value}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-4">
+        <h3 className="text-[13px] font-semibold text-[#78716C]">触发规则</h3>
+        <div className="mt-2 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white">
+          {detail.triggerRules.map((item, index) => (
+            <div key={`${item.key}-${item.value}`}>
+              <div className="flex items-center justify-between px-4 py-3">
+                <span className="text-sm text-[#78716C]">{item.key}</span>
+                <span className={`text-sm ${item.highlight ? 'font-semibold text-[#C75B3A]' : 'text-[#1C1917]'}`}>
+                  {item.value}
+                </span>
+              </div>
+              {index !== detail.triggerRules.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-4">
+        <h3 className="text-[13px] font-semibold text-[#78716C]">输出目标</h3>
+        <div className="mt-2 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white">
+          {detail.targets.map((item, index) => (
+            <div key={item.id}>
+              <div className="px-4 py-3">
+                <p className="text-sm font-medium text-[#1C1917]">{item.name}</p>
+                <p className="text-xs text-[#A8A29E]">{item.description}</p>
+              </div>
+              {index !== detail.targets.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mt-4">
+        <h3 className="text-[13px] font-semibold text-[#78716C]">最近执行</h3>
+        <div className="mt-2 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white">
+          {detail.recentLogs.map((item, index) => (
+            <div key={item.id}>
+              <div className="flex items-center justify-between px-4 py-3">
+                <div>
+                  <p className="text-sm font-medium text-[#1C1917]">{item.title}</p>
+                  <p className="text-xs text-[#A8A29E]">{item.time}</p>
+                </div>
+                <span className="text-xs text-[#78716C]">{item.duration ?? '--'}</span>
+              </div>
+              {index !== detail.recentLogs.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <div className="pb-[calc(env(safe-area-inset-bottom,0px)+20px)] pt-4">
+        <button
+          type="button"
+          data-testid="agent-detail-chat-button"
+          className="w-full rounded-[14px] bg-[#C75B3A] px-4 py-3 text-sm font-semibold text-white"
+        >
+          与 Agent 对话
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/ui/new/pages/agents/AgentDetailPage.tsx
+++ b/src/ui/new/pages/agents/AgentDetailPage.tsx
@@ -11,15 +11,34 @@ function getTargetIcon(target: AgentHubListItem) {
 
 export function AgentDetailPage({ agentId }: { agentId?: string }) {
   const [detail, setDetail] = useState<AgentDetailData | null>(null);
+  const [loading, setLoading] = useState(true);
   const targetId = agentId ?? '';
 
   useEffect(() => {
     let disposed = false;
     const load = async () => {
-      if (!targetId) return;
-      const response = await getAgentHubService().getAgentDetail(targetId);
-      if (!disposed) {
-        setDetail(response);
+      if (!targetId) {
+        if (!disposed) {
+          setDetail(null);
+          setLoading(false);
+        }
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const response = await getAgentHubService().getAgentDetail(targetId);
+        if (!disposed) {
+          setDetail(response);
+        }
+      } catch {
+        if (!disposed) {
+          setDetail(null);
+        }
+      } finally {
+        if (!disposed) {
+          setLoading(false);
+        }
       }
     };
     void load();
@@ -28,10 +47,31 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
     };
   }, [targetId]);
 
-  if (!detail) {
+  if (loading) {
     return (
       <div data-testid="agent-detail-page" className="min-h-full px-5 py-4 text-sm text-[#A8A29E] dark:text-[#78716C]">
         Agent 详情加载中...
+      </div>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <div data-testid="agent-detail-page" className="min-h-full bg-[#FAF7F5] px-5 py-3 dark:bg-[#0C0A09]">
+        <section
+          data-testid="agent-detail-empty-state"
+          className="mt-6 rounded-2xl border border-[#E7E5E4] bg-white px-4 py-6 text-center dark:border-[#292524] dark:bg-[#1C1917]"
+        >
+          <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">未找到 Agent 详情</p>
+          <p className="mt-1 text-xs text-[#A8A29E] dark:text-[#78716C]">该节点可能已删除或尚未配置详情数据。</p>
+          <button
+            type="button"
+            onClick={() => window.history.back()}
+            className="mt-4 rounded-lg bg-[#F5F0ED] px-3 py-2 text-xs font-medium text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
+          >
+            返回上一页
+          </button>
+        </section>
       </div>
     );
   }

--- a/src/ui/new/pages/agents/AgentDetailPage.tsx
+++ b/src/ui/new/pages/agents/AgentDetailPage.tsx
@@ -30,89 +30,89 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
 
   if (!detail) {
     return (
-      <div data-testid="agent-detail-page" className="min-h-full px-5 py-4 text-sm text-[#A8A29E]">
+      <div data-testid="agent-detail-page" className="min-h-full px-5 py-4 text-sm text-[#A8A29E] dark:text-[#78716C]">
         Agent 详情加载中...
       </div>
     );
   }
 
   return (
-    <div data-testid="agent-detail-page" className="min-h-full bg-[#FAF7F5] px-5 py-3">
+    <div data-testid="agent-detail-page" className="min-h-full bg-[#FAF7F5] px-5 py-3 dark:bg-[#0C0A09]">
       <header data-testid="agent-detail-header" className="mb-3 flex items-center justify-between">
         <button
           type="button"
           data-testid="agent-detail-back-button"
           onClick={() => window.history.back()}
-          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C]"
+          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
           aria-label="返回（Back）"
         >
           <ArrowLeft size={16} />
         </button>
-        <h1 className="text-[17px] font-bold text-[#1C1917]">{detail.title}</h1>
+        <h1 className="text-[17px] font-bold text-[#1C1917] dark:text-[#FAFAF9]">{detail.title}</h1>
         <button
           type="button"
-          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C]"
+          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
           aria-label="更多（More）"
         >
           <MoreHorizontal size={16} />
         </button>
       </header>
 
-      <section className="rounded-[18px] border border-[#E7E5E4] bg-white p-4">
+      <section className="rounded-[18px] border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#C75B3A20] text-[#C75B3A]">
             <Sparkles size={18} />
           </div>
           <div>
-            <p className="text-[16px] font-bold text-[#1C1917]">{detail.title}</p>
+            <p className="text-[16px] font-bold text-[#1C1917] dark:text-[#FAFAF9]">{detail.title}</p>
             <p className="text-xs text-[#22C55E]">● 运行中</p>
           </div>
         </div>
-        <p className="mt-2 text-sm text-[#78716C]">{detail.description}</p>
+        <p className="mt-2 text-sm text-[#78716C] dark:text-[#A8A29E]">{detail.description}</p>
         <div className="mt-3 grid grid-cols-3 gap-2">
           {detail.stats.map((stat) => (
-            <div key={stat.label} className="rounded-lg bg-[#FAF7F5] py-2 text-center">
-              <span className="text-[11px] text-[#A8A29E]">{stat.label}</span>
-              <p className="text-sm font-semibold text-[#1C1917]">{stat.value}</p>
+            <div key={stat.label} className="rounded-lg bg-[#FAF7F5] py-2 text-center dark:bg-[#292524]">
+              <span className="text-[11px] text-[#A8A29E] dark:text-[#78716C]">{stat.label}</span>
+              <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{stat.value}</p>
             </div>
           ))}
         </div>
       </section>
 
       <section className="mt-4">
-        <h3 className="text-[13px] font-semibold text-[#78716C]">触发规则</h3>
-        <div className="mt-2 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white">
+        <h3 className="text-[13px] font-semibold text-[#78716C] dark:text-[#A8A29E]">触发规则</h3>
+        <div className="mt-2 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white dark:border-[#292524] dark:bg-[#1C1917]">
           {detail.triggerRules.map((item, index) => (
             <div key={`${item.key}-${item.value}`}>
               <div className="flex items-center justify-between px-4 py-3">
-                <span className="text-sm text-[#78716C]">{item.key}</span>
-                <span className={`text-sm ${item.highlight ? 'font-semibold text-[#C75B3A]' : 'text-[#1C1917]'}`}>
+                <span className="text-sm text-[#78716C] dark:text-[#A8A29E]">{item.key}</span>
+                <span className={`text-sm ${item.highlight ? 'font-semibold text-[#C75B3A]' : 'text-[#1C1917] dark:text-[#FAFAF9]'}`}>
                   {item.value}
                 </span>
               </div>
-              {index !== detail.triggerRules.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
+              {index !== detail.triggerRules.length - 1 && <div className="h-px bg-[#F5F0ED] dark:bg-[#292524]" />}
             </div>
           ))}
         </div>
       </section>
 
       <section className="mt-4">
-        <h3 className="text-[13px] font-semibold text-[#78716C]">输出目标</h3>
-        <div className="mt-2 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white">
+        <h3 className="text-[13px] font-semibold text-[#78716C] dark:text-[#A8A29E]">输出目标</h3>
+        <div className="mt-2 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white dark:border-[#292524] dark:bg-[#1C1917]">
           {detail.targets.map((item, index) => {
             const Icon = getTargetIcon(item);
             return (
               <div key={item.id}>
                 <div className="flex items-center gap-3 px-4 py-3">
-                  <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#F5F0ED] text-[#78716C]">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]">
                     <Icon size={14} />
                   </div>
                   <div className="min-w-0 flex-1">
-                    <p className="text-sm font-medium text-[#1C1917]">{item.name}</p>
-                    <p className="text-xs text-[#A8A29E]">{item.description}</p>
+                    <p className="text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{item.name}</p>
+                    <p className="text-xs text-[#A8A29E] dark:text-[#78716C]">{item.description}</p>
                   </div>
                 </div>
-                {index !== detail.targets.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
+                {index !== detail.targets.length - 1 && <div className="h-px bg-[#F5F0ED] dark:bg-[#292524]" />}
               </div>
             );
           })}
@@ -120,8 +120,8 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
       </section>
 
       <section className="mt-4">
-        <h3 className="text-[13px] font-semibold text-[#78716C]">最近执行</h3>
-        <div className="mt-2 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white">
+        <h3 className="text-[13px] font-semibold text-[#78716C] dark:text-[#A8A29E]">最近执行</h3>
+        <div className="mt-2 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white dark:border-[#292524] dark:bg-[#1C1917]">
           {detail.recentLogs.map((item, index) => (
             <div key={item.id}>
               <div className="flex items-center justify-between px-4 py-3">
@@ -130,16 +130,16 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
                     <CheckCheck size={12} />
                   </div>
                   <div>
-                    <p className="text-sm font-medium text-[#1C1917]">{item.title}</p>
-                    <p className="text-xs text-[#A8A29E]">{item.time}</p>
+                    <p className="text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{item.title}</p>
+                    <p className="text-xs text-[#A8A29E] dark:text-[#78716C]">{item.time}</p>
                   </div>
                 </div>
-                <div className="flex items-center gap-1 text-xs text-[#78716C]">
+                <div className="flex items-center gap-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
                   <Clock3 size={11} />
                   {item.duration ?? '--'}
                 </div>
               </div>
-              {index !== detail.recentLogs.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
+              {index !== detail.recentLogs.length - 1 && <div className="h-px bg-[#F5F0ED] dark:bg-[#292524]" />}
             </div>
           ))}
         </div>

--- a/src/ui/new/pages/agents/AgentDetailPage.tsx
+++ b/src/ui/new/pages/agents/AgentDetailPage.tsx
@@ -1,6 +1,13 @@
+import { ArrowLeft, CheckCheck, Clock3, MessageCircle, MoreHorizontal, Send, Sparkles } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { getAgentHubService } from '@/lib/services';
-import type { AgentDetailData } from '@/lib/types/agent-hub';
+import type { AgentDetailData, AgentHubListItem } from '@/lib/types/agent-hub';
+
+function getTargetIcon(target: AgentHubListItem) {
+  if (target.id.includes('telegram')) return Send;
+  if (target.id.includes('wechat')) return MessageCircle;
+  return Sparkles;
+}
 
 export function AgentDetailPage({ agentId }: { agentId?: string }) {
   const [detail, setDetail] = useState<AgentDetailData | null>(null);
@@ -30,15 +37,43 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
   }
 
   return (
-    <div data-testid="agent-detail-page" className="min-h-full bg-[#FAF7F5] px-5 py-4">
+    <div data-testid="agent-detail-page" className="min-h-full bg-[#FAF7F5] px-5 py-3">
+      <header data-testid="agent-detail-header" className="mb-3 flex items-center justify-between">
+        <button
+          type="button"
+          data-testid="agent-detail-back-button"
+          onClick={() => window.history.back()}
+          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C]"
+          aria-label="返回（Back）"
+        >
+          <ArrowLeft size={16} />
+        </button>
+        <h1 className="text-[17px] font-bold text-[#1C1917]">{detail.title}</h1>
+        <button
+          type="button"
+          className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C]"
+          aria-label="更多（More）"
+        >
+          <MoreHorizontal size={16} />
+        </button>
+      </header>
+
       <section className="rounded-[18px] border border-[#E7E5E4] bg-white p-4">
-        <p className="text-[18px] font-bold text-[#1C1917]">{detail.title}</p>
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#C75B3A20] text-[#C75B3A]">
+            <Sparkles size={18} />
+          </div>
+          <div>
+            <p className="text-[16px] font-bold text-[#1C1917]">{detail.title}</p>
+            <p className="text-xs text-[#22C55E]">● 运行中</p>
+          </div>
+        </div>
         <p className="mt-2 text-sm text-[#78716C]">{detail.description}</p>
-        <div className="mt-3 flex justify-between gap-2">
+        <div className="mt-3 grid grid-cols-3 gap-2">
           {detail.stats.map((stat) => (
-            <div key={stat.label} className="flex flex-1 flex-col items-center rounded-lg bg-[#FAF7F5] py-2">
+            <div key={stat.label} className="rounded-lg bg-[#FAF7F5] py-2 text-center">
               <span className="text-[11px] text-[#A8A29E]">{stat.label}</span>
-              <span className="text-sm font-semibold text-[#1C1917]">{stat.value}</span>
+              <p className="text-sm font-semibold text-[#1C1917]">{stat.value}</p>
             </div>
           ))}
         </div>
@@ -64,15 +99,23 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
       <section className="mt-4">
         <h3 className="text-[13px] font-semibold text-[#78716C]">输出目标</h3>
         <div className="mt-2 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white">
-          {detail.targets.map((item, index) => (
-            <div key={item.id}>
-              <div className="px-4 py-3">
-                <p className="text-sm font-medium text-[#1C1917]">{item.name}</p>
-                <p className="text-xs text-[#A8A29E]">{item.description}</p>
+          {detail.targets.map((item, index) => {
+            const Icon = getTargetIcon(item);
+            return (
+              <div key={item.id}>
+                <div className="flex items-center gap-3 px-4 py-3">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#F5F0ED] text-[#78716C]">
+                    <Icon size={14} />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-[#1C1917]">{item.name}</p>
+                    <p className="text-xs text-[#A8A29E]">{item.description}</p>
+                  </div>
+                </div>
+                {index !== detail.targets.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
               </div>
-              {index !== detail.targets.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
-            </div>
-          ))}
+            );
+          })}
         </div>
       </section>
 
@@ -82,11 +125,19 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
           {detail.recentLogs.map((item, index) => (
             <div key={item.id}>
               <div className="flex items-center justify-between px-4 py-3">
-                <div>
-                  <p className="text-sm font-medium text-[#1C1917]">{item.title}</p>
-                  <p className="text-xs text-[#A8A29E]">{item.time}</p>
+                <div className="flex items-start gap-2">
+                  <div className="mt-0.5 rounded-full bg-[#22C55E15] p-1 text-[#22C55E]">
+                    <CheckCheck size={12} />
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium text-[#1C1917]">{item.title}</p>
+                    <p className="text-xs text-[#A8A29E]">{item.time}</p>
+                  </div>
                 </div>
-                <span className="text-xs text-[#78716C]">{item.duration ?? '--'}</span>
+                <div className="flex items-center gap-1 text-xs text-[#78716C]">
+                  <Clock3 size={11} />
+                  {item.duration ?? '--'}
+                </div>
               </div>
               {index !== detail.recentLogs.length - 1 && <div className="h-px bg-[#F5F0ED]" />}
             </div>
@@ -98,6 +149,10 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
         <button
           type="button"
           data-testid="agent-detail-chat-button"
+          onClick={() => {
+            if (!targetId) return;
+            window.location.href = `/agents/chat/${targetId}`;
+          }}
           className="w-full rounded-[14px] bg-[#C75B3A] px-4 py-3 text-sm font-semibold text-white"
         >
           与 Agent 对话

--- a/src/ui/new/pages/agents/AgentDetailPage.tsx
+++ b/src/ui/new/pages/agents/AgentDetailPage.tsx
@@ -4,10 +4,10 @@ import type { AgentDetailData } from '@/lib/types/agent-hub';
 
 export function AgentDetailPage({ agentId }: { agentId?: string }) {
   const [detail, setDetail] = useState<AgentDetailData | null>(null);
+  const targetId = agentId ?? '';
 
   useEffect(() => {
     let disposed = false;
-    const targetId = agentId ?? '';
     const load = async () => {
       if (!targetId) return;
       const response = await getAgentHubService().getAgentDetail(targetId);
@@ -19,7 +19,7 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
     return () => {
       disposed = true;
     };
-  }, [agentId]);
+  }, [targetId]);
 
   if (!detail) {
     return (
@@ -106,4 +106,3 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
     </div>
   );
 }
-

--- a/src/ui/new/pages/agents/AgentMarketPage.tsx
+++ b/src/ui/new/pages/agents/AgentMarketPage.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react';
+import { getAgentHubService } from '@/lib/services';
+import type { AgentMarketCategory, AgentMarketItem } from '@/lib/types/agent-hub';
+
+export function AgentMarketPage() {
+  const [categories, setCategories] = useState<AgentMarketCategory[]>([]);
+  const [activeCategoryId, setActiveCategoryId] = useState('all');
+  const [items, setItems] = useState<AgentMarketItem[]>([]);
+
+  useEffect(() => {
+    let disposed = false;
+    const service = getAgentHubService();
+    const load = async () => {
+      const [nextCategories, nextItems] = await Promise.all([
+        service.listMarketCategories(),
+        service.getMarketItems({ categoryId: 'all' }),
+      ]);
+      if (disposed) return;
+      setCategories(nextCategories);
+      setItems(nextItems);
+    };
+    void load();
+    return () => {
+      disposed = true;
+    };
+  }, []);
+
+  const handleCategoryChange = async (categoryId: string) => {
+    setActiveCategoryId(categoryId);
+    const nextItems = await getAgentHubService().getMarketItems({ categoryId });
+    setItems(nextItems);
+  };
+
+  return (
+    <div data-testid="agent-market-page" className="min-h-full bg-[#FAF7F5]">
+      <header className="px-5 py-3">
+        <h1 className="text-[17px] font-bold text-[#1C1917]">市场</h1>
+      </header>
+
+      <div className="px-5">
+        <div className="rounded-xl bg-[#F5F0ED] px-4 py-2 text-sm text-[#A8A29E]">搜索 Agent、数据源、知识包...</div>
+      </div>
+
+      <div className="mt-3 flex gap-2 overflow-x-auto px-5 pb-1">
+        {categories.map((category) => {
+          const active = category.id === activeCategoryId;
+          return (
+            <button
+              key={category.id}
+              type="button"
+              onClick={() => {
+                void handleCategoryChange(category.id);
+              }}
+              className={`shrink-0 rounded-full px-3 py-1.5 text-[13px] ${
+                active ? 'bg-[#C75B3A] text-white' : 'bg-[#F5F0ED] text-[#78716C]'
+              }`}
+            >
+              {category.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mt-3 px-5">
+        <div className="flex items-center justify-between">
+          <h2 className="text-[16px] font-bold text-[#1C1917]">热门推荐</h2>
+          <span className="text-[13px] text-[#C75B3A]">查看全部</span>
+        </div>
+
+        <div className="mt-2 space-y-3 pb-[calc(env(safe-area-inset-bottom,0px)+108px)]">
+          {items.map((item) => (
+            <article key={item.id} className="rounded-2xl border border-[#F5F0ED] bg-white p-4">
+              <p className="text-sm font-semibold text-[#1C1917]">{item.name}</p>
+              <p className="mt-1 text-xs text-[#78716C]">{item.summary}</p>
+              <div className="mt-2 flex items-center justify-between">
+                <div className="flex flex-wrap gap-1">
+                  {item.tags.map((tag) => (
+                    <span key={`${item.id}-${tag}`} className="rounded bg-[#F5F0ED] px-2 py-0.5 text-[11px] text-[#78716C]">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+                <span className="text-[11px] text-[#A8A29E]">{item.installsText}</span>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/ui/new/pages/agents/AgentMarketPage.tsx
+++ b/src/ui/new/pages/agents/AgentMarketPage.tsx
@@ -1,6 +1,13 @@
+import { ArrowDownToLine, ArrowLeft, Search, Sparkles, Store, Users } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { getAgentHubService } from '@/lib/services';
 import type { AgentMarketCategory, AgentMarketItem } from '@/lib/types/agent-hub';
+
+function getMarketCardIcon(item: AgentMarketItem) {
+  if (item.id.includes('calendar')) return Store;
+  if (item.id.includes('knowledge')) return Users;
+  return Sparkles;
+}
 
 export function AgentMarketPage() {
   const [categories, setCategories] = useState<AgentMarketCategory[]>([]);
@@ -33,12 +40,27 @@ export function AgentMarketPage() {
 
   return (
     <div data-testid="agent-market-page" className="min-h-full bg-[#FAF7F5]">
-      <header className="px-5 py-3">
-        <h1 className="text-[17px] font-bold text-[#1C1917]">市场</h1>
+      <header className="grid grid-cols-[auto,1fr,auto] items-center px-5 py-3">
+        <button
+          type="button"
+          onClick={() => window.history.back()}
+          className="flex items-center gap-1 text-[12px] text-[#C75B3A]"
+        >
+          <ArrowLeft size={14} />
+          返回
+        </button>
+        <h1 className="text-center text-[17px] font-bold text-[#1C1917]">市场</h1>
+        <span />
       </header>
 
       <div className="px-5">
-        <div className="rounded-xl bg-[#F5F0ED] px-4 py-2 text-sm text-[#A8A29E]">搜索 Agent、数据源、知识包...</div>
+        <label
+          data-testid="agent-market-search"
+          className="flex items-center gap-2 rounded-xl bg-[#F5F0ED] px-3 py-2 text-sm text-[#A8A29E]"
+        >
+          <Search size={14} />
+          搜索 Agent、数据源、知识包...
+        </label>
       </div>
 
       <div className="mt-3 flex gap-2 overflow-x-auto px-5 pb-1">
@@ -68,25 +90,41 @@ export function AgentMarketPage() {
         </div>
 
         <div className="mt-2 space-y-3 pb-[calc(env(safe-area-inset-bottom,0px)+108px)]">
-          {items.map((item) => (
-            <article key={item.id} className="rounded-2xl border border-[#F5F0ED] bg-white p-4">
-              <p className="text-sm font-semibold text-[#1C1917]">{item.name}</p>
-              <p className="mt-1 text-xs text-[#78716C]">{item.summary}</p>
-              <div className="mt-2 flex items-center justify-between">
-                <div className="flex flex-wrap gap-1">
-                  {item.tags.map((tag) => (
-                    <span key={`${item.id}-${tag}`} className="rounded bg-[#F5F0ED] px-2 py-0.5 text-[11px] text-[#78716C]">
-                      {tag}
-                    </span>
-                  ))}
+          {items.map((item) => {
+            const Icon = getMarketCardIcon(item);
+            return (
+              <article key={item.id} className="rounded-2xl border border-[#F5F0ED] bg-white p-4">
+                <div className="flex items-start gap-3">
+                  <div
+                    className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl"
+                    style={{ backgroundColor: `${item.tintColor}20`, color: item.tintColor }}
+                  >
+                    <Icon size={16} />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-semibold text-[#1C1917]">{item.name}</p>
+                    <p className="text-[11px] text-[#A8A29E]">by exomind team</p>
+                  </div>
                 </div>
-                <span className="text-[11px] text-[#A8A29E]">{item.installsText}</span>
-              </div>
-            </article>
-          ))}
+                <p className="mt-2 text-xs text-[#78716C]">{item.summary}</p>
+                <div className="mt-2 flex items-center justify-between">
+                  <div className="flex flex-wrap gap-1">
+                    {item.tags.slice(0, 2).map((tag) => (
+                      <span key={`${item.id}-${tag}`} className="rounded bg-[#F5F0ED] px-2 py-0.5 text-[11px] text-[#78716C]">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                  <div className="flex items-center gap-1 text-[11px] text-[#A8A29E]">
+                    <ArrowDownToLine size={11} />
+                    {item.installsText}
+                  </div>
+                </div>
+              </article>
+            );
+          })}
         </div>
       </div>
     </div>
   );
 }
-

--- a/src/ui/new/pages/agents/AgentMarketPage.tsx
+++ b/src/ui/new/pages/agents/AgentMarketPage.tsx
@@ -39,7 +39,7 @@ export function AgentMarketPage() {
   };
 
   return (
-    <div data-testid="agent-market-page" className="min-h-full bg-[#FAF7F5]">
+    <div data-testid="agent-market-page" className="min-h-full bg-[#FAF7F5] dark:bg-[#0C0A09]">
       <header className="grid grid-cols-[auto,1fr,auto] items-center px-5 py-3">
         <button
           type="button"
@@ -49,14 +49,14 @@ export function AgentMarketPage() {
           <ArrowLeft size={14} />
           返回
         </button>
-        <h1 className="text-center text-[17px] font-bold text-[#1C1917]">市场</h1>
+        <h1 className="text-center text-[17px] font-bold text-[#1C1917] dark:text-[#FAFAF9]">市场</h1>
         <span />
       </header>
 
       <div className="px-5">
         <label
           data-testid="agent-market-search"
-          className="flex items-center gap-2 rounded-xl bg-[#F5F0ED] px-3 py-2 text-sm text-[#A8A29E]"
+          className="flex items-center gap-2 rounded-xl bg-[#F5F0ED] px-3 py-2 text-sm text-[#A8A29E] dark:bg-[#292524] dark:text-[#78716C]"
         >
           <Search size={14} />
           搜索 Agent、数据源、知识包...
@@ -74,7 +74,7 @@ export function AgentMarketPage() {
                 void handleCategoryChange(category.id);
               }}
               className={`shrink-0 rounded-full px-3 py-1.5 text-[13px] ${
-                active ? 'bg-[#C75B3A] text-white' : 'bg-[#F5F0ED] text-[#78716C]'
+                active ? 'bg-[#C75B3A] text-white' : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'
               }`}
             >
               {category.label}
@@ -85,7 +85,7 @@ export function AgentMarketPage() {
 
       <div className="mt-3 px-5">
         <div className="flex items-center justify-between">
-          <h2 className="text-[16px] font-bold text-[#1C1917]">热门推荐</h2>
+          <h2 className="text-[16px] font-bold text-[#1C1917] dark:text-[#FAFAF9]">热门推荐</h2>
           <span className="text-[13px] text-[#C75B3A]">查看全部</span>
         </div>
 
@@ -93,7 +93,7 @@ export function AgentMarketPage() {
           {items.map((item) => {
             const Icon = getMarketCardIcon(item);
             return (
-              <article key={item.id} className="rounded-2xl border border-[#F5F0ED] bg-white p-4">
+              <article key={item.id} className="rounded-2xl border border-[#F5F0ED] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
                 <div className="flex items-start gap-3">
                   <div
                     className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl"
@@ -102,20 +102,20 @@ export function AgentMarketPage() {
                     <Icon size={16} />
                   </div>
                   <div className="min-w-0 flex-1">
-                    <p className="text-sm font-semibold text-[#1C1917]">{item.name}</p>
-                    <p className="text-[11px] text-[#A8A29E]">by exomind team</p>
+                    <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{item.name}</p>
+                    <p className="text-[11px] text-[#A8A29E] dark:text-[#78716C]">by exomind team</p>
                   </div>
                 </div>
-                <p className="mt-2 text-xs text-[#78716C]">{item.summary}</p>
+                <p className="mt-2 text-xs text-[#78716C] dark:text-[#A8A29E]">{item.summary}</p>
                 <div className="mt-2 flex items-center justify-between">
                   <div className="flex flex-wrap gap-1">
                     {item.tags.slice(0, 2).map((tag) => (
-                      <span key={`${item.id}-${tag}`} className="rounded bg-[#F5F0ED] px-2 py-0.5 text-[11px] text-[#78716C]">
+                      <span key={`${item.id}-${tag}`} className="rounded bg-[#F5F0ED] px-2 py-0.5 text-[11px] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]">
                         {tag}
                       </span>
                     ))}
                   </div>
-                  <div className="flex items-center gap-1 text-[11px] text-[#A8A29E]">
+                  <div className="flex items-center gap-1 text-[11px] text-[#A8A29E] dark:text-[#78716C]">
                     <ArrowDownToLine size={11} />
                     {item.installsText}
                   </div>

--- a/tests/e2e/agent-hub.issue204.test.ts
+++ b/tests/e2e/agent-hub.issue204.test.ts
@@ -32,7 +32,7 @@ test.describe('Issue #204 Agent Hub（Agent Hub 全视图）', () => {
     await page.getByTestId('agent-list-item-agent-daily').click();
     await expect(page).toHaveURL(/\/agents\/agent\/agent-daily$/);
     await expect(page.getByTestId('agent-detail-page')).toBeVisible();
-    await expect(page.getByText('日报 Agent')).toBeVisible();
+    await expect(page.getByRole('heading', { name: '日报 Agent' })).toBeVisible();
   });
 
   test('chat streaming + market browse（对话流式与市场浏览）', async ({ page }) => {
@@ -51,4 +51,3 @@ test.describe('Issue #204 Agent Hub（Agent Hub 全视图）', () => {
     await expect(page.getByText('Code Review Agent')).toBeVisible();
   });
 });
-

--- a/tests/e2e/agent-hub.issue204.test.ts
+++ b/tests/e2e/agent-hub.issue204.test.ts
@@ -1,0 +1,54 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function setupIssue204Flags(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('exomind:uiMode', 'new');
+    localStorage.setItem('exomind:agentPageEnabled', 'true');
+    localStorage.setItem('exomind:useMockData', 'true');
+  });
+}
+
+test.describe('Issue #204 Agent Hub（Agent Hub 全视图）', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupIssue204Flags(page);
+  });
+
+  test('main views + add node sheet + list-to-detail navigation（主视图和详情跳转）', async ({ page }) => {
+    await page.goto('/agents');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('agent-hub-page')).toBeVisible();
+    await expect(page.getByTestId('agent-topology-view')).toBeVisible();
+
+    await page.getByTestId('agent-view-toggle-list').click();
+    await expect(page.getByTestId('agent-list-view')).toBeVisible();
+
+    await page.getByTestId('agent-add-node-button').click();
+    await expect(page.getByTestId('agent-add-node-sheet')).toBeVisible();
+    await expect(page.getByText('从市场安装')).toBeVisible();
+    await page.getByTestId('agent-add-node-close').click();
+    await expect(page.getByTestId('agent-add-node-sheet')).toBeHidden();
+
+    await page.getByTestId('agent-list-item-agent-daily').click();
+    await expect(page).toHaveURL(/\/agents\/agent\/agent-daily$/);
+    await expect(page.getByTestId('agent-detail-page')).toBeVisible();
+    await expect(page.getByText('日报 Agent')).toBeVisible();
+  });
+
+  test('chat streaming + market browse（对话流式与市场浏览）', async ({ page }) => {
+    await page.goto('/agents/chat/agent-daily');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('agent-conversation-page')).toBeVisible();
+    await page.getByPlaceholder('输入消息...').fill('今天情况如何');
+    await page.getByTestId('agent-chat-send-button').click();
+    await expect(page.getByText(/已收到|今天共收集了/)).toBeVisible();
+
+    await page.goto('/agents/market');
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId('agent-market-page')).toBeVisible();
+    await expect(page.getByText('热门推荐')).toBeVisible();
+    await expect(page.getByText('Code Review Agent')).toBeVisible();
+  });
+});
+

--- a/tests/e2e/agent-hub.issue204.test.ts
+++ b/tests/e2e/agent-hub.issue204.test.ts
@@ -51,3 +51,37 @@ test.describe('Issue #204 Agent Hub（Agent Hub 全视图）', () => {
     await expect(page.getByText('Code Review Agent')).toBeVisible();
   });
 });
+
+test.describe('Issue #204 Agent Hub runtime toggle（运行时切换测试数据）', () => {
+  test('switches to mock topology without full reload and keeps dark surface（不刷新切换到 mock 并保持暗色背景）', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('exomind:uiMode', 'new');
+      localStorage.setItem('exomind:agentPageEnabled', 'true');
+      localStorage.setItem('exomind:developerMode', 'true');
+      localStorage.setItem('exomind:themePreference', 'dark');
+      localStorage.setItem('exomind:useMockData', 'false');
+      for (const key of Object.keys(localStorage)) {
+        if (key.startsWith('agent_hub_')) {
+          localStorage.removeItem(key);
+        }
+      }
+    });
+
+    await page.goto('/agents');
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId('agent-hub-page')).toBeVisible();
+    await expect(page.getByTestId('agent-topology-node-agent-daily')).toHaveCount(0);
+
+    await page.getByRole('link', { name: '设置' }).click();
+    await expect(page.getByTestId('new-settings-use-mock-data-switch')).toBeVisible();
+    await page.getByTestId('new-settings-use-mock-data-switch').click();
+
+    await page.getByRole('link', { name: 'Agent' }).click();
+    await expect(page.getByTestId('agent-topology-node-agent-daily')).toBeVisible();
+
+    const pageBackground = await page.getByTestId('agent-hub-page').evaluate((node) => {
+      return window.getComputedStyle(node).backgroundColor;
+    });
+    expect(pageBackground).toBe('rgb(12, 10, 9)');
+  });
+});

--- a/tests/e2e/playwright.issue204.config.ts
+++ b/tests/e2e/playwright.issue204.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const WEB_PORT = 1420;
+const BASE_URL = `http://localhost:${WEB_PORT}`;
+
+export default defineConfig({
+  testDir: '.',
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    baseURL: BASE_URL,
+    trace: 'retain-on-failure',
+    launchOptions: {
+      channel: 'chrome',
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    },
+  ],
+  webServer: {
+    command: 'bun run dev',
+    cwd: '../..',
+    url: BASE_URL,
+    reuseExistingServer: true,
+    timeout: 180000,
+    env: {
+      ...process.env,
+      EXOMIND_WEB_PORT: String(WEB_PORT),
+      EXOMIND_HMR_PORT: '1421',
+      EXOMIND_POUCHDB_PORT: '7420',
+      EXOMIND_ASR_PORT: '2420',
+      VITE_SYNC_SERVER_URL: 'http://localhost:7420',
+      VITE_ASR_SERVER_URL: 'http://localhost:2420',
+    },
+  },
+});
+

--- a/tests/unit/adapters/agent-mock-adapter.issue204.test.ts
+++ b/tests/unit/adapters/agent-mock-adapter.issue204.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { AgentMockAdapter } from '@/lib/adapters/mock/agent-mock-adapter';
+
+describe('agent mock adapter issue-204（Agent Mock 适配器）', () => {
+  let adapter: AgentMockAdapter;
+
+  beforeEach(() => {
+    adapter = new AgentMockAdapter();
+  });
+
+  it('returns topology/list/device/add-node data（返回拓扑/列表/设备/添加节点数据）', async () => {
+    const [topology, listView, deviceView, addNodeOptions] = await Promise.all([
+      adapter.getTopology(),
+      adapter.getListView(),
+      adapter.getDeviceView(),
+      adapter.listAddNodeOptions(),
+    ]);
+
+    expect(topology.nodes.length).toBeGreaterThan(0);
+    expect(listView.length).toBeGreaterThan(0);
+    expect(deviceView.length).toBeGreaterThan(0);
+    expect(addNodeOptions.map((item) => item.id)).toContain('market');
+  });
+
+  it('supports market query filter（支持市场分类和关键字筛选）', async () => {
+    const all = await adapter.getMarketItems();
+    const filteredByCategory = await adapter.getMarketItems({ categoryId: 'agent' });
+    const filteredByQuery = await adapter.getMarketItems({ query: 'Code' });
+
+    expect(all.length).toBeGreaterThan(0);
+    expect(filteredByCategory.every((item) => item.tags.includes('agent'))).toBe(true);
+    expect(filteredByQuery.some((item) => item.name.includes('Code'))).toBe(true);
+  });
+
+  it('streams response chunks and marks done（流式返回分片并结束）', async () => {
+    const chunks = [];
+    for await (const chunk of adapter.streamConversation({
+      agentId: 'agent-daily',
+      prompt: '今天的总结',
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.at(-1)?.done).toBe(true);
+  });
+});
+

--- a/tests/unit/adapters/agent-web-adapter.issue204.test.ts
+++ b/tests/unit/adapters/agent-web-adapter.issue204.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { AgentWebAdapter, AGENT_WEB_STORAGE_KEYS } from '@/lib/adapters/agent-web-adapter';
+import type { AgentHubTopologyData } from '@/lib/types/agent-hub';
+
+describe('agent web adapter issue-204（Agent Web 适配器）', () => {
+  let adapter: AgentWebAdapter;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    adapter = new AgentWebAdapter();
+  });
+
+  it('returns safe defaults when storage is empty（无数据时返回安全默认值）', async () => {
+    const topology = await adapter.getTopology();
+    const listView = await adapter.getListView();
+    const deviceView = await adapter.getDeviceView();
+    const addNodeOptions = await adapter.listAddNodeOptions();
+
+    expect(topology.nodes).toEqual([]);
+    expect(topology.edges).toEqual([]);
+    expect(listView).toEqual([]);
+    expect(deviceView).toEqual([]);
+    expect(addNodeOptions.length).toBeGreaterThan(0);
+  });
+
+  it('reads topology data from storage（可从存储读取拓扑）', async () => {
+    const seededTopology: AgentHubTopologyData = {
+      nodes: [
+        {
+          id: 'agent-daily',
+          type: 'agent',
+          name: '日报 Agent',
+          status: 'running',
+          layer: 'middle',
+          brandColor: '#C75B3A',
+        },
+      ],
+      edges: [],
+      selectedNodeId: null,
+    };
+
+    window.localStorage.setItem(
+      `exomind_${AGENT_WEB_STORAGE_KEYS.topology}`,
+      JSON.stringify(seededTopology)
+    );
+
+    const topology = await adapter.getTopology();
+    expect(topology.nodes[0]?.name).toBe('日报 Agent');
+  });
+
+  it('streams a placeholder assistant message（可流式输出占位回复）', async () => {
+    const deltas: string[] = [];
+
+    for await (const chunk of adapter.streamConversation({
+      agentId: 'agent-web',
+      prompt: 'hello',
+    })) {
+      deltas.push(chunk.delta);
+    }
+
+    expect(deltas.join('')).toContain('placeholder');
+  });
+});
+

--- a/tests/unit/agent-hub/agent-types-contract.issue204.test.ts
+++ b/tests/unit/agent-hub/agent-types-contract.issue204.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { AGENT_HUB_VIEW_MODES } from '@/lib/types/agent-hub';
+import { AGENT_PORT_KEYWORDS } from '@/lib/environment/interfaces/agent.port';
+import type {
+  AgentAddNodeOption,
+  AgentConversationChunk,
+  AgentConversationMessage,
+  AgentDetailData,
+  AgentDeviceGroup,
+  AgentHubListSection,
+  AgentHubTopologyData,
+  AgentMarketCategory,
+  AgentMarketItem,
+} from '@/lib/types/agent-hub';
+import type { IAgentPort } from '@/lib/environment/interfaces/agent.port';
+
+function buildTopologyFixture(): AgentHubTopologyData {
+  return {
+    nodes: [
+      {
+        id: 'agent-daily',
+        type: 'agent',
+        name: '日报 Agent',
+        status: 'running',
+        layer: 'middle',
+        brandColor: '#C75B3A',
+      },
+    ],
+    edges: [
+      {
+        id: 'edge-rss-to-daily',
+        fromNodeId: 'input-rss',
+        toNodeId: 'agent-daily',
+        color: '#C75B3A90',
+      },
+    ],
+    selectedNodeId: 'agent-daily',
+  };
+}
+
+class FakeAgentPort implements IAgentPort {
+  async getTopology(): Promise<AgentHubTopologyData> {
+    return buildTopologyFixture();
+  }
+
+  async getListView(): Promise<AgentHubListSection[]> {
+    return [];
+  }
+
+  async getDeviceView(): Promise<AgentDeviceGroup[]> {
+    return [];
+  }
+
+  async listAddNodeOptions(): Promise<AgentAddNodeOption[]> {
+    return [];
+  }
+
+  async getAgentDetail(_agentId: string): Promise<AgentDetailData | null> {
+    return null;
+  }
+
+  async getActorDetail(_actorId: string): Promise<AgentDetailData | null> {
+    return null;
+  }
+
+  async listMarketCategories(): Promise<AgentMarketCategory[]> {
+    return [];
+  }
+
+  async getMarketItems(_params?: { categoryId?: string; query?: string }): Promise<AgentMarketItem[]> {
+    return [];
+  }
+
+  async getConversation(_agentId: string): Promise<AgentConversationMessage[]> {
+    return [];
+  }
+
+  async *streamConversation(
+    _input: { agentId: string; prompt: string }
+  ): AsyncGenerator<AgentConversationChunk, void, void> {
+    yield {
+      messageId: 'msg-1',
+      delta: '你好，',
+      done: false,
+    };
+    yield {
+      messageId: 'msg-1',
+      delta: '世界',
+      done: true,
+    };
+  }
+}
+
+describe('agent hub type contracts issue-204（Agent Hub 类型契约）', () => {
+  it('exposes runtime constants for view mode and port contract（暴露运行时常量契约）', () => {
+    expect(AGENT_HUB_VIEW_MODES).toEqual(['topology', 'list', 'device']);
+    expect(AGENT_PORT_KEYWORDS).toContain('streamConversation');
+  });
+
+  it('defines topology/list/device/detail/market/chat domain models（覆盖核心视图类型）', async () => {
+    const port = new FakeAgentPort();
+    const topology = await port.getTopology();
+
+    expect(topology.nodes[0]?.name).toBe('日报 Agent');
+    expect(topology.edges[0]?.toNodeId).toBe('agent-daily');
+  });
+});

--- a/tests/unit/environment/bootstrap.test.ts
+++ b/tests/unit/environment/bootstrap.test.ts
@@ -14,6 +14,7 @@ describe('environment bootstrap', () => {
     expect(result.storage.constructor.name).toBe('WebStorageAdapter');
     expect(result.eventlog.constructor.name).toBe('WebEventLogStorageAdapter');
     expect(result.task.constructor.name).toBe('TaskWebAdapter');
+    expect(result.agent.constructor.name).toBe('AgentWebAdapter');
   });
 
   it('createRuntimeBootstrap should use pouchdb eventlog adapter for tauri runtime', () => {
@@ -26,10 +27,12 @@ describe('environment bootstrap', () => {
     expect(tauriResult.eventlog.constructor.name).toBe('WebEventLogStorageAdapter');
     expect(tauriResult.eventlog.constructor.name).toBe(webResult.eventlog.constructor.name);
     expect(tauriResult.task.constructor.name).toBe('TaskWebAdapter');
+    expect(tauriResult.agent.constructor.name).toBe('AgentWebAdapter');
   });
 
   it('createRuntimeBootstrap should use mock task adapter when mock flag is enabled', () => {
     const result = createRuntimeBootstrap({ runtime: 'web', useMockData: true });
     expect(result.task.constructor.name).toBe('TaskMockAdapter');
+    expect(result.agent.constructor.name).toBe('AgentMockAdapter');
   });
 });

--- a/tests/unit/environment/environment-mock-data-sync.issue204.test.ts
+++ b/tests/unit/environment/environment-mock-data-sync.issue204.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('environment mock-data sync issue-204（环境应在运行中同步 mock 开关）', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    window.localStorage.clear();
+  });
+
+  it('refreshes task/agent adapters after mock flag toggles（切换后刷新 task/agent 适配器）', async () => {
+    window.localStorage.setItem('exomind:useMockData', 'false');
+
+    const { ExoMindEnvironment } = await import('@/lib/environment/environment');
+
+    ExoMindEnvironment.resetForTests();
+    const environmentBeforeToggle = ExoMindEnvironment.getInstance();
+    expect(environmentBeforeToggle.agent.constructor.name).toBe('AgentWebAdapter');
+    expect(environmentBeforeToggle.task.constructor.name).toBe('TaskWebAdapter');
+
+    window.localStorage.setItem('exomind:useMockData', 'true');
+
+    const environmentAfterToggle = ExoMindEnvironment.getInstance();
+    expect(environmentAfterToggle.agent.constructor.name).toBe('AgentMockAdapter');
+    expect(environmentAfterToggle.task.constructor.name).toBe('TaskMockAdapter');
+  });
+});

--- a/tests/unit/services/agent-hub-service-mock-toggle.issue204.test.ts
+++ b/tests/unit/services/agent-hub-service-mock-toggle.issue204.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IAgentPort } from '@/lib/environment/interfaces/agent.port';
+
+function createAgentPort(label: string): IAgentPort {
+  return {
+    getTopology: vi.fn(async () => ({
+      nodes: [{ id: `node-${label}`, type: 'agent', name: label, status: 'running', layer: 'middle', brandColor: '#C75B3A' }],
+      edges: [],
+      selectedNodeId: null,
+    })),
+    getListView: vi.fn(async () => []),
+    getDeviceView: vi.fn(async () => []),
+    listAddNodeOptions: vi.fn(async () => []),
+    getAgentDetail: vi.fn(async () => null),
+    getActorDetail: vi.fn(async () => null),
+    listMarketCategories: vi.fn(async () => []),
+    getMarketItems: vi.fn(async () => []),
+    getConversation: vi.fn(async () => []),
+    streamConversation: vi.fn(async function* () {
+      yield {
+        messageId: `msg-${label}`,
+        delta: label,
+        done: true,
+      };
+    }),
+  };
+}
+
+describe('agent hub service mock toggle issue-204（切换 mock 数据后应生效）', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('re-reads environment when adapter source changes（切换后应读取新环境）', async () => {
+    const mockAgentPort = createAgentPort('mock');
+    const webAgentPort = createAgentPort('web');
+
+    let currentEnv: { agent: IAgentPort } = { agent: webAgentPort };
+    const getInstance = vi.fn(() => currentEnv);
+
+    vi.doMock('@/lib/environment/environment', () => ({
+      ExoMindEnvironment: {
+        getInstance,
+      },
+    }));
+
+    const module = await import('@/lib/services/agent-hub.service');
+    const service = module.getAgentHubService();
+
+    await service.getTopology();
+    expect(webAgentPort.getTopology).toHaveBeenCalledTimes(1);
+    expect(mockAgentPort.getTopology).toHaveBeenCalledTimes(0);
+
+    currentEnv = { agent: mockAgentPort };
+    await service.getTopology();
+
+    expect(mockAgentPort.getTopology).toHaveBeenCalledTimes(1);
+    expect(getInstance).toHaveBeenCalledTimes(2);
+  });
+});
+

--- a/tests/unit/services/agent-hub.service.issue204.test.ts
+++ b/tests/unit/services/agent-hub.service.issue204.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentHubServiceImpl } from '@/lib/services/agent-hub.service';
+import type { IAgentPort } from '@/lib/environment/interfaces/agent.port';
+
+describe('agent hub service issue-204（Agent Hub 服务）', () => {
+  let agentPort: IAgentPort;
+  let service: AgentHubServiceImpl;
+
+  beforeEach(() => {
+    agentPort = {
+      getTopology: vi.fn(async () => ({ nodes: [], edges: [], selectedNodeId: null })),
+      getListView: vi.fn(async () => []),
+      getDeviceView: vi.fn(async () => []),
+      listAddNodeOptions: vi.fn(async () => []),
+      getAgentDetail: vi.fn(async () => null),
+      getActorDetail: vi.fn(async () => null),
+      listMarketCategories: vi.fn(async () => []),
+      getMarketItems: vi.fn(async () => []),
+      getConversation: vi.fn(async () => []),
+      streamConversation: vi.fn(async function* () {
+        yield {
+          messageId: 'msg-1',
+          delta: 'hello',
+          done: true,
+        };
+      }),
+    };
+
+    service = new AgentHubServiceImpl({ agent: agentPort });
+  });
+
+  it('delegates reads to agent port（读取请求转发到 agent port）', async () => {
+    await service.getTopology();
+    await service.getListView();
+    await service.getDeviceView();
+    await service.listAddNodeOptions();
+    await service.listMarketCategories();
+    await service.getMarketItems({ categoryId: 'agent' });
+
+    expect(agentPort.getTopology).toHaveBeenCalledTimes(1);
+    expect(agentPort.getListView).toHaveBeenCalledTimes(1);
+    expect(agentPort.getDeviceView).toHaveBeenCalledTimes(1);
+    expect(agentPort.listAddNodeOptions).toHaveBeenCalledTimes(1);
+    expect(agentPort.listMarketCategories).toHaveBeenCalledTimes(1);
+    expect(agentPort.getMarketItems).toHaveBeenCalledWith({ categoryId: 'agent' });
+  });
+
+  it('delegates detail and chat methods（详情与对话方法转发）', async () => {
+    await service.getAgentDetail('agent-1');
+    await service.getActorDetail('actor-1');
+    await service.getConversation('agent-1');
+
+    const chunks = [];
+    for await (const chunk of service.streamConversation({ agentId: 'agent-1', prompt: 'hi' })) {
+      chunks.push(chunk);
+    }
+
+    expect(agentPort.getAgentDetail).toHaveBeenCalledWith('agent-1');
+    expect(agentPort.getActorDetail).toHaveBeenCalledWith('actor-1');
+    expect(agentPort.getConversation).toHaveBeenCalledWith('agent-1');
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.done).toBe(true);
+  });
+});
+

--- a/tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AgentDetailPage } from '@/ui/new/pages/agents/AgentDetailPage';
+import { ActorDetailPage } from '@/ui/new/pages/agents/ActorDetailPage';
+import { AGENT_HUB_MOCK_FIXTURE } from '@/lib/adapters/mock/fixtures/agent-hub';
+
+const serviceMocks = vi.hoisted(() => ({
+  getAgentDetail: vi.fn(),
+  getActorDetail: vi.fn(),
+}));
+
+vi.mock('@/lib/services', () => ({
+  getAgentHubService: () => ({
+    getAgentDetail: serviceMocks.getAgentDetail,
+    getActorDetail: serviceMocks.getActorDetail,
+  }),
+}));
+
+describe('agent/actor detail pages issue-204（详情页）', () => {
+  beforeEach(() => {
+    serviceMocks.getAgentDetail.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.agentDetails['agent-daily']);
+    serviceMocks.getActorDetail.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.actorDetails['actor-timer']);
+  });
+
+  it('renders agent detail sections and chat CTA（Agent 详情区块与对话入口）', async () => {
+    render(<AgentDetailPage agentId="agent-daily" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-detail-page')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('日报 Agent')).toBeInTheDocument();
+    expect(screen.getByText('触发规则')).toBeInTheDocument();
+    expect(screen.getByText('输出目标')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-detail-chat-button')).toBeInTheDocument();
+  });
+
+  it('renders actor detail sections（Actor 详情区块）', async () => {
+    render(<ActorDetailPage actorId="actor-timer" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('actor-detail-page')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('定时唤醒')).toBeInTheDocument();
+    expect(screen.getByText('触发规则')).toBeInTheDocument();
+    expect(screen.getByText('最近执行')).toBeInTheDocument();
+  });
+});
+

--- a/tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx
@@ -29,7 +29,9 @@ describe('agent/actor detail pages issue-204（详情页）', () => {
       expect(screen.getByTestId('agent-detail-page')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('日报 Agent')).toBeInTheDocument();
+    expect(screen.getAllByText('日报 Agent').length).toBeGreaterThan(0);
+    expect(screen.getByTestId('agent-detail-header')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-detail-back-button')).toBeInTheDocument();
     expect(screen.getByText('触发规则')).toBeInTheDocument();
     expect(screen.getByText('输出目标')).toBeInTheDocument();
     expect(screen.getByTestId('agent-detail-chat-button')).toBeInTheDocument();
@@ -42,9 +44,9 @@ describe('agent/actor detail pages issue-204（详情页）', () => {
       expect(screen.getByTestId('actor-detail-page')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('定时唤醒')).toBeInTheDocument();
+    expect(screen.getAllByText('定时唤醒').length).toBeGreaterThan(0);
+    expect(screen.getByTestId('actor-detail-header')).toBeInTheDocument();
     expect(screen.getByText('触发规则')).toBeInTheDocument();
     expect(screen.getByText('最近执行')).toBeInTheDocument();
   });
 });
-

--- a/tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx
@@ -51,4 +51,28 @@ describe('agent/actor detail pages issue-204（详情页）', () => {
     expect(screen.getByText('最近执行')).toBeInTheDocument();
     expect(screen.getByTestId('actor-detail-page').className).toContain('dark:bg-[#0C0A09]');
   });
+
+  it('renders agent empty state when detail is missing（Agent 空详情应展示空态）', async () => {
+    serviceMocks.getAgentDetail.mockResolvedValueOnce(null);
+    render(<AgentDetailPage agentId="agent-summary" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-detail-empty-state')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Agent 详情加载中...')).not.toBeInTheDocument();
+    expect(screen.getByText('未找到 Agent 详情')).toBeInTheDocument();
+  });
+
+  it('renders actor empty state when detail is missing（Actor 空详情应展示空态）', async () => {
+    serviceMocks.getActorDetail.mockResolvedValueOnce(null);
+    render(<ActorDetailPage actorId="actor-cleaner" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('actor-detail-empty-state')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Actor 详情加载中...')).not.toBeInTheDocument();
+    expect(screen.getByText('未找到 Actor 详情')).toBeInTheDocument();
+  });
 });

--- a/tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx
@@ -35,6 +35,7 @@ describe('agent/actor detail pages issue-204（详情页）', () => {
     expect(screen.getByText('触发规则')).toBeInTheDocument();
     expect(screen.getByText('输出目标')).toBeInTheDocument();
     expect(screen.getByTestId('agent-detail-chat-button')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-detail-page').className).toContain('dark:bg-[#0C0A09]');
   });
 
   it('renders actor detail sections（Actor 详情区块）', async () => {
@@ -48,5 +49,6 @@ describe('agent/actor detail pages issue-204（详情页）', () => {
     expect(screen.getByTestId('actor-detail-header')).toBeInTheDocument();
     expect(screen.getByText('触发规则')).toBeInTheDocument();
     expect(screen.getByText('最近执行')).toBeInTheDocument();
+    expect(screen.getByTestId('actor-detail-page').className).toContain('dark:bg-[#0C0A09]');
   });
 });

--- a/tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx
@@ -38,6 +38,8 @@ describe('agent chat and market issue-204（对话与市场）', () => {
       expect(screen.getByTestId('agent-conversation-page')).toBeInTheDocument();
     });
 
+    expect(screen.getByTestId('agent-conversation-header')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-chat-input-bar')).toBeInTheDocument();
     expect(screen.getByText('你好！我是日报 Agent。有什么需要我整理的吗？')).toBeInTheDocument();
     fireEvent.change(screen.getByPlaceholderText('输入消息...'), { target: { value: '今天情况如何' } });
     fireEvent.click(screen.getByTestId('agent-chat-send-button'));
@@ -54,9 +56,10 @@ describe('agent chat and market issue-204（对话与市场）', () => {
       expect(screen.getByTestId('agent-market-page')).toBeInTheDocument();
     });
 
+    expect(screen.getByTestId('agent-market-search')).toBeInTheDocument();
+    expect(screen.getAllByText('by exomind team').length).toBeGreaterThan(0);
     expect(screen.getByText('热门推荐')).toBeInTheDocument();
     expect(screen.getByText('Code Review Agent')).toBeInTheDocument();
     expect(screen.getByText('Google Calendar 数据源')).toBeInTheDocument();
   });
 });
-

--- a/tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { AgentConversationPage } from '@/ui/new/pages/agents/AgentConversationPage';
+import { AgentMarketPage } from '@/ui/new/pages/agents/AgentMarketPage';
+import { AGENT_HUB_MOCK_FIXTURE } from '@/lib/adapters/mock/fixtures/agent-hub';
+
+const serviceMocks = vi.hoisted(() => ({
+  getConversation: vi.fn(),
+  streamConversation: vi.fn(),
+  listMarketCategories: vi.fn(),
+  getMarketItems: vi.fn(),
+}));
+
+vi.mock('@/lib/services', () => ({
+  getAgentHubService: () => ({
+    getConversation: serviceMocks.getConversation,
+    streamConversation: serviceMocks.streamConversation,
+    listMarketCategories: serviceMocks.listMarketCategories,
+    getMarketItems: serviceMocks.getMarketItems,
+  }),
+}));
+
+describe('agent chat and market issue-204（对话与市场）', () => {
+  beforeEach(() => {
+    serviceMocks.getConversation.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.conversations['agent-daily'] ?? []);
+    serviceMocks.streamConversation.mockImplementation(async function* () {
+      yield { messageId: 'stream-1', delta: '今天共收集了 ', done: false };
+      yield { messageId: 'stream-1', delta: '19 条信息', done: true };
+    });
+    serviceMocks.listMarketCategories.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.marketCategories);
+    serviceMocks.getMarketItems.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.marketItems);
+  });
+
+  it('renders chat history and streaming response（加载历史并流式输出）', async () => {
+    render(<AgentConversationPage agentId="agent-daily" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-conversation-page')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('你好！我是日报 Agent。有什么需要我整理的吗？')).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('输入消息...'), { target: { value: '今天情况如何' } });
+    fireEvent.click(screen.getByTestId('agent-chat-send-button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('今天共收集了 19 条信息')).toBeInTheDocument();
+    });
+  });
+
+  it('renders market categories and cards（加载市场分类与卡片）', async () => {
+    render(<AgentMarketPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-market-page')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('热门推荐')).toBeInTheDocument();
+    expect(screen.getByText('Code Review Agent')).toBeInTheDocument();
+    expect(screen.getByText('Google Calendar 数据源')).toBeInTheDocument();
+  });
+});
+

--- a/tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx
@@ -40,6 +40,7 @@ describe('agent chat and market issue-204（对话与市场）', () => {
 
     expect(screen.getByTestId('agent-conversation-header')).toBeInTheDocument();
     expect(screen.getByTestId('agent-chat-input-bar')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-conversation-page').className).toContain('dark:bg-[#0C0A09]');
     expect(screen.getByText('你好！我是日报 Agent。有什么需要我整理的吗？')).toBeInTheDocument();
     fireEvent.change(screen.getByPlaceholderText('输入消息...'), { target: { value: '今天情况如何' } });
     fireEvent.click(screen.getByTestId('agent-chat-send-button'));
@@ -57,6 +58,7 @@ describe('agent chat and market issue-204（对话与市场）', () => {
     });
 
     expect(screen.getByTestId('agent-market-search')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-market-page').className).toContain('dark:bg-[#0C0A09]');
     expect(screen.getAllByText('by exomind team').length).toBeGreaterThan(0);
     expect(screen.getByText('热门推荐')).toBeInTheDocument();
     expect(screen.getByText('Code Review Agent')).toBeInTheDocument();

--- a/tests/unit/ui/agent-hub/agent-routing.issue204.test.ts
+++ b/tests/unit/ui/agent-hub/agent-routing.issue204.test.ts
@@ -1,0 +1,26 @@
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('issue-204 agent routing wiring（Agent 路由接线）', () => {
+  const sourcePath = path.resolve('src/routes-new.tsx');
+  const source = readFileSync(sourcePath, 'utf-8');
+
+  it('keeps /agents main route（保留主入口）', () => {
+    expect(source).toContain("path: '/agents'");
+  });
+
+  it('adds agent detail route（新增 Agent 详情路由）', () => {
+    expect(source).toContain("path: '/agents/agent/$agentId'");
+  });
+
+  it('adds actor detail route（新增 Actor 详情路由）', () => {
+    expect(source).toContain("path: '/agents/actor/$actorId'");
+  });
+
+  it('adds chat and market routes（新增对话与市场路由）', () => {
+    expect(source).toContain("path: '/agents/chat/$agentId'");
+    expect(source).toContain("path: '/agents/market'");
+  });
+});
+

--- a/tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
@@ -35,10 +35,15 @@ describe('agents page issue-204（主页面三视图与添加节点）', () => {
     });
 
     expect(screen.getByTestId('agent-topology-view')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-topology-canvas')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-topology-edge-e-rss-daily')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('agent-view-toggle-list'));
     expect(screen.getByTestId('agent-list-view')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-list-filter-all')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-list-item-agent-daily-chevron')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('agent-view-toggle-device'));
     expect(screen.getByTestId('agent-device-view')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-device-overview-card')).toBeInTheDocument();
   });
 
   it('supports selecting topology node and opening add node sheet（支持节点选中与添加节点弹窗）', async () => {
@@ -50,6 +55,7 @@ describe('agents page issue-204（主页面三视图与添加节点）', () => {
 
     fireEvent.click(screen.getByTestId('agent-topology-node-agent-daily'));
     expect(screen.getByTestId('agent-topology-node-detail-card')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-topology-node-agent-summary')).toHaveAttribute('data-muted', 'true');
 
     fireEvent.click(screen.getByTestId('agent-add-node-button'));
     expect(screen.getByTestId('agent-add-node-sheet')).toBeInTheDocument();
@@ -59,4 +65,3 @@ describe('agents page issue-204（主页面三视图与添加节点）', () => {
     expect(screen.queryByTestId('agent-add-node-sheet')).not.toBeInTheDocument();
   });
 });
-

--- a/tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
@@ -75,4 +75,17 @@ describe('agents page issue-204（主页面三视图与添加节点）', () => {
     expect(screen.getByTestId('agent-hub-page').className).toContain('dark:bg-[#0C0A09]');
     expect(screen.getByTestId('agent-topology-canvas').className).toContain('dark:bg-[#1C1917]');
   });
+
+  it('uses task-page sized title（标题字号与任务页一致）', async () => {
+    render(<AgentsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Agent 网络' })).toBeInTheDocument();
+    });
+
+    const heading = screen.getByRole('heading', { name: 'Agent 网络' });
+    expect(heading.className).toContain('text-lg');
+    expect(heading.className).toContain('font-semibold');
+    expect(heading.className).not.toContain('text-[30px]');
+  });
 });

--- a/tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
@@ -64,4 +64,15 @@ describe('agents page issue-204（主页面三视图与添加节点）', () => {
     fireEvent.click(screen.getByTestId('agent-add-node-close'));
     expect(screen.queryByTestId('agent-add-node-sheet')).not.toBeInTheDocument();
   });
+
+  it('keeps dark-mode classes on key surfaces（关键区域包含暗色样式类）', async () => {
+    render(<AgentsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-topology-canvas')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('agent-hub-page').className).toContain('dark:bg-[#0C0A09]');
+    expect(screen.getByTestId('agent-topology-canvas').className).toContain('dark:bg-[#1C1917]');
+  });
 });

--- a/tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { AgentsPage } from '@/ui/new/pages/AgentsPage';
+import { AGENT_HUB_MOCK_FIXTURE } from '@/lib/adapters/mock/fixtures/agent-hub';
+
+const serviceMocks = vi.hoisted(() => ({
+  getTopology: vi.fn(),
+  getListView: vi.fn(),
+  getDeviceView: vi.fn(),
+  listAddNodeOptions: vi.fn(),
+}));
+
+vi.mock('@/lib/services', () => ({
+  getAgentHubService: () => ({
+    getTopology: serviceMocks.getTopology,
+    getListView: serviceMocks.getListView,
+    getDeviceView: serviceMocks.getDeviceView,
+    listAddNodeOptions: serviceMocks.listAddNodeOptions,
+  }),
+}));
+
+describe('agents page issue-204（主页面三视图与添加节点）', () => {
+  beforeEach(() => {
+    serviceMocks.getTopology.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.topology);
+    serviceMocks.getListView.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.listSections);
+    serviceMocks.getDeviceView.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.deviceGroups);
+    serviceMocks.listAddNodeOptions.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.addNodeOptions);
+  });
+
+  it('switches topology/list/device views（支持拓扑/列表/设备切换）', async () => {
+    render(<AgentsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-hub-page')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('agent-topology-view')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('agent-view-toggle-list'));
+    expect(screen.getByTestId('agent-list-view')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('agent-view-toggle-device'));
+    expect(screen.getByTestId('agent-device-view')).toBeInTheDocument();
+  });
+
+  it('supports selecting topology node and opening add node sheet（支持节点选中与添加节点弹窗）', async () => {
+    render(<AgentsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-topology-view')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('agent-topology-node-agent-daily'));
+    expect(screen.getByTestId('agent-topology-node-detail-card')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('agent-add-node-button'));
+    expect(screen.getByTestId('agent-add-node-sheet')).toBeInTheDocument();
+    expect(screen.getByText('从市场安装')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('agent-add-node-close'));
+    expect(screen.queryByTestId('agent-add-node-sheet')).not.toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
# feat(agent-hub): 前端 UI 设计 + 实现 — 全视图 (GH#204)

## 目标
严格对照 `pencil/eventlog-ui-design.pen` 完成 Agent Hub 全视图 UI 实现，并保持 mock/真实数据适配可切换（上层零改动）。

## 实现内容
- Agent Hub 三视图：拓扑 / 列表 / 设备
- Agent 详情页、Actor 详情页
- 对话页（流式输出）
- 市场浏览页
- 添加节点弹窗（含市场入口）
- mock 架构：
  - `src/config/mock-data.ts`
  - `src/lib/adapters/mock/agent-mock-adapter.ts`
  - `src/lib/adapters/agent-web-adapter.ts`
  - `src/lib/environment/bootstrap.ts` 根据 flag 注入
  - `src/lib/services/agent-hub.service.ts` 对上层统一收口

## 关键技术点
- 拓扑画布使用绝对定位 + SVG 连线，实现节点高亮与非关联节点/边淡化。
- Settings 开发者区保留「使用测试数据」开关，切换后无需改页面代码。
- 路由接线：
  - `/agents`
  - `/agents/agent/$agentId`
  - `/agents/actor/$actorId`
  - `/agents/chat/$agentId`
  - `/agents/market`

## 测试与验证
- 单测：
  - `bun vitest tests/unit/agent-hub tests/unit/adapters/agent-mock-adapter.issue204.test.ts tests/unit/adapters/agent-web-adapter.issue204.test.ts tests/unit/environment/bootstrap.test.ts tests/unit/services/agent-hub.service.issue204.test.ts tests/unit/ui/agent-hub/agents-page.issue204.test.tsx tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx tests/unit/ui/agent-hub/agent-routing.issue204.test.ts`
- E2E：
  - `bun run test:e2e:issue204`
- 构建：
  - `bun run build`

## 评审结论
- 详见 PR 评论：
  - 进度评论：`docs/pr/issue-204-progress-comment.md`
  - 评审评论：`docs/pr/issue-204-review-comment.md`
- 结论：Approve

