### PR TITLE
feat(settings): 控制当下页语音转写行为（#106）

### DIFF
--- a/src/config/voice-transcript-send-mode.ts
+++ b/src/config/voice-transcript-send-mode.ts
@@ -1,0 +1,58 @@
+const VOICE_TRANSCRIPT_SEND_MODE_STORAGE_KEY = 'exomind:voiceTranscriptSendMode';
+const VOICE_TRANSCRIPT_SEND_MODE_CHANGED_EVENT = 'exomind:voice-transcript-send-mode-changed';
+
+export const VOICE_TRANSCRIPT_SEND_MODE_VALUES = ['insert', 'direct-send'] as const;
+export type VoiceTranscriptSendMode = (typeof VOICE_TRANSCRIPT_SEND_MODE_VALUES)[number];
+
+function normalizeMode(rawValue: string | null | undefined): VoiceTranscriptSendMode {
+  if (rawValue === 'direct-send') return 'direct-send';
+  return 'insert';
+}
+
+function getStorage():
+  | Pick<Storage, 'getItem' | 'setItem'>
+  | null {
+  if (typeof window === 'undefined') return null;
+  const localStorageLike = window.localStorage as Partial<Storage> | undefined;
+  if (!localStorageLike) return null;
+  if (typeof localStorageLike.getItem !== 'function') return null;
+  if (typeof localStorageLike.setItem !== 'function') return null;
+  return localStorageLike as Pick<Storage, 'getItem' | 'setItem'>;
+}
+
+export function getVoiceTranscriptSendMode(): VoiceTranscriptSendMode {
+  const storage = getStorage();
+  if (!storage) return 'insert';
+  return normalizeMode(storage.getItem(VOICE_TRANSCRIPT_SEND_MODE_STORAGE_KEY));
+}
+
+export function setVoiceTranscriptSendMode(mode: VoiceTranscriptSendMode): void {
+  const storage = getStorage();
+  if (!storage) return;
+  storage.setItem(VOICE_TRANSCRIPT_SEND_MODE_STORAGE_KEY, mode);
+  window.dispatchEvent(new CustomEvent<VoiceTranscriptSendMode>(VOICE_TRANSCRIPT_SEND_MODE_CHANGED_EVENT, { detail: mode }));
+}
+
+export function subscribeVoiceTranscriptSendModeChanges(listener: (mode: VoiceTranscriptSendMode) => void): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key !== VOICE_TRANSCRIPT_SEND_MODE_STORAGE_KEY) return;
+    listener(normalizeMode(event.newValue));
+  };
+
+  const handleCustomEvent = (event: Event) => {
+    const customEvent = event as CustomEvent<VoiceTranscriptSendMode>;
+    listener(normalizeMode(customEvent.detail));
+  };
+
+  window.addEventListener('storage', handleStorage);
+  window.addEventListener(VOICE_TRANSCRIPT_SEND_MODE_CHANGED_EVENT, handleCustomEvent);
+
+  return () => {
+    window.removeEventListener('storage', handleStorage);
+    window.removeEventListener(VOICE_TRANSCRIPT_SEND_MODE_CHANGED_EVENT, handleCustomEvent);
+  };
+}

--- a/src/ui/new/components/NewNowInputRow.tsx
+++ b/src/ui/new/components/NewNowInputRow.tsx
@@ -15,6 +15,11 @@ import { getClipboardService } from '@/lib/services';
 import type { ClipboardFailureReason } from '@/lib/services';
 import { VoiceInputButton, type VoiceInputButtonHandle } from '@/components/VoiceInputButton';
 import type { VoiceMessageInputHandle } from '@/components/VoiceMessageInput';
+import {
+  getVoiceTranscriptSendMode,
+  subscribeVoiceTranscriptSendModeChanges,
+  type VoiceTranscriptSendMode,
+} from '@/config/voice-transcript-send-mode';
 
 interface NewNowInputRowProps {
   onSend: (content: string) => void;
@@ -46,6 +51,9 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
   const [pasteFeedback, setPasteFeedback] = useState<'idle' | 'success' | 'error'>('idle');
   const [attachmentFeedback, setAttachmentFeedback] = useState<'idle' | 'pending'>('idle');
   const [pasteFailureLabel, setPasteFailureLabel] = useState('未粘贴');
+  const [voiceTranscriptSendMode, setVoiceTranscriptSendMode] = useState<VoiceTranscriptSendMode>(
+    () => getVoiceTranscriptSendMode()
+  );
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const voiceButtonRef = useRef<VoiceInputButtonHandle | null>(null);
   const pasteFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -77,6 +85,8 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
       attachmentFeedbackTimerRef.current = null;
     }
   }, []);
+
+  useEffect(() => subscribeVoiceTranscriptSendModeChanges(setVoiceTranscriptSendMode), []);
 
   const submitInput = useCallback(() => {
     const trimmed = value.trim();
@@ -136,9 +146,16 @@ export const NewNowInputRow = forwardRef<VoiceMessageInputHandle, NewNowInputRow
   }, [insertClipboardText]);
 
   const handleVoiceResult = useCallback((text: string) => {
-    if (!text.trim()) return;
-    setValue((prev) => (prev.trim() ? `${prev} ${text}` : text));
-  }, []);
+    const normalized = text.trim();
+    if (!normalized) return;
+
+    if (voiceTranscriptSendMode === 'direct-send') {
+      onSend(normalized);
+      return;
+    }
+
+    setValue((prev) => (prev.trim() ? `${prev} ${normalized}` : normalized));
+  }, [onSend, voiceTranscriptSendMode]);
 
   const handleVoiceError = useCallback((error: string) => {
     console.error('[new-now-input][voice]', error);

--- a/src/ui/new/pages/NewSettingsPage.tsx
+++ b/src/ui/new/pages/NewSettingsPage.tsx
@@ -45,6 +45,12 @@ import {
   setCommandPaletteEnabled,
   subscribeCommandPaletteEnabledChanges,
 } from '@/config/command-palette-enabled';
+import {
+  getVoiceTranscriptSendMode,
+  setVoiceTranscriptSendMode,
+  subscribeVoiceTranscriptSendModeChanges,
+  type VoiceTranscriptSendMode,
+} from '@/config/voice-transcript-send-mode';
 import { syncDevtoolsWithSettings } from '@/lib/debug/devtools-runtime';
 import {
   TIMER_END_SOUND_PRESETS,
@@ -66,6 +72,7 @@ import {
   Command,
   Download,
   Monitor,
+  Mic,
   Moon,
   MoonStar,
   Sun,
@@ -153,6 +160,9 @@ export function NewSettingsPage() {
   const [useMockData, setUseMockData] = useState<boolean>(() => getUseMockDataEnabled());
   const [devtoolsEnabled, setDevtoolsEnabledState] = useState<boolean>(() => getDevtoolsEnabled());
   const [commandPaletteEnabled, setCommandPaletteEnabledState] = useState<boolean>(() => getCommandPaletteEnabled());
+  const [voiceTranscriptSendMode, setVoiceTranscriptSendModeState] = useState<VoiceTranscriptSendMode>(
+    () => getVoiceTranscriptSendMode()
+  );
   const [timerPreferences, setTimerPreferencesState] = useState(() => getTimerPreferences());
   const [soundPickerOpen, setSoundPickerOpen] = useState(false);
   const [syncDialogOpen, setSyncDialogOpen] = useState(false);
@@ -348,6 +358,11 @@ export function NewSettingsPage() {
     setCommandPaletteEnabledState(checked);
   };
 
+  const handleVoiceTranscriptSendModeChange = (mode: VoiceTranscriptSendMode) => {
+    setVoiceTranscriptSendMode(mode);
+    setVoiceTranscriptSendModeState(mode);
+  };
+
   const navigate = useNavigate();
 
   const handleOpenVoiceInputSettings = () => {
@@ -410,6 +425,12 @@ export function NewSettingsPage() {
   useEffect(() => {
     return subscribeCommandPaletteEnabledChanges((enabled) => {
       setCommandPaletteEnabledState(enabled);
+    });
+  }, []);
+
+  useEffect(() => {
+    return subscribeVoiceTranscriptSendModeChanges((mode) => {
+      setVoiceTranscriptSendModeState(mode);
     });
   }, []);
 
@@ -575,6 +596,52 @@ export function NewSettingsPage() {
         <section className="space-y-2" data-testid="new-settings-input-section">
           <SectionTitle>输入</SectionTitle>
           <SectionCard>
+            <div data-testid="new-settings-voice-transcript-mode-row">
+              <SettingRow
+                icon={<Mic className="h-[18px] w-[18px] text-[#78716C]" />}
+                label="语音转写后"
+                right={(
+                  <div
+                    role="group"
+                    aria-label="语音转写后行为"
+                    className="flex items-center rounded-[10px] bg-[#F5F0ED] p-[3px] dark:bg-[#292524]"
+                  >
+                    <button
+                      type="button"
+                      data-testid="new-settings-voice-transcript-mode-insert"
+                      aria-pressed={voiceTranscriptSendMode === 'insert'}
+                      onClick={() => handleVoiceTranscriptSendModeChange('insert')}
+                      disabled={loading}
+                      className={`rounded-[8px] px-2.5 py-1.5 text-xs transition-colors disabled:cursor-not-allowed ${
+                        voiceTranscriptSendMode === 'insert'
+                          ? 'bg-white font-medium text-[#1C1917] shadow-[0_1px_3px_rgba(0,0,0,0.08)] dark:bg-[#44403C] dark:text-[#FAFAF9]'
+                          : 'text-[#A8A29E]'
+                      }`}
+                    >
+                      插入输入框
+                    </button>
+                    <button
+                      type="button"
+                      data-testid="new-settings-voice-transcript-mode-direct-send"
+                      aria-pressed={voiceTranscriptSendMode === 'direct-send'}
+                      onClick={() => handleVoiceTranscriptSendModeChange('direct-send')}
+                      disabled={loading}
+                      className={`rounded-[8px] px-2.5 py-1.5 text-xs transition-colors disabled:cursor-not-allowed ${
+                        voiceTranscriptSendMode === 'direct-send'
+                          ? 'bg-white font-medium text-[#1C1917] shadow-[0_1px_3px_rgba(0,0,0,0.08)] dark:bg-[#44403C] dark:text-[#FAFAF9]'
+                          : 'text-[#A8A29E]'
+                      }`}
+                    >
+                      直接发送
+                    </button>
+                  </div>
+                )}
+              />
+            </div>
+            <div className="pb-[14px] pl-[46px] pr-4">
+              <span className="text-xs text-[#A8A29E]">仅作用于「当下」页面输入框，默认插入输入框</span>
+            </div>
+            <Divider />
             <div data-testid="new-settings-voice-token-row">
               <SettingRow
                 icon={<Bot className="h-[18px] w-[18px] text-[#78716C]" />}

--- a/tests/unit/components/settings/setup-settings-mocks.tsx
+++ b/tests/unit/components/settings/setup-settings-mocks.tsx
@@ -75,6 +75,12 @@ vi.mock('@/config/command-palette-enabled', () => ({
   subscribeCommandPaletteEnabledChanges: vi.fn(() => () => {}),
 }));
 
+vi.mock('@/config/voice-transcript-send-mode', () => ({
+  getVoiceTranscriptSendMode: vi.fn(() => 'insert'),
+  setVoiceTranscriptSendMode: vi.fn(),
+  subscribeVoiceTranscriptSendModeChanges: vi.fn(() => () => {}),
+}));
+
 vi.mock('@/lib/debug/devtools-runtime', () => ({
   syncDevtoolsWithSettings: vi.fn().mockResolvedValue(undefined),
 }));

--- a/tests/unit/config/voice-transcript-send-mode.test.ts
+++ b/tests/unit/config/voice-transcript-send-mode.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getVoiceTranscriptSendMode,
+  setVoiceTranscriptSendMode,
+  subscribeVoiceTranscriptSendModeChanges,
+} from '@/config/voice-transcript-send-mode';
+
+describe('voice transcript send mode（语音转写发送模式）', () => {
+  let storage: Record<string, string>;
+
+  beforeEach(() => {
+    storage = {};
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => (key in storage ? storage[key] : null),
+        setItem: (key: string, value: string) => {
+          storage[key] = value;
+        },
+      },
+    });
+  });
+
+  it('defaults to insert when missing（未设置时默认插入输入框）', () => {
+    expect(getVoiceTranscriptSendMode()).toBe('insert');
+  });
+
+  it('persists and emits custom event（保存并广播模式变更）', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeVoiceTranscriptSendModeChanges(listener);
+
+    setVoiceTranscriptSendMode('direct-send');
+
+    expect(storage['exomind:voiceTranscriptSendMode']).toBe('direct-send');
+    expect(listener).toHaveBeenCalledWith('direct-send');
+    unsubscribe();
+  });
+
+  it('handles storage event updates（支持 storage 事件同步）', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeVoiceTranscriptSendModeChanges(listener);
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'exomind:voiceTranscriptSendMode',
+      newValue: 'direct-send',
+    }));
+
+    expect(listener).toHaveBeenCalledWith('direct-send');
+    unsubscribe();
+  });
+});

--- a/tests/unit/settings/new-settings-input-section.issue199.test.tsx
+++ b/tests/unit/settings/new-settings-input-section.issue199.test.tsx
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import '../components/settings/setup-settings-mocks.tsx';
 import { NewSettingsPage } from '@/ui/new/pages/NewSettingsPage';
+import { setVoiceTranscriptSendMode } from '@/config/voice-transcript-send-mode';
 
 describe('NewSettingsPage input section（输入分组语音配置）', () => {
   beforeEach(() => {
@@ -15,8 +16,20 @@ describe('NewSettingsPage input section（输入分组语音配置）', () => {
     render(<NewSettingsPage />);
 
     expect(screen.getByTestId('new-settings-input-section')).toBeInTheDocument();
+    expect(screen.getByText('语音转写后')).toBeInTheDocument();
     expect(screen.getByText('MOSS API Token')).toBeInTheDocument();
     expect(screen.getByText('MOSS 语音测试')).toBeInTheDocument();
+  });
+
+  it('toggles voice transcript send mode from input section', () => {
+    const setModeMock = vi.mocked(setVoiceTranscriptSendMode);
+    render(<NewSettingsPage />);
+
+    fireEvent.click(screen.getByTestId('new-settings-voice-transcript-mode-direct-send'));
+    expect(setModeMock).toHaveBeenCalledWith('direct-send');
+
+    fireEvent.click(screen.getByTestId('new-settings-voice-transcript-mode-insert'));
+    expect(setModeMock).toHaveBeenCalledWith('insert');
   });
 
   it('saves MOSS token from input settings dialog', () => {

--- a/tests/unit/ui/new-now-input-row.test.tsx
+++ b/tests/unit/ui/new-now-input-row.test.tsx
@@ -3,8 +3,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { NewNowInputRow } from '@/ui/new/components/NewNowInputRow';
 
-const { mockReadClipboardText, mockToast, startVoiceSpy, setLatestVoiceProps, getLatestVoiceProps } = vi.hoisted(() => {
+const {
+  mockReadClipboardText,
+  mockToast,
+  startVoiceSpy,
+  setLatestVoiceProps,
+  getLatestVoiceProps,
+  getVoiceTranscriptSendMode,
+  subscribeVoiceTranscriptSendModeChanges,
+  resetVoiceTranscriptMode,
+  emitVoiceTranscriptMode,
+} = vi.hoisted(() => {
   let latestVoiceProps: any = null;
+  let mode: 'insert' | 'direct-send' = 'insert';
+  let listeners: Array<(nextMode: 'insert' | 'direct-send') => void> = [];
   return {
     mockReadClipboardText: vi.fn(),
     mockToast: vi.fn(),
@@ -13,6 +25,21 @@ const { mockReadClipboardText, mockToast, startVoiceSpy, setLatestVoiceProps, ge
       latestVoiceProps = props;
     },
     getLatestVoiceProps: () => latestVoiceProps,
+    getVoiceTranscriptSendMode: vi.fn(() => mode),
+    subscribeVoiceTranscriptSendModeChanges: vi.fn((listener: (nextMode: 'insert' | 'direct-send') => void) => {
+      listeners.push(listener);
+      return () => {
+        listeners = listeners.filter((item) => item !== listener);
+      };
+    }),
+    resetVoiceTranscriptMode: () => {
+      mode = 'insert';
+      listeners = [];
+    },
+    emitVoiceTranscriptMode: (nextMode: 'insert' | 'direct-send') => {
+      mode = nextMode;
+      listeners.forEach((listener) => listener(nextMode));
+    },
   };
 });
 
@@ -40,12 +67,20 @@ vi.mock('@/components/ui/toast-hook', () => ({
   toast: mockToast,
 }));
 
+vi.mock('@/config/voice-transcript-send-mode', () => ({
+  getVoiceTranscriptSendMode,
+  subscribeVoiceTranscriptSendModeChanges,
+}));
+
 describe('NewNowInputRow', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     mockReadClipboardText.mockReset();
     mockToast.mockReset();
     startVoiceSpy.mockReset();
+    getVoiceTranscriptSendMode.mockClear();
+    subscribeVoiceTranscriptSendModeChanges.mockClear();
+    resetVoiceTranscriptMode();
     setLatestVoiceProps(null);
   });
 
@@ -137,6 +172,20 @@ describe('NewNowInputRow', () => {
     });
 
     expect((textarea as HTMLTextAreaElement).value).toBe('已有文本 语音识别内容');
+  });
+
+  it('sends voice transcript directly when mode is direct-send', () => {
+    const onSend = vi.fn();
+    emitVoiceTranscriptMode('direct-send');
+    render(<NewNowInputRow onSend={onSend} placeholder="输入内容记录事件..." />);
+    const textarea = screen.getByTestId('new-now-input-textarea');
+
+    act(() => {
+      getLatestVoiceProps()?.onResult?.('  直接发送内容  ');
+    });
+
+    expect(onSend).toHaveBeenCalledWith('直接发送内容');
+    expect((textarea as HTMLTextAreaElement).value).toBe('');
   });
 
   it('logs voice errors for troubleshooting', () => {


### PR DESCRIPTION
## 背景
对齐 #106：关键不在“按空格”按键本身，而是**触发语音转写后如何处理结果文本**。

## 本次实现
- 仅作用于「当下 /eventlog」页面输入框（`NewNowInputRow`）
- 在设置页「输入」分组新增“语音转写后”行为开关：
  - `插入输入框`（默认，保持老行为）
  - `直接发送`（转写后直接写入事件日志）
- 新增配置模块：`voiceTranscriptSendMode`（支持持久化与订阅）

## 影响范围
- `src/config/voice-transcript-send-mode.ts`（新增）
- `src/ui/new/pages/NewSettingsPage.tsx`
- `src/ui/new/components/NewNowInputRow.tsx`
- `tests/unit/config/voice-transcript-send-mode.test.ts`（新增）
- `tests/unit/ui/new-now-input-row.test.tsx`
- `tests/unit/settings/new-settings-input-section.issue199.test.tsx`
- `tests/unit/components/settings/setup-settings-mocks.tsx`

## 验证
- `npx vitest run tests/unit/config/voice-transcript-send-mode.test.ts tests/unit/ui/new-now-input-row.test.tsx tests/unit/settings/new-settings-input-section.issue199.test.tsx`
- `npx tsc --pretty false`
- `npx vite build`

以上均通过。

## 手动验证状态
- 已启动 Web dev server（5173）供联调测试。
- 当前正在进行手动体验验证。

Refs #106
