### PR TITLE
fix(test): stop EventStorage from leaking events_* dirs into repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,7 +75,7 @@ htmlcov/
 *.tmp
 *.temp
 .cache/
-.tmp/
+.tmp/pouchdb-event-storage/
 .turbo/
 pnpm-store/
 

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ htmlcov/
 *.tmp
 *.temp
 .cache/
+.tmp/
 .turbo/
 pnpm-store/
 

--- a/src/lib/storage/event-storage.ts
+++ b/src/lib/storage/event-storage.ts
@@ -8,7 +8,7 @@
 // 使用默认导入
 import PouchDB from 'pouchdb';
 
-const TEST_POUCHDB_PREFIX_ENV = 'EXOMIND_EVENT_STORAGE_PREFIX';
+const POUCHDB_PREFIX_ENV = 'EXOMIND_EVENT_STORAGE_PREFIX';
 const DEFAULT_TEST_POUCHDB_PREFIX = '.tmp/pouchdb-event-storage/';
 
 /**
@@ -71,7 +71,8 @@ function normalizePouchDbPrefix(prefix: string): string {
   if (trimmed.length === 0) {
     return DEFAULT_TEST_POUCHDB_PREFIX;
   }
-  return trimmed.endsWith('/') || trimmed.endsWith('\\') ? trimmed : `${trimmed}/`;
+  const normalized = trimmed.replace(/\\/g, '/');
+  return normalized.endsWith('/') ? normalized : `${normalized}/`;
 }
 
 function readNodeEnv(name: string): string | undefined {
@@ -86,13 +87,13 @@ function resolvePouchDbPrefix(explicitPrefix?: string): string | undefined {
     return normalizePouchDbPrefix(explicitPrefix);
   }
 
-  const envPrefix = readNodeEnv(TEST_POUCHDB_PREFIX_ENV);
+  const envPrefix = readNodeEnv(POUCHDB_PREFIX_ENV);
   if (typeof envPrefix === 'string' && envPrefix.trim().length > 0) {
     return normalizePouchDbPrefix(envPrefix);
   }
 
   // Vitest in Node runtime writes LevelDB files; isolate under .tmp to avoid root pollution.
-  if (readNodeEnv('VITEST')) {
+  if (readNodeEnv('VITEST') || readNodeEnv('VITEST_WORKER_ID') || readNodeEnv('NODE_ENV') === 'test') {
     return DEFAULT_TEST_POUCHDB_PREFIX;
   }
 
@@ -101,6 +102,10 @@ function resolvePouchDbPrefix(explicitPrefix?: string): string | undefined {
 
 // 单例缓存
 const storageInstances: Map<string, EventStorage> = new Map();
+
+function buildStorageCacheKey(userId: string, prefix?: string): string {
+  return `${prefix ?? ''}::${userId}`;
+}
 
 /**
  * 获取当前用户 ID（与 ChatPage 保持一致）
@@ -136,12 +141,14 @@ export function getCurrentUserId(): string {
  */
 export function getEventStorage(userId?: string): EventStorage {
   const id = userId || getCurrentUserId();
+  const prefix = resolvePouchDbPrefix();
+  const cacheKey = buildStorageCacheKey(id, prefix);
 
-  if (!storageInstances.has(id)) {
-    storageInstances.set(id, new EventStorage(id));
+  if (!storageInstances.has(cacheKey)) {
+    storageInstances.set(cacheKey, new EventStorage(id, { pouchDbPrefix: prefix }));
   }
 
-  return storageInstances.get(id)!;
+  return storageInstances.get(cacheKey)!;
 }
 
 /**

--- a/src/lib/storage/event-storage.ts
+++ b/src/lib/storage/event-storage.ts
@@ -8,6 +8,9 @@
 // 使用默认导入
 import PouchDB from 'pouchdb';
 
+const TEST_POUCHDB_PREFIX_ENV = 'EXOMIND_EVENT_STORAGE_PREFIX';
+const DEFAULT_TEST_POUCHDB_PREFIX = '.tmp/pouchdb-event-storage/';
+
 /**
  * 事件接口
  */
@@ -55,6 +58,46 @@ const BY_ID_MAP = `function(doc) {
     emit(doc._id, doc);
   }
 }`;
+
+interface EventStorageOptions {
+  /**
+   * Optional PouchDB prefix override（可选：覆盖 PouchDB 落盘前缀）
+   */
+  pouchDbPrefix?: string;
+}
+
+function normalizePouchDbPrefix(prefix: string): string {
+  const trimmed = prefix.trim();
+  if (trimmed.length === 0) {
+    return DEFAULT_TEST_POUCHDB_PREFIX;
+  }
+  return trimmed.endsWith('/') || trimmed.endsWith('\\') ? trimmed : `${trimmed}/`;
+}
+
+function readNodeEnv(name: string): string | undefined {
+  if (typeof process === 'undefined' || !process.env) {
+    return undefined;
+  }
+  return process.env[name];
+}
+
+function resolvePouchDbPrefix(explicitPrefix?: string): string | undefined {
+  if (typeof explicitPrefix === 'string' && explicitPrefix.trim().length > 0) {
+    return normalizePouchDbPrefix(explicitPrefix);
+  }
+
+  const envPrefix = readNodeEnv(TEST_POUCHDB_PREFIX_ENV);
+  if (typeof envPrefix === 'string' && envPrefix.trim().length > 0) {
+    return normalizePouchDbPrefix(envPrefix);
+  }
+
+  // Vitest in Node runtime writes LevelDB files; isolate under .tmp to avoid root pollution.
+  if (readNodeEnv('VITEST')) {
+    return DEFAULT_TEST_POUCHDB_PREFIX;
+  }
+
+  return undefined;
+}
 
 // 单例缓存
 const storageInstances: Map<string, EventStorage> = new Map();
@@ -125,9 +168,12 @@ export class EventStorage {
    *
    * @param userId - 用户 ID，用于隔离不同用户的数据
    */
-  constructor(userId: string) {
+  constructor(userId: string, options: EventStorageOptions = {}) {
     const dbName = `events_${userId}`;
-    this.db = new PouchDB<Event>(dbName);
+    const prefix = resolvePouchDbPrefix(options.pouchDbPrefix);
+    this.db = prefix
+      ? new PouchDB<Event>(dbName, { prefix })
+      : new PouchDB<Event>(dbName);
     this.initializeDesignDoc();
   }
 

--- a/tests/storage/event-storage-path.issue128.test.ts
+++ b/tests/storage/event-storage-path.issue128.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { EventStorage } from '@/lib/storage/event-storage';
+
+async function removeDirWithRetry(targetPath: string): Promise<void> {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      await fs.promises.rm(targetPath, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code && !['EBUSY', 'ENOTEMPTY', 'EPERM', 'ENOENT'].includes(code)) {
+        throw error;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+    }
+  }
+}
+
+async function removeRootArtifacts(baseName: string): Promise<void> {
+  const repoRoot = process.cwd();
+  const dbPath = path.join(repoRoot, baseName);
+  const mrviewPrefix = `${baseName}-mrview-`;
+
+  if (fs.existsSync(dbPath)) {
+    await removeDirWithRetry(dbPath);
+  }
+
+  const entries = await fs.promises.readdir(repoRoot, { withFileTypes: true });
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory() && entry.name.startsWith(mrviewPrefix))
+      .map((entry) => removeDirWithRetry(path.join(repoRoot, entry.name)))
+  );
+}
+
+describe('EventStorage path isolation (issue #128)', () => {
+  let storage: EventStorage;
+  let dbBaseName: string;
+
+  beforeEach(async () => {
+    const userId = `issue128-path-${Date.now()}`;
+    dbBaseName = `events_${userId}`;
+    await removeRootArtifacts(dbBaseName);
+    storage = new EventStorage(userId);
+  });
+
+  afterEach(async () => {
+    if (storage) {
+      await storage.stopSync();
+      await storage.clearAll();
+      await storage.close();
+    }
+
+    await removeRootArtifacts(dbBaseName);
+  });
+
+  it('does not leak events_* folders in repository root during tests（测试期间不污染仓库根目录）', async () => {
+    const event = {
+      id: `evt-${Date.now()}`,
+      content: 'issue128-regression',
+      createdAt: new Date().toISOString(),
+    };
+
+    await storage.addEvent(event);
+    await storage.getEvents();
+
+    const repoRoot = process.cwd();
+    const rootDbPath = path.join(repoRoot, dbBaseName);
+    const rootEntries = await fs.promises.readdir(repoRoot, { withFileTypes: true });
+    const mrviewDirs = rootEntries.filter((entry) => entry.isDirectory() && entry.name.startsWith(`${dbBaseName}-mrview-`));
+
+    expect(fs.existsSync(rootDbPath)).toBe(false);
+    expect(mrviewDirs).toHaveLength(0);
+  });
+});

--- a/tests/storage/event-storage-path.issue128.test.ts
+++ b/tests/storage/event-storage-path.issue128.test.ts
@@ -5,11 +5,13 @@ import path from 'node:path';
 import { EventStorage } from '@/lib/storage/event-storage';
 
 async function removeDirWithRetry(targetPath: string): Promise<void> {
+  let lastError: unknown = null;
   for (let attempt = 0; attempt < 5; attempt++) {
     try {
       await fs.promises.rm(targetPath, { recursive: true, force: true });
       return;
     } catch (error) {
+      lastError = error;
       const code = (error as NodeJS.ErrnoException).code;
       if (code && !['EBUSY', 'ENOTEMPTY', 'EPERM', 'ENOENT'].includes(code)) {
         throw error;
@@ -17,6 +19,10 @@ async function removeDirWithRetry(targetPath: string): Promise<void> {
 
       await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
     }
+  }
+
+  if (lastError) {
+    throw lastError;
   }
 }
 

--- a/tests/storage/event-storage-singleton-prefix.issue286.test.ts
+++ b/tests/storage/event-storage-singleton-prefix.issue286.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  clearAllStorageInstances,
+  getEventStorage,
+} from '@/lib/storage/event-storage';
+
+const PREFIX_ENV = 'EXOMIND_EVENT_STORAGE_PREFIX';
+
+async function closeUniqueStorages(storages: Array<ReturnType<typeof getEventStorage>>): Promise<void> {
+  const unique = Array.from(new Set(storages));
+  await Promise.all(unique.map(async (storage) => {
+    await storage.stopSync();
+    await storage.clearAll();
+    await storage.close();
+  }));
+}
+
+describe('EventStorage singleton cache key with prefix（单例缓存应包含前缀）', () => {
+  const originalPrefix = process.env[PREFIX_ENV];
+
+  afterEach(async () => {
+    clearAllStorageInstances();
+    if (originalPrefix === undefined) {
+      delete process.env[PREFIX_ENV];
+    } else {
+      process.env[PREFIX_ENV] = originalPrefix;
+    }
+  });
+
+  it('creates different singleton instances when prefix changes（前缀变化时不应复用旧实例）', async () => {
+    const userId = `singleton-prefix-${Date.now()}`;
+    process.env[PREFIX_ENV] = '.tmp/pouchdb-event-storage/a';
+    const first = getEventStorage(userId);
+
+    process.env[PREFIX_ENV] = '.tmp/pouchdb-event-storage/b';
+    const second = getEventStorage(userId);
+
+    await closeUniqueStorages([first, second]);
+    expect(first).not.toBe(second);
+  });
+});


### PR DESCRIPTION
## Summary
- isolate EventStorage PouchDB disk artifacts during Vitest/Node runtime by applying a default prefix (`.tmp/pouchdb-event-storage/`)
- support `EXOMIND_EVENT_STORAGE_PREFIX` for custom test/runtime override
- add regression test to prevent root-level `events_*` leakage

## Root Cause
`EventStorage` previously used `new PouchDB(dbName)` unconditionally. In Vitest (Node runtime), PouchDB LevelDB created directories in repo root (`events_*` + `*-mrview-*`).

## Changes
- `src/lib/storage/event-storage.ts`
  - add runtime prefix resolver
  - apply default prefix when `VITEST` is present
  - keep DB naming unchanged (`events_<userId>`)
- `tests/storage/event-storage-path.issue128.test.ts`
  - new regression test: verifies no root-level `events_*` directories are created
- `.gitignore`
  - ignore `.tmp/`

## Verification
```powershell
bunx vitest run tests/storage/event-storage-path.issue128.test.ts tests/storage/event-storage.test.ts tests/storage/remote-sync.test.ts tests/integration/chat-event-storage.test.ts --reporter=dot
# 4 files passed, 33 tests passed

bun run build
# exit 0
```

Additional check:
- root-level `events_*` count remained unchanged during verification (`before=30`, `after=30`), indicating no new root leakage.

Closes #128