### PR TITLE
feat(runtime): add GET /topology system endpoint (#201)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,25 +646,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,12 +892,6 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embed-resource"
@@ -3428,26 +3403,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4110,7 +4065,6 @@ dependencies = [
  "libc",
  "ntapi",
  "once_cell",
- "rayon",
  "windows 0.52.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,6 +913,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,6 +1054,7 @@ dependencies = [
  "http-body-util",
  "serde",
  "serde_json",
+ "sysinfo",
  "thiserror 1.0.69",
  "tokio",
  "tower",
@@ -2335,6 +2361,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3393,6 +3428,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4045,6 +4100,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows 0.52.0",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4091,7 +4161,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -4162,7 +4232,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4325,7 +4395,7 @@ dependencies = [
  "tokio-tungstenite 0.28.0",
  "uuid",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -4347,7 +4417,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -4373,7 +4443,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4399,7 +4469,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -5335,7 +5405,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -5359,7 +5429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -5417,6 +5487,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -5435,6 +5515,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5973,7 +6062,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/crates/exomind-runtime/Cargo.toml
+++ b/crates/exomind-runtime/Cargo.toml
@@ -12,7 +12,7 @@ axum = "0.7"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net"] }
 thiserror = "1"
-sysinfo = "0.30"
+sysinfo = { version = "0.30", default-features = false }
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/crates/exomind-runtime/Cargo.toml
+++ b/crates/exomind-runtime/Cargo.toml
@@ -12,6 +12,7 @@ axum = "0.7"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net"] }
 thiserror = "1"
+sysinfo = "0.30"
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -3,7 +3,14 @@ use serde::Serialize;
 use std::env;
 use thiserror::Error;
 
+pub mod routes;
+
 pub const RUNTIME_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Clone, Copy, Debug)]
+pub struct RuntimeState {
+    pub port: u16,
+}
 
 #[derive(Debug, Error)]
 pub enum PortConfigError {
@@ -26,8 +33,11 @@ pub fn configured_port_from_env() -> Result<u16, PortConfigError> {
 }
 
 /// Build HTTP router (HTTP 路由构建入口).
-pub fn app() -> Router {
-    Router::new().route("/health", get(health))
+pub fn app(runtime_port: u16) -> Router {
+    Router::<RuntimeState>::new()
+        .route("/health", get(health))
+        .merge(routes::router())
+        .with_state(RuntimeState { port: runtime_port })
 }
 
 #[derive(Debug, Serialize)]
@@ -54,7 +64,7 @@ mod tests {
 
     #[tokio::test]
     async fn health_endpoint_returns_ok_with_version() {
-        let response = app()
+        let response = app(3001)
             .oneshot(
                 Request::builder()
                     .uri("/health")
@@ -76,5 +86,30 @@ mod tests {
                 "version": RUNTIME_VERSION
             })
         );
+    }
+
+    #[tokio::test]
+    async fn topology_endpoint_returns_runtime_topology() {
+        let response = app(3002)
+            .oneshot(
+                Request::builder()
+                    .uri("/topology")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(StatusCode::OK, response.status());
+
+        let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let payload: Value = serde_json::from_slice(&body_bytes).unwrap();
+
+        assert!(!payload["hostname"].as_str().unwrap_or_default().is_empty());
+        assert!(!payload["os"].as_str().unwrap_or_default().is_empty());
+        assert!(!payload["arch"].as_str().unwrap_or_default().is_empty());
+        assert!(payload["uptime_secs"].is_u64());
+        assert_eq!(payload["version"], RUNTIME_VERSION);
+        assert_eq!(payload["port"], serde_json::json!(3002));
     }
 }

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -7,7 +7,7 @@ pub mod routes;
 
 pub const RUNTIME_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct RuntimeState {
     pub port: u16,
 }
@@ -64,7 +64,8 @@ mod tests {
 
     #[tokio::test]
     async fn health_endpoint_returns_ok_with_version() {
-        let response = app(3001)
+        const TEST_PORT: u16 = 3001;
+        let response = app(TEST_PORT)
             .oneshot(
                 Request::builder()
                     .uri("/health")
@@ -90,7 +91,8 @@ mod tests {
 
     #[tokio::test]
     async fn topology_endpoint_returns_runtime_topology() {
-        let response = app(3002)
+        const TEST_PORT: u16 = 3002;
+        let response = app(TEST_PORT)
             .oneshot(
                 Request::builder()
                     .uri("/topology")
@@ -110,6 +112,6 @@ mod tests {
         assert!(!payload["arch"].as_str().unwrap_or_default().is_empty());
         assert!(payload["uptime_secs"].is_u64());
         assert_eq!(payload["version"], RUNTIME_VERSION);
-        assert_eq!(payload["port"], serde_json::json!(3002));
+        assert_eq!(payload["port"], serde_json::json!(TEST_PORT));
     }
 }

--- a/crates/exomind-runtime/src/main.rs
+++ b/crates/exomind-runtime/src/main.rs
@@ -9,6 +9,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("exomind-rt listening on http://{local_addr}");
 
-    axum::serve(listener, exomind_runtime::app()).await?;
+    axum::serve(listener, exomind_runtime::app(local_addr.port())).await?;
     Ok(())
 }

--- a/crates/exomind-runtime/src/routes/mod.rs
+++ b/crates/exomind-runtime/src/routes/mod.rs
@@ -1,0 +1,10 @@
+use axum::{routing::get, Router};
+
+use crate::RuntimeState;
+
+pub mod topology;
+
+/// Build route tree for runtime APIs（构建 runtime API 路由树）.
+pub fn router() -> Router<RuntimeState> {
+    Router::new().route("/topology", get(topology::get_topology))
+}

--- a/crates/exomind-runtime/src/routes/topology.rs
+++ b/crates/exomind-runtime/src/routes/topology.rs
@@ -1,0 +1,45 @@
+use axum::{extract::State, Json};
+use serde::Serialize;
+use sysinfo::System;
+
+use crate::{RuntimeState, RUNTIME_VERSION};
+
+#[derive(Debug, Serialize)]
+pub struct TopologyResponse {
+    pub hostname: String,
+    pub os: String,
+    pub arch: String,
+    pub uptime_secs: u64,
+    pub version: &'static str,
+    pub port: u16,
+}
+
+pub async fn get_topology(State(state): State<RuntimeState>) -> Json<TopologyResponse> {
+    Json(TopologyResponse {
+        hostname: read_hostname(),
+        os: read_os(),
+        arch: read_arch(),
+        uptime_secs: System::uptime(),
+        version: RUNTIME_VERSION,
+        port: state.port,
+    })
+}
+
+fn read_hostname() -> String {
+    System::host_name()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "unknown-host".to_string())
+}
+
+fn read_os() -> String {
+    System::long_os_version()
+        .or_else(System::name)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| std::env::consts::OS.to_string())
+}
+
+fn read_arch() -> String {
+    System::cpu_arch()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| std::env::consts::ARCH.to_string())
+}

--- a/crates/exomind-runtime/src/routes/topology.rs
+++ b/crates/exomind-runtime/src/routes/topology.rs
@@ -1,8 +1,18 @@
 use axum::{extract::State, Json};
 use serde::Serialize;
+use std::sync::OnceLock;
 use sysinfo::System;
 
 use crate::{RuntimeState, RUNTIME_VERSION};
+
+#[derive(Debug, Clone)]
+struct TopologyStaticInfo {
+    hostname: String,
+    os: String,
+    arch: String,
+}
+
+static TOPOLOGY_STATIC_INFO: OnceLock<TopologyStaticInfo> = OnceLock::new();
 
 #[derive(Debug, Serialize)]
 pub struct TopologyResponse {
@@ -15,14 +25,24 @@ pub struct TopologyResponse {
 }
 
 pub async fn get_topology(State(state): State<RuntimeState>) -> Json<TopologyResponse> {
+    // Cache mostly-static host identity data（缓存基本静态的主机身份信息）.
+    let static_info = TOPOLOGY_STATIC_INFO.get_or_init(build_static_info);
     Json(TopologyResponse {
-        hostname: read_hostname(),
-        os: read_os(),
-        arch: read_arch(),
+        hostname: static_info.hostname.clone(),
+        os: static_info.os.clone(),
+        arch: static_info.arch.clone(),
         uptime_secs: System::uptime(),
         version: RUNTIME_VERSION,
         port: state.port,
     })
+}
+
+fn build_static_info() -> TopologyStaticInfo {
+    TopologyStaticInfo {
+        hostname: read_hostname(),
+        os: read_os(),
+        arch: read_arch(),
+    }
 }
 
 fn read_hostname() -> String {
@@ -33,7 +53,7 @@ fn read_hostname() -> String {
 
 fn read_os() -> String {
     System::long_os_version()
-        .or_else(System::name)
+        .or_else(|| System::name())
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| std::env::consts::OS.to_string())
 }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -10,3 +10,6 @@ export * from './message';
 
 // Agent Hub 类型定义
 export * from './agent-hub';
+
+// Runtime 拓扑类型定义
+export * from './runtime-topology';

--- a/src/lib/types/runtime-topology.ts
+++ b/src/lib/types/runtime-topology.ts
@@ -6,7 +6,7 @@ export interface RuntimeTopologyResponse {
   hostname: string; // 主机名
   os: string; // 操作系统
   arch: string; // CPU 架构（CPU architecture）
-  uptime_secs: number; // 运行时长（秒）
+  uptime_secs: number; // 保持 snake_case 与 Rust JSON 契约一致（wire format alignment）
   version: string; // runtime 版本
   port: number; // runtime 监听端口
 }

--- a/src/lib/types/runtime-topology.ts
+++ b/src/lib/types/runtime-topology.ts
@@ -1,0 +1,12 @@
+/**
+ * Runtime topology response（运行时拓扑响应）
+ * Mirrors Rust `TopologyResponse` contract（与 Rust `TopologyResponse` 结构体对齐）
+ */
+export interface RuntimeTopologyResponse {
+  hostname: string; // 主机名
+  os: string; // 操作系统
+  arch: string; // CPU 架构（CPU architecture）
+  uptime_secs: number; // 运行时长（秒）
+  version: string; // runtime 版本
+  port: number; // runtime 监听端口
+}


### PR DESCRIPTION
## Summary（变更摘要）
- add `GET /topology` endpoint in `exomind-runtime` for host runtime topology info（新增主机拓扑信息端点）
- register runtime routes via `crates/exomind-runtime/src/routes/{mod,topology}.rs` and wire runtime port into app state（注册路由并注入运行端口）
- add Rust/TS contract alignment: `TopologyResponse` + `RuntimeTopologyResponse`（Rust/TS 类型契约对齐）

## Test Plan（测试计划）
- [x] `cargo test -p exomind-runtime`
- [x] `cargo build -p exomind-runtime`
- [x] runtime smoke check: `GET /topology` returns expected JSON fields

## Related Issue（关联）
- Refs #201