### PR TITLE
feat(issue-230): 集成开发者工具开关与 Eruda 统一注入

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exomind",
-  "version": "0.3.0-beta1",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exomind",
-      "version": "0.3.0-beta1",
+      "version": "0.3.3",
       "dependencies": {
         "@noble/hashes": "^2.0.1",
         "@playwright/test": "^1.58.1",
@@ -20,7 +20,10 @@
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "agentation-mcp": "^1.2.0",
+        "baseline-browser-mapping": "^2.10.0",
+        "caniuse-lite": "^1.0.30001772",
         "class-variance-authority": "^0.7.1",
+        "eruda": "^3.4.3",
         "events": "^3.3.0",
         "katex": "^0.16.28",
         "lucide-react": "^0.563.0",
@@ -37,6 +40,7 @@
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
         "socket.io-client": "^4.8.3",
+        "vaul": "^1.1.2",
         "zustand": "^5.0.11"
       },
       "devDependencies": {
@@ -125,7 +129,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -441,7 +444,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -463,7 +465,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2338,7 +2339,6 @@
       "version": "10.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2696,7 +2696,6 @@
     "node_modules/@types/react": {
       "version": "18.3.27",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2706,7 +2705,6 @@
       "version": "18.3.7",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3138,11 +3136,15 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "dev": true,
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/better-sqlite3": {
@@ -3282,7 +3284,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3364,8 +3365,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001767",
-      "dev": true,
+      "version": "1.0.30001774",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
+      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
       "funding": [
         {
           "type": "opencollective",
@@ -3954,6 +3956,12 @@
         "errno": "cli.js"
       }
     },
+    "node_modules/eruda": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eruda/-/eruda-3.4.3.tgz",
+      "integrity": "sha512-J2TsF4dXSspOXev5bJ6mljv0dRrxj21wklrDzbvPmYaEmVoC+2psylyRi70nUPFh1mTQfIBsSusUtAMZtUN+/w==",
+      "license": "MIT"
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "license": "MIT",
@@ -4504,7 +4512,6 @@
       "version": "20.5.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -4785,7 +4792,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
       "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5123,7 +5129,6 @@
       "version": "1.21.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6783,7 +6788,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6874,7 +6878,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7289,7 +7292,6 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7300,7 +7302,6 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7820,7 +7821,6 @@
     "node_modules/seroval": {
       "version": "1.5.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -8189,7 +8189,6 @@
       "version": "3.4.19",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -8736,6 +8735,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vaul": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.2.tgz",
+      "integrity": "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "license": "MIT",
@@ -8776,7 +8788,6 @@
       "version": "6.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -8850,7 +8861,6 @@
       "version": "4.0.18",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -9087,7 +9097,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "baseline-browser-mapping": "^2.10.0",
     "caniuse-lite": "^1.0.30001772",
     "class-variance-authority": "^0.7.1",
+    "eruda": "^3.4.3",
     "events": "^3.3.0",
     "katex": "^0.16.28",
     "lucide-react": "^0.563.0",

--- a/src/config/devtools-mode.ts
+++ b/src/config/devtools-mode.ts
@@ -1,0 +1,54 @@
+const DEVTOOLS_ENABLED_STORAGE_KEY = 'exomind:devtoolsEnabled';
+const DEVTOOLS_CHANGED_EVENT = 'exomind:devtools-changed';
+
+function normalizeBoolean(rawValue: string | null | undefined): boolean {
+  return rawValue === 'true';
+}
+
+function getStorage():
+  | Pick<Storage, 'getItem' | 'setItem'>
+  | null {
+  if (typeof window === 'undefined') return null;
+  const localStorageLike = window.localStorage as Partial<Storage> | undefined;
+  if (!localStorageLike) return null;
+  if (typeof localStorageLike.getItem !== 'function') return null;
+  if (typeof localStorageLike.setItem !== 'function') return null;
+  return localStorageLike as Pick<Storage, 'getItem' | 'setItem'>;
+}
+
+export function getDevtoolsEnabled(): boolean {
+  const storage = getStorage();
+  if (!storage) return false;
+  return normalizeBoolean(storage.getItem(DEVTOOLS_ENABLED_STORAGE_KEY));
+}
+
+export function setDevtoolsEnabled(enabled: boolean): void {
+  const storage = getStorage();
+  if (!storage) return;
+  storage.setItem(DEVTOOLS_ENABLED_STORAGE_KEY, String(enabled));
+  window.dispatchEvent(new CustomEvent<boolean>(DEVTOOLS_CHANGED_EVENT, { detail: enabled }));
+}
+
+export function subscribeDevtoolsChanges(listener: (enabled: boolean) => void): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key !== DEVTOOLS_ENABLED_STORAGE_KEY) return;
+    listener(normalizeBoolean(event.newValue));
+  };
+
+  const handleCustomEvent = (event: Event) => {
+    const customEvent = event as CustomEvent<boolean>;
+    listener(Boolean(customEvent.detail));
+  };
+
+  window.addEventListener('storage', handleStorage);
+  window.addEventListener(DEVTOOLS_CHANGED_EVENT, handleCustomEvent);
+
+  return () => {
+    window.removeEventListener('storage', handleStorage);
+    window.removeEventListener(DEVTOOLS_CHANGED_EVENT, handleCustomEvent);
+  };
+}

--- a/src/lib/debug/devtools-runtime.ts
+++ b/src/lib/debug/devtools-runtime.ts
@@ -1,0 +1,42 @@
+import { getDeveloperModeEnabled } from '@/config/developer-mode';
+import { getDevtoolsEnabled } from '@/config/devtools-mode';
+
+type ErudaModule = typeof import('eruda');
+type ErudaInstance = ErudaModule['default'];
+
+let erudaModulePromise: Promise<ErudaModule> | null = null;
+let erudaInstance: ErudaInstance | null = null;
+let isInitialized = false;
+
+function shouldEnableDevtools(): boolean {
+  if (typeof window === 'undefined') return false;
+  return getDeveloperModeEnabled() && getDevtoolsEnabled();
+}
+
+async function loadEruda(): Promise<ErudaInstance> {
+  if (!erudaModulePromise) {
+    erudaModulePromise = import('eruda');
+  }
+  const module = await erudaModulePromise;
+  return module.default;
+}
+
+export async function syncDevtoolsWithSettings(): Promise<void> {
+  try {
+    if (!shouldEnableDevtools()) {
+      if (isInitialized && erudaInstance) {
+        erudaInstance.destroy();
+      }
+      isInitialized = false;
+      return;
+    }
+
+    if (isInitialized) return;
+
+    erudaInstance = await loadEruda();
+    erudaInstance.init();
+    isInitialized = true;
+  } catch (error) {
+    console.warn('[devtools-runtime] Failed to sync devtools:', error);
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import { syncDevtoolsWithSettings } from "./lib/debug/devtools-runtime";
+
+void syncDevtoolsWithSettings();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/src/ui/new/pages/NewSettingsPage.tsx
+++ b/src/ui/new/pages/NewSettingsPage.tsx
@@ -35,7 +35,13 @@ import {
   setUseMockDataEnabled,
   subscribeUseMockDataChanges,
 } from '@/config/mock-data';
+import {
+  getDevtoolsEnabled,
+  setDevtoolsEnabled,
+  subscribeDevtoolsChanges,
+} from '@/config/devtools-mode';
 import { setUIMode } from '@/config/ui-mode';
+import { syncDevtoolsWithSettings } from '@/lib/debug/devtools-runtime';
 import {
   TIMER_END_SOUND_PRESETS,
   getTimerEndSoundPresetById,
@@ -89,6 +95,7 @@ export function NewSettingsPage() {
     () => getAgentPageEnabled()
   );
   const [useMockData, setUseMockData] = useState<boolean>(() => getUseMockDataEnabled());
+  const [devtoolsEnabled, setDevtoolsEnabledState] = useState<boolean>(() => getDevtoolsEnabled());
   const [timerPreferences, setTimerPreferencesState] = useState(() => getTimerPreferences());
   const [soundPickerOpen, setSoundPickerOpen] = useState(false);
   const [syncDialogOpen, setSyncDialogOpen] = useState(false);
@@ -250,6 +257,11 @@ export function NewSettingsPage() {
   const handleDeveloperModeToggle = (checked: boolean) => {
     setDeveloperModeEnabled(checked);
     setDeveloperMode(checked);
+    if (!checked) {
+      setDevtoolsEnabled(false);
+      setDevtoolsEnabledState(false);
+    }
+    void syncDevtoolsWithSettings();
   };
 
   const handleAgentPageEnabledToggle = (checked: boolean) => {
@@ -262,6 +274,12 @@ export function NewSettingsPage() {
     setUseMockData(checked);
     // Reload page（刷新页面）to re-bootstrap runtime adapters（重建运行时适配器注入）.
     window.location.reload();
+  };
+
+  const handleDevtoolsToggle = (checked: boolean) => {
+    setDevtoolsEnabled(checked);
+    setDevtoolsEnabledState(checked);
+    void syncDevtoolsWithSettings();
   };
 
   const navigate = useNavigate();
@@ -280,6 +298,12 @@ export function NewSettingsPage() {
   useEffect(() => {
     return subscribeUseMockDataChanges((enabled) => {
       setUseMockData(enabled);
+    });
+  }, []);
+
+  useEffect(() => {
+    return subscribeDevtoolsChanges((enabled) => {
+      setDevtoolsEnabledState(enabled);
     });
   }, []);
 
@@ -514,6 +538,18 @@ export function NewSettingsPage() {
                       data-testid="new-settings-use-mock-data-switch"
                       checked={useMockData}
                       onCheckedChange={handleUseMockDataToggle}
+                    />
+                  }
+                />
+                <Divider />
+                <SettingRow
+                  icon={<Code className="h-[18px] w-[18px] text-[#78716C]" />}
+                  label="开发者工具"
+                  right={
+                    <Switch
+                      data-testid="new-settings-devtools-switch"
+                      checked={devtoolsEnabled}
+                      onCheckedChange={handleDevtoolsToggle}
                     />
                   }
                 />

--- a/tests/unit/components/settings/DeveloperSection.test.tsx
+++ b/tests/unit/components/settings/DeveloperSection.test.tsx
@@ -7,6 +7,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import './setup-settings-mocks.tsx';
 import { getDeveloperModeEnabled } from '@/config/developer-mode';
+import { setDevtoolsEnabled } from '@/config/devtools-mode';
+import { syncDevtoolsWithSettings } from '@/lib/debug/devtools-runtime';
 import { NewSettingsPage } from '@/ui/new/pages/NewSettingsPage';
 
 beforeEach(() => {
@@ -29,6 +31,19 @@ describe('NewSettingsPage - Developer Section (developerMode=true)', () => {
   it('renders mock data toggle', () => {
     render(<NewSettingsPage />);
     expect(screen.getByText('使用测试数据')).toBeInTheDocument();
+  });
+
+  it('renders devtools toggle', () => {
+    render(<NewSettingsPage />);
+    expect(screen.getByText('开发者工具')).toBeInTheDocument();
+  });
+
+  it('updates devtools state and syncs runtime on toggle', () => {
+    render(<NewSettingsPage />);
+    const toggle = screen.getByTestId('new-settings-devtools-switch');
+    fireEvent.click(toggle);
+    expect(vi.mocked(setDevtoolsEnabled)).toHaveBeenCalledWith(true);
+    expect(vi.mocked(syncDevtoolsWithSettings)).toHaveBeenCalled();
   });
 
   it('renders old pages row', () => {

--- a/tests/unit/components/settings/setup-settings-mocks.tsx
+++ b/tests/unit/components/settings/setup-settings-mocks.tsx
@@ -63,6 +63,16 @@ vi.mock('@/config/mock-data', () => ({
   subscribeUseMockDataChanges: vi.fn(() => () => {}),
 }));
 
+vi.mock('@/config/devtools-mode', () => ({
+  getDevtoolsEnabled: vi.fn(() => false),
+  setDevtoolsEnabled: vi.fn(),
+  subscribeDevtoolsChanges: vi.fn(() => () => {}),
+}));
+
+vi.mock('@/lib/debug/devtools-runtime', () => ({
+  syncDevtoolsWithSettings: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('@/config/ui-mode', () => ({
   setUIMode: vi.fn(),
 }));

--- a/tests/unit/config/devtools-mode.test.ts
+++ b/tests/unit/config/devtools-mode.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getDevtoolsEnabled,
+  setDevtoolsEnabled,
+  subscribeDevtoolsChanges,
+} from '@/config/devtools-mode';
+
+describe('devtools flag（开发者工具开关）', () => {
+  let storage: Record<string, string>;
+
+  beforeEach(() => {
+    storage = {};
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => (key in storage ? storage[key] : null),
+        setItem: (key: string, value: string) => {
+          storage[key] = value;
+        },
+      },
+    });
+  });
+
+  it('defaults to false when key is missing（未设置时默认关闭）', () => {
+    expect(getDevtoolsEnabled()).toBe(false);
+  });
+
+  it('persists and emits custom event when toggled（切换时持久化并发事件）', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeDevtoolsChanges(listener);
+
+    setDevtoolsEnabled(true);
+
+    expect(storage['exomind:devtoolsEnabled']).toBe('true');
+    expect(listener).toHaveBeenCalledWith(true);
+
+    unsubscribe();
+  });
+
+  it('handles storage event updates（支持 storage 事件同步）', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeDevtoolsChanges(listener);
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'exomind:devtoolsEnabled',
+      newValue: 'true',
+    }));
+
+    expect(listener).toHaveBeenCalledWith(true);
+    unsubscribe();
+  });
+});

--- a/tests/unit/debug/devtools-runtime.test.ts
+++ b/tests/unit/debug/devtools-runtime.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getDeveloperModeEnabled: vi.fn(),
+  getDevtoolsEnabled: vi.fn(),
+  erudaInit: vi.fn(),
+  erudaDestroy: vi.fn(),
+}));
+
+vi.mock('@/config/developer-mode', () => ({
+  getDeveloperModeEnabled: mocks.getDeveloperModeEnabled,
+}));
+
+vi.mock('@/config/devtools-mode', () => ({
+  getDevtoolsEnabled: mocks.getDevtoolsEnabled,
+}));
+
+vi.mock('eruda', () => ({
+  default: {
+    init: mocks.erudaInit,
+    destroy: mocks.erudaDestroy,
+  },
+}));
+
+describe('devtools runtime（开发者工具注入）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mocks.getDeveloperModeEnabled.mockReturnValue(false);
+    mocks.getDevtoolsEnabled.mockReturnValue(false);
+  });
+
+  it('does not initialize when switches are off（关闭时不初始化）', async () => {
+    const { syncDevtoolsWithSettings } = await import('@/lib/debug/devtools-runtime');
+    await syncDevtoolsWithSettings();
+
+    expect(mocks.erudaInit).not.toHaveBeenCalled();
+    expect(mocks.erudaDestroy).not.toHaveBeenCalled();
+  });
+
+  it('initializes once when repeatedly synced（重复同步只初始化一次）', async () => {
+    mocks.getDeveloperModeEnabled.mockReturnValue(true);
+    mocks.getDevtoolsEnabled.mockReturnValue(true);
+    const { syncDevtoolsWithSettings } = await import('@/lib/debug/devtools-runtime');
+
+    await syncDevtoolsWithSettings();
+    await syncDevtoolsWithSettings();
+
+    expect(mocks.erudaInit).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys after toggled off（关闭后销毁）', async () => {
+    mocks.getDeveloperModeEnabled.mockReturnValue(true);
+    mocks.getDevtoolsEnabled.mockReturnValue(true);
+    const { syncDevtoolsWithSettings } = await import('@/lib/debug/devtools-runtime');
+
+    await syncDevtoolsWithSettings();
+    expect(mocks.erudaInit).toHaveBeenCalledTimes(1);
+
+    mocks.getDevtoolsEnabled.mockReturnValue(false);
+    await syncDevtoolsWithSettings();
+    await syncDevtoolsWithSettings();
+
+    expect(mocks.erudaDestroy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- 集成 `eruda` 作为开发者工具底层实现。
- 新增 `devtools` 配置模块（localStorage + 事件订阅）。
- 新增统一 runtime 注入器，按 `developerMode && devtoolsEnabled` 条件动态 init/destroy。
- 在 `main.tsx` 启动时统一调用注入同步。
- 仅在新设置页开发者区新增「开发者工具」开关，并实现即时生效。
- 与开发者模式强绑定：关闭开发者模式会自动关闭开发者工具。

## Changes
- `package.json`, `package-lock.json`: 新增依赖 `eruda`。
- `src/config/devtools-mode.ts`: 新增开发者工具开关配置。
- `src/lib/debug/devtools-runtime.ts`: 新增统一注入器（内部调用 Eruda）。
- `src/main.tsx`: 启动时同步注入状态。
- `src/ui/new/pages/NewSettingsPage.tsx`: 新增开关 + 强绑定逻辑。
- `tests/unit/config/devtools-mode.test.ts`: 新增配置层测试。
- `tests/unit/debug/devtools-runtime.test.ts`: 新增 runtime 测试。
- `tests/unit/components/settings/DeveloperSection.test.tsx`: 补充开发者工具开关用例。
- `tests/unit/components/settings/setup-settings-mocks.tsx`: 增加 devtools 相关 mocks。

## Test Evidence
- `npx vitest run tests/unit/config/devtools-mode.test.ts tests/unit/debug/devtools-runtime.test.ts tests/unit/components/settings/DeveloperSection.test.tsx tests/unit/settings/new-settings-mock-data-toggle.issue213.test.tsx`
  - 结果：4 files passed, 14 tests passed
- `npx tsc --noEmit`
  - 结果：通过
- `npx vite build`
  - 结果：通过（存在既有警告，含 eruda chunk 体积与 eval 警告）

## Notes
- 当前执行环境未安装 `bun`，因此未直接执行 `bun run build`；已用等价命令 `npx tsc --noEmit` + `npx vite build` 完成构建验证。

Closes #230
