### PR TITLE
refactor(clipboard): unify read/write via service with web+tauri adapters

### DIFF
--- a/docs/pr/clipboard-tauri-regression-investigation-2026-02-25.md
+++ b/docs/pr/clipboard-tauri-regression-investigation-2026-02-25.md
@@ -1,0 +1,194 @@
+# Clipboard 调研报告（Tauri 复制回归）
+
+日期：2026-02-25  
+范围：定位「Tauri 端复制失败」根因，并给出可验证修复。
+
+## 1. 现象与复现
+
+- 现象：Tauri 端点击「复制」失败。
+- 对照：历史可用版本为 `0.3.3-build.20260223T1558`（commit: `181a74e4fc3f59814e6b98283a42ce710f82aebe`）。
+
+## 2. 历史基线（可用版本）代码路径
+
+在 `181a74e` 中，`MessageActions` 直接使用 Web Clipboard API：
+
+```tsx
+const handleCopy = useCallback(async () => {
+  try {
+    await navigator.clipboard.writeText(content);
+    setCopied(true);
+    timerRef.current = setTimeout(() => setCopied(false), 1500);
+  } catch (err) {
+    console.error('[MessageActions] clipboard.writeText failed:', err);
+    toast({ title: '复制失败，请重试', variant: 'destructive' });
+  }
+}, [content]);
+```
+
+该路径不依赖 Tauri plugin invoke 的 ACL 授权。
+
+## 3. 回归引入点（重构后）
+
+在 commit `091f5eb`（`refactor(clipboard): move clipboard I/O into service and runtime adapters`）后，复制/粘贴改为走 service + tauri adapter：
+
+```ts
+export class TauriClipboardAdapter implements IClipboardPort {
+  async readText(): Promise<string> {
+    const text = await invoke<string>('plugin:clipboard-manager|read_text');
+    return typeof text === 'string' ? text : '';
+  }
+
+  async writeText(text: string): Promise<void> {
+    await invoke('plugin:clipboard-manager|write_text', { text });
+  }
+}
+```
+
+## 4. ACL 配置证据（关键根因）
+
+重构时 capability 配置是：
+
+```json
+{
+  "permissions": [
+    "core:default",
+    "opener:default",
+    "clipboard-manager:default",
+    "mcp-bridge:default"
+  ]
+}
+```
+
+而生成的 ACL schema 明确说明：
+
+```json
+{
+  "identifier": "default",
+  "description": "No features are enabled by default ... Clipboard interaction needs to be explicitly enabled.",
+  "permissions": []
+}
+```
+
+并且 `allow-read-text` / `allow-write-text` 才是实际开放命令的权限：
+
+```json
+{
+  "identifier": "allow-write-text",
+  "commands": {
+    "allow": ["write_text"],
+    "deny": []
+  }
+}
+```
+
+结论：`clipboard-manager:default` 不会授予 `write_text/read_text`，导致 invoke 路径失败。
+
+## 5. 根因结论
+
+这是一个“路径切换 + 权限未显式开放”的回归：
+
+1. 旧版：`navigator.clipboard.writeText`（可工作）  
+2. 新版：`invoke('plugin:clipboard-manager|write_text')`（需要 ACL 显式授权）  
+3. 配置仍是 `clipboard-manager:default`（实际不授权命令）  
+4. 结果：Tauri 复制失败
+
+## 6. 修复方案与代码
+
+### 6.1 修复 ACL：显式开放读写文本
+
+`src-tauri/capabilities/default.json`：
+
+```json
+{
+  "permissions": [
+    "core:default",
+    "opener:default",
+    "clipboard-manager:allow-read-text",
+    "clipboard-manager:allow-write-text",
+    "mcp-bridge:default"
+  ]
+}
+```
+
+### 6.2 修复适配器：invoke 失败时回退 Web Clipboard
+
+`src/lib/adapters/clipboard-tauri-adapter.ts`：
+
+```ts
+export class TauriClipboardAdapter implements IClipboardPort {
+  isAvailable(): boolean {
+    return true;
+  }
+
+  async readText(): Promise<string> {
+    try {
+      const text = await invoke<string>('plugin:clipboard-manager|read_text');
+      return typeof text === 'string' ? text : '';
+    } catch (tauriError) {
+      if (typeof navigator !== 'undefined' && typeof navigator.clipboard?.readText === 'function') {
+        return navigator.clipboard.readText();
+      }
+      throw tauriError;
+    }
+  }
+
+  async writeText(text: string): Promise<void> {
+    try {
+      await invoke('plugin:clipboard-manager|write_text', { text });
+      return;
+    } catch (tauriError) {
+      if (typeof navigator !== 'undefined' && typeof navigator.clipboard?.writeText === 'function') {
+        await navigator.clipboard.writeText(text);
+        return;
+      }
+      throw tauriError;
+    }
+  }
+}
+```
+
+## 7. 回归防护测试
+
+新增 `tests/unit/adapters/clipboard-tauri-adapter.test.ts`，覆盖四类场景：
+
+```ts
+it('uses tauri invoke for write by default', async () => {
+  vi.mocked(invoke).mockResolvedValue(undefined);
+  const adapter = new TauriClipboardAdapter();
+  await adapter.writeText('copy-from-tauri');
+  expect(invoke).toHaveBeenCalledWith('plugin:clipboard-manager|write_text', { text: 'copy-from-tauri' });
+});
+
+it('falls back to navigator clipboard write when tauri invoke fails', async () => {
+  const tauriError = new Error('clipboard command denied');
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  vi.mocked(invoke).mockRejectedValue(tauriError);
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+  const adapter = new TauriClipboardAdapter();
+  await adapter.writeText('copy-from-web');
+  expect(writeText).toHaveBeenCalledWith('copy-from-web');
+});
+```
+
+## 8. 验证证据
+
+已执行并通过：
+
+```bash
+npx vitest run tests/unit/adapters/clipboard-tauri-adapter.test.ts tests/unit/adapters/clipboard-web-adapter.test.ts tests/unit/services/clipboard.service.test.ts
+npx vitest run tests/unit/components/MessageActions.test.tsx tests/unit/ui/new-now-input-row.test.tsx
+npx tsc --noEmit
+npx vite build
+```
+
+说明：仓库当前 `npx vitest run` 全量仍有大量历史失败项（与本次 clipboard 改动无直接关系），本次报告以 clipboard 相关链路专项通过为准。
+
+## 9. 影响面说明
+
+本次修复影响的 clipboard 功能入口：
+
+- 聊天气泡复制：`src/components/Chat/MessageActions.tsx`
+- 新输入区粘贴：`src/ui/new/components/NewNowInputRow.tsx`
+- ASR 测试页复制：`src/pages/MOSSASRTestPage.tsx`
+
+这些入口通过同一 service 层调用，都会受益于本次 ACL + adapter fallback 修复。

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,7 +6,8 @@
   "permissions": [
     "core:default",
     "opener:default",
-    "clipboard-manager:default",
+    "clipboard-manager:allow-read-text",
+    "clipboard-manager:allow-write-text",
     "mcp-bridge:default"
   ]
 }

--- a/src/components/Chat/MessageActions.tsx
+++ b/src/components/Chat/MessageActions.tsx
@@ -5,7 +5,7 @@
  * 每条消息气泡下方显示复制/引用按钮
  */
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { Copy, Check, Quote } from 'lucide-react';
 import { toast } from '@/components/ui/toast-hook';
 import { getClipboardService } from '@/lib/services';
@@ -17,15 +17,34 @@ interface MessageActionsProps {
 
 export function MessageActions({ content, align }: MessageActionsProps) {
   const [copied, setCopied] = useState(false);
+  const [copyFailed, setCopyFailed] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout>>();
 
+  useEffect(() => () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+  }, []);
+
   const handleCopy = useCallback(async () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = undefined;
+    }
+
     const result = await getClipboardService().writeText(content);
     if (!result.ok) {
+      setCopied(false);
+      setCopyFailed(true);
+      timerRef.current = setTimeout(() => {
+        setCopyFailed(false);
+      }, 1500);
       console.error('[MessageActions] clipboard.writeText failed:', result.error, { reason: result.reason });
       toast({ title: result.title, description: result.description, variant: 'destructive' });
       return;
     }
+
+    setCopyFailed(false);
     setCopied(true);
     timerRef.current = setTimeout(() => setCopied(false), 1500);
   }, [content]);
@@ -40,7 +59,9 @@ export function MessageActions({ content, align }: MessageActionsProps) {
       <button
         data-testid="msg-copy-btn"
         onClick={handleCopy}
-        className="flex items-center gap-1 rounded-lg px-2 py-1 text-[11px] text-[#C8C0BA] hover:bg-stone-100 dark:hover:bg-stone-800"
+        className={`flex items-center gap-1 rounded-lg px-2 py-1 text-[11px] hover:bg-stone-100 dark:hover:bg-stone-800 ${
+          copyFailed ? 'text-red-500 dark:text-red-400' : 'text-[#C8C0BA]'
+        }`}
       >
         {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
         {copied ? '已复制' : '复制'}

--- a/src/components/Chat/MessageActions.tsx
+++ b/src/components/Chat/MessageActions.tsx
@@ -8,6 +8,7 @@
 import { useState, useCallback, useRef } from 'react';
 import { Copy, Check, Quote } from 'lucide-react';
 import { toast } from '@/components/ui/toast-hook';
+import { getClipboardService } from '@/lib/services';
 
 interface MessageActionsProps {
   content: string;
@@ -19,14 +20,14 @@ export function MessageActions({ content, align }: MessageActionsProps) {
   const timerRef = useRef<ReturnType<typeof setTimeout>>();
 
   const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(content);
-      setCopied(true);
-      timerRef.current = setTimeout(() => setCopied(false), 1500);
-    } catch (err) {
-      console.error('[MessageActions] clipboard.writeText failed:', err);
-      toast({ title: '复制失败，请重试', variant: 'destructive' });
+    const result = await getClipboardService().writeText(content);
+    if (!result.ok) {
+      console.error('[MessageActions] clipboard.writeText failed:', result.error, { reason: result.reason });
+      toast({ title: result.title, description: result.description, variant: 'destructive' });
+      return;
     }
+    setCopied(true);
+    timerRef.current = setTimeout(() => setCopied(false), 1500);
   }, [content]);
 
   if (!content?.trim()) return null;

--- a/src/components/Chat/MessageActions.tsx
+++ b/src/components/Chat/MessageActions.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { Copy, Check, Quote } from 'lucide-react';
+import { Copy, Check, Quote, X } from 'lucide-react';
 import { toast } from '@/components/ui/toast-hook';
 import { getClipboardService } from '@/lib/services';
 
@@ -63,8 +63,12 @@ export function MessageActions({ content, align }: MessageActionsProps) {
           copyFailed ? 'text-red-500 dark:text-red-400' : 'text-[#C8C0BA]'
         }`}
       >
-        {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-        {copied ? '已复制' : '复制'}
+        {copyFailed
+          ? <X className="h-3.5 w-3.5" />
+          : copied
+            ? <Check className="h-3.5 w-3.5" />
+            : <Copy className="h-3.5 w-3.5" />}
+        {copyFailed ? '未复制' : copied ? '已复制' : '复制'}
       </button>
       <button
         data-testid="msg-quote-btn"

--- a/src/components/Chat/MessageActions.tsx
+++ b/src/components/Chat/MessageActions.tsx
@@ -9,15 +9,24 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import { Copy, Check, Quote, X } from 'lucide-react';
 import { toast } from '@/components/ui/toast-hook';
 import { getClipboardService } from '@/lib/services';
+import type { ClipboardFailureReason } from '@/lib/services';
 
 interface MessageActionsProps {
   content: string;
   align: 'start' | 'end';
 }
 
+function getCopyFailureLabel(reason: ClipboardFailureReason): string {
+  if (reason === 'permission-denied') return '无权限';
+  if (reason === 'not-focused') return '未激活';
+  if (reason === 'insecure-context' || reason === 'not-supported') return '不支持';
+  return '未复制';
+}
+
 export function MessageActions({ content, align }: MessageActionsProps) {
   const [copied, setCopied] = useState(false);
   const [copyFailed, setCopyFailed] = useState(false);
+  const [copyFailureLabel, setCopyFailureLabel] = useState('未复制');
   const timerRef = useRef<ReturnType<typeof setTimeout>>();
 
   useEffect(() => () => {
@@ -35,6 +44,7 @@ export function MessageActions({ content, align }: MessageActionsProps) {
     const result = await getClipboardService().writeText(content);
     if (!result.ok) {
       setCopied(false);
+      setCopyFailureLabel(getCopyFailureLabel(result.reason));
       setCopyFailed(true);
       timerRef.current = setTimeout(() => {
         setCopyFailed(false);
@@ -68,7 +78,7 @@ export function MessageActions({ content, align }: MessageActionsProps) {
           : copied
             ? <Check className="h-3.5 w-3.5" />
             : <Copy className="h-3.5 w-3.5" />}
-        {copyFailed ? '未复制' : copied ? '已复制' : '复制'}
+        {copyFailed ? copyFailureLabel : copied ? '已复制' : '复制'}
       </button>
       <button
         data-testid="msg-quote-btn"

--- a/src/lib/adapters/clipboard-tauri-adapter.ts
+++ b/src/lib/adapters/clipboard-tauri-adapter.ts
@@ -1,0 +1,17 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { IClipboardPort } from '@/lib/environment/interfaces/clipboard.port';
+
+export class TauriClipboardAdapter implements IClipboardPort {
+  isAvailable(): boolean {
+    return true;
+  }
+
+  async readText(): Promise<string> {
+    const text = await invoke<string>('plugin:clipboard-manager|read_text');
+    return typeof text === 'string' ? text : '';
+  }
+
+  async writeText(text: string): Promise<void> {
+    await invoke('plugin:clipboard-manager|write_text', { text });
+  }
+}

--- a/src/lib/adapters/clipboard-tauri-adapter.ts
+++ b/src/lib/adapters/clipboard-tauri-adapter.ts
@@ -7,11 +7,27 @@ export class TauriClipboardAdapter implements IClipboardPort {
   }
 
   async readText(): Promise<string> {
-    const text = await invoke<string>('plugin:clipboard-manager|read_text');
-    return typeof text === 'string' ? text : '';
+    try {
+      const text = await invoke<string>('plugin:clipboard-manager|read_text');
+      return typeof text === 'string' ? text : '';
+    } catch (tauriError) {
+      if (typeof navigator !== 'undefined' && typeof navigator.clipboard?.readText === 'function') {
+        return navigator.clipboard.readText();
+      }
+      throw tauriError;
+    }
   }
 
   async writeText(text: string): Promise<void> {
-    await invoke('plugin:clipboard-manager|write_text', { text });
+    try {
+      await invoke('plugin:clipboard-manager|write_text', { text });
+      return;
+    } catch (tauriError) {
+      if (typeof navigator !== 'undefined' && typeof navigator.clipboard?.writeText === 'function') {
+        await navigator.clipboard.writeText(text);
+        return;
+      }
+      throw tauriError;
+    }
   }
 }

--- a/src/lib/adapters/clipboard-web-adapter.ts
+++ b/src/lib/adapters/clipboard-web-adapter.ts
@@ -1,0 +1,50 @@
+import type { IClipboardPort } from '@/lib/environment/interfaces/clipboard.port';
+
+function createNamedError(name: string, message: string): Error {
+  const error = new Error(message);
+  error.name = name;
+  return error;
+}
+
+export class WebClipboardAdapter implements IClipboardPort {
+  isAvailable(): boolean {
+    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+      return false;
+    }
+
+    return window.isSecureContext && typeof navigator.clipboard?.readText === 'function';
+  }
+
+  async readText(): Promise<string> {
+    if (typeof window === 'undefined' || !window.isSecureContext) {
+      throw createNamedError('InsecureContextError', 'clipboard requires secure context');
+    }
+
+    if (typeof navigator === 'undefined' || typeof navigator.clipboard?.readText !== 'function') {
+      throw createNamedError('NotSupportedError', 'clipboard read not supported');
+    }
+
+    window.focus();
+    await new Promise<void>((resolve) => {
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(() => resolve());
+        return;
+      }
+      resolve();
+    });
+
+    return navigator.clipboard.readText();
+  }
+
+  async writeText(text: string): Promise<void> {
+    if (typeof window === 'undefined' || !window.isSecureContext) {
+      throw createNamedError('InsecureContextError', 'clipboard requires secure context');
+    }
+
+    if (typeof navigator === 'undefined' || typeof navigator.clipboard?.writeText !== 'function') {
+      throw createNamedError('NotSupportedError', 'clipboard write not supported');
+    }
+
+    await navigator.clipboard.writeText(text);
+  }
+}

--- a/src/lib/adapters/clipboard-web-adapter.ts
+++ b/src/lib/adapters/clipboard-web-adapter.ts
@@ -6,6 +6,27 @@ function createNamedError(name: string, message: string): Error {
   return error;
 }
 
+function copyTextByExecCommand(text: string): boolean {
+  if (typeof document === 'undefined' || typeof document.execCommand !== 'function') {
+    return false;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.cssText = 'position:fixed; left:-9999px; top:-9999px; opacity:0;';
+  document.body.appendChild(textarea);
+
+  textarea.select();
+  textarea.setSelectionRange(0, textarea.value.length);
+
+  try {
+    return document.execCommand('copy');
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
 export class WebClipboardAdapter implements IClipboardPort {
   isAvailable(): boolean {
     if (typeof window === 'undefined' || typeof navigator === 'undefined') {
@@ -37,14 +58,28 @@ export class WebClipboardAdapter implements IClipboardPort {
   }
 
   async writeText(text: string): Promise<void> {
-    if (typeof window === 'undefined' || !window.isSecureContext) {
-      throw createNamedError('InsecureContextError', 'clipboard requires secure context');
+    const secure = typeof window !== 'undefined' && window.isSecureContext;
+    const hasNativeWrite = typeof navigator !== 'undefined' && typeof navigator.clipboard?.writeText === 'function';
+    const insecureContextError = createNamedError('InsecureContextError', 'clipboard requires secure context');
+    let fallbackError: Error | null = null;
+
+    if (secure && hasNativeWrite) {
+      try {
+        await navigator.clipboard.writeText(text);
+        return;
+      } catch (error) {
+        fallbackError = error instanceof Error ? error : new Error('clipboard write failed');
+      }
+    } else if (!secure) {
+      fallbackError = insecureContextError;
+    } else {
+      fallbackError = createNamedError('NotSupportedError', 'clipboard write not supported');
     }
 
-    if (typeof navigator === 'undefined' || typeof navigator.clipboard?.writeText !== 'function') {
-      throw createNamedError('NotSupportedError', 'clipboard write not supported');
+    if (copyTextByExecCommand(text)) {
+      return;
     }
 
-    await navigator.clipboard.writeText(text);
+    throw fallbackError ?? createNamedError('NotSupportedError', 'clipboard write not supported');
   }
 }

--- a/src/lib/environment/bootstrap.ts
+++ b/src/lib/environment/bootstrap.ts
@@ -6,10 +6,13 @@ import { AgentMockAdapter } from '@/lib/adapters/mock/agent-mock-adapter';
 import { TaskMockAdapter } from '@/lib/adapters/mock/task-mock-adapter';
 import { TaskWebAdapter } from '@/lib/adapters/task-web-adapter';
 import { VolcanoEngineASRAdapter } from '../adapters/asr/volcano-engine-asr';
+import { TauriClipboardAdapter } from '../adapters/clipboard-tauri-adapter';
+import { WebClipboardAdapter } from '../adapters/clipboard-web-adapter';
 import { WebEventLogStorageAdapter } from '../adapters/web-eventlog-storage';
 import { WebStorageAdapter } from '../adapters/web-storage';
 import type { IAgentPort } from './interfaces/agent.port';
 import type { IASRPort } from './interfaces/asr.port';
+import type { IClipboardPort } from './interfaces/clipboard.port';
 import type { IEventLogPort } from './interfaces/eventlog.port';
 import type { IMePort } from './interfaces/me.port';
 import type { IStoragePort } from './interfaces/storage.port';
@@ -20,6 +23,7 @@ export type RuntimeKind = 'web' | 'tauri';
 export interface RuntimeBootstrapResult {
   runtime: RuntimeKind;
   asr: IASRPort;
+  clipboard: IClipboardPort;
   storage: IStoragePort;
   eventlog: IEventLogPort;
   task: ITaskPort;
@@ -60,6 +64,7 @@ export function detectRuntime(globalObject: unknown = globalThis): RuntimeKind {
 export function createRuntimeBootstrap(options: RuntimeBootstrapOptions = {}): RuntimeBootstrapResult {
   const runtime = options.runtime ?? detectRuntime(options.globalObject);
   const asr = new VolcanoEngineASRAdapter();
+  const clipboard: IClipboardPort = runtime === 'tauri' ? new TauriClipboardAdapter() : new WebClipboardAdapter();
   const useMockData = options.useMockData ?? getUseMockDataEnabled();
   const task: ITaskPort = useMockData ? new TaskMockAdapter() : new TaskWebAdapter();
   const me: IMePort = useMockData ? new MeMockAdapter() : new MeWebAdapter();
@@ -69,6 +74,7 @@ export function createRuntimeBootstrap(options: RuntimeBootstrapOptions = {}): R
     return {
       runtime,
       asr,
+      clipboard,
       storage: new TauriStorageAdapter(),
       // 临时统一到 PouchDB，避免 Tauri 原生 EventLog 与 UI 读取源分裂（#144）
       eventlog: new WebEventLogStorageAdapter(),
@@ -81,6 +87,7 @@ export function createRuntimeBootstrap(options: RuntimeBootstrapOptions = {}): R
   return {
     runtime,
     asr,
+    clipboard,
     storage: new WebStorageAdapter(),
     eventlog: new WebEventLogStorageAdapter(),
     task,

--- a/src/lib/environment/environment.ts
+++ b/src/lib/environment/environment.ts
@@ -13,6 +13,7 @@
 
 import type { IASRPort } from './interfaces/asr.port';
 import type { IAgentPort } from './interfaces/agent.port';
+import type { IClipboardPort } from './interfaces/clipboard.port';
 import type { IEventLogPort } from './interfaces/eventlog.port';
 import type { IMePort } from './interfaces/me.port';
 import type { IStoragePort } from './interfaces/storage.port';
@@ -27,6 +28,8 @@ import { getUseMockDataEnabled } from '@/config/mock-data';
 export interface Environment {
   /** 语音识别能力 */
   asr: IASRPort;
+  /** 剪贴板读取能力 */
+  clipboard: IClipboardPort;
   /** 存储能力 */
   storage: IStoragePort;
   /** 事件日志能力 */
@@ -46,6 +49,7 @@ export interface Environment {
  */
 export class ExoMindEnvironment implements Environment {
   asr: IASRPort;
+  clipboard: IClipboardPort;
   storage: IStoragePort;
   eventlog: IEventLogPort;
   task: ITaskPort;
@@ -61,6 +65,7 @@ export class ExoMindEnvironment implements Environment {
     const bootstrap = createRuntimeBootstrap({ runtime, useMockData: useMockDataEnabled });
     this.runtime = bootstrap.runtime;
     this.asr = bootstrap.asr;
+    this.clipboard = bootstrap.clipboard;
     this.storage = bootstrap.storage;
     this.eventlog = bootstrap.eventlog;
     this.task = bootstrap.task;
@@ -111,6 +116,7 @@ export class ExoMindEnvironment implements Environment {
   capabilities(): Record<string, boolean> {
     return {
       asr: this.asr.isAvailable(),
+      clipboard: this.clipboard.isAvailable(),
       storage: true,
       eventlog: true,
       task: true,

--- a/src/lib/environment/interfaces/clipboard.port.ts
+++ b/src/lib/environment/interfaces/clipboard.port.ts
@@ -1,0 +1,21 @@
+/**
+ * IClipboardPort - 剪贴板读取接口
+ *
+ * 职责：读取系统/浏览器剪贴板中的文本内容。
+ */
+export interface IClipboardPort {
+  /**
+   * 读取剪贴板文本
+   */
+  readText(): Promise<string>;
+
+  /**
+   * 写入文本到剪贴板
+   */
+  writeText(text: string): Promise<void>;
+
+  /**
+   * 检查当前运行环境是否支持读取剪贴板
+   */
+  isAvailable(): boolean;
+}

--- a/src/lib/services/clipboard.service.ts
+++ b/src/lib/services/clipboard.service.ts
@@ -1,0 +1,180 @@
+import { ExoMindEnvironment } from '@/lib/environment/environment';
+import type { IClipboardPort } from '@/lib/environment/interfaces/clipboard.port';
+
+export type ClipboardFailureReason =
+  | 'insecure-context'
+  | 'not-supported'
+  | 'not-focused'
+  | 'permission-denied'
+  | 'unknown';
+
+export type ClipboardReadResult =
+  | { ok: true; text: string }
+  | {
+      ok: false;
+      reason: ClipboardFailureReason;
+      title: string;
+      description: string;
+      error: unknown;
+    };
+
+export type ClipboardWriteResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: ClipboardFailureReason;
+      title: string;
+      description: string;
+      error: unknown;
+    };
+
+type ClipboardEnvironmentLike = {
+  clipboard: IClipboardPort;
+};
+
+function inferClipboardFailureReason(err: unknown): ClipboardFailureReason {
+  const name = typeof err === 'object' && err && 'name' in err
+    ? String((err as { name?: unknown }).name ?? '')
+    : '';
+  const message = typeof err === 'object' && err && 'message' in err
+    ? String((err as { message?: unknown }).message ?? '').toLowerCase()
+    : '';
+
+  if (message.includes('secure context') || name === 'InsecureContextError') {
+    return 'insecure-context';
+  }
+  if (name === 'NotSupportedError') {
+    return 'not-supported';
+  }
+  if (message.includes('document is not focused')) {
+    return 'not-focused';
+  }
+  if (name === 'NotAllowedError' || name === 'SecurityError') {
+    return 'permission-denied';
+  }
+  return 'unknown';
+}
+
+function getClipboardFailureMessage(reason: ClipboardFailureReason): { title: string; description: string } {
+  if (reason === 'insecure-context') {
+    return {
+      title: '当前页面不支持读取剪贴板',
+      description: '请改用 localhost 或 https 访问；http://局域网IP 通常会被浏览器限制读取剪贴板。',
+    };
+  }
+
+  if (reason === 'permission-denied') {
+    return {
+      title: '浏览器阻止读取剪贴板',
+      description: '请在站点权限中允许剪贴板读取后重试，或直接在输入框内手动粘贴。',
+    };
+  }
+
+  if (reason === 'not-focused') {
+    return {
+      title: '页面未激活，无法读取剪贴板',
+      description: '请先点击页面任意位置再重试，或直接在输入框内手动粘贴。',
+    };
+  }
+
+  if (reason === 'not-supported') {
+    return {
+      title: '当前页面环境不支持读取剪贴板',
+      description: '请确认不是受限 WebView/内嵌页，并优先使用 localhost 或 https 访问；也可直接在输入框内手动粘贴。',
+    };
+  }
+
+  return {
+    title: '读取剪贴板失败，请重试',
+    description: '你可以先点击输入框，再使用 Ctrl/Cmd+V（移动端长按）手动粘贴。',
+  };
+}
+
+function getClipboardWriteFailureMessage(reason: ClipboardFailureReason): { title: string; description: string } {
+  if (reason === 'insecure-context') {
+    return {
+      title: '当前页面不支持复制到剪贴板',
+      description: '请改用 localhost 或 https 访问；http://局域网IP 通常会被浏览器限制剪贴板能力。',
+    };
+  }
+
+  if (reason === 'permission-denied') {
+    return {
+      title: '浏览器阻止写入剪贴板',
+      description: '请在站点权限中允许剪贴板写入后重试。',
+    };
+  }
+
+  if (reason === 'not-supported') {
+    return {
+      title: '当前页面环境不支持复制',
+      description: '请确认不是受限 WebView/内嵌页，或使用手动复制。',
+    };
+  }
+
+  return {
+    title: '复制失败，请重试',
+    description: '你可以手动选中文本后复制。',
+  };
+}
+
+export interface ClipboardService {
+  readText(): Promise<ClipboardReadResult>;
+  writeText(text: string): Promise<ClipboardWriteResult>;
+  isAvailable(): boolean;
+}
+
+export class ClipboardServiceImpl implements ClipboardService {
+  private readonly env: ClipboardEnvironmentLike;
+
+  constructor(env?: ClipboardEnvironmentLike) {
+    this.env = env ?? ExoMindEnvironment.getInstance();
+  }
+
+  isAvailable(): boolean {
+    return this.env.clipboard.isAvailable();
+  }
+
+  async readText(): Promise<ClipboardReadResult> {
+    try {
+      const text = await this.env.clipboard.readText();
+      return { ok: true, text };
+    } catch (error) {
+      const reason = inferClipboardFailureReason(error);
+      const message = getClipboardFailureMessage(reason);
+      return {
+        ok: false,
+        reason,
+        title: message.title,
+        description: message.description,
+        error,
+      };
+    }
+  }
+
+  async writeText(text: string): Promise<ClipboardWriteResult> {
+    try {
+      await this.env.clipboard.writeText(text);
+      return { ok: true };
+    } catch (error) {
+      const reason = inferClipboardFailureReason(error);
+      const message = getClipboardWriteFailureMessage(reason);
+      return {
+        ok: false,
+        reason,
+        title: message.title,
+        description: message.description,
+        error,
+      };
+    }
+  }
+}
+
+let clipboardServiceInstance: ClipboardService | null = null;
+
+export function getClipboardService(): ClipboardService {
+  if (!clipboardServiceInstance) {
+    clipboardServiceInstance = new ClipboardServiceImpl();
+  }
+  return clipboardServiceInstance;
+}

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -15,6 +15,8 @@ export { MeServiceImpl, getMeService } from './me.service';
 export type { MeService } from './me.service';
 export { AgentHubServiceImpl, getAgentHubService } from './agent-hub.service';
 export type { AgentHubService } from './agent-hub.service';
+export { ClipboardServiceImpl, getClipboardService } from './clipboard.service';
+export type { ClipboardService, ClipboardReadResult, ClipboardFailureReason } from './clipboard.service';
 
 // 重新导出类型（这些类型在 types/event 中定义）
 export type { TimerMode, TimerConfig } from '../types/event';

--- a/src/pages/MOSSASRTestPage.tsx
+++ b/src/pages/MOSSASRTestPage.tsx
@@ -15,7 +15,7 @@ import { useEffect, useState, useRef, useCallback } from 'react';
 import { MOSSASRAdapter, MOSSASRResult } from '../lib/adapters/asr/moss-asr';
 import { VoiceInputButton } from '../components/VoiceInputButton';
 import type { ASRResult } from '../lib/environment/interfaces/asr.port';
-import { getEventLogService } from '@/lib/services';
+import { getClipboardService, getEventLogService } from '@/lib/services';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -56,6 +56,20 @@ export function MOSSASRTestPage() {
   const startTimeRef = useRef<number>(0);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
 
+  const storageGetItem = useCallback((key: string): string | null => {
+    if (typeof localStorage?.getItem !== 'function') {
+      return null;
+    }
+    return localStorage.getItem(key);
+  }, []);
+
+  const storageSetItem = useCallback((key: string, value: string): void => {
+    if (typeof localStorage?.setItem !== 'function') {
+      return;
+    }
+    localStorage.setItem(key, value);
+  }, []);
+
   // 初始化适配器
   const getAdapter = useCallback(() => {
     if (!adapterRef.current) {
@@ -68,12 +82,12 @@ export function MOSSASRTestPage() {
 
   // 从 localStorage 恢复 API Key
   useEffect(() => {
-    const savedKey = localStorage.getItem('moss_api_key');
+    const savedKey = storageGetItem('moss_api_key');
     if (savedKey) {
       setApiKey(savedKey);
       addLog('已恢复保存的 API Key');
     }
-  }, []);
+  }, [storageGetItem]);
 
   // 检查可用性
   useEffect(() => {
@@ -129,7 +143,7 @@ export function MOSSASRTestPage() {
 
   const handleSaveApiKey = () => {
     if (apiKey) {
-      localStorage.setItem('moss_api_key', apiKey);
+      storageSetItem('moss_api_key', apiKey);
       addLog('✓ API Key 已保存到本地');
     }
   };
@@ -395,6 +409,15 @@ export function MOSSASRTestPage() {
     });
   };
 
+  const handleCopyInputText = async () => {
+    const result = await getClipboardService().writeText(inputText);
+    if (!result.ok) {
+      addLogEntry(`⚠️ ${result.title}`);
+      return;
+    }
+    addLogEntry('📋 已复制识别文本');
+  };
+
   const voiceButtonAdapterConfig = apiKey ? { apiKey } : undefined;
 
   return (
@@ -601,7 +624,7 @@ export function MOSSASRTestPage() {
                     type="button"
                     variant="outline"
                     size="sm"
-                    onClick={() => navigator.clipboard.writeText(inputText)}
+                    onClick={handleCopyInputText}
                   >
                     复制
                   </Button>

--- a/src/ui/new/components/NewNowInputRow.tsx
+++ b/src/ui/new/components/NewNowInputRow.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from '@/components/ui/toast-hook';
 import { getClipboardService } from '@/lib/services';
+import type { ClipboardFailureReason } from '@/lib/services';
 import type { VoiceMessageInputHandle } from '@/components/VoiceMessageInput';
 
 interface NewNowInputRowProps {
@@ -29,12 +30,20 @@ const getClipboardDebugSnapshot = () => {
   return { protocol, host, secure, hasNavigatorClipboard, hasReadText };
 };
 
+function getPasteFailureLabel(reason: ClipboardFailureReason): string {
+  if (reason === 'permission-denied') return '无权限';
+  if (reason === 'not-focused') return '未激活';
+  if (reason === 'insecure-context' || reason === 'not-supported') return '不支持';
+  return '未粘贴';
+}
+
 export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRowProps>(function NewNowInputRow({
   onSend,
   placeholder = '记录当下的事实...',
 }, ref) {
   const [value, setValue] = useState('');
   const [pasteFeedback, setPasteFeedback] = useState<'idle' | 'success' | 'error'>('idle');
+  const [pasteFailureLabel, setPasteFailureLabel] = useState('未粘贴');
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const pasteFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -99,6 +108,7 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
         ...getClipboardDebugSnapshot(),
         reason: result.reason,
       });
+      setPasteFailureLabel(getPasteFailureLabel(result.reason));
       setPasteFeedback('error');
       pasteFeedbackTimerRef.current = setTimeout(() => {
         setPasteFeedback('idle');
@@ -183,7 +193,7 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
                   ? (
                     <span className="inline-flex items-center gap-0.5 text-[10px] font-medium leading-none">
                       <X size={10} className="h-2.5 w-2.5" />
-                      未粘贴
+                      {pasteFailureLabel}
                     </span>
                   )
                   : <Clipboard size={16} />}

--- a/src/ui/new/components/NewNowInputRow.tsx
+++ b/src/ui/new/components/NewNowInputRow.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Clipboard, Image, SendHorizontal } from 'lucide-react';
+import { Clipboard, Image, SendHorizontal, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from '@/components/ui/toast-hook';
@@ -179,7 +179,14 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
             >
               {pasteFeedback === 'success'
                 ? <span className="text-[10px] font-medium leading-none">已粘贴</span>
-                : <Clipboard size={16} />}
+                : pasteFeedback === 'error'
+                  ? (
+                    <span className="inline-flex items-center gap-0.5 text-[10px] font-medium leading-none">
+                      <X size={10} className="h-2.5 w-2.5" />
+                      未粘贴
+                    </span>
+                  )
+                  : <Clipboard size={16} />}
             </button>
           </div>
 

--- a/src/ui/new/components/NewNowInputRow.tsx
+++ b/src/ui/new/components/NewNowInputRow.tsx
@@ -8,16 +8,26 @@ import {
   useState,
 } from 'react';
 import { Clipboard, Image, SendHorizontal } from 'lucide-react';
-import { invoke, isTauri } from '@tauri-apps/api/core';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from '@/components/ui/toast-hook';
+import { getClipboardService } from '@/lib/services';
 import type { VoiceMessageInputHandle } from '@/components/VoiceMessageInput';
 
 interface NewNowInputRowProps {
   onSend: (content: string) => void;
   placeholder?: string;
 }
+
+const getClipboardDebugSnapshot = () => {
+  const protocol = typeof window !== 'undefined' ? window.location.protocol : 'unknown';
+  const host = typeof window !== 'undefined' ? window.location.host : 'unknown';
+  const secure = typeof window !== 'undefined' ? window.isSecureContext : false;
+  const hasNavigatorClipboard = typeof navigator !== 'undefined' && !!navigator.clipboard;
+  const hasReadText = typeof navigator !== 'undefined' && typeof navigator.clipboard?.readText === 'function';
+
+  return { protocol, host, secure, hasNavigatorClipboard, hasReadText };
+};
 
 export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRowProps>(function NewNowInputRow({
   onSend,
@@ -68,39 +78,19 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
     });
   }, []);
 
-  const readClipboardFromTauri = useCallback(async (): Promise<string | null> => {
-    const isRunningInTauri = await isTauri();
-    if (!isRunningInTauri) {
-      return null;
-    }
-
-    try {
-      const text = await invoke<string>('plugin:clipboard-manager|read_text');
-      return typeof text === 'string' ? text : '';
-    } catch (err) {
-      console.warn('[clipboard] tauri read failed:', err);
-      return null;
-    }
-  }, []);
-
   const handlePasteFromClipboard = useCallback(async () => {
-    try {
-      const tauriText = await readClipboardFromTauri();
-      if (tauriText !== null) {
-        insertClipboardText(tauriText);
-        return;
-      }
-
-      if (typeof navigator === 'undefined' || !navigator.clipboard?.readText) {
-        throw new Error('clipboard read not supported');
-      }
-      const text = await navigator.clipboard.readText();
-      insertClipboardText(text);
-    } catch (err) {
-      console.warn('[clipboard] readText failed:', err);
-      toast({ title: '读取剪贴板失败，请重试', variant: 'destructive' });
+    const result = await getClipboardService().readText();
+    if (!result.ok) {
+      console.warn('[clipboard] readText failed:', result.error, {
+        ...getClipboardDebugSnapshot(),
+        reason: result.reason,
+      });
+      textareaRef.current?.focus();
+      toast({ title: result.title, description: result.description, variant: 'destructive' });
+      return;
     }
-  }, [insertClipboardText, readClipboardFromTauri]);
+    insertClipboardText(result.text);
+  }, [insertClipboardText]);
 
   const handleKeyDown = useCallback((event: KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === 'Escape') {

--- a/src/ui/new/components/NewNowInputRow.tsx
+++ b/src/ui/new/components/NewNowInputRow.tsx
@@ -43,9 +43,11 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
 }, ref) {
   const [value, setValue] = useState('');
   const [pasteFeedback, setPasteFeedback] = useState<'idle' | 'success' | 'error'>('idle');
+  const [attachmentFeedback, setAttachmentFeedback] = useState<'idle' | 'pending'>('idle');
   const [pasteFailureLabel, setPasteFailureLabel] = useState('未粘贴');
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const pasteFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const attachmentFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const resizeTextarea = useCallback((target?: HTMLTextAreaElement | null) => {
     const el = target ?? textareaRef.current;
@@ -67,6 +69,10 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
     if (pasteFeedbackTimerRef.current) {
       clearTimeout(pasteFeedbackTimerRef.current);
       pasteFeedbackTimerRef.current = null;
+    }
+    if (attachmentFeedbackTimerRef.current) {
+      clearTimeout(attachmentFeedbackTimerRef.current);
+      attachmentFeedbackTimerRef.current = null;
     }
   }, []);
 
@@ -138,6 +144,19 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
     }
   }, [submitInput]);
 
+  const handleAttachmentClick = useCallback(() => {
+    if (attachmentFeedbackTimerRef.current) {
+      clearTimeout(attachmentFeedbackTimerRef.current);
+      attachmentFeedbackTimerRef.current = null;
+    }
+
+    setAttachmentFeedback('pending');
+    attachmentFeedbackTimerRef.current = setTimeout(() => {
+      setAttachmentFeedback('idle');
+      attachmentFeedbackTimerRef.current = null;
+    }, 1500);
+  }, []);
+
   useImperativeHandle(ref, () => ({
     focusText: () => {
       textareaRef.current?.focus();
@@ -153,11 +172,16 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
         <div className="flex items-center gap-2">
           <button
             type="button"
-            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#EDECE9] text-stone-500 dark:bg-[#292524] dark:text-[#A8A29E]"
-            aria-label="附件"
+            onClick={handleAttachmentClick}
+            className={`flex h-9 shrink-0 items-center justify-center rounded-full bg-[#EDECE9] px-2 text-stone-500 dark:bg-[#292524] dark:text-[#A8A29E] ${
+              attachmentFeedback === 'pending' ? 'min-w-[56px]' : 'w-9'
+            }`}
+            aria-label={attachmentFeedback === 'pending' ? '待开发' : '附件'}
             data-testid="new-now-attachment-button"
           >
-            <Image size={16} />
+            {attachmentFeedback === 'pending'
+              ? <span className="text-[10px] font-medium leading-none">待开发</span>
+              : <Image size={16} />}
           </button>
 
           <div className="relative flex-1">

--- a/src/ui/new/components/NewNowInputRow.tsx
+++ b/src/ui/new/components/NewNowInputRow.tsx
@@ -34,7 +34,9 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
   placeholder = '记录当下的事实...',
 }, ref) {
   const [value, setValue] = useState('');
+  const [pasteFeedback, setPasteFeedback] = useState<'idle' | 'success' | 'error'>('idle');
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const pasteFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const resizeTextarea = useCallback((target?: HTMLTextAreaElement | null) => {
     const el = target ?? textareaRef.current;
@@ -51,6 +53,13 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
   useEffect(() => {
     resizeTextarea();
   }, [value, resizeTextarea]);
+
+  useEffect(() => () => {
+    if (pasteFeedbackTimerRef.current) {
+      clearTimeout(pasteFeedbackTimerRef.current);
+      pasteFeedbackTimerRef.current = null;
+    }
+  }, []);
 
   const submitInput = useCallback(() => {
     const trimmed = value.trim();
@@ -79,16 +88,32 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
   }, []);
 
   const handlePasteFromClipboard = useCallback(async () => {
+    if (pasteFeedbackTimerRef.current) {
+      clearTimeout(pasteFeedbackTimerRef.current);
+      pasteFeedbackTimerRef.current = null;
+    }
+
     const result = await getClipboardService().readText();
     if (!result.ok) {
       console.warn('[clipboard] readText failed:', result.error, {
         ...getClipboardDebugSnapshot(),
         reason: result.reason,
       });
+      setPasteFeedback('error');
+      pasteFeedbackTimerRef.current = setTimeout(() => {
+        setPasteFeedback('idle');
+        pasteFeedbackTimerRef.current = null;
+      }, 1500);
       textareaRef.current?.focus();
       toast({ title: result.title, description: result.description, variant: 'destructive' });
       return;
     }
+
+    setPasteFeedback('success');
+    pasteFeedbackTimerRef.current = setTimeout(() => {
+      setPasteFeedback('idle');
+      pasteFeedbackTimerRef.current = null;
+    }, 1500);
     insertClipboardText(result.text);
   }, [insertClipboardText]);
 
@@ -136,17 +161,25 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
               onKeyDown={handleKeyDown}
               placeholder={placeholder}
               rows={1}
-              className="min-h-[44px] rounded-3xl border-[#E7E5E4] bg-white px-4 py-2 pr-10 text-sm text-stone-700 placeholder:text-stone-400 dark:border-[#292524] dark:bg-[#1C1917] dark:text-[#FAFAF9] dark:placeholder:text-[#57534E]"
+              className="min-h-[44px] rounded-3xl border-[#E7E5E4] bg-white px-4 py-2 pr-16 text-sm text-stone-700 placeholder:text-stone-400 dark:border-[#292524] dark:bg-[#1C1917] dark:text-[#FAFAF9] dark:placeholder:text-[#57534E]"
               data-testid="new-now-input-textarea"
             />
             <button
               type="button"
               onClick={handlePasteFromClipboard}
-              className="absolute right-[7px] top-1/2 flex h-[30px] w-[30px] -translate-y-1/2 items-center justify-center rounded-[15px] text-stone-400 dark:text-[#78716C]"
+              className={`absolute right-[7px] top-1/2 flex h-[30px] min-w-[30px] -translate-y-1/2 items-center justify-center rounded-[15px] px-2 ${
+                pasteFeedback === 'error'
+                  ? 'text-red-500 dark:text-red-400'
+                  : pasteFeedback === 'success'
+                    ? 'bg-emerald-50 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-300'
+                    : 'text-stone-400 dark:text-[#78716C]'
+              }`}
               aria-label="剪贴板"
               data-testid="new-now-input-inline-button"
             >
-              <Clipboard size={16} />
+              {pasteFeedback === 'success'
+                ? <span className="text-[10px] font-medium leading-none">已粘贴</span>
+                : <Clipboard size={16} />}
             </button>
           </div>
 

--- a/tests/unit/adapters/clipboard-tauri-adapter.test.ts
+++ b/tests/unit/adapters/clipboard-tauri-adapter.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { TauriClipboardAdapter } from '@/lib/adapters/clipboard-tauri-adapter';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+describe('TauriClipboardAdapter', () => {
+  const originalClipboard = navigator.clipboard;
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true });
+    vi.mocked(invoke).mockReset();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'clipboard', { value: originalClipboard, configurable: true });
+    vi.restoreAllMocks();
+  });
+
+  it('uses tauri invoke for write by default', async () => {
+    vi.mocked(invoke).mockResolvedValue(undefined);
+    const adapter = new TauriClipboardAdapter();
+
+    await adapter.writeText('copy-from-tauri');
+
+    expect(invoke).toHaveBeenCalledWith('plugin:clipboard-manager|write_text', { text: 'copy-from-tauri' });
+  });
+
+  it('falls back to navigator clipboard write when tauri invoke fails', async () => {
+    const tauriError = new Error('clipboard command denied');
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(invoke).mockRejectedValue(tauriError);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    const adapter = new TauriClipboardAdapter();
+    await adapter.writeText('copy-from-web');
+
+    expect(invoke).toHaveBeenCalledWith('plugin:clipboard-manager|write_text', { text: 'copy-from-web' });
+    expect(writeText).toHaveBeenCalledWith('copy-from-web');
+  });
+
+  it('falls back to navigator clipboard read when tauri invoke fails', async () => {
+    const tauriError = new Error('clipboard command denied');
+    const readText = vi.fn().mockResolvedValue('from-navigator');
+    vi.mocked(invoke).mockRejectedValue(tauriError);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { readText },
+      configurable: true,
+    });
+
+    const adapter = new TauriClipboardAdapter();
+    await expect(adapter.readText()).resolves.toBe('from-navigator');
+
+    expect(invoke).toHaveBeenCalledWith('plugin:clipboard-manager|read_text');
+    expect(readText).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows tauri error when both tauri and navigator clipboard are unavailable', async () => {
+    const tauriError = new Error('clipboard command denied');
+    vi.mocked(invoke).mockRejectedValue(tauriError);
+    const adapter = new TauriClipboardAdapter();
+
+    await expect(adapter.writeText('copy')).rejects.toBe(tauriError);
+    await expect(adapter.readText()).rejects.toBe(tauriError);
+  });
+});

--- a/tests/unit/adapters/clipboard-web-adapter.test.ts
+++ b/tests/unit/adapters/clipboard-web-adapter.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WebClipboardAdapter } from '@/lib/adapters/clipboard-web-adapter';
+
+describe('WebClipboardAdapter', () => {
+  const originalSecureContext = window.isSecureContext;
+  const originalClipboard = navigator.clipboard;
+  const originalExecCommand = document.execCommand;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'isSecureContext', { value: false, configurable: true });
+    Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true });
+    Object.defineProperty(document, 'execCommand', { value: undefined, configurable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'isSecureContext', { value: originalSecureContext, configurable: true });
+    Object.defineProperty(navigator, 'clipboard', { value: originalClipboard, configurable: true });
+    Object.defineProperty(document, 'execCommand', { value: originalExecCommand, configurable: true });
+    vi.restoreAllMocks();
+  });
+
+  it('uses native clipboard write in secure context when available', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window, 'isSecureContext', { value: true, configurable: true });
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    const adapter = new WebClipboardAdapter();
+    await adapter.writeText('native-copy');
+
+    expect(writeText).toHaveBeenCalledWith('native-copy');
+  });
+
+  it('falls back to execCommand copy when insecure context', async () => {
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, 'execCommand', { value: execCommand, configurable: true });
+
+    const adapter = new WebClipboardAdapter();
+    await adapter.writeText('fallback-copy');
+
+    expect(execCommand).toHaveBeenCalledWith('copy');
+  });
+
+  it('falls back to execCommand copy when native clipboard write fails', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('native denied'));
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(window, 'isSecureContext', { value: true, configurable: true });
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    Object.defineProperty(document, 'execCommand', { value: execCommand, configurable: true });
+
+    const adapter = new WebClipboardAdapter();
+    await adapter.writeText('fallback-after-native-error');
+
+    expect(writeText).toHaveBeenCalledWith('fallback-after-native-error');
+    expect(execCommand).toHaveBeenCalledWith('copy');
+  });
+
+  it('throws insecure-context error when both native and fallback are unavailable', async () => {
+    const adapter = new WebClipboardAdapter();
+
+    await expect(adapter.writeText('copy')).rejects.toMatchObject({
+      name: 'InsecureContextError',
+      message: 'clipboard requires secure context',
+    });
+  });
+});

--- a/tests/unit/components/MessageActions.test.tsx
+++ b/tests/unit/components/MessageActions.test.tsx
@@ -9,15 +9,22 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { MessageActions } from '@/components/Chat/MessageActions';
 
-describe('MessageActions', () => {
-  const mockWriteText = vi.fn().mockResolvedValue(undefined);
+const { mockClipboardWriteText } = vi.hoisted(() => ({
+  mockClipboardWriteText: vi.fn(),
+}));
 
+vi.mock('@/lib/services', () => ({
+  getClipboardService: () => ({
+    writeText: mockClipboardWriteText,
+    readText: vi.fn(),
+    isAvailable: () => true,
+  }),
+}));
+
+describe('MessageActions', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    mockWriteText.mockResolvedValue(undefined);
-    vi.stubGlobal('navigator', {
-      clipboard: { writeText: mockWriteText },
-    });
+    mockClipboardWriteText.mockResolvedValue({ ok: true });
   });
 
   afterEach(() => {
@@ -64,7 +71,7 @@ describe('MessageActions', () => {
     await act(async () => {
       fireEvent.click(screen.getByTestId('msg-copy-btn'));
     });
-    expect(mockWriteText).toHaveBeenCalledWith('test message');
+    expect(mockClipboardWriteText).toHaveBeenCalledWith('test message');
   });
 
   it('shows success feedback after copy', async () => {
@@ -91,7 +98,13 @@ describe('MessageActions', () => {
   // --- 复制失败 ---
 
   it('shows toast on clipboard failure', async () => {
-    mockWriteText.mockRejectedValue(new Error('denied'));
+    mockClipboardWriteText.mockResolvedValue({
+      ok: false,
+      reason: 'unknown',
+      title: '复制失败，请重试',
+      description: '你可以手动选中文本后复制。',
+      error: new Error('denied'),
+    });
 
     render(<MessageActions content="test message" align="start" />);
     await act(async () => {

--- a/tests/unit/components/MessageActions.test.tsx
+++ b/tests/unit/components/MessageActions.test.tsx
@@ -125,6 +125,33 @@ describe('MessageActions', () => {
     expect(screen.getByTestId('msg-copy-btn').className).not.toContain('text-red-500');
   });
 
+  it.each([
+    ['permission-denied', '无权限'],
+    ['not-focused', '未激活'],
+    ['insecure-context', '不支持'],
+  ])('maps %s failure reason to %s label', async (reason, label) => {
+    mockClipboardWriteText.mockResolvedValue({
+      ok: false,
+      reason,
+      title: '复制失败',
+      description: 'mock',
+      error: new Error('mock'),
+    });
+
+    render(<MessageActions content="test message" align="start" />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('msg-copy-btn'));
+    });
+
+    expect(screen.getByText(label)).toBeInTheDocument();
+    expect(screen.getByTestId('msg-copy-btn').className).toContain('text-red-500');
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.queryByText(label)).not.toBeInTheDocument();
+  });
+
   // --- 引用按钮预留 ---
 
   it('renders quote button as disabled placeholder', () => {

--- a/tests/unit/components/MessageActions.test.tsx
+++ b/tests/unit/components/MessageActions.test.tsx
@@ -113,14 +113,15 @@ describe('MessageActions', () => {
 
     // Should NOT show success feedback
     expect(screen.queryByText('已复制')).not.toBeInTheDocument();
-    // Should still show original text
-    expect(screen.getByText('复制')).toBeInTheDocument();
+    // Should show failure text
+    expect(screen.getByText('未复制')).toBeInTheDocument();
     // Should show temporary error style
     expect(screen.getByTestId('msg-copy-btn').className).toContain('text-red-500');
 
     act(() => {
       vi.advanceTimersByTime(1500);
     });
+    expect(screen.getByText('复制')).toBeInTheDocument();
     expect(screen.getByTestId('msg-copy-btn').className).not.toContain('text-red-500');
   });
 

--- a/tests/unit/components/MessageActions.test.tsx
+++ b/tests/unit/components/MessageActions.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { MessageActions } from '@/components/Chat/MessageActions';
 
 const { mockClipboardWriteText } = vi.hoisted(() => ({
@@ -115,6 +115,13 @@ describe('MessageActions', () => {
     expect(screen.queryByText('已复制')).not.toBeInTheDocument();
     // Should still show original text
     expect(screen.getByText('复制')).toBeInTheDocument();
+    // Should show temporary error style
+    expect(screen.getByTestId('msg-copy-btn').className).toContain('text-red-500');
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.getByTestId('msg-copy-btn').className).not.toContain('text-red-500');
   });
 
   // --- 引用按钮预留 ---

--- a/tests/unit/environment/bootstrap.test.ts
+++ b/tests/unit/environment/bootstrap.test.ts
@@ -11,6 +11,7 @@ describe('environment bootstrap', () => {
     const result = createRuntimeBootstrap({ runtime: 'web', useMockData: false });
 
     expect(result.runtime).toBe('web');
+    expect(result.clipboard.constructor.name).toBe('WebClipboardAdapter');
     expect(result.storage.constructor.name).toBe('WebStorageAdapter');
     expect(result.eventlog.constructor.name).toBe('WebEventLogStorageAdapter');
     expect(result.task.constructor.name).toBe('TaskWebAdapter');
@@ -23,6 +24,8 @@ describe('environment bootstrap', () => {
     const tauriResult = createRuntimeBootstrap({ runtime: 'tauri', useMockData: false });
 
     expect(tauriResult.runtime).toBe('tauri');
+    expect(tauriResult.clipboard.constructor.name).toBe('TauriClipboardAdapter');
+    expect(tauriResult.clipboard.constructor.name).not.toBe(webResult.clipboard.constructor.name);
     expect(tauriResult.storage.constructor.name).toBe('TauriStorageAdapter');
     expect(tauriResult.storage.constructor.name).not.toBe(webResult.storage.constructor.name);
     expect(tauriResult.eventlog.constructor.name).toBe('WebEventLogStorageAdapter');

--- a/tests/unit/pages/MOSSASRTestPage.test.tsx
+++ b/tests/unit/pages/MOSSASRTestPage.test.tsx
@@ -18,7 +18,9 @@ const isDomAvailable = typeof document !== 'undefined';
 (isDomAvailable ? describe : describe.skip)('MOSSASRTestPage', () => {
   beforeEach(() => {
     latestVoiceButtonProps = null;
-    localStorage.clear();
+    if (typeof window.localStorage?.clear === 'function') {
+      window.localStorage.clear();
+    }
   });
 
   it('does not pass adapterConfig when apiKey is empty', () => {

--- a/tests/unit/services/clipboard.service.test.ts
+++ b/tests/unit/services/clipboard.service.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ClipboardServiceImpl } from '@/lib/services/clipboard.service';
+import type { IClipboardPort } from '@/lib/environment/interfaces/clipboard.port';
+
+describe('clipboard service', () => {
+  it('returns clipboard text when port succeeds', async () => {
+    const clipboard: IClipboardPort = {
+      readText: vi.fn().mockResolvedValue('from-port'),
+      writeText: vi.fn().mockResolvedValue(undefined),
+      isAvailable: vi.fn().mockReturnValue(true),
+    };
+    const service = new ClipboardServiceImpl({ clipboard });
+
+    const result = await service.readText();
+    expect(result).toEqual({ ok: true, text: 'from-port' });
+  });
+
+  it('maps insecure-context error to actionable message', async () => {
+    const error = new Error('clipboard requires secure context');
+    error.name = 'InsecureContextError';
+    const clipboard: IClipboardPort = {
+      readText: vi.fn().mockRejectedValue(error),
+      writeText: vi.fn().mockResolvedValue(undefined),
+      isAvailable: vi.fn().mockReturnValue(false),
+    };
+    const service = new ClipboardServiceImpl({ clipboard });
+
+    const result = await service.readText();
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('insecure-context');
+    expect(result.title).toBe('当前页面不支持读取剪贴板');
+  });
+
+  it('maps document-not-focused error to focus guidance', async () => {
+    const error = new Error('Document is not focused');
+    error.name = 'NotAllowedError';
+    const clipboard: IClipboardPort = {
+      readText: vi.fn().mockRejectedValue(error),
+      writeText: vi.fn().mockResolvedValue(undefined),
+      isAvailable: vi.fn().mockReturnValue(true),
+    };
+    const service = new ClipboardServiceImpl({ clipboard });
+
+    const result = await service.readText();
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('not-focused');
+    expect(result.title).toBe('页面未激活，无法读取剪贴板');
+  });
+
+  it('maps unsupported error to environment guidance', async () => {
+    const error = new Error('clipboard read not supported');
+    error.name = 'NotSupportedError';
+    const clipboard: IClipboardPort = {
+      readText: vi.fn().mockRejectedValue(error),
+      writeText: vi.fn().mockResolvedValue(undefined),
+      isAvailable: vi.fn().mockReturnValue(false),
+    };
+    const service = new ClipboardServiceImpl({ clipboard });
+
+    const result = await service.readText();
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('not-supported');
+    expect(result.title).toBe('当前页面环境不支持读取剪贴板');
+  });
+
+  it('returns ok when write succeeds', async () => {
+    const clipboard: IClipboardPort = {
+      readText: vi.fn().mockResolvedValue('unused'),
+      writeText: vi.fn().mockResolvedValue(undefined),
+      isAvailable: vi.fn().mockReturnValue(true),
+    };
+    const service = new ClipboardServiceImpl({ clipboard });
+
+    const result = await service.writeText('hello');
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('maps write failure to copy message', async () => {
+    const error = new Error('write denied');
+    error.name = 'NotAllowedError';
+    const clipboard: IClipboardPort = {
+      readText: vi.fn().mockResolvedValue('unused'),
+      writeText: vi.fn().mockRejectedValue(error),
+      isAvailable: vi.fn().mockReturnValue(true),
+    };
+    const service = new ClipboardServiceImpl({ clipboard });
+
+    const result = await service.writeText('hello');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('permission-denied');
+    expect(result.title).toBe('浏览器阻止写入剪贴板');
+  });
+});

--- a/tests/unit/ui/new-now-input-row.test.tsx
+++ b/tests/unit/ui/new-now-input-row.test.tsx
@@ -3,15 +3,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { NewNowInputRow } from '@/ui/new/components/NewNowInputRow';
 
-const { mockInvoke, mockIsTauri, mockToast } = vi.hoisted(() => ({
-  mockInvoke: vi.fn(),
-  mockIsTauri: vi.fn(),
+const { mockReadClipboardText, mockToast } = vi.hoisted(() => ({
+  mockReadClipboardText: vi.fn(),
   mockToast: vi.fn(),
 }));
 
-vi.mock('@tauri-apps/api/core', () => ({
-  invoke: mockInvoke,
-  isTauri: mockIsTauri,
+vi.mock('@/lib/services', () => ({
+  getClipboardService: () => ({
+    readText: mockReadClipboardText,
+    isAvailable: () => true,
+  }),
 }));
 
 vi.mock('@/components/ui/toast-hook', () => ({
@@ -20,8 +21,7 @@ vi.mock('@/components/ui/toast-hook', () => ({
 
 describe('NewNowInputRow', () => {
   beforeEach(() => {
-    mockInvoke.mockReset();
-    mockIsTauri.mockReset();
+    mockReadClipboardText.mockReset();
     mockToast.mockReset();
   });
 
@@ -44,49 +44,26 @@ describe('NewNowInputRow', () => {
     expect((textarea as HTMLTextAreaElement).value).toBe('');
   });
 
-  it('uses tauri clipboard command when running in tauri runtime', async () => {
-    mockIsTauri.mockResolvedValue(true);
-    const mockReadText = vi.fn().mockResolvedValue('浏览器文本');
-    vi.stubGlobal('navigator', {
-      clipboard: { readText: mockReadText },
-    });
-    mockInvoke.mockResolvedValue('Tauri 文本');
+  it('inserts clipboard text via clipboard service', async () => {
+    mockReadClipboardText.mockResolvedValue({ ok: true, text: '服务层剪贴板文本' });
 
     render(<NewNowInputRow onSend={vi.fn()} placeholder="输入内容记录事件..." />);
     fireEvent.click(screen.getByTestId('new-now-input-inline-button'));
 
     await waitFor(() => {
-      expect(mockInvoke).toHaveBeenCalledWith('plugin:clipboard-manager|read_text');
+      expect(mockReadClipboardText).toHaveBeenCalledTimes(1);
     });
-    expect(mockReadText).not.toHaveBeenCalled();
-    expect((screen.getByTestId('new-now-input-textarea') as HTMLTextAreaElement).value).toBe('Tauri 文本');
+    expect((screen.getByTestId('new-now-input-textarea') as HTMLTextAreaElement).value).toBe('服务层剪贴板文本');
     expect(mockToast).not.toHaveBeenCalled();
   });
 
-  it('falls back to navigator clipboard on web runtime', async () => {
-    mockIsTauri.mockResolvedValue(false);
-    const mockReadText = vi.fn().mockResolvedValue('Web 文本');
-    vi.stubGlobal('navigator', {
-      clipboard: { readText: mockReadText },
-    });
-
-    render(<NewNowInputRow onSend={vi.fn()} placeholder="输入内容记录事件..." />);
-    fireEvent.click(screen.getByTestId('new-now-input-inline-button'));
-
-    await waitFor(() => {
-      expect(mockReadText).toHaveBeenCalledTimes(1);
-    });
-    expect(mockInvoke).not.toHaveBeenCalled();
-    expect((screen.getByTestId('new-now-input-textarea') as HTMLTextAreaElement).value).toBe('Web 文本');
-    expect(mockToast).not.toHaveBeenCalled();
-  });
-
-  it('shows toast when tauri and web clipboard reads both fail', async () => {
-    mockIsTauri.mockResolvedValue(true);
-    mockInvoke.mockRejectedValue(new Error('tauri denied'));
-    const mockReadText = vi.fn().mockRejectedValue(new Error('web denied'));
-    vi.stubGlobal('navigator', {
-      clipboard: { readText: mockReadText },
+  it('shows secure-context guidance from clipboard service', async () => {
+    mockReadClipboardText.mockResolvedValue({
+      ok: false,
+      reason: 'insecure-context',
+      title: '当前页面不支持读取剪贴板',
+      description: '请改用 localhost 或 https 访问；http://局域网IP 通常会被浏览器限制读取剪贴板。',
+      error: new Error('secure context'),
     });
 
     render(<NewNowInputRow onSend={vi.fn()} placeholder="输入内容记录事件..." />);
@@ -94,7 +71,8 @@ describe('NewNowInputRow', () => {
 
     await waitFor(() => {
       expect(mockToast).toHaveBeenCalledWith({
-        title: '读取剪贴板失败，请重试',
+        title: '当前页面不支持读取剪贴板',
+        description: '请改用 localhost 或 https 访问；http://局域网IP 通常会被浏览器限制读取剪贴板。',
         variant: 'destructive',
       });
     });

--- a/tests/unit/ui/new-now-input-row.test.tsx
+++ b/tests/unit/ui/new-now-input-row.test.tsx
@@ -83,11 +83,13 @@ describe('NewNowInputRow', () => {
         description: '请改用 localhost 或 https 访问；http://局域网IP 通常会被浏览器限制读取剪贴板。',
         variant: 'destructive',
     });
+    expect(screen.getByText('未粘贴')).toBeInTheDocument();
     expect(screen.getByTestId('new-now-input-inline-button').className).toContain('text-red-500');
 
     act(() => {
       vi.advanceTimersByTime(1500);
     });
+    expect(screen.queryByText('未粘贴')).not.toBeInTheDocument();
     expect(screen.getByTestId('new-now-input-inline-button').className).not.toContain('text-red-500');
   });
 });

--- a/tests/unit/ui/new-now-input-row.test.tsx
+++ b/tests/unit/ui/new-now-input-row.test.tsx
@@ -65,7 +65,7 @@ describe('NewNowInputRow', () => {
     expect(screen.queryByText('已粘贴')).not.toBeInTheDocument();
   });
 
-  it('shows secure-context guidance from clipboard service', async () => {
+  it('shows mapped "不支持" label for insecure-context', async () => {
     mockReadClipboardText.mockResolvedValue({
       ok: false,
       reason: 'insecure-context',
@@ -83,8 +83,51 @@ describe('NewNowInputRow', () => {
         description: '请改用 localhost 或 https 访问；http://局域网IP 通常会被浏览器限制读取剪贴板。',
         variant: 'destructive',
     });
-    expect(screen.getByText('未粘贴')).toBeInTheDocument();
+    expect(screen.getByText('不支持')).toBeInTheDocument();
     expect(screen.getByTestId('new-now-input-inline-button').className).toContain('text-red-500');
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.queryByText('不支持')).not.toBeInTheDocument();
+    expect(screen.getByTestId('new-now-input-inline-button').className).not.toContain('text-red-500');
+  });
+
+  it('shows mapped "无权限" label for permission-denied', async () => {
+    mockReadClipboardText.mockResolvedValue({
+      ok: false,
+      reason: 'permission-denied',
+      title: '浏览器阻止读取剪贴板',
+      description: '请在站点权限中允许剪贴板读取后重试，或直接在输入框内手动粘贴。',
+      error: new Error('permission denied'),
+    });
+
+    render(<NewNowInputRow onSend={vi.fn()} placeholder="输入内容记录事件..." />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('new-now-input-inline-button'));
+    });
+    expect(screen.getByText('无权限')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.queryByText('无权限')).not.toBeInTheDocument();
+  });
+
+  it('falls back to "未粘贴" label for unknown reason', async () => {
+    mockReadClipboardText.mockResolvedValue({
+      ok: false,
+      reason: 'unknown',
+      title: '读取剪贴板失败，请重试',
+      description: '你可以先点击输入框，再使用 Ctrl/Cmd+V（移动端长按）手动粘贴。',
+      error: new Error('unknown'),
+    });
+
+    render(<NewNowInputRow onSend={vi.fn()} placeholder="输入内容记录事件..." />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('new-now-input-inline-button'));
+    });
+    expect(screen.getByText('未粘贴')).toBeInTheDocument();
 
     act(() => {
       vi.advanceTimersByTime(1500);

--- a/tests/unit/ui/new-now-input-row.test.tsx
+++ b/tests/unit/ui/new-now-input-row.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { NewNowInputRow } from '@/ui/new/components/NewNowInputRow';
 
 const { mockReadClipboardText, mockToast } = vi.hoisted(() => ({
@@ -21,11 +21,14 @@ vi.mock('@/components/ui/toast-hook', () => ({
 
 describe('NewNowInputRow', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     mockReadClipboardText.mockReset();
     mockToast.mockReset();
   });
 
   afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
     cleanup();
     vi.unstubAllGlobals();
   });
@@ -48,13 +51,18 @@ describe('NewNowInputRow', () => {
     mockReadClipboardText.mockResolvedValue({ ok: true, text: '服务层剪贴板文本' });
 
     render(<NewNowInputRow onSend={vi.fn()} placeholder="输入内容记录事件..." />);
-    fireEvent.click(screen.getByTestId('new-now-input-inline-button'));
-
-    await waitFor(() => {
-      expect(mockReadClipboardText).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('new-now-input-inline-button'));
     });
+    expect(mockReadClipboardText).toHaveBeenCalledTimes(1);
     expect((screen.getByTestId('new-now-input-textarea') as HTMLTextAreaElement).value).toBe('服务层剪贴板文本');
+    expect(screen.getByText('已粘贴')).toBeInTheDocument();
     expect(mockToast).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.queryByText('已粘贴')).not.toBeInTheDocument();
   });
 
   it('shows secure-context guidance from clipboard service', async () => {
@@ -67,14 +75,19 @@ describe('NewNowInputRow', () => {
     });
 
     render(<NewNowInputRow onSend={vi.fn()} placeholder="输入内容记录事件..." />);
-    fireEvent.click(screen.getByTestId('new-now-input-inline-button'));
-
-    await waitFor(() => {
-      expect(mockToast).toHaveBeenCalledWith({
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('new-now-input-inline-button'));
+    });
+    expect(mockToast).toHaveBeenCalledWith({
         title: '当前页面不支持读取剪贴板',
         description: '请改用 localhost 或 https 访问；http://局域网IP 通常会被浏览器限制读取剪贴板。',
         variant: 'destructive',
-      });
     });
+    expect(screen.getByTestId('new-now-input-inline-button').className).toContain('text-red-500');
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.getByTestId('new-now-input-inline-button').className).not.toContain('text-red-500');
   });
 });

--- a/tests/unit/ui/new-now-input-row.test.tsx
+++ b/tests/unit/ui/new-now-input-row.test.tsx
@@ -47,6 +47,18 @@ describe('NewNowInputRow', () => {
     expect((textarea as HTMLTextAreaElement).value).toBe('');
   });
 
+  it('shows temporary "待开发" placeholder after attachment click', () => {
+    render(<NewNowInputRow onSend={vi.fn()} placeholder="输入内容记录事件..." />);
+    fireEvent.click(screen.getByTestId('new-now-attachment-button'));
+
+    expect(screen.getByText('待开发')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.queryByText('待开发')).not.toBeInTheDocument();
+  });
+
   it('inserts clipboard text via clipboard service', async () => {
     mockReadClipboardText.mockResolvedValue({ ok: true, text: '服务层剪贴板文本' });
 


### PR DESCRIPTION
## Summary
- Extract clipboard capability into `IClipboardPort` and runtime bootstrap injection
- Add `WebClipboardAdapter` and `TauriClipboardAdapter` for dual-platform read/write support
- Add `ClipboardService` to centralize error mapping and user-facing messages
- Migrate UI callers (`NewNowInputRow`, `MessageActions`, `MOSSASRTestPage`) to service layer
- Update and add unit tests for service, UI wiring, and bootstrap adapter selection

## Validation
- npx vitest run tests/unit/services/clipboard.service.test.ts tests/unit/components/MessageActions.test.tsx tests/unit/ui/new-now-input-row.test.tsx tests/unit/environment/bootstrap.test.ts tests/unit/pages/MOSSASRTestPage.test.tsx
- npx tsc --noEmit
- npx vite build

## Linked Issues
- Refs #226
