### PR TITLE
feat(Android): 通知栏快速管理时间块（类滴答清单）(#249)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@radix-ui/react-toast": "^1.2.15",
         "@tanstack/react-router": "^1.158.0",
         "@tauri-apps/api": "^2",
+        "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-opener": "^2",
         "agentation-mcp": "^1.2.0",
         "baseline-browser-mapping": "^2.10.0",
@@ -2326,6 +2327,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-notification": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.3.tgz",
+      "integrity": "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-opener": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@radix-ui/react-toast": "^1.2.15",
     "@tanstack/react-router": "^1.158.0",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2",
     "agentation-mcp": "^1.2.0",
     "baseline-browser-mapping": "^2.10.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-clipboard-manager = "2"
+tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
     "opener:default",
     "clipboard-manager:allow-read-text",
     "clipboard-manager:allow-write-text",
+    "notification:default",
     "mcp-bridge:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_notification::init())
         .manage(ws_client_state.clone())
         .invoke_handler(tauri::generate_handler![
             greet,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,16 @@
 import { RouterProvider } from "@tanstack/react-router";
+import { useEffect } from "react";
 import { newUiRouter } from "@/routes-new";
 import { ThemeController } from "@/components/ThemeController";
 import { Toaster } from "@/components/ui/toaster";
+import { bindTimeBlockNotificationBridge } from "@/lib/services/timeblock-notification.service";
 import "./App.css";
 
 function App() {
+  useEffect(() => {
+    return bindTimeBlockNotificationBridge();
+  }, []);
+
   return (
     <>
       <ThemeController />

--- a/src/components/Chat/ChatPage.tsx
+++ b/src/components/Chat/ChatPage.tsx
@@ -35,6 +35,11 @@ import {
   normalizeStorageEventsAscending,
   prependOlderEventsAscending,
 } from './chat-event-pagination';
+import {
+  consumePendingTimeBlockNotificationAction,
+  subscribeTimeBlockNotificationAction,
+} from '@/lib/services/timeblock-notification-dispatcher';
+import { applyTimeBlockNotificationActionToWidget } from '@/lib/services/timeblock-notification-ui-action';
 
 const PAGE_SIZE = 50;
 const TOP_LOAD_THRESHOLD = 40;
@@ -302,6 +307,26 @@ export function ChatPage({ variant = 'default', hideHeader = false }: ChatPagePr
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [variant]);
+
+  useEffect(() => {
+    const resolveTimerWidget = () => (
+      variant === 'new-mobile'
+        ? newFocusTimerWidgetRef.current
+        : timeBlockWidgetRef.current
+    );
+
+    const handleAction = (action: 'start' | 'pause' | 'resume' | 'end' | 'open') => {
+      void applyTimeBlockNotificationActionToWidget(action, resolveTimerWidget());
+    };
+
+    const unsubscribe = subscribeTimeBlockNotificationAction(handleAction);
+    const pendingAction = consumePendingTimeBlockNotificationAction();
+    if (pendingAction) {
+      handleAction(pendingAction);
+    }
+
+    return unsubscribe;
   }, [variant]);
 
   // 格式化时间

--- a/src/config/timeblock-notification-enabled.ts
+++ b/src/config/timeblock-notification-enabled.ts
@@ -1,0 +1,54 @@
+const TIMEBLOCK_NOTIFICATION_ENABLED_STORAGE_KEY = 'exomind:timeblockNotificationEnabled';
+const TIMEBLOCK_NOTIFICATION_ENABLED_CHANGED_EVENT = 'exomind:timeblock-notification-enabled-changed';
+
+function normalizeBoolean(rawValue: string | null | undefined): boolean {
+  return rawValue === 'true';
+}
+
+function getStorage():
+  | Pick<Storage, 'getItem' | 'setItem'>
+  | null {
+  if (typeof window === 'undefined') return null;
+  const localStorageLike = window.localStorage as Partial<Storage> | undefined;
+  if (!localStorageLike) return null;
+  if (typeof localStorageLike.getItem !== 'function') return null;
+  if (typeof localStorageLike.setItem !== 'function') return null;
+  return localStorageLike as Pick<Storage, 'getItem' | 'setItem'>;
+}
+
+export function getTimeblockNotificationEnabled(): boolean {
+  const storage = getStorage();
+  if (!storage) return false;
+  return normalizeBoolean(storage.getItem(TIMEBLOCK_NOTIFICATION_ENABLED_STORAGE_KEY));
+}
+
+export function setTimeblockNotificationEnabled(enabled: boolean): void {
+  const storage = getStorage();
+  if (!storage) return;
+  storage.setItem(TIMEBLOCK_NOTIFICATION_ENABLED_STORAGE_KEY, String(enabled));
+  window.dispatchEvent(new CustomEvent<boolean>(TIMEBLOCK_NOTIFICATION_ENABLED_CHANGED_EVENT, { detail: enabled }));
+}
+
+export function subscribeTimeblockNotificationEnabledChanges(listener: (enabled: boolean) => void): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key !== TIMEBLOCK_NOTIFICATION_ENABLED_STORAGE_KEY) return;
+    listener(normalizeBoolean(event.newValue));
+  };
+
+  const handleCustomEvent = (event: Event) => {
+    const customEvent = event as CustomEvent<boolean>;
+    listener(Boolean(customEvent.detail));
+  };
+
+  window.addEventListener('storage', handleStorage);
+  window.addEventListener(TIMEBLOCK_NOTIFICATION_ENABLED_CHANGED_EVENT, handleCustomEvent);
+
+  return () => {
+    window.removeEventListener('storage', handleStorage);
+    window.removeEventListener(TIMEBLOCK_NOTIFICATION_ENABLED_CHANGED_EVENT, handleCustomEvent);
+  };
+}

--- a/src/lib/services/timeblock-notification-dispatcher.ts
+++ b/src/lib/services/timeblock-notification-dispatcher.ts
@@ -1,0 +1,35 @@
+export type TimeBlockNotificationAction = 'start' | 'pause' | 'resume' | 'end' | 'open';
+
+const TIMEBLOCK_NOTIFICATION_ACTION_EVENT = 'exomind:timeblock-notification-action';
+
+let pendingAction: TimeBlockNotificationAction | null = null;
+
+export function dispatchTimeBlockNotificationAction(action: TimeBlockNotificationAction): void {
+  pendingAction = action;
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent<TimeBlockNotificationAction>(TIMEBLOCK_NOTIFICATION_ACTION_EVENT, { detail: action }));
+}
+
+export function subscribeTimeBlockNotificationAction(listener: (action: TimeBlockNotificationAction) => void): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const handleEvent = (event: Event) => {
+    const customEvent = event as CustomEvent<TimeBlockNotificationAction>;
+    if (!customEvent.detail) return;
+    listener(customEvent.detail);
+  };
+
+  window.addEventListener(TIMEBLOCK_NOTIFICATION_ACTION_EVENT, handleEvent);
+  return () => {
+    window.removeEventListener(TIMEBLOCK_NOTIFICATION_ACTION_EVENT, handleEvent);
+  };
+}
+
+export function consumePendingTimeBlockNotificationAction(): TimeBlockNotificationAction | null {
+  const action = pendingAction;
+  pendingAction = null;
+  return action;
+}
+

--- a/src/lib/services/timeblock-notification-ui-action.ts
+++ b/src/lib/services/timeblock-notification-ui-action.ts
@@ -1,0 +1,42 @@
+import type { TimeBlockNotificationAction } from './timeblock-notification-dispatcher';
+
+export interface TimeBlockActionWidgetHandle {
+  expandAndFocusTaskName: () => void;
+  getTimerState: () => 'idle' | 'running' | 'paused' | 'ended';
+  pauseOrResume: () => Promise<void>;
+  endDialog: () => void;
+}
+
+export async function applyTimeBlockNotificationActionToWidget(
+  action: TimeBlockNotificationAction,
+  widget: TimeBlockActionWidgetHandle | null,
+): Promise<void> {
+  if (!widget) return;
+
+  const timerState = widget.getTimerState();
+
+  if (action === 'start') {
+    widget.expandAndFocusTaskName();
+    return;
+  }
+
+  if (action === 'pause') {
+    if (timerState === 'running') {
+      await widget.pauseOrResume();
+    }
+    return;
+  }
+
+  if (action === 'resume') {
+    if (timerState === 'paused') {
+      await widget.pauseOrResume();
+    }
+    return;
+  }
+
+  if (action === 'end') {
+    if (timerState === 'running' || timerState === 'paused') {
+      widget.endDialog();
+    }
+  }
+}

--- a/src/lib/services/timeblock-notification.service.ts
+++ b/src/lib/services/timeblock-notification.service.ts
@@ -1,0 +1,281 @@
+import { isTauri } from '@tauri-apps/api/core';
+import {
+  getTimeblockNotificationEnabled,
+  subscribeTimeblockNotificationEnabledChanges,
+} from '@/config/timeblock-notification-enabled';
+import type { ActiveBlockData } from '@/lib/types/event';
+import { getTimeBlockService, type TimeBlockService } from './timeblock.service';
+import {
+  dispatchTimeBlockNotificationAction,
+  type TimeBlockNotificationAction,
+} from './timeblock-notification-dispatcher';
+
+export const TIMEBLOCK_NOTIFICATION_ID = 249001;
+export const TIMEBLOCK_NOTIFICATION_SCOPE = 'timeblock';
+export const TIMEBLOCK_NOTIFICATION_ACTION_TYPE = {
+  idle: 'timeblock-idle',
+  running: 'timeblock-running',
+  paused: 'timeblock-paused',
+} as const;
+
+type TimeBlockNotificationMode = keyof typeof TIMEBLOCK_NOTIFICATION_ACTION_TYPE;
+
+type PermissionState = 'default' | 'denied' | 'granted' | 'prompt' | 'prompt-with-rationale';
+
+type ActionType = {
+  id: string;
+  actions: Array<{ id: string; title: string }>;
+};
+
+type NotificationOptions = {
+  id?: number;
+  title?: string;
+  body?: string;
+  actionTypeId?: string;
+  ongoing?: boolean;
+  autoCancel?: boolean;
+  extra?: Record<string, unknown>;
+};
+
+type Unlisten = (() => void) | { unlisten?: () => void; unregister?: () => void };
+
+type NotificationPlugin = {
+  isPermissionGranted: () => Promise<boolean>;
+  requestPermission: () => Promise<PermissionState>;
+  registerActionTypes: (types: ActionType[]) => Promise<void>;
+  sendNotification: (options: NotificationOptions | string) => void;
+  onAction: (cb: (payload: unknown) => void) => Promise<Unlisten>;
+  removeActive?: (ids: number[]) => Promise<void>;
+};
+
+type RuntimeInfo = {
+  isTauriRuntime: boolean;
+  isAndroid: boolean;
+};
+
+export type TimeBlockNotificationModel = {
+  mode: TimeBlockNotificationMode;
+  title: string;
+  body: string;
+  actionTypeId: string;
+};
+
+export function resolveTimeBlockNotificationModel(block: ActiveBlockData | null): TimeBlockNotificationModel {
+  if (!block) {
+    return {
+      mode: 'idle',
+      title: '时间块 · 待开始',
+      body: '暂无进行中时间块',
+      actionTypeId: TIMEBLOCK_NOTIFICATION_ACTION_TYPE.idle,
+    };
+  }
+
+  if (block.paused) {
+    return {
+      mode: 'paused',
+      title: '时间块已暂停',
+      body: block.name,
+      actionTypeId: TIMEBLOCK_NOTIFICATION_ACTION_TYPE.paused,
+    };
+  }
+
+  return {
+    mode: 'running',
+    title: '时间块进行中',
+    body: block.name,
+    actionTypeId: TIMEBLOCK_NOTIFICATION_ACTION_TYPE.running,
+  };
+}
+
+export function resolveNotificationActionFromPayload(payload: unknown): TimeBlockNotificationAction | null {
+  if (!payload || typeof payload !== 'object') return null;
+
+  const data = payload as {
+    actionId?: unknown;
+    notification?: {
+      extra?: Record<string, unknown>;
+    };
+  };
+
+  const scope = data.notification?.extra?.scope;
+  if (scope && scope !== TIMEBLOCK_NOTIFICATION_SCOPE) {
+    return null;
+  }
+
+  const actionId = typeof data.actionId === 'string' ? data.actionId : '';
+
+  if (actionId === 'tap') return 'open';
+  if (actionId === 'start') return 'start';
+  if (actionId === 'pause') return 'pause';
+  if (actionId === 'resume') return 'resume';
+  if (actionId === 'end') return 'end';
+  if (actionId === 'open') return 'open';
+
+  return null;
+}
+
+function resolveUnlisten(listener: Unlisten): () => void {
+  if (typeof listener === 'function') return listener;
+  if (typeof listener.unlisten === 'function') return listener.unlisten.bind(listener);
+  if (typeof listener.unregister === 'function') return listener.unregister.bind(listener);
+  return () => {};
+}
+
+async function resolveRuntimeInfo(): Promise<RuntimeInfo> {
+  const isTauriRuntime = await isTauri();
+  const userAgent = typeof navigator === 'undefined' ? '' : navigator.userAgent;
+  return {
+    isTauriRuntime,
+    isAndroid: /android/i.test(userAgent),
+  };
+}
+
+async function loadNotificationPlugin(): Promise<NotificationPlugin> {
+  const module = await import('@tauri-apps/plugin-notification');
+  return module as unknown as NotificationPlugin;
+}
+
+const TIMEBLOCK_NOTIFICATION_ACTION_TYPES: ActionType[] = [
+  {
+    id: TIMEBLOCK_NOTIFICATION_ACTION_TYPE.idle,
+    actions: [
+      { id: 'start', title: '开始' },
+      { id: 'open', title: '打开 App' },
+    ],
+  },
+  {
+    id: TIMEBLOCK_NOTIFICATION_ACTION_TYPE.running,
+    actions: [
+      { id: 'pause', title: '暂停' },
+      { id: 'end', title: '结束' },
+      { id: 'open', title: '打开 App' },
+    ],
+  },
+  {
+    id: TIMEBLOCK_NOTIFICATION_ACTION_TYPE.paused,
+    actions: [
+      { id: 'resume', title: '继续' },
+      { id: 'end', title: '结束' },
+      { id: 'open', title: '打开 App' },
+    ],
+  },
+];
+
+export class TimeBlockNotificationServiceImpl {
+  private readonly timeBlockService: TimeBlockService;
+  private readonly runtimeInfoProvider: () => Promise<RuntimeInfo>;
+  private readonly notificationPluginLoader: () => Promise<NotificationPlugin>;
+  private readonly dispatchAction: (action: TimeBlockNotificationAction) => void;
+  private isEnabled = false;
+  private isStarted = false;
+  private unlistenAction: (() => void) | null = null;
+  private unlistenBlockChange: (() => void) | null = null;
+  private plugin: NotificationPlugin | null = null;
+
+  constructor(options?: {
+    timeBlockService?: TimeBlockService;
+    runtimeInfoProvider?: () => Promise<RuntimeInfo>;
+    notificationPluginLoader?: () => Promise<NotificationPlugin>;
+    dispatchAction?: (action: TimeBlockNotificationAction) => void;
+  }) {
+    this.timeBlockService = options?.timeBlockService ?? getTimeBlockService();
+    this.runtimeInfoProvider = options?.runtimeInfoProvider ?? resolveRuntimeInfo;
+    this.notificationPluginLoader = options?.notificationPluginLoader ?? loadNotificationPlugin;
+    this.dispatchAction = options?.dispatchAction ?? dispatchTimeBlockNotificationAction;
+  }
+
+  async setEnabled(enabled: boolean): Promise<void> {
+    if (enabled) {
+      this.isEnabled = true;
+      await this.start();
+      return;
+    }
+
+    this.isEnabled = false;
+    await this.stop();
+  }
+
+  async start(): Promise<void> {
+    if (!this.isEnabled || this.isStarted) return;
+
+    const runtime = await this.runtimeInfoProvider();
+    if (!runtime.isTauriRuntime || !runtime.isAndroid) return;
+
+    const plugin = await this.notificationPluginLoader();
+    const permissionGranted = await plugin.isPermissionGranted()
+      || (await plugin.requestPermission()) === 'granted';
+
+    if (!permissionGranted) return;
+
+    await plugin.registerActionTypes(TIMEBLOCK_NOTIFICATION_ACTION_TYPES);
+    const listener = await plugin.onAction((payload) => {
+      const action = resolveNotificationActionFromPayload(payload);
+      if (!action) return;
+      this.dispatchAction(action);
+    });
+
+    this.plugin = plugin;
+    this.unlistenAction = resolveUnlisten(listener);
+    this.unlistenBlockChange = this.timeBlockService.onBlockChange((block) => {
+      void this.pushNotification(block);
+    });
+
+    const activeBlock = await this.timeBlockService.loadActiveBlock();
+    await this.pushNotification(activeBlock);
+    this.isStarted = true;
+  }
+
+  async stop(): Promise<void> {
+    if (!this.isStarted) return;
+
+    this.unlistenAction?.();
+    this.unlistenBlockChange?.();
+    this.unlistenAction = null;
+    this.unlistenBlockChange = null;
+
+    if (this.plugin?.removeActive) {
+      await this.plugin.removeActive([TIMEBLOCK_NOTIFICATION_ID]);
+    }
+
+    this.plugin = null;
+    this.isStarted = false;
+  }
+
+  private async pushNotification(block: ActiveBlockData | null): Promise<void> {
+    if (!this.plugin) return;
+    const model = resolveTimeBlockNotificationModel(block);
+    this.plugin.sendNotification({
+      id: TIMEBLOCK_NOTIFICATION_ID,
+      title: model.title,
+      body: model.body,
+      actionTypeId: model.actionTypeId,
+      ongoing: model.mode !== 'idle',
+      autoCancel: false,
+      extra: { scope: TIMEBLOCK_NOTIFICATION_SCOPE },
+    });
+  }
+}
+
+let singletonService: TimeBlockNotificationServiceImpl | null = null;
+
+export function getTimeBlockNotificationService(): TimeBlockNotificationServiceImpl {
+  if (!singletonService) {
+    singletonService = new TimeBlockNotificationServiceImpl();
+  }
+  return singletonService;
+}
+
+export function bindTimeBlockNotificationBridge(): () => void {
+  const service = getTimeBlockNotificationService();
+  void service.setEnabled(getTimeblockNotificationEnabled());
+
+  const unsubscribe = subscribeTimeblockNotificationEnabledChanges((enabled) => {
+    void service.setEnabled(enabled);
+  });
+
+  return () => {
+    unsubscribe();
+    void service.setEnabled(false);
+  };
+}
+

--- a/src/routes-new.tsx
+++ b/src/routes-new.tsx
@@ -9,6 +9,7 @@ import { getCommandRegistryService } from '@/lib/services/command-registry.servi
 import { getCommandPaletteService } from '@/lib/services/command-palette.service';
 import { createCoreNavigationCommands, type CoreNavigationPath } from '@/lib/services/command-palette.commands';
 import { CommandPalette } from '@/ui/new/components/CommandPalette';
+import { subscribeTimeBlockNotificationAction } from '@/lib/services/timeblock-notification-dispatcher';
 
 const NewFocusPage = lazy(async () => {
   const module = await import('@/ui/new/pages/NewFocusPage');
@@ -155,6 +156,14 @@ function NewLayout() {
       window.removeEventListener('keydown', handleKeyDown);
     };
   }, [commandPaletteActive, paletteService]);
+
+  useEffect(() => {
+    return subscribeTimeBlockNotificationAction((action) => {
+      if (action === 'start' || action === 'end' || action === 'open') {
+        void navigate({ to: '/eventlog' });
+      }
+    });
+  }, [navigate]);
 
   const commandContext = useMemo(() => ({
     currentPath: location.pathname,

--- a/src/ui/new/pages/NewSettingsPage.tsx
+++ b/src/ui/new/pages/NewSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ChangeEvent } from 'react';
 import { invoke, isTauri } from '@tauri-apps/api/core';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -45,6 +45,11 @@ import {
   setCommandPaletteEnabled,
   subscribeCommandPaletteEnabledChanges,
 } from '@/config/command-palette-enabled';
+import {
+  getTimeblockNotificationEnabled,
+  setTimeblockNotificationEnabled,
+  subscribeTimeblockNotificationEnabledChanges,
+} from '@/config/timeblock-notification-enabled';
 import { syncDevtoolsWithSettings } from '@/lib/debug/devtools-runtime';
 import {
   TIMER_END_SOUND_PRESETS,
@@ -69,6 +74,7 @@ import {
   Moon,
   MoonStar,
   Sun,
+  Target,
   Timer,
   Upload,
   Wifi,
@@ -153,6 +159,9 @@ export function NewSettingsPage() {
   const [useMockData, setUseMockData] = useState<boolean>(() => getUseMockDataEnabled());
   const [devtoolsEnabled, setDevtoolsEnabledState] = useState<boolean>(() => getDevtoolsEnabled());
   const [commandPaletteEnabled, setCommandPaletteEnabledState] = useState<boolean>(() => getCommandPaletteEnabled());
+  const [timeblockNotificationEnabled, setTimeblockNotificationEnabledState] = useState<boolean>(
+    () => getTimeblockNotificationEnabled()
+  );
   const [timerPreferences, setTimerPreferencesState] = useState(() => getTimerPreferences());
   const [soundPickerOpen, setSoundPickerOpen] = useState(false);
   const [syncDialogOpen, setSyncDialogOpen] = useState(false);
@@ -169,6 +178,12 @@ export function NewSettingsPage() {
   const [loading, setLoading] = useState(false);
   const [comingSoonVisible, setComingSoonVisible] = useState(false);
   const comingSoonTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const timeblockNotificationSupported = useMemo(() => {
+    if (typeof window === 'undefined') return false;
+    const isTauriRuntime = '__TAURI_INTERNALS__' in window;
+    const userAgent = window.navigator?.userAgent ?? '';
+    return isTauriRuntime && /android/i.test(userAgent);
+  }, []);
 
   const showComingSoon = () => {
     if (comingSoonTimer.current) clearTimeout(comingSoonTimer.current);
@@ -348,6 +363,11 @@ export function NewSettingsPage() {
     setCommandPaletteEnabledState(checked);
   };
 
+  const handleTimeblockNotificationToggle = (checked: boolean) => {
+    setTimeblockNotificationEnabled(checked);
+    setTimeblockNotificationEnabledState(checked);
+  };
+
   const navigate = useNavigate();
 
   const handleOpenVoiceInputSettings = () => {
@@ -410,6 +430,12 @@ export function NewSettingsPage() {
   useEffect(() => {
     return subscribeCommandPaletteEnabledChanges((enabled) => {
       setCommandPaletteEnabledState(enabled);
+    });
+  }, []);
+
+  useEffect(() => {
+    return subscribeTimeblockNotificationEnabledChanges((enabled) => {
+      setTimeblockNotificationEnabledState(enabled);
     });
   }, []);
 
@@ -887,6 +913,22 @@ export function NewSettingsPage() {
                   onCheckedChange={handleCommandPaletteToggle}
                 />
               </div>
+              {timeblockNotificationSupported && (
+                <div
+                  className="flex items-center justify-between rounded-xl border border-[#F0ECE8] px-4 py-3 dark:border-[#292524]"
+                  data-testid="feature-toggle-timeblock-notification-row"
+                >
+                  <div className="flex items-center gap-2">
+                    <Target className="h-[16px] w-[16px] text-[#78716C]" />
+                    <span className="text-sm text-[#1C1917] dark:text-[#FAFAF9]">时间块通知快捷控制</span>
+                  </div>
+                  <Switch
+                    data-testid="feature-toggle-timeblock-notification-switch"
+                    checked={timeblockNotificationEnabled}
+                    onCheckedChange={handleTimeblockNotificationToggle}
+                  />
+                </div>
+              )}
             </div>
           </div>
         </DrawerContent>

--- a/tests/unit/components/settings/setup-settings-mocks.tsx
+++ b/tests/unit/components/settings/setup-settings-mocks.tsx
@@ -75,6 +75,12 @@ vi.mock('@/config/command-palette-enabled', () => ({
   subscribeCommandPaletteEnabledChanges: vi.fn(() => () => {}),
 }));
 
+vi.mock('@/config/timeblock-notification-enabled', () => ({
+  getTimeblockNotificationEnabled: vi.fn(() => false),
+  setTimeblockNotificationEnabled: vi.fn(),
+  subscribeTimeblockNotificationEnabledChanges: vi.fn(() => () => {}),
+}));
+
 vi.mock('@/lib/debug/devtools-runtime', () => ({
   syncDevtoolsWithSettings: vi.fn().mockResolvedValue(undefined),
 }));

--- a/tests/unit/config/timeblock-notification-enabled.test.ts
+++ b/tests/unit/config/timeblock-notification-enabled.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getTimeblockNotificationEnabled,
+  setTimeblockNotificationEnabled,
+  subscribeTimeblockNotificationEnabledChanges,
+} from '@/config/timeblock-notification-enabled';
+
+describe('timeblock notification flag（时间块通知开关）', () => {
+  let storage: Record<string, string>;
+
+  beforeEach(() => {
+    storage = {};
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => (key in storage ? storage[key] : null),
+        setItem: (key: string, value: string) => {
+          storage[key] = value;
+        },
+        removeItem: (key: string) => {
+          delete storage[key];
+        },
+        clear: () => {
+          for (const key of Object.keys(storage)) {
+            delete storage[key];
+          }
+        },
+      },
+    });
+  });
+
+  it('defaults to false when key is missing（默认关闭）', () => {
+    expect(getTimeblockNotificationEnabled()).toBe(false);
+  });
+
+  it('persists and emits custom event when toggled（切换时持久化并发事件）', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeTimeblockNotificationEnabledChanges(listener);
+
+    setTimeblockNotificationEnabled(true);
+
+    expect(storage['exomind:timeblockNotificationEnabled']).toBe('true');
+    expect(listener).toHaveBeenCalledWith(true);
+
+    unsubscribe();
+  });
+
+  it('handles storage event updates（支持 storage 事件同步）', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeTimeblockNotificationEnabledChanges(listener);
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'exomind:timeblockNotificationEnabled',
+      newValue: 'true',
+    }));
+
+    expect(listener).toHaveBeenCalledWith(true);
+    unsubscribe();
+  });
+});

--- a/tests/unit/services/timeblock-notification-dispatcher.issue249.test.ts
+++ b/tests/unit/services/timeblock-notification-dispatcher.issue249.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  consumePendingTimeBlockNotificationAction,
+  dispatchTimeBlockNotificationAction,
+  subscribeTimeBlockNotificationAction,
+} from '@/lib/services/timeblock-notification-dispatcher';
+
+describe('timeblock notification dispatcher issue-249（动作分发与挂起恢复）', () => {
+  it('notifies subscribers and stores pending action（通知订阅者并缓存挂起动作）', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeTimeBlockNotificationAction(listener);
+
+    dispatchTimeBlockNotificationAction('start');
+
+    expect(listener).toHaveBeenCalledWith('start');
+    expect(consumePendingTimeBlockNotificationAction()).toBe('start');
+    expect(consumePendingTimeBlockNotificationAction()).toBeNull();
+
+    unsubscribe();
+  });
+});
+

--- a/tests/unit/services/timeblock-notification-ui-action.issue249.test.ts
+++ b/tests/unit/services/timeblock-notification-ui-action.issue249.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { applyTimeBlockNotificationActionToWidget } from '@/lib/services/timeblock-notification-ui-action';
+
+function createWidget(state: 'idle' | 'running' | 'paused' | 'ended') {
+  return {
+    expandAndFocusTaskName: vi.fn(),
+    getTimerState: vi.fn(() => state),
+    pauseOrResume: vi.fn().mockResolvedValue(undefined),
+    endDialog: vi.fn(),
+  };
+}
+
+describe('timeblock notification ui action issue-249（通知动作到控件行为映射）', () => {
+  it('expands task input on start action（start -> 展开并聚焦输入）', async () => {
+    const widget = createWidget('idle');
+    await applyTimeBlockNotificationActionToWidget('start', widget);
+    expect(widget.expandAndFocusTaskName).toHaveBeenCalledTimes(1);
+  });
+
+  it('pauses only when current timer is running（pause 只在运行态触发）', async () => {
+    const runningWidget = createWidget('running');
+    await applyTimeBlockNotificationActionToWidget('pause', runningWidget);
+    expect(runningWidget.pauseOrResume).toHaveBeenCalledTimes(1);
+
+    const pausedWidget = createWidget('paused');
+    await applyTimeBlockNotificationActionToWidget('pause', pausedWidget);
+    expect(pausedWidget.pauseOrResume).not.toHaveBeenCalled();
+  });
+
+  it('resumes only when current timer is paused（resume 只在暂停态触发）', async () => {
+    const pausedWidget = createWidget('paused');
+    await applyTimeBlockNotificationActionToWidget('resume', pausedWidget);
+    expect(pausedWidget.pauseOrResume).toHaveBeenCalledTimes(1);
+
+    const runningWidget = createWidget('running');
+    await applyTimeBlockNotificationActionToWidget('resume', runningWidget);
+    expect(runningWidget.pauseOrResume).not.toHaveBeenCalled();
+  });
+
+  it('opens end dialog only in active states（end 仅在运行/暂停态触发反馈流程）', async () => {
+    const runningWidget = createWidget('running');
+    await applyTimeBlockNotificationActionToWidget('end', runningWidget);
+    expect(runningWidget.endDialog).toHaveBeenCalledTimes(1);
+
+    const pausedWidget = createWidget('paused');
+    await applyTimeBlockNotificationActionToWidget('end', pausedWidget);
+    expect(pausedWidget.endDialog).toHaveBeenCalledTimes(1);
+
+    const idleWidget = createWidget('idle');
+    await applyTimeBlockNotificationActionToWidget('end', idleWidget);
+    expect(idleWidget.endDialog).not.toHaveBeenCalled();
+
+    const endedWidget = createWidget('ended');
+    await applyTimeBlockNotificationActionToWidget('end', endedWidget);
+    expect(endedWidget.endDialog).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/timeblock-notification.service.issue249.test.ts
+++ b/tests/unit/services/timeblock-notification.service.issue249.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ActiveBlockData } from '@/lib/types/event';
+import type { TimeBlockService } from '@/lib/services/timeblock.service';
+import {
+  resolveNotificationActionFromPayload,
+  resolveTimeBlockNotificationModel,
+  TimeBlockNotificationServiceImpl,
+} from '@/lib/services/timeblock-notification.service';
+
+function createActiveBlock(overrides?: Partial<ActiveBlockData>): ActiveBlockData {
+  return {
+    startId: 'block-1',
+    name: '深度工作',
+    mode: 'countup',
+    elapsed: 120000,
+    startTime: 1700000000000,
+    paused: false,
+    ...overrides,
+  };
+}
+
+describe('timeblock notification service issue-249（通知桥接服务）', () => {
+  it('maps block state to notification model（时间块状态映射通知模型）', () => {
+    const idle = resolveTimeBlockNotificationModel(null);
+    expect(idle.mode).toBe('idle');
+    expect(idle.actionTypeId).toContain('idle');
+
+    const running = resolveTimeBlockNotificationModel(createActiveBlock({ paused: false }));
+    expect(running.mode).toBe('running');
+    expect(running.actionTypeId).toContain('running');
+
+    const paused = resolveTimeBlockNotificationModel(createActiveBlock({ paused: true }));
+    expect(paused.mode).toBe('paused');
+    expect(paused.actionTypeId).toContain('paused');
+  });
+
+  it('parses action payload from notification callback（解析通知动作回调）', () => {
+    expect(resolveNotificationActionFromPayload({
+      actionId: 'pause',
+      notification: { extra: { scope: 'timeblock' } },
+    })).toBe('pause');
+
+    expect(resolveNotificationActionFromPayload({
+      actionId: 'tap',
+      notification: { extra: { scope: 'timeblock' } },
+    })).toBe('open');
+
+    expect(resolveNotificationActionFromPayload({
+      actionId: 'pause',
+      notification: { extra: { scope: 'other' } },
+    })).toBeNull();
+  });
+
+  it('starts bridge only on tauri android and dispatches actions（仅 tauri android 启动并派发动作）', async () => {
+    let onBlockChangeCallback: ((block: ActiveBlockData | null) => void) | null = null;
+    let onActionCallback: ((payload: unknown) => void) | null = null;
+
+    const timeBlockService = {
+      loadActiveBlock: vi.fn().mockResolvedValue(null),
+      onBlockChange: vi.fn((cb: (block: ActiveBlockData | null) => void) => {
+        onBlockChangeCallback = cb;
+        return () => {
+          onBlockChangeCallback = null;
+        };
+      }),
+    } as unknown as TimeBlockService;
+
+    const plugin = {
+      isPermissionGranted: vi.fn().mockResolvedValue(true),
+      requestPermission: vi.fn().mockResolvedValue('granted'),
+      registerActionTypes: vi.fn().mockResolvedValue(undefined),
+      sendNotification: vi.fn(),
+      onAction: vi.fn(async (cb: (payload: unknown) => void) => {
+        onActionCallback = cb;
+        return () => {
+          onActionCallback = null;
+        };
+      }),
+      removeActive: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const dispatchAction = vi.fn();
+    const service = new TimeBlockNotificationServiceImpl({
+      timeBlockService,
+      runtimeInfoProvider: async () => ({ isTauriRuntime: true, isAndroid: true }),
+      notificationPluginLoader: async () => plugin,
+      dispatchAction,
+    });
+
+    await service.setEnabled(true);
+
+    expect(plugin.registerActionTypes).toHaveBeenCalledTimes(1);
+    expect(plugin.sendNotification).toHaveBeenCalledWith(expect.objectContaining({
+      title: '时间块 · 待开始',
+      actionTypeId: expect.stringContaining('idle'),
+    }));
+
+    onBlockChangeCallback?.(createActiveBlock({ paused: true }));
+    expect(plugin.sendNotification).toHaveBeenLastCalledWith(expect.objectContaining({
+      title: '时间块已暂停',
+      actionTypeId: expect.stringContaining('paused'),
+    }));
+
+    onActionCallback?.({
+      actionId: 'resume',
+      notification: { extra: { scope: 'timeblock' } },
+    });
+    expect(dispatchAction).toHaveBeenCalledWith('resume');
+
+    await service.setEnabled(false);
+    expect(plugin.removeActive).toHaveBeenCalledWith([249001]);
+  });
+
+  it('does not start when runtime is not tauri android（非 tauri android 不启动）', async () => {
+    const pluginLoader = vi.fn();
+    const timeBlockService = {
+      loadActiveBlock: vi.fn().mockResolvedValue(null),
+      onBlockChange: vi.fn(() => () => {}),
+    } as unknown as TimeBlockService;
+    const service = new TimeBlockNotificationServiceImpl({
+      timeBlockService,
+      runtimeInfoProvider: async () => ({ isTauriRuntime: false, isAndroid: true }),
+      notificationPluginLoader: pluginLoader as never,
+    });
+
+    await service.setEnabled(true);
+    expect(pluginLoader).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary\n- 实现 #249 Phase A：Android 通知动作与 TimeBlock UI 的桥接\n- 新增 Tauri Notification 插件接入与设置开关（仅 Tauri Android 显示）\n- 新增 dispatcher/service/ui-action 及单元测试\n\n## Test Evidence\n- npx vitest run tests/unit/config/timeblock-notification-enabled.test.ts tests/unit/services/timeblock-notification-dispatcher.issue249.test.ts tests/unit/services/timeblock-notification-ui-action.issue249.test.ts tests/unit/services/timeblock-notification.service.issue249.test.ts\n- npx tsc --pretty false\n- npx vite build\n\nCloses #249