### PR TITLE
fix(ui): command palette scroll sync + toggle entry optimization (issue #243)

### DIFF
--- a/src/ui/new/components/CommandPalette.tsx
+++ b/src/ui/new/components/CommandPalette.tsx
@@ -15,6 +15,7 @@ export function CommandPalette({ context }: CommandPaletteProps) {
   const [paletteState, setPaletteState] = useState(() => paletteService.getState());
   const [errorMessage, setErrorMessage] = useState('');
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     return paletteService.subscribe(setPaletteState);
@@ -49,6 +50,18 @@ export function CommandPalette({ context }: CommandPaletteProps) {
       paletteService.setHighlightedIndex(0);
     }
   }, [commands.length, paletteService, paletteState.highlightedIndex, paletteState.open]);
+
+  useEffect(() => {
+    if (!paletteState.open || paletteState.highlightedIndex < 0 || commands.length === 0) {
+      return;
+    }
+
+    const activeItem = listRef.current?.querySelector<HTMLElement>('[data-active="true"]');
+    activeItem?.scrollIntoView({
+      block: 'nearest',
+      inline: 'nearest',
+    });
+  }, [commands, paletteState.highlightedIndex, paletteState.open]);
 
   const highlighted = paletteState.highlightedIndex >= 0
     ? commands[paletteState.highlightedIndex] ?? null
@@ -139,7 +152,11 @@ export function CommandPalette({ context }: CommandPaletteProps) {
           </label>
         </div>
 
-        <div className="max-h-[320px] overflow-y-auto p-2" data-testid="command-palette-list">
+        <div
+          ref={listRef}
+          className="max-h-[320px] overflow-y-auto p-2"
+          data-testid="command-palette-list"
+        >
           {commands.length === 0 ? (
             <div className="rounded-xl border border-dashed border-[#D6D3D1] px-3 py-4 text-center text-xs text-[#A8A29E] dark:border-[#3A3432] dark:text-[#B8B1AC]">
               未找到匹配命令
@@ -153,6 +170,7 @@ export function CommandPalette({ context }: CommandPaletteProps) {
                   <li key={command.id}>
                     <button
                       type="button"
+                      data-active={active ? 'true' : undefined}
                       data-testid={`command-palette-item-${command.id}`}
                       disabled={!command.available}
                       onClick={() => {

--- a/src/ui/new/pages/NewSettingsPage.tsx
+++ b/src/ui/new/pages/NewSettingsPage.tsx
@@ -63,6 +63,7 @@ import {
   Check,
   ChevronRight,
   Code,
+  Command,
   Download,
   Monitor,
   Moon,
@@ -703,18 +704,6 @@ export function NewSettingsPage() {
                   onClick={() => setFeatureTogglesDialogOpen(true)}
                   right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
                 />
-                <Divider />
-                <SettingRow
-                  icon={<Code className="h-[18px] w-[18px] text-[#78716C]" />}
-                  label="命令面板（测试）"
-                  right={
-                    <Switch
-                      data-testid="new-settings-command-palette-switch"
-                      checked={commandPaletteEnabled}
-                      onCheckedChange={handleCommandPaletteToggle}
-                    />
-                  }
-                />
               </>
             )}
           </SectionCard>
@@ -874,10 +863,28 @@ export function NewSettingsPage() {
             <p className="mt-1 text-center text-xs text-[#A8A29E]">启用或关闭实验性功能</p>
             <div className="mt-4 space-y-2">
               <div className="flex items-center justify-between rounded-xl border border-[#F0ECE8] px-4 py-3 dark:border-[#292524]">
-                <span className="text-sm text-[#1C1917] dark:text-[#FAFAF9]">Agent 页面</span>
+                <div className="flex items-center gap-2">
+                  <Bot className="h-[16px] w-[16px] text-[#78716C]" />
+                  <span className="text-sm text-[#1C1917] dark:text-[#FAFAF9]">Agent 页面</span>
+                </div>
                 <Switch
+                  data-testid="feature-toggle-agent-page-switch"
                   checked={agentPageEnabled}
                   onCheckedChange={handleAgentPageEnabledToggle}
+                />
+              </div>
+              <div
+                className="flex items-center justify-between rounded-xl border border-[#F0ECE8] px-4 py-3 dark:border-[#292524]"
+                data-testid="feature-toggle-command-palette-row"
+              >
+                <div className="flex items-center gap-2">
+                  <Command className="h-[16px] w-[16px] text-[#78716C]" />
+                  <span className="text-sm text-[#1C1917] dark:text-[#FAFAF9]">命令面板</span>
+                </div>
+                <Switch
+                  data-testid="feature-toggle-command-palette-switch"
+                  checked={commandPaletteEnabled}
+                  onCheckedChange={handleCommandPaletteToggle}
                 />
               </div>
             </div>

--- a/tests/unit/components/settings/DeveloperSection.test.tsx
+++ b/tests/unit/components/settings/DeveloperSection.test.tsx
@@ -8,6 +8,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import './setup-settings-mocks.tsx';
 import { getDeveloperModeEnabled } from '@/config/developer-mode';
 import { setDevtoolsEnabled } from '@/config/devtools-mode';
+import { setCommandPaletteEnabled } from '@/config/command-palette-enabled';
 import { syncDevtoolsWithSettings } from '@/lib/debug/devtools-runtime';
 import { NewSettingsPage } from '@/ui/new/pages/NewSettingsPage';
 
@@ -26,6 +27,7 @@ describe('NewSettingsPage - Developer Section (developerMode=true)', () => {
     const row = screen.getByText('功能开关');
     fireEvent.click(row);
     expect(screen.getByText('Agent 页面')).toBeInTheDocument();
+    expect(screen.getByText('命令面板')).toBeInTheDocument();
   });
 
   it('renders mock data toggle', () => {
@@ -44,5 +46,15 @@ describe('NewSettingsPage - Developer Section (developerMode=true)', () => {
     fireEvent.click(toggle);
     expect(vi.mocked(setDevtoolsEnabled)).toHaveBeenCalledWith(true);
     expect(vi.mocked(syncDevtoolsWithSettings)).toHaveBeenCalled();
+  });
+
+  it('updates command palette state inside feature toggles drawer', () => {
+    render(<NewSettingsPage />);
+    fireEvent.click(screen.getByText('功能开关'));
+
+    const toggle = screen.getByTestId('feature-toggle-command-palette-switch');
+    fireEvent.click(toggle);
+
+    expect(vi.mocked(setCommandPaletteEnabled)).toHaveBeenCalledWith(true);
   });
 });

--- a/tests/unit/components/settings/setup-settings-mocks.tsx
+++ b/tests/unit/components/settings/setup-settings-mocks.tsx
@@ -69,6 +69,12 @@ vi.mock('@/config/devtools-mode', () => ({
   subscribeDevtoolsChanges: vi.fn(() => () => {}),
 }));
 
+vi.mock('@/config/command-palette-enabled', () => ({
+  getCommandPaletteEnabled: vi.fn(() => false),
+  setCommandPaletteEnabled: vi.fn(),
+  subscribeCommandPaletteEnabledChanges: vi.fn(() => () => {}),
+}));
+
 vi.mock('@/lib/debug/devtools-runtime', () => ({
   syncDevtoolsWithSettings: vi.fn().mockResolvedValue(undefined),
 }));

--- a/tests/unit/ui/command-palette-scroll.issue243.test.tsx
+++ b/tests/unit/ui/command-palette-scroll.issue243.test.tsx
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { CommandPalette } from '@/ui/new/components/CommandPalette';
+import type { CommandContext } from '@/lib/types/command-palette';
+
+type PaletteState = {
+  open: boolean;
+  query: string;
+  highlightedIndex: number;
+};
+
+const mocks = vi.hoisted(() => {
+  const listeners = new Set<(state: PaletteState) => void>();
+  const initialState: PaletteState = {
+    open: false,
+    query: '',
+    highlightedIndex: 0,
+  };
+
+  let state: PaletteState = { ...initialState };
+
+  const emit = () => {
+    for (const listener of listeners) {
+      listener(state);
+    }
+  };
+
+  const paletteService = {
+    getState: () => state,
+    subscribe: (listener: (next: PaletteState) => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    open: (initialQuery = '') => {
+      state = {
+        open: true,
+        query: initialQuery,
+        highlightedIndex: 0,
+      };
+      emit();
+    },
+    close: () => {
+      state = { ...initialState };
+      emit();
+    },
+    toggle: (initialQuery = '') => {
+      if (state.open) {
+        paletteService.close();
+        return;
+      }
+      paletteService.open(initialQuery);
+    },
+    setQuery: (query: string) => {
+      state = {
+        ...state,
+        query,
+        highlightedIndex: 0,
+      };
+      emit();
+    },
+    setHighlightedIndex: (index: number) => {
+      state = {
+        ...state,
+        highlightedIndex: Math.max(-1, Math.trunc(index)),
+      };
+      emit();
+    },
+    moveHighlight: (delta: number, itemCount: number) => {
+      if (itemCount <= 0) {
+        paletteService.setHighlightedIndex(-1);
+        return;
+      }
+      const baseIndex = state.highlightedIndex < 0 ? 0 : state.highlightedIndex;
+      const nextIndex = (baseIndex + delta + itemCount) % itemCount;
+      paletteService.setHighlightedIndex(nextIndex);
+    },
+  };
+
+  return {
+    paletteService,
+    commands: [
+      {
+        id: 'navigate:now',
+        title: '打开当下',
+        description: '跳转到当下页面',
+        category: 'navigation',
+        permissionTier: 'safe',
+        aliases: ['now'],
+        keywords: ['eventlog'],
+        available: true,
+        score: 10,
+      },
+      {
+        id: 'navigate:tasks',
+        title: '打开任务',
+        description: '跳转到任务页面',
+        category: 'navigation',
+        permissionTier: 'safe',
+        aliases: ['tasks'],
+        keywords: ['todo'],
+        available: true,
+        score: 9,
+      },
+      {
+        id: 'navigate:settings',
+        title: '打开设置',
+        description: '跳转到设置页面',
+        category: 'navigation',
+        permissionTier: 'safe',
+        aliases: ['settings'],
+        keywords: ['config'],
+        available: true,
+        score: 8,
+      },
+    ],
+    execute: vi.fn(async () => ({ ok: true as const })),
+  };
+});
+
+vi.mock('@/lib/services/command-palette.service', () => ({
+  getCommandPaletteService: () => mocks.paletteService,
+}));
+
+vi.mock('@/lib/services/command-registry.service', () => ({
+  getCommandRegistryService: () => ({
+    search: () => mocks.commands,
+    execute: mocks.execute,
+  }),
+}));
+
+describe('command palette scroll sync issue-243（高亮项滚动同步）', () => {
+  const context: CommandContext = {
+    currentPath: '/tasks',
+    platform: 'web',
+    developerModeEnabled: true,
+    commandPaletteEnabled: true,
+    featureFlags: {
+      agentPageEnabled: true,
+      goalsV2Enabled: false,
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.paletteService.close();
+    mocks.paletteService.open('');
+  });
+
+  it('scrolls highlighted item into view when arrow navigation changes focus（键盘切换高亮时触发滚动）', async () => {
+    const scrollIntoViewMock = vi.mocked(Element.prototype.scrollIntoView);
+    render(<CommandPalette context={context} />);
+
+    const input = await screen.findByTestId('command-palette-input');
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalled();
+      expect(screen.getByTestId('command-palette-item-navigate:now')).toHaveAttribute('data-active', 'true');
+    });
+
+    const beforeMoveCalls = scrollIntoViewMock.mock.calls.length;
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('command-palette-item-navigate:tasks')).toHaveAttribute('data-active', 'true');
+      expect(scrollIntoViewMock.mock.calls.length).toBeGreaterThan(beforeMoveCalls);
+    });
+
+    const lastCallOptions = scrollIntoViewMock.mock.calls.at(-1)?.[0] as ScrollIntoViewOptions | undefined;
+    expect(lastCallOptions).toMatchObject({
+      block: 'nearest',
+      inline: 'nearest',
+    });
+  });
+});


### PR DESCRIPTION
## 变更摘要
- 修复命令面板键盘高亮切换时列表不跟随滚动的问题（高亮项自动 `scrollIntoView`）。
- 将“命令面板”开关从开发者主列表移动到“功能开关”抽屉。
- 功能开关抽屉中的“命令面板”改为 `Command`（⌘）图标展示。
- 补充对应单测，覆盖滚动同步与设置入口变更。

## 关联
- refs #243

## 测试证据
- `npx vitest run tests/unit/ui/command-palette-scroll.issue243.test.tsx tests/unit/components/settings/DeveloperSection.test.tsx tests/unit/ui/new-task-command-palette.issue243.test.tsx tests/unit/ui/page-more-menu.issue243.test.tsx tests/unit/config/command-palette-enabled.test.ts`
  - 结果：`5 passed, 14 passed`
- `npx tsc --noEmit`
  - 结果：通过

## 风险与回归点
- 仅涉及命令面板组件与设置页功能开关 UI，不影响业务数据结构。
- 已通过 command-palette 相关回归测试验证。
