### PR TITLE
fix(Settings): 恢复新 UI 在 Android 的导入导出原生链路 (issue #222)

### DIFF
--- a/src/ui/new/pages/NewSettingsPage.tsx
+++ b/src/ui/new/pages/NewSettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { ChangeEvent } from 'react';
+import { invoke, isTauri } from '@tauri-apps/api/core';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer';
 import { Switch } from '@/components/ui/switch';
@@ -155,9 +156,26 @@ export function NewSettingsPage() {
     try {
       const service = getEventLogService();
       const json = await service.exportEventsAsJson();
+      const payload = JSON.parse(json) as { events?: unknown[] };
+      const count = Array.isArray(payload.events) ? payload.events.length : 0;
+      const defaultName = buildBackupFileName();
 
-      downloadJsonFallback(json, buildBackupFileName());
-      setStatusMessage('已导出事件备份');
+      const isRunningInTauri = await isTauri();
+      if (isRunningInTauri) {
+        const savedPath = await invoke<string | null>('save_json_file', {
+          content: json,
+          defaultName,
+        });
+        if (!savedPath) {
+          setStatusMessage('已取消保存。');
+          return;
+        }
+        setStatusMessage(`导出成功，共 ${count} 条事件。保存路径：${savedPath}`);
+        return;
+      }
+
+      downloadJsonFallback(json, defaultName);
+      setStatusMessage(`导出成功，共 ${count} 条事件。`);
     } catch (error) {
       const message = error instanceof Error ? error.message : '未知错误';
       setErrorMessage(`导出失败：${message}`);
@@ -167,39 +185,65 @@ export function NewSettingsPage() {
   };
 
   const downloadJsonFallback = (json: string, filename: string) => {
-    const blob = new Blob([json], { type: 'application/json' });
+    const blob = new Blob([json], { type: 'application/json;charset=utf-8' });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    a.click();
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
     URL.revokeObjectURL(url);
   };
 
   const handleImportBackup = async () => {
     clearNotice();
-    fileInputRef.current?.click();
-  };
 
-  const handleFileInputChange = async (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    const content = await file.text();
-    await processImport({ path: file.name, content });
-    e.target.value = '';
-  };
+    const isRunningInTauri = await isTauri();
+    if (!isRunningInTauri) {
+      fileInputRef.current?.click();
+      return;
+    }
 
-  const processImport = async (picked: PickedJsonFile) => {
     setLoading(true);
     try {
-      const service = getEventLogService();
-      const result = await service.importEventsFromJson(picked.content, importStrategy);
-      setStatusMessage(`已导入 ${result.imported} 条事件，跳过 ${result.skipped} 条`);
+      const picked = await invoke<PickedJsonFile | null>('pick_json_file');
+      if (!picked) {
+        setStatusMessage('已取消导入。');
+        return;
+      }
+      await processImport(picked);
     } catch (error) {
       const message = error instanceof Error ? error.message : '未知错误';
       setErrorMessage(`导入失败：${message}`);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleFileInputChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setLoading(true);
+    try {
+      const content = await file.text();
+      await processImport({ path: file.name, content });
+    } finally {
+      e.target.value = '';
+      setLoading(false);
+    }
+  };
+
+  const processImport = async (picked: PickedJsonFile) => {
+    try {
+      const service = getEventLogService();
+      const result = await service.importEventsFromJson(picked.content, importStrategy);
+      setStatusMessage(
+        `导入成功：新增 ${result.imported} 条，跳过 ${result.skipped} 条，当前共 ${result.total} 条。来源：${picked.path}`
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '未知错误';
+      setErrorMessage(`导入失败：${message}`);
     }
   };
 

--- a/tests/unit/settings/new-settings-export-runtime.issue222.test.tsx
+++ b/tests/unit/settings/new-settings-export-runtime.issue222.test.tsx
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mocks = vi.hoisted(() => ({
+  exportEventsAsJson: vi.fn(),
+  importEventsFromJson: vi.fn(),
+  isTauri: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: mocks.isTauri,
+  invoke: mocks.invoke,
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/lib/services', () => ({
+  getEventLogService: () => ({
+    exportEventsAsJson: mocks.exportEventsAsJson,
+    importEventsFromJson: mocks.importEventsFromJson,
+  }),
+}));
+
+vi.mock('@/config/port-env', () => ({
+  getSyncServerUrlOverride: () => null,
+  resolveSyncServerUrl: () => 'http://127.0.0.1:6984',
+  setSyncServerUrlOverride: vi.fn(),
+}));
+
+vi.mock('@/config/theme', () => ({
+  getThemePreference: () => 'system',
+  setThemePreference: vi.fn(),
+}));
+
+vi.mock('@/config/developer-mode', () => ({
+  getDeveloperModeEnabled: () => false,
+  setDeveloperModeEnabled: vi.fn(),
+}));
+
+vi.mock('@/config/agent-page-enabled', () => ({
+  getAgentPageEnabled: () => false,
+  setAgentPageEnabled: vi.fn(),
+}));
+
+vi.mock('@/config/mock-data', () => ({
+  getUseMockDataEnabled: () => false,
+  setUseMockDataEnabled: vi.fn(),
+  subscribeUseMockDataChanges: () => () => {},
+}));
+
+vi.mock('@/config/timer-preferences', () => ({
+  getTimerPreferences: () => ({
+    countdownEndMode: 'soft',
+    countdownEndSoundEnabled: false,
+    countdownEndSoundPresetId: 'timer-end-ring-10',
+  }),
+  subscribeTimerPreferencesChanges: () => () => {},
+  updateTimerPreferences: (partial: Record<string, unknown>) => ({
+    countdownEndMode: 'soft',
+    countdownEndSoundEnabled: false,
+    countdownEndSoundPresetId: 'timer-end-ring-10',
+    ...partial,
+  }),
+}));
+
+vi.mock('@/config/ui-mode', () => ({
+  setUIMode: vi.fn(),
+}));
+
+vi.mock('@/ui/new/components/UserCard', () => ({
+  UserCard: () => <div data-testid="mock-user-card" />,
+}));
+
+vi.mock('@/ui/new/components/MoreSection', () => ({
+  MoreSection: () => null,
+}));
+
+vi.mock('@/ui/new/components/LegalSection', () => ({
+  LegalSection: () => null,
+}));
+
+vi.mock('@/ui/new/components/AboutSection', () => ({
+  AboutSection: () => null,
+}));
+
+import { NewSettingsPage } from '@/ui/new/pages/NewSettingsPage';
+
+const createObjectURLMock = vi.fn(() => 'blob:mock');
+const revokeObjectURLMock = vi.fn();
+
+Object.defineProperty(URL, 'createObjectURL', {
+  value: createObjectURLMock,
+  writable: true,
+});
+
+Object.defineProperty(URL, 'revokeObjectURL', {
+  value: revokeObjectURLMock,
+  writable: true,
+});
+
+describe('NewSettingsPage export/import runtime routing (issue-222)', () => {
+  let anchorClickSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.exportEventsAsJson.mockResolvedValue(JSON.stringify({ events: [{ id: 'evt-1' }] }));
+    mocks.importEventsFromJson.mockResolvedValue({ imported: 0, skipped: 0, total: 0 });
+    mocks.isTauri.mockResolvedValue(false);
+    mocks.invoke.mockResolvedValue(null);
+    anchorClickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    anchorClickSpy.mockRestore();
+  });
+
+  it('uses tauri native save command for export in tauri runtime', async () => {
+    mocks.isTauri.mockResolvedValue(true);
+    mocks.invoke.mockResolvedValue('/storage/emulated/0/Download/exomind-eventlog-2026-02-24.json');
+
+    render(<NewSettingsPage />);
+    fireEvent.click(screen.getByRole('button', { name: '导出备份' }));
+
+    await waitFor(() => {
+      expect(mocks.invoke).toHaveBeenCalledWith('save_json_file', expect.objectContaining({
+        content: expect.stringContaining('"events"'),
+        defaultName: expect.stringMatching(/^exomind-eventlog-\d{4}-\d{2}-\d{2}\.json$/),
+      }));
+    });
+
+    expect(screen.getByText(/导出成功，共 1 条事件。保存路径：/)).toBeInTheDocument();
+    expect(anchorClickSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps blob download fallback in web runtime', async () => {
+    mocks.isTauri.mockResolvedValue(false);
+
+    render(<NewSettingsPage />);
+    fireEvent.click(screen.getByRole('button', { name: '导出备份' }));
+
+    await waitFor(() => {
+      expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(anchorClickSpy).toHaveBeenCalledTimes(1);
+    expect(mocks.invoke).not.toHaveBeenCalled();
+    expect(screen.getByText('导出成功，共 1 条事件。')).toBeInTheDocument();
+  });
+
+  it('uses tauri native pick command for import in tauri runtime', async () => {
+    mocks.isTauri.mockResolvedValue(true);
+    mocks.invoke.mockImplementation((command: string) => {
+      if (command === 'pick_json_file') {
+        return Promise.resolve({
+          path: 'content://downloads/document/eventlog.json',
+          content: JSON.stringify({
+            version: 1,
+            events: [
+              { id: 'evt-2', timestamp: 1700000000001, content: 'hello', tags: ['note'] },
+            ],
+          }),
+        });
+      }
+      return Promise.resolve(null);
+    });
+    mocks.importEventsFromJson.mockResolvedValue({ imported: 1, skipped: 0, total: 2 });
+
+    render(<NewSettingsPage />);
+    fireEvent.click(screen.getByRole('button', { name: '导入数据' }));
+
+    await waitFor(() => {
+      expect(mocks.invoke).toHaveBeenCalledWith('pick_json_file');
+    });
+
+    expect(mocks.importEventsFromJson).toHaveBeenCalledWith(expect.stringContaining('"version":1'), 'merge');
+    expect(screen.getByText(/导入成功：新增 1 条/)).toBeInTheDocument();
+    expect(screen.getByText(/来源：content:\/\/downloads\/document\/eventlog\.json/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- 修复 `NewSettingsPage` 在 Tauri/Android 运行时未走原生文件能力的问题。
- 导出：恢复 `isTauri()` + `invoke('save_json_file')`，仅 Web 保留 blob 下载降级。
- 导入：恢复 `isTauri()` + `invoke('pick_json_file')`，仅 Web 使用 `<input type="file">`。
- 新增新 UI 运行时回归测试，覆盖 Tauri/Web 双路径。

## Root Cause
新 UI 设置页在重构后只保留了浏览器下载/选文件分支，丢失了 Tauri 原生文件选择与写入分支，导致 Android APP 中提示成功但文件未落盘。

## Changes
- `src/ui/new/pages/NewSettingsPage.tsx`
  - 导出恢复 Tauri 原生保存命令路由
  - 导入恢复 Tauri 原生选文件命令路由
  - 状态提示对齐旧设置页（包含取消与保存路径信息）
- `tests/unit/settings/new-settings-export-runtime.issue222.test.tsx`
  - 新增 3 个用例：Tauri 导出、Web 导出、Tauri 导入

## Validation
- `npx vitest run tests/unit/settings/new-settings-export-runtime.issue222.test.tsx`
  - 3 passed

Closes #222

@Hailaylin 请帮忙检阅。
