### PR TITLE
fix(input): use Tauri native clipboard read for new UI input row (issue #226)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "exomind",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exomind"
-version = "0.3.2"
+version = "0.3.3"
 description = "ExoMind - A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
+tauri-plugin-clipboard-manager = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
@@ -44,4 +45,3 @@ lto = true
 opt-level = "s"
 panic = "abort"
 strip = true
-

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "opener:default",
+    "clipboard-manager:default",
     "mcp-bridge:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,6 +26,7 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .manage(ws_client_state.clone())
         .invoke_handler(tauri::generate_handler![
             greet,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ExoMind",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "identifier": "com.exomind.app",
   "build": {
     "beforeDevCommand": "bun run dev",
@@ -36,4 +36,3 @@
     ]
   }
 }
-

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { router } from "@/routes";
 import { newUiRouter } from "@/routes-new";
 import { ThemeController } from "@/components/ThemeController";
+import { Toaster } from "@/components/ui/toaster";
 import { getUIMode, subscribeUIModeChanges, type UIMode } from "@/config/ui-mode";
 import "./App.css";
 
@@ -21,6 +22,7 @@ function App() {
     <>
       <ThemeController />
       <RouterProvider key={uiMode} router={activeRouter} />
+      <Toaster />
     </>
   );
 }

--- a/src/components/Settings/SettingsPage.tsx
+++ b/src/components/Settings/SettingsPage.tsx
@@ -37,7 +37,7 @@ function buildBackupFileName(): string {
 
 export function SettingsPage() {
   const envMap = import.meta.env as Record<string, string | undefined>;
-  const versionBuildInfo = resolveVersionBuildInfo(envMap, '0.3.0-beta1');
+  const versionBuildInfo = resolveVersionBuildInfo(envMap, '0.3.3');
   const autoSyncServerUrl = resolveSyncServerUrl(envMap, {
     syncServerOverride: null,
   });

--- a/src/ui/new/components/NewNowInputRow.tsx
+++ b/src/ui/new/components/NewNowInputRow.tsx
@@ -8,8 +8,10 @@ import {
   useState,
 } from 'react';
 import { Clipboard, Image, SendHorizontal } from 'lucide-react';
+import { invoke } from '@tauri-apps/api/core';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { toast } from '@/components/ui/toast-hook';
 import type { VoiceMessageInputHandle } from '@/components/VoiceMessageInput';
 
 interface NewNowInputRowProps {
@@ -47,30 +49,57 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
     setValue('');
   }, [onSend, value]);
 
-  const handlePasteFromClipboard = useCallback(async () => {
+  const insertClipboardText = useCallback((text: string) => {
+    if (!text) return;
+    setValue((prev) => {
+      const textarea = textareaRef.current;
+      if (textarea) {
+        const start = textarea.selectionStart;
+        const end = textarea.selectionEnd;
+        const next = prev.slice(0, start) + text + prev.slice(end);
+        // 延迟设置光标位置到粘贴文本之后
+        requestAnimationFrame(() => {
+          textarea.selectionStart = textarea.selectionEnd = start + text.length;
+          textarea.focus();
+        });
+        return next;
+      }
+      return prev + text;
+    });
+  }, []);
+
+  const readClipboardFromTauri = useCallback(async (): Promise<string | null> => {
+    if (typeof window === 'undefined' || window.__TAURI__ === undefined) {
+      return null;
+    }
+
     try {
-      const text = await navigator.clipboard.readText();
-      if (!text) return;
-      setValue((prev) => {
-        const textarea = textareaRef.current;
-        if (textarea) {
-          const start = textarea.selectionStart;
-          const end = textarea.selectionEnd;
-          const next = prev.slice(0, start) + text + prev.slice(end);
-          // 延迟设置光标位置到粘贴文本之后
-          requestAnimationFrame(() => {
-            textarea.selectionStart = textarea.selectionEnd = start + text.length;
-            textarea.focus();
-          });
-          return next;
-        }
-        return prev + text;
-      });
+      const text = await invoke<string>('plugin:clipboard-manager|read_text');
+      return typeof text === 'string' ? text : '';
     } catch (err) {
-      // 权限被拒绝或不支持
-      console.warn('[clipboard] readText failed:', err);
+      console.warn('[clipboard] tauri read failed:', err);
+      return null;
     }
   }, []);
+
+  const handlePasteFromClipboard = useCallback(async () => {
+    try {
+      const tauriText = await readClipboardFromTauri();
+      if (tauriText !== null) {
+        insertClipboardText(tauriText);
+        return;
+      }
+
+      if (typeof navigator === 'undefined' || !navigator.clipboard?.readText) {
+        throw new Error('clipboard read not supported');
+      }
+      const text = await navigator.clipboard.readText();
+      insertClipboardText(text);
+    } catch (err) {
+      console.warn('[clipboard] readText failed:', err);
+      toast({ title: '读取剪贴板失败，请重试', variant: 'destructive' });
+    }
+  }, [insertClipboardText, readClipboardFromTauri]);
 
   const handleKeyDown = useCallback((event: KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === 'Escape') {

--- a/src/ui/new/components/NewNowInputRow.tsx
+++ b/src/ui/new/components/NewNowInputRow.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from 'react';
 import { Clipboard, Image, SendHorizontal } from 'lucide-react';
-import { invoke } from '@tauri-apps/api/core';
+import { invoke, isTauri } from '@tauri-apps/api/core';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from '@/components/ui/toast-hook';
@@ -69,7 +69,8 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
   }, []);
 
   const readClipboardFromTauri = useCallback(async (): Promise<string | null> => {
-    if (typeof window === 'undefined' || window.__TAURI__ === undefined) {
+    const isRunningInTauri = await isTauri();
+    if (!isRunningInTauri) {
       return null;
     }
 

--- a/src/ui/new/pages/NewSettingsPage.tsx
+++ b/src/ui/new/pages/NewSettingsPage.tsx
@@ -77,7 +77,7 @@ function buildBackupFileName(): string {
 
 export function NewSettingsPage() {
   const envMap = import.meta.env as Record<string, string | undefined>;
-  const versionBuildInfo = resolveVersionBuildInfo(envMap, '0.3.0-beta1');
+  const versionBuildInfo = resolveVersionBuildInfo(envMap, '0.3.3');
   const autoSyncServerUrl = resolveSyncServerUrl(envMap, {
     syncServerOverride: null,
   });

--- a/tests/unit/ui/new-now-input-row.test.tsx
+++ b/tests/unit/ui/new-now-input-row.test.tsx
@@ -3,13 +3,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { NewNowInputRow } from '@/ui/new/components/NewNowInputRow';
 
-const { mockInvoke, mockToast } = vi.hoisted(() => ({
+const { mockInvoke, mockIsTauri, mockToast } = vi.hoisted(() => ({
   mockInvoke: vi.fn(),
+  mockIsTauri: vi.fn(),
   mockToast: vi.fn(),
 }));
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: mockInvoke,
+  isTauri: mockIsTauri,
 }));
 
 vi.mock('@/components/ui/toast-hook', () => ({
@@ -19,11 +21,11 @@ vi.mock('@/components/ui/toast-hook', () => ({
 describe('NewNowInputRow', () => {
   beforeEach(() => {
     mockInvoke.mockReset();
+    mockIsTauri.mockReset();
     mockToast.mockReset();
   });
 
   afterEach(() => {
-    delete (window as Window & { __TAURI__?: unknown }).__TAURI__;
     cleanup();
     vi.unstubAllGlobals();
   });
@@ -43,7 +45,7 @@ describe('NewNowInputRow', () => {
   });
 
   it('uses tauri clipboard command when running in tauri runtime', async () => {
-    Object.defineProperty(window, '__TAURI__', { value: {}, configurable: true });
+    mockIsTauri.mockResolvedValue(true);
     const mockReadText = vi.fn().mockResolvedValue('浏览器文本');
     vi.stubGlobal('navigator', {
       clipboard: { readText: mockReadText },
@@ -62,6 +64,7 @@ describe('NewNowInputRow', () => {
   });
 
   it('falls back to navigator clipboard on web runtime', async () => {
+    mockIsTauri.mockResolvedValue(false);
     const mockReadText = vi.fn().mockResolvedValue('Web 文本');
     vi.stubGlobal('navigator', {
       clipboard: { readText: mockReadText },
@@ -79,7 +82,7 @@ describe('NewNowInputRow', () => {
   });
 
   it('shows toast when tauri and web clipboard reads both fail', async () => {
-    Object.defineProperty(window, '__TAURI__', { value: {}, configurable: true });
+    mockIsTauri.mockResolvedValue(true);
     mockInvoke.mockRejectedValue(new Error('tauri denied'));
     const mockReadText = vi.fn().mockRejectedValue(new Error('web denied'));
     vi.stubGlobal('navigator', {

--- a/tests/unit/ui/new-now-input-row.test.tsx
+++ b/tests/unit/ui/new-now-input-row.test.tsx
@@ -1,12 +1,31 @@
 import React from 'react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { NewNowInputRow } from '@/ui/new/components/NewNowInputRow';
 
+const { mockInvoke, mockToast } = vi.hoisted(() => ({
+  mockInvoke: vi.fn(),
+  mockToast: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: mockInvoke,
+}));
+
+vi.mock('@/components/ui/toast-hook', () => ({
+  toast: mockToast,
+}));
+
 describe('NewNowInputRow', () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+    mockToast.mockReset();
+  });
+
   afterEach(() => {
+    delete (window as Window & { __TAURI__?: unknown }).__TAURI__;
     cleanup();
-    vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('submits text by send button and clears input', () => {
@@ -22,5 +41,59 @@ describe('NewNowInputRow', () => {
     expect(onSend).toHaveBeenCalledWith('像素级复刻输入行');
     expect((textarea as HTMLTextAreaElement).value).toBe('');
   });
-});
 
+  it('uses tauri clipboard command when running in tauri runtime', async () => {
+    Object.defineProperty(window, '__TAURI__', { value: {}, configurable: true });
+    const mockReadText = vi.fn().mockResolvedValue('浏览器文本');
+    vi.stubGlobal('navigator', {
+      clipboard: { readText: mockReadText },
+    });
+    mockInvoke.mockResolvedValue('Tauri 文本');
+
+    render(<NewNowInputRow onSend={vi.fn()} placeholder="输入内容记录事件..." />);
+    fireEvent.click(screen.getByTestId('new-now-input-inline-button'));
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('plugin:clipboard-manager|read_text');
+    });
+    expect(mockReadText).not.toHaveBeenCalled();
+    expect((screen.getByTestId('new-now-input-textarea') as HTMLTextAreaElement).value).toBe('Tauri 文本');
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it('falls back to navigator clipboard on web runtime', async () => {
+    const mockReadText = vi.fn().mockResolvedValue('Web 文本');
+    vi.stubGlobal('navigator', {
+      clipboard: { readText: mockReadText },
+    });
+
+    render(<NewNowInputRow onSend={vi.fn()} placeholder="输入内容记录事件..." />);
+    fireEvent.click(screen.getByTestId('new-now-input-inline-button'));
+
+    await waitFor(() => {
+      expect(mockReadText).toHaveBeenCalledTimes(1);
+    });
+    expect(mockInvoke).not.toHaveBeenCalled();
+    expect((screen.getByTestId('new-now-input-textarea') as HTMLTextAreaElement).value).toBe('Web 文本');
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it('shows toast when tauri and web clipboard reads both fail', async () => {
+    Object.defineProperty(window, '__TAURI__', { value: {}, configurable: true });
+    mockInvoke.mockRejectedValue(new Error('tauri denied'));
+    const mockReadText = vi.fn().mockRejectedValue(new Error('web denied'));
+    vi.stubGlobal('navigator', {
+      clipboard: { readText: mockReadText },
+    });
+
+    render(<NewNowInputRow onSend={vi.fn()} placeholder="输入内容记录事件..." />);
+    fireEvent.click(screen.getByTestId('new-now-input-inline-button'));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith({
+        title: '读取剪贴板失败，请重试',
+        variant: 'destructive',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- fix #226: new UI `NewNowInputRow` clipboard button now prefers Tauri native clipboard read via `invoke('plugin:clipboard-manager|read_text')`
- keep web fallback: if not in Tauri runtime, continue using `navigator.clipboard.readText()`
- add failure feedback toast instead of silent warning when both paths fail
- register Tauri clipboard plugin and capability permissions

## Why
`navigator.clipboard.readText()` is often blocked in Android WebView (NotAllowedError). Tauri native clipboard path avoids this WebView limitation.

## Changes
- frontend: `src/ui/new/components/NewNowInputRow.tsx`
  - extracted insert helper
  - Tauri runtime detection (`window.__TAURI__`) + native clipboard invoke
  - browser fallback + destructive toast on final failure
- tauri: `src-tauri/src/lib.rs`
  - added `.plugin(tauri_plugin_clipboard_manager::init())`
- tauri: `src-tauri/Cargo.toml`
  - added `tauri-plugin-clipboard-manager = "2"`
- tauri capability: `src-tauri/capabilities/default.json`
  - added `clipboard-manager:default`
- tests: `tests/unit/ui/new-now-input-row.test.tsx`
  - tauri path test
  - web fallback test
  - failure toast test

## Verification
- `npx vitest run tests/unit/ui/new-now-input-row.test.tsx`
  - passed (4/4)
- `cargo check --manifest-path src-tauri/Cargo.toml`
  - passed

Fixes #226
