### PR TITLE
wip: align issue-204 agent routing and issue-213 task tab flow

### DIFF
--- a/src/lib/adapters/mock/fixtures/tasks.ts
+++ b/src/lib/adapters/mock/fixtures/tasks.ts
@@ -7,6 +7,7 @@ export const MOCK_TASKS_FIXTURE: TaskItem[] = [
     id: 'task-001',
     title: '完成 Task List 视图设计',
     note: 'Pencil 像素对齐检查',
+    dueAt: '2026-02-25T10:00:00.000Z',
     status: 'in_progress',
     progress: 42,
     estimatedMinutes: 120,
@@ -25,6 +26,7 @@ export const MOCK_TASKS_FIXTURE: TaskItem[] = [
     id: 'task-002',
     title: '设计 Agent Hub 认知架构视图',
     note: '先整理节点关系',
+    dueAt: '2026-02-26T09:00:00.000Z',
     status: 'todo',
     progress: 10,
     estimatedMinutes: 180,
@@ -40,6 +42,7 @@ export const MOCK_TASKS_FIXTURE: TaskItem[] = [
   {
     id: 'task-003',
     title: '暗色模式适配',
+    dueAt: '2026-03-02T12:00:00.000Z',
     status: 'todo',
     progress: 0,
     estimatedMinutes: 90,
@@ -72,6 +75,7 @@ export const MOCK_TASKS_FIXTURE: TaskItem[] = [
   {
     id: 'task-005',
     title: '集成测试与 Bug 修复',
+    dueAt: '2026-02-21T18:10:00.000Z',
     status: 'done',
     progress: 100,
     estimatedMinutes: 160,
@@ -374,4 +378,3 @@ export const MOCK_TASK_GOAL_GROUPS_FIXTURE: TaskGoalGroup[] = [
     ],
   },
 ];
-

--- a/src/lib/services/task.service.ts
+++ b/src/lib/services/task.service.ts
@@ -13,6 +13,7 @@ type TaskEnvironmentLike = {
 
 export interface TaskService {
   listTasks(): Promise<TaskItem[]>;
+  listTasksByTab(tab: TaskListTab): Promise<TaskItem[]>;
   getLongTermGoals(): Promise<TaskGoalGroup[]>;
   getTask(taskId: string): Promise<TaskItem | null>;
   createTask(input: CreateTaskInput): Promise<TaskItem>;
@@ -20,6 +21,57 @@ export interface TaskService {
   pauseTask(taskId: string): Promise<TaskItem | null>;
   resumeTask(taskId: string): Promise<TaskItem | null>;
   upsertTask(task: TaskItem): Promise<void>;
+}
+
+export type TaskListTab = 'now' | 'today' | 'week' | 'month';
+
+function parseIsoDate(iso: string | undefined): Date | null {
+  if (!iso) return null;
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function isSameLocalDay(left: Date, right: Date): boolean {
+  return left.getFullYear() === right.getFullYear()
+    && left.getMonth() === right.getMonth()
+    && left.getDate() === right.getDate();
+}
+
+function isWithinCurrentWeek(date: Date, now: Date): boolean {
+  const day = now.getDay();
+  const mondayOffset = day === 0 ? -6 : 1 - day;
+  const start = new Date(now);
+  start.setHours(0, 0, 0, 0);
+  start.setDate(now.getDate() + mondayOffset);
+
+  const end = new Date(start);
+  end.setDate(start.getDate() + 7);
+
+  return date >= start && date < end;
+}
+
+function isWithinCurrentMonth(date: Date, now: Date): boolean {
+  return date.getFullYear() === now.getFullYear() && date.getMonth() === now.getMonth();
+}
+
+function sortByDueThenUpdated(tasks: TaskItem[]): TaskItem[] {
+  return [...tasks].sort((left, right) => {
+    const leftDue = parseIsoDate(left.dueAt);
+    const rightDue = parseIsoDate(right.dueAt);
+    if (leftDue && rightDue) {
+      return leftDue.getTime() - rightDue.getTime();
+    }
+    if (leftDue) return -1;
+    if (rightDue) return 1;
+
+    const leftUpdated = parseIsoDate(left.updatedAt)?.getTime() ?? 0;
+    const rightUpdated = parseIsoDate(right.updatedAt)?.getTime() ?? 0;
+    return rightUpdated - leftUpdated;
+  });
+}
+
+function isActionable(task: TaskItem): boolean {
+  return task.status !== 'done';
 }
 
 export class TaskServiceImpl implements TaskService {
@@ -31,6 +83,44 @@ export class TaskServiceImpl implements TaskService {
 
   async listTasks(): Promise<TaskItem[]> {
     return this.env.task.listTasks();
+  }
+
+  async listTasksByTab(tab: TaskListTab): Promise<TaskItem[]> {
+    const allTasks = await this.env.task.listTasks();
+    const now = new Date();
+
+    if (tab === 'now') {
+      const inProgress = allTasks.filter((task) => task.status === 'in_progress');
+      if (inProgress.length > 0) {
+        return sortByDueThenUpdated(inProgress);
+      }
+      return sortByDueThenUpdated(allTasks.filter(isActionable)).slice(0, 5);
+    }
+
+    if (tab === 'today') {
+      return sortByDueThenUpdated(allTasks.filter((task) => {
+        if (!isActionable(task)) return false;
+        const due = parseIsoDate(task.dueAt);
+        const updatedAt = parseIsoDate(task.updatedAt);
+        const dueToday = due ? isSameLocalDay(due, now) : false;
+        const activeToday = updatedAt ? isSameLocalDay(updatedAt, now) : false;
+        return dueToday || activeToday;
+      }));
+    }
+
+    if (tab === 'week') {
+      return sortByDueThenUpdated(allTasks.filter((task) => {
+        if (!isActionable(task)) return false;
+        const due = parseIsoDate(task.dueAt);
+        return !due || isWithinCurrentWeek(due, now);
+      }));
+    }
+
+    return sortByDueThenUpdated(allTasks.filter((task) => {
+      if (!isActionable(task)) return false;
+      const due = parseIsoDate(task.dueAt);
+      return !due || isWithinCurrentMonth(due, now);
+    }));
   }
 
   async getLongTermGoals(): Promise<TaskGoalGroup[]> {
@@ -70,4 +160,3 @@ export function getTaskService(): TaskService {
   }
   return taskServiceInstance;
 }
-

--- a/src/lib/types/task.ts
+++ b/src/lib/types/task.ts
@@ -13,6 +13,7 @@ export interface TaskItem {
   id: string;
   title: string;
   note?: string;
+  dueAt?: string; // due time（截止时间，ISO）
   status: TaskStatus;
   progress: number; // 0-100
   estimatedMinutes?: number;
@@ -74,4 +75,3 @@ export interface TaskGoalGroup {
   badgeTone: TaskGoalStatusTone;
   goals: TaskGoalCard[];
 }
-

--- a/src/ui/new/pages/AgentsPage.tsx
+++ b/src/ui/new/pages/AgentsPage.tsx
@@ -22,6 +22,7 @@ import {
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
 import { getAgentHubService } from '@/lib/services';
 import type {
   AgentAddNodeOption,
@@ -657,6 +658,7 @@ function AddNodeSheet({
 }
 
 export function AgentsPage() {
+  const navigate = useNavigate();
   const [viewMode, setViewMode] = useState<AgentHubViewMode>('topology');
   const [topology, setTopology] = useState<AgentHubTopologyData>({ nodes: [], edges: [], selectedNodeId: null });
   const [listSections, setListSections] = useState<AgentHubListSection[]>([]);
@@ -689,7 +691,7 @@ export function AgentsPage() {
   }, []);
 
   const navigateByPath = (path: string) => {
-    window.location.href = path;
+    void navigate({ to: path as never });
   };
 
   const content = useMemo(() => {

--- a/src/ui/new/pages/NewTasksPage.tsx
+++ b/src/ui/new/pages/NewTasksPage.tsx
@@ -1,179 +1,61 @@
-import { EllipsisVertical, Github, Plus, SlidersHorizontal } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { EllipsisVertical, Plus, SlidersHorizontal } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
 import { getTaskService } from '@/lib/services';
-import type { TaskGoalCard, TaskGoalGroup, TaskGoalStatusTone, TaskItem } from '@/lib/types/task';
+import type { TaskItem } from '@/lib/types/task';
+import type { TaskListTab } from '@/lib/services/task.service';
 
-type TaskTab = 'now' | 'today' | 'week' | 'month' | 'goals';
-
-const TAB_ITEMS: Array<{ id: TaskTab; label: string }> = [
+const TAB_ITEMS: Array<{ id: TaskListTab; label: string }> = [
   { id: 'now', label: '当下' },
   { id: 'today', label: '今日' },
   { id: 'week', label: '一周' },
   { id: 'month', label: '月' },
-  { id: 'goals', label: '长期' },
 ];
 
-const TONE_TEXT_CLASS: Record<TaskGoalStatusTone, string> = {
-  success: 'text-[#16A34A] dark:text-[#86EFAC]',
-  warning: 'text-[#C75B3A] dark:text-[#FDBA74]',
-  danger: 'text-[#DC2626] dark:text-[#FCA5A5]',
-  brand: 'text-[#C75B3A] dark:text-[#FDBA74]',
-  info: 'text-[#3B82F6] dark:text-[#93C5FD]',
-  indigo: 'text-[#6366F1] dark:text-[#A5B4FC]',
-  lime: 'text-[#84CC16] dark:text-[#BEF264]',
-  pink: 'text-[#EC4899] dark:text-[#F9A8D4]',
-  neutral: 'text-[#A8A29E] dark:text-[#D6D3D1]',
-};
-
-const TONE_BG_CLASS: Record<TaskGoalStatusTone, string> = {
-  success: 'bg-[#F0FDF4] dark:bg-[#1E2B22]',
-  warning: 'bg-[#FFF7ED] dark:bg-[#3A2A22]',
-  danger: 'bg-[#FEF2F2] dark:bg-[#3A2323]',
-  brand: 'bg-[#FFF7ED] dark:bg-[#3A2A22]',
-  info: 'bg-[#EFF6FF] dark:bg-[#1D2837]',
-  indigo: 'bg-[#EEF2FF] dark:bg-[#2A2E45]',
-  lime: 'bg-[#F7FEE7] dark:bg-[#2A321D]',
-  pink: 'bg-[#FDF2F8] dark:bg-[#3A2431]',
-  neutral: 'bg-[#F5F0ED] dark:bg-[#2A2523]',
-};
-
-const TONE_FILL_CLASS: Record<TaskGoalStatusTone, string> = {
-  success: 'bg-[#16A34A]',
-  warning: 'bg-[#C75B3A]',
-  danger: 'bg-[#DC2626]',
-  brand: 'bg-[#C75B3A]',
-  info: 'bg-[#3B82F6]',
-  indigo: 'bg-[#6366F1]',
-  lime: 'bg-[#84CC16]',
-  pink: 'bg-[#EC4899]',
-  neutral: 'bg-[#A8A29E]',
+const EMPTY_TEXT: Record<TaskListTab, string> = {
+  now: '当前没有进行中的任务。',
+  today: '今天还没有需要推进的任务。',
+  week: '本周任务列表为空。',
+  month: '本月任务列表为空。',
 };
 
 function formatTaskMeta(task: TaskItem): string {
   const estimated = task.estimatedMinutes ? `预计 ${task.estimatedMinutes}min` : '未估时';
   const spent = task.spentMinutes ? `已用 ${task.spentMinutes}min` : '未计时';
-  return `${estimated} · ${spent}`;
-}
-
-function GoalCard({ goal }: { goal: TaskGoalCard }) {
-  return (
-    <article
-      data-testid={`tasks-goal-card-${goal.id}`}
-      className="overflow-hidden rounded-xl border border-[#E7E5E4] bg-white dark:border-[#3A3432] dark:bg-[#1C1917]"
-    >
-      <div className="flex">
-        <div className={`w-1 shrink-0 self-stretch ${TONE_FILL_CLASS[goal.accentTone]}`} />
-        <div className="w-full space-y-1 px-3 py-2.5">
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-1.5">
-              <p className="text-[13px] font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{goal.title}</p>
-              {goal.showGithubIcon ? <Github size={14} className="text-[#78716C] dark:text-[#A8A29E]" /> : null}
-            </div>
-            <div className={`inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 ${TONE_BG_CLASS[goal.status.tone]}`}>
-              <span className="text-[9px] leading-none">{goal.status.icon}</span>
-              <span className={`text-[10px] font-semibold leading-none ${TONE_TEXT_CLASS[goal.status.tone]}`}>{goal.status.text}</span>
-            </div>
-          </div>
-
-          <p className="text-[11px] text-[#78716C] dark:text-[#CFC5BE]">{goal.focus}</p>
-          <p className="text-[10px] text-[#A8A29E] dark:text-[#B8B1AC]">{goal.acceptance}</p>
-
-          <div className="inline-flex items-center gap-1">
-            <span className={`h-1.5 w-1.5 rounded-full ${TONE_FILL_CLASS[goal.stageTone]}`} />
-            <span className={`text-[10px] font-semibold ${TONE_TEXT_CLASS[goal.stageTone]}`}>{goal.stage}</span>
-          </div>
-
-          {goal.progress ? (
-            <div className="flex items-center gap-2">
-              <div className="h-1 w-full rounded bg-[#F5F0ED] dark:bg-[#2A2523]">
-                <div
-                  className={`h-full rounded ${TONE_FILL_CLASS[goal.progress.tone]}`}
-                  style={{
-                    width: `${Math.max(0, Math.min(100, goal.progress.value))}%`,
-                  }}
-                />
-              </div>
-              <span className={`shrink-0 text-[11px] font-semibold ${TONE_TEXT_CLASS[goal.progress.tone]}`}>
-                {goal.progress.label ?? `${goal.progress.value}%`}
-              </span>
-            </div>
-          ) : null}
-
-          {goal.timeline ? <p className="text-[11px] text-[#A8A29E] dark:text-[#B8B1AC]">{goal.timeline}</p> : null}
-        </div>
-      </div>
-    </article>
-  );
-}
-
-function GoalGroupSection({ group }: { group: TaskGoalGroup }) {
-  return (
-    <section data-testid={`tasks-goals-group-${group.id}`} className="space-y-2 text-[#1C1917] dark:text-[#FAFAF9]">
-      <div className="flex items-center gap-2">
-        <span className="text-[10px] text-[#78716C] dark:text-[#A8A29E]">▼</span>
-        <span className="text-sm">{group.icon}</span>
-        <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{group.title}</p>
-        <div className="h-px flex-1 bg-[#E7E5E4] dark:bg-[#3A3432]" />
-        <span className={`inline-flex items-center justify-center rounded-[10px] px-2 py-0.5 text-[11px] font-semibold ${TONE_BG_CLASS[group.badgeTone]} ${TONE_TEXT_CLASS[group.badgeTone]}`}>
-          {group.badgeText}
-        </span>
-      </div>
-
-      <div className="space-y-2">
-        {group.goals.map((goal) => (
-          <GoalCard key={goal.id} goal={goal} />
-        ))}
-      </div>
-    </section>
-  );
+  const due = task.dueAt ? `截止 ${new Date(task.dueAt).toLocaleDateString('zh-CN')}` : '无截止';
+  return `${due} · ${estimated} · ${spent}`;
 }
 
 export function NewTasksPage() {
-  const [activeTab, setActiveTab] = useState<TaskTab>('now');
+  const [activeTab, setActiveTab] = useState<TaskListTab>('now');
   const [tasks, setTasks] = useState<TaskItem[]>([]);
-  const [goalGroups, setGoalGroups] = useState<TaskGoalGroup[]>([]);
   const [quickInput, setQuickInput] = useState('');
+  const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
-    let disposed = false;
-    const load = async () => {
-      const [list, goals] = await Promise.all([
-        getTaskService().listTasks(),
-        getTaskService().getLongTermGoals(),
-      ]);
-      if (!disposed) {
-        setTasks(list);
-        setGoalGroups(goals);
-      }
-    };
-    void load();
-    return () => {
-      disposed = true;
-    };
+  const loadTasks = useCallback(async (tab: TaskListTab) => {
+    setLoading(true);
+    try {
+      const list = await getTaskService().listTasksByTab(tab);
+      setTasks(list);
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  const visibleTasks = useMemo(() => {
-    if (activeTab === 'now') {
-      const active = tasks.filter((item) => item.status === 'in_progress');
-      return active.length > 0 ? active : tasks.slice(0, 3);
-    }
-    if (activeTab === 'today') {
-      return tasks.slice(0, 5);
-    }
-    return tasks;
-  }, [activeTab, tasks]);
+  useEffect(() => {
+    void loadTasks(activeTab);
+  }, [activeTab, loadTasks]);
 
-  const handleQuickAdd = async () => {
+  const handleQuickAdd = useCallback(async () => {
     const title = quickInput.trim();
     if (!title) return;
-    const created = await getTaskService().createTask({
+    await getTaskService().createTask({
       title,
       mode: 'countdown',
       targetMinutes: 25,
     });
-    setTasks((prev) => [created, ...prev]);
     setQuickInput('');
-  };
+    await loadTasks(activeTab);
+  }, [activeTab, loadTasks, quickInput]);
 
   return (
     <div className="min-h-full bg-[#FAF7F5] dark:bg-[#0C0A09]" data-testid="new-tasks-page">
@@ -208,22 +90,13 @@ export function NewTasksPage() {
           })}
         </div>
 
-        {activeTab === 'goals' ? (
-          <div className="space-y-3" data-testid="tasks-goals-content">
-            {goalGroups.length > 0 ? (
-              goalGroups.map((group) => <GoalGroupSection key={group.id} group={group} />)
-            ) : (
-              <p
-                data-testid="tasks-goals-empty"
-                className="rounded-2xl border border-dashed border-[#D6D3D1] bg-[#FAF7F5] px-4 py-5 text-sm text-[#A8A29E] dark:border-[#3A3432] dark:bg-[#1C1917] dark:text-[#B8B1AC]"
-              >
-                暂无长期目标数据，请在开发者设置中开启测试数据（Mock Data）。
-              </p>
-            )}
+        {loading ? (
+          <div className="rounded-2xl border border-dashed border-[#D6D3D1] bg-[#FAF7F5] px-4 py-5 text-sm text-[#A8A29E] dark:border-[#3A3432] dark:bg-[#1C1917] dark:text-[#B8B1AC]">
+            加载中...
           </div>
-        ) : (
+        ) : tasks.length > 0 ? (
           <div className="space-y-3">
-            {visibleTasks.map((task) => (
+            {tasks.map((task) => (
               <article
                 key={task.id}
                 className="rounded-2xl border border-[#E7E5E4] bg-white px-4 py-3 dark:border-[#292524] dark:bg-[#1C1917]"
@@ -232,6 +105,10 @@ export function NewTasksPage() {
                 <p className="mt-1 text-xs text-[#A8A29E]">{formatTaskMeta(task)}</p>
               </article>
             ))}
+          </div>
+        ) : (
+          <div className="rounded-2xl border border-dashed border-[#D6D3D1] bg-[#FAF7F5] px-4 py-5 text-sm text-[#A8A29E] dark:border-[#3A3432] dark:bg-[#1C1917] dark:text-[#B8B1AC]">
+            {EMPTY_TEXT[activeTab]}
           </div>
         )}
       </div>
@@ -258,11 +135,10 @@ export function NewTasksPage() {
             className="flex h-9 w-9 items-center justify-center rounded-full bg-[#C75B3A] text-white"
             aria-label="添加任务（Add Task）"
           >
-            <Plus size={18} />
+            <Plus size={16} />
           </button>
         </div>
       </div>
     </div>
   );
 }
-

--- a/src/ui/new/pages/agents/ActorDetailPage.tsx
+++ b/src/ui/new/pages/agents/ActorDetailPage.tsx
@@ -1,9 +1,11 @@
 import { AlarmClock, ArrowLeft, Clock3, MoreHorizontal, TriangleAlert } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
 import { getAgentHubService } from '@/lib/services';
 import type { AgentDetailData } from '@/lib/types/agent-hub';
 
 export function ActorDetailPage({ actorId }: { actorId?: string }) {
+  const navigate = useNavigate();
   const [detail, setDetail] = useState<AgentDetailData | null>(null);
   const [loading, setLoading] = useState(true);
   const targetId = actorId ?? '';
@@ -60,7 +62,9 @@ export function ActorDetailPage({ actorId }: { actorId?: string }) {
           <p className="mt-1 text-xs text-[#A8A29E] dark:text-[#78716C]">该节点可能已删除或尚未配置详情数据。</p>
           <button
             type="button"
-            onClick={() => window.history.back()}
+            onClick={() => {
+              void navigate({ to: '/agents' });
+            }}
             className="mt-4 rounded-lg bg-[#F5F0ED] px-3 py-2 text-xs font-medium text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
           >
             返回上一页
@@ -75,7 +79,9 @@ export function ActorDetailPage({ actorId }: { actorId?: string }) {
       <header data-testid="actor-detail-header" className="mb-3 flex items-center justify-between">
         <button
           type="button"
-          onClick={() => window.history.back()}
+          onClick={() => {
+            void navigate({ to: '/agents' });
+          }}
           className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
           aria-label="返回（Back）"
         >

--- a/src/ui/new/pages/agents/AgentConversationPage.tsx
+++ b/src/ui/new/pages/agents/AgentConversationPage.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft, Bot, MoreHorizontal, SendHorizontal, UserRound } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
 import { getAgentHubService } from '@/lib/services';
 import type { AgentConversationMessage } from '@/lib/types/agent-hub';
 
@@ -13,6 +14,7 @@ function createMessage(id: string, role: 'agent' | 'user', content: string): Age
 }
 
 export function AgentConversationPage({ agentId }: { agentId?: string }) {
+  const navigate = useNavigate();
   const [messages, setMessages] = useState<AgentConversationMessage[]>([]);
   const [inputValue, setInputValue] = useState('');
   const [sending, setSending] = useState(false);
@@ -79,7 +81,9 @@ export function AgentConversationPage({ agentId }: { agentId?: string }) {
       <header data-testid="agent-conversation-header" className="flex items-center justify-between px-4 py-3">
         <button
           type="button"
-          onClick={() => window.history.back()}
+          onClick={() => {
+            void navigate({ to: '/agents' });
+          }}
           className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
           aria-label="返回（Back）"
         >

--- a/src/ui/new/pages/agents/AgentDetailPage.tsx
+++ b/src/ui/new/pages/agents/AgentDetailPage.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft, CheckCheck, Clock3, MessageCircle, MoreHorizontal, Send, Sparkles } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
 import { getAgentHubService } from '@/lib/services';
 import type { AgentDetailData, AgentHubListItem } from '@/lib/types/agent-hub';
 
@@ -10,6 +11,7 @@ function getTargetIcon(target: AgentHubListItem) {
 }
 
 export function AgentDetailPage({ agentId }: { agentId?: string }) {
+  const navigate = useNavigate();
   const [detail, setDetail] = useState<AgentDetailData | null>(null);
   const [loading, setLoading] = useState(true);
   const targetId = agentId ?? '';
@@ -66,7 +68,9 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
           <p className="mt-1 text-xs text-[#A8A29E] dark:text-[#78716C]">该节点可能已删除或尚未配置详情数据。</p>
           <button
             type="button"
-            onClick={() => window.history.back()}
+            onClick={() => {
+              void navigate({ to: '/agents' });
+            }}
             className="mt-4 rounded-lg bg-[#F5F0ED] px-3 py-2 text-xs font-medium text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
           >
             返回上一页
@@ -82,7 +86,9 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
         <button
           type="button"
           data-testid="agent-detail-back-button"
-          onClick={() => window.history.back()}
+          onClick={() => {
+            void navigate({ to: '/agents' });
+          }}
           className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
           aria-label="返回（Back）"
         >
@@ -191,7 +197,7 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
           data-testid="agent-detail-chat-button"
           onClick={() => {
             if (!targetId) return;
-            window.location.href = `/agents/chat/${targetId}`;
+            void navigate({ to: '/agents/chat/$agentId', params: { agentId: targetId } });
           }}
           className="w-full rounded-[14px] bg-[#C75B3A] px-4 py-3 text-sm font-semibold text-white"
         >

--- a/src/ui/new/pages/agents/AgentMarketPage.tsx
+++ b/src/ui/new/pages/agents/AgentMarketPage.tsx
@@ -1,5 +1,6 @@
 import { ArrowDownToLine, ArrowLeft, Search, Sparkles, Store, Users } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
 import { getAgentHubService } from '@/lib/services';
 import type { AgentMarketCategory, AgentMarketItem } from '@/lib/types/agent-hub';
 
@@ -10,6 +11,7 @@ function getMarketCardIcon(item: AgentMarketItem) {
 }
 
 export function AgentMarketPage() {
+  const navigate = useNavigate();
   const [categories, setCategories] = useState<AgentMarketCategory[]>([]);
   const [activeCategoryId, setActiveCategoryId] = useState('all');
   const [items, setItems] = useState<AgentMarketItem[]>([]);
@@ -43,7 +45,9 @@ export function AgentMarketPage() {
       <header className="grid grid-cols-[auto,1fr,auto] items-center px-5 py-3">
         <button
           type="button"
-          onClick={() => window.history.back()}
+          onClick={() => {
+            void navigate({ to: '/agents' });
+          }}
           className="flex items-center gap-1 text-[12px] text-[#C75B3A]"
         >
           <ArrowLeft size={14} />

--- a/tests/e2e/task-ui.issue213.test.ts
+++ b/tests/e2e/task-ui.issue213.test.ts
@@ -21,6 +21,7 @@ test.describe('Issue #213 Task UI（任务界面）', () => {
     await expect(page.getByRole('heading', { name: '任务' })).toBeVisible();
     await expect(page.getByRole('button', { name: '当下' })).toBeVisible();
     await expect(page.getByRole('button', { name: '今日' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '月' })).toBeVisible();
     await expect(page.getByPlaceholder('快速添加任务...')).toBeVisible();
     await expect(page.getByText('完成 Task List 视图设计')).toBeVisible();
 
@@ -30,11 +31,6 @@ test.describe('Issue #213 Task UI（任务界面）', () => {
     await quickInput.press('Enter');
     await page.getByRole('button', { name: '一周' }).click();
     await expect(page.getByText(createdTitle)).toBeVisible();
-
-    await page.getByRole('button', { name: '长期' }).click();
-    await expect(page.getByTestId('tasks-goals-content')).toBeVisible();
-    await expect(page.getByText('商业项目')).toBeVisible();
-    await expect(page.getByText('Exomind v0.3 发布')).toBeVisible();
   });
 
   test('任务详情卡片交互（模式切换/暂停/输入）', async ({ page }) => {

--- a/tests/unit/services/task.service.test.ts
+++ b/tests/unit/services/task.service.test.ts
@@ -1,9 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TaskServiceImpl } from '@/lib/services/task.service';
 import type { ITaskPort } from '@/lib/environment/interfaces/task.port';
 import type { TaskGoalGroup, TaskItem } from '@/lib/types/task';
 
-function createTask(id: string): TaskItem {
+function createTask(id: string, overrides?: Partial<TaskItem>): TaskItem {
   return {
     id,
     title: `Task ${id}`,
@@ -18,6 +18,7 @@ function createTask(id: string): TaskItem {
       remainingMs: 25 * 60 * 1000,
       targetMinutes: 25,
     },
+    ...overrides,
   };
 }
 
@@ -52,8 +53,35 @@ describe('task service（任务服务）', () => {
   let service: TaskServiceImpl;
 
   beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-25T10:00:00.000Z'));
+
     taskPort = {
-      listTasks: vi.fn(async () => [createTask('1'), createTask('2')]),
+      listTasks: vi.fn(async () => [
+        createTask('in-progress', {
+          status: 'in_progress',
+          dueAt: '2026-02-25T15:00:00.000Z',
+          updatedAt: '2026-02-25T08:00:00.000Z',
+        }),
+        createTask('today-active', {
+          status: 'todo',
+          dueAt: '2026-02-25T20:00:00.000Z',
+          updatedAt: '2026-02-25T09:00:00.000Z',
+        }),
+        createTask('week-with-due', {
+          status: 'todo',
+          dueAt: '2026-02-27T12:00:00.000Z',
+          updatedAt: '2026-02-24T09:00:00.000Z',
+        }),
+        createTask('no-due', {
+          status: 'todo',
+          updatedAt: '2026-02-24T10:00:00.000Z',
+        }),
+        createTask('done-task', {
+          status: 'done',
+          dueAt: '2026-02-25T11:00:00.000Z',
+        }),
+      ]),
       getLongTermGoals: vi.fn(async () => [createGoalGroup('g1')]),
       getTaskById: vi.fn(async (taskId: string) => createTask(taskId)),
       createTask: vi.fn(async (input) => createTask(input.title)),
@@ -84,10 +112,32 @@ describe('task service（任务服务）', () => {
     service = new TaskServiceImpl({ task: taskPort });
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('loads task list（加载任务列表）', async () => {
     const tasks = await service.listTasks();
-    expect(tasks).toHaveLength(2);
+    expect(tasks).toHaveLength(5);
     expect(taskPort.listTasks).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies now tab rule（当下仅进行中）', async () => {
+    const tasks = await service.listTasksByTab('now');
+    expect(tasks.map((task) => task.id)).toEqual(['in-progress']);
+  });
+
+  it('applies today tab rule（今日按截止和活跃筛选）', async () => {
+    const tasks = await service.listTasksByTab('today');
+    expect(tasks.map((task) => task.id)).toEqual(['in-progress', 'today-active']);
+  });
+
+  it('places no-due tasks at bottom for week/month（周月视图无截止置底）', async () => {
+    const weekTasks = await service.listTasksByTab('week');
+    expect(weekTasks.map((task) => task.id)).toEqual(['in-progress', 'today-active', 'week-with-due', 'no-due']);
+
+    const monthTasks = await service.listTasksByTab('month');
+    expect(monthTasks.at(-1)?.id).toBe('no-due');
   });
 
   it('loads long-term goals（加载长期目标）', async () => {
@@ -128,4 +178,3 @@ describe('task service（任务服务）', () => {
     });
   });
 });
-

--- a/tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx
@@ -7,6 +7,11 @@ import { AGENT_HUB_MOCK_FIXTURE } from '@/lib/adapters/mock/fixtures/agent-hub';
 const serviceMocks = vi.hoisted(() => ({
   getAgentDetail: vi.fn(),
   getActorDetail: vi.fn(),
+  navigate: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => serviceMocks.navigate,
 }));
 
 vi.mock('@/lib/services', () => ({
@@ -20,6 +25,7 @@ describe('agent/actor detail pages issue-204（详情页）', () => {
   beforeEach(() => {
     serviceMocks.getAgentDetail.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.agentDetails['agent-daily']);
     serviceMocks.getActorDetail.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.actorDetails['actor-timer']);
+    serviceMocks.navigate.mockReset();
   });
 
   it('renders agent detail sections and chat CTA（Agent 详情区块与对话入口）', async () => {
@@ -36,6 +42,12 @@ describe('agent/actor detail pages issue-204（详情页）', () => {
     expect(screen.getByText('输出目标')).toBeInTheDocument();
     expect(screen.getByTestId('agent-detail-chat-button')).toBeInTheDocument();
     expect(screen.getByTestId('agent-detail-page').className).toContain('dark:bg-[#0C0A09]');
+
+    screen.getByTestId('agent-detail-chat-button').click();
+    expect(serviceMocks.navigate).toHaveBeenCalledWith({
+      to: '/agents/chat/$agentId',
+      params: { agentId: 'agent-daily' },
+    });
   });
 
   it('renders actor detail sections（Actor 详情区块）', async () => {

--- a/tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx
@@ -9,6 +9,11 @@ const serviceMocks = vi.hoisted(() => ({
   streamConversation: vi.fn(),
   listMarketCategories: vi.fn(),
   getMarketItems: vi.fn(),
+  navigate: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => serviceMocks.navigate,
 }));
 
 vi.mock('@/lib/services', () => ({
@@ -29,6 +34,7 @@ describe('agent chat and market issue-204（对话与市场）', () => {
     });
     serviceMocks.listMarketCategories.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.marketCategories);
     serviceMocks.getMarketItems.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.marketItems);
+    serviceMocks.navigate.mockReset();
   });
 
   it('renders chat history and streaming response（加载历史并流式输出）', async () => {
@@ -63,5 +69,8 @@ describe('agent chat and market issue-204（对话与市场）', () => {
     expect(screen.getByText('热门推荐')).toBeInTheDocument();
     expect(screen.getByText('Code Review Agent')).toBeInTheDocument();
     expect(screen.getByText('Google Calendar 数据源')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '返回' }));
+    expect(serviceMocks.navigate).toHaveBeenCalledWith({ to: '/agents' });
   });
 });

--- a/tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
@@ -8,6 +8,11 @@ const serviceMocks = vi.hoisted(() => ({
   getListView: vi.fn(),
   getDeviceView: vi.fn(),
   listAddNodeOptions: vi.fn(),
+  navigate: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => serviceMocks.navigate,
 }));
 
 vi.mock('@/lib/services', () => ({
@@ -25,6 +30,7 @@ describe('agents page issue-204（主页面三视图与添加节点）', () => {
     serviceMocks.getListView.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.listSections);
     serviceMocks.getDeviceView.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.deviceGroups);
     serviceMocks.listAddNodeOptions.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.addNodeOptions);
+    serviceMocks.navigate.mockReset();
   });
 
   it('switches topology/list/device views（支持拓扑/列表/设备切换）', async () => {
@@ -63,6 +69,19 @@ describe('agents page issue-204（主页面三视图与添加节点）', () => {
 
     fireEvent.click(screen.getByTestId('agent-add-node-close'));
     expect(screen.queryByTestId('agent-add-node-sheet')).not.toBeInTheDocument();
+  });
+
+  it('navigates to market via router navigation（从弹窗跳转市场页）', async () => {
+    render(<AgentsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-topology-view')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('agent-add-node-button'));
+    fireEvent.click(screen.getByTestId('agent-add-node-option-market'));
+
+    expect(serviceMocks.navigate).toHaveBeenCalledWith({ to: '/agents/market' });
   });
 
   it('keeps dark-mode classes on key surfaces（关键区域包含暗色样式类）', async () => {

--- a/tests/unit/ui/new-task-pages.issue213.test.tsx
+++ b/tests/unit/ui/new-task-pages.issue213.test.tsx
@@ -1,19 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MOCK_TASK_GOAL_GROUPS_FIXTURE } from '@/lib/adapters/mock/fixtures/tasks';
 import { NewTaskTimerCard } from '@/ui/new/components/NewTaskTimerCard';
 import { NewTasksPage } from '@/ui/new/pages/NewTasksPage';
 import type { TaskItem } from '@/lib/types/task';
 
-const listTasksMock = vi.fn();
-const longTermGoalsMock = vi.fn();
+const listTasksByTabMock = vi.fn();
 const createTaskMock = vi.fn();
 
 vi.mock('@/lib/services', () => ({
   getTaskService: () => ({
-    listTasks: listTasksMock,
-    getLongTermGoals: longTermGoalsMock,
+    listTasksByTab: listTasksByTabMock,
     createTask: createTaskMock,
+    listTasks: vi.fn(),
+    getLongTermGoals: vi.fn(),
     getTask: vi.fn(),
     setTimerMode: vi.fn(),
     pauseTask: vi.fn(),
@@ -26,6 +25,7 @@ const sampleTask: TaskItem = {
   id: 'task-1',
   title: '完成 Task List 视图设计',
   status: 'in_progress',
+  dueAt: '2026-02-25T10:00:00.000Z',
   progress: 45,
   createdAt: '2026-02-23T00:00:00.000Z',
   updatedAt: '2026-02-23T00:00:00.000Z',
@@ -40,11 +40,12 @@ const sampleTask: TaskItem = {
 
 describe('issue-213 task ui pages（任务页面还原）', () => {
   beforeEach(() => {
-    listTasksMock.mockReset();
-    longTermGoalsMock.mockReset();
+    listTasksByTabMock.mockReset();
     createTaskMock.mockReset();
-    listTasksMock.mockResolvedValue([sampleTask]);
-    longTermGoalsMock.mockResolvedValue(MOCK_TASK_GOAL_GROUPS_FIXTURE);
+    listTasksByTabMock.mockImplementation(async (tab: string) => {
+      if (tab === 'today') return [];
+      return [sampleTask];
+    });
     createTaskMock.mockResolvedValue(sampleTask);
   });
 
@@ -74,45 +75,29 @@ describe('issue-213 task ui pages（任务页面还原）', () => {
     expect(factInput).toBeInTheDocument();
   });
 
-  it('renders task list page and quick-add input（任务列表页与快速输入）', async () => {
+  it('renders task list tabs and quick-add input（任务列表与快速输入）', async () => {
     render(<NewTasksPage />);
     expect(screen.getByText('任务')).toBeInTheDocument();
     expect(screen.getByText('当下')).toBeInTheDocument();
     expect(screen.getByText('今日')).toBeInTheDocument();
+    expect(screen.getByText('一周')).toBeInTheDocument();
+    expect(screen.getByText('月')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('快速添加任务...')).toBeInTheDocument();
 
     await waitFor(() => {
       expect(screen.getByText('完成 Task List 视图设计')).toBeInTheDocument();
     });
+
+    expect(listTasksByTabMock).toHaveBeenCalledWith('now');
   });
 
-  it('renders long-term goals from pencil fixture（长期页渲染设计稿数据）', async () => {
+  it('shows tab-specific empty state（按标签展示空状态）', async () => {
     render(<NewTasksPage />);
-    fireEvent.click(screen.getByRole('button', { name: '长期' }));
+    fireEvent.click(screen.getByRole('button', { name: '今日' }));
 
     await waitFor(() => {
-      expect(screen.getByTestId('tasks-goals-content')).toBeInTheDocument();
-      expect(screen.getByText('商业项目')).toBeInTheDocument();
-      expect(screen.getByText('Exomind v0.3 发布')).toBeInTheDocument();
-      expect(screen.getByText('科学研究')).toBeInTheDocument();
-      expect(screen.getByText('人工认知生命理论')).toBeInTheDocument();
-      expect(screen.getByText('知识学习')).toBeInTheDocument();
-      expect(screen.getByText('眼睛健康')).toBeInTheDocument();
+      expect(screen.getByText('今天还没有需要推进的任务。')).toBeInTheDocument();
     });
-  });
-
-  it('applies dark-mode classes for long-term goals section（长期区域暗色模式样式）', async () => {
-    render(<NewTasksPage />);
-    fireEvent.click(screen.getByRole('button', { name: '长期' }));
-
-    await waitFor(() => {
-      const group = screen.getByTestId('tasks-goals-group-goal-group-business');
-      const card = screen.getByTestId('tasks-goal-card-goal-biz-exomind-release');
-
-      expect(group.className).toContain('dark:text-[#FAFAF9]');
-      expect(card.className).toContain('dark:border-[#3A3432]');
-      expect(card.className).toContain('dark:bg-[#1C1917]');
-    });
+    expect(listTasksByTabMock).toHaveBeenCalledWith('today');
   });
 });
-


### PR DESCRIPTION
## 背景与来龙去脉
近期项目在 UI 方向上的共识已比较明确：

- #224 指出当前状态是“新 UI 架构可行，但实现仍未完全收口”，旧 UI 退场仍有阻塞项。
- #225 将“新 UI 设为默认”定义为下一阶段里程碑，但需要先完成关键能力补齐并降低迁移风险。
- #239 进一步把近期主线收敛为：`新UI收口 + 同步一致 + 架构最小闭环`，避免长期双轨带来的维护与回归成本。

在这个背景下，本 PR 不新增新主题，而是把 `#204 (Agent Hub)` 与 `#213 (Task UI)` 里已经明确的收敛工作先做实，并保证可测试、可回归。

## 本 PR 在主线中的定位
这是一个“新 UI 收敛增量 PR（Draft）”，目标是减少双轨迁移中的技术噪音，优先统一两条具体能力线：

1. Task 页签规则下沉到 Service（对应 #213 子议题 #233）
2. Agent Hub 页面跳转统一走 Router（对应 #204 子议题 #235）

> 选择放在同一分支/同一 PR，是为了避免跨 PR 依赖导致阶段性不兼容（同批页面与测试强相关）。

## 变更范围
### A. Task（#213 / #233）
- `TaskService` 新增 `listTasksByTab(tab)`，把 `now/today/week/month` 规则下沉到服务层。
- 新增 `dueAt` 字段并固化排序行为（无截止任务在 week/month 视图置底）。
- `NewTasksPage` 从“前端切片”改为“按 tab 拉取服务数据”，并移除 `Goals/长期` tab 渲染。
- 同步更新 mock fixtures 与相关测试。

### B. Agent Hub（#204 / #235）
- 主页与子页导航从 `window.location.href` / `window.history.back()` 迁移到 TanStack Router `useNavigate`。
- 覆盖页面：主页、详情、Actor 详情、对话页、市场页。
- 同步补充关键跳转行为的单测断言。

## 关联议题
- Relates to #204
- Relates to #213
- Relates to #233
- Relates to #235
- Context: #224 #225 #239

## 验证
已执行：
- `npx tsc --noEmit` ✅
- `npx vitest run tests/unit/services/task.service.test.ts tests/unit/ui/new-task-pages.issue213.test.tsx tests/unit/ui/agent-hub/agents-page.issue204.test.tsx tests/unit/ui/agent-hub/agent-chat-market.issue204.test.tsx tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx` ✅（23 tests passed）

当前环境限制：
- `bun run build` ⛔ 当前 shell 环境无 `bun`
- Playwright E2E ⛔ 当前设备平台报 `Unsupported platform: android`

## 非目标（本 PR 不包含）
- 语音链路补齐（#199）
- 新 UI 默认值切换（#225）
- 旧 UI 退场清理（#224 后续动作）
- Agent/Task 后端模型与真实服务闭环（#205 / #214）

## 下一步建议
1. 在具备 `bun` + 可运行浏览器驱动的环境补齐 `build` 与 E2E 证据。
2. 以 #199 为优先收敛语音阻塞项，再推进 #225 的默认切换。
3. 待本 PR 稳定后，继续执行 #224 中的旧 UI 退场清单。
