### PR TITLE
feat(agent-hub): add /agents and /agents/:id/chat SSE with runtime registry (#201)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,6 +1026,7 @@ name = "exomind-runtime"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "futures-util",
  "http-body-util",
  "serde",
  "serde_json",

--- a/crates/exomind-runtime/Cargo.toml
+++ b/crates/exomind-runtime/Cargo.toml
@@ -9,13 +9,14 @@ path = "src/main.rs"
 
 [dependencies]
 axum = "0.7"
+futures-util = "0.3"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net"] }
 thiserror = "1"
 sysinfo = { version = "0.30", default-features = false }
 
 [dev-dependencies]
 http-body-util = "0.1"
-serde_json = "1"
 tower = { version = "0.5", features = ["util"] }
 

--- a/crates/exomind-runtime/src/agent/echo.rs
+++ b/crates/exomind-runtime/src/agent/echo.rs
@@ -1,0 +1,31 @@
+use super::{Agent, ChatChunk};
+
+/// Built-in echo agent (内置回显 Agent).
+#[derive(Debug, Default)]
+pub struct EchoAgent;
+
+impl EchoAgent {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Agent for EchoAgent {
+    fn id(&self) -> &'static str {
+        "echo"
+    }
+
+    fn name(&self) -> &'static str {
+        "Echo Agent"
+    }
+
+    fn description(&self) -> &'static str {
+        "回显输入内容"
+    }
+
+    fn chat_chunks(&self, message: String) -> Vec<ChatChunk> {
+        vec![ChatChunk {
+            content: format!("Echo: {message}"),
+        }]
+    }
+}

--- a/crates/exomind-runtime/src/agent/echo.rs
+++ b/crates/exomind-runtime/src/agent/echo.rs
@@ -1,4 +1,5 @@
 use super::{Agent, ChatChunk};
+use futures_util::stream::{self, BoxStream, StreamExt};
 
 /// Built-in echo agent (内置回显 Agent).
 #[derive(Debug, Default)]
@@ -23,9 +24,10 @@ impl Agent for EchoAgent {
         "回显输入内容"
     }
 
-    fn chat_chunks(&self, message: String) -> Vec<ChatChunk> {
-        vec![ChatChunk {
+    fn chat_stream(&self, message: String) -> BoxStream<'static, ChatChunk> {
+        stream::iter(vec![ChatChunk {
             content: format!("Echo: {message}"),
-        }]
+        }])
+        .boxed()
     }
 }

--- a/crates/exomind-runtime/src/agent/mod.rs
+++ b/crates/exomind-runtime/src/agent/mod.rs
@@ -1,6 +1,7 @@
+use futures_util::stream::BoxStream;
 use serde::Serialize;
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 pub mod echo;
 
@@ -29,7 +30,7 @@ pub trait Agent: Send + Sync {
         "available"
     }
 
-    fn chat_chunks(&self, message: String) -> Vec<ChatChunk>;
+    fn chat_stream(&self, message: String) -> BoxStream<'static, ChatChunk>;
 }
 
 #[derive(Clone, Default)]
@@ -42,37 +43,46 @@ impl AgentRegistry {
         Self::default()
     }
 
+    fn read_agents(&self) -> RwLockReadGuard<'_, HashMap<String, Arc<dyn Agent>>> {
+        match self.agents.read() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    fn write_agents(&self) -> RwLockWriteGuard<'_, HashMap<String, Arc<dyn Agent>>> {
+        match self.agents.write() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
     /// Register an agent at runtime (运行时注册 Agent).
     pub fn register(&self, agent: Arc<dyn Agent>) -> Option<Arc<dyn Agent>> {
         let id = agent.id().to_string();
-        self.agents.write().ok()?.insert(id, agent)
+        self.write_agents().insert(id, agent)
     }
 
     /// Unregister by id at runtime (运行时注销 Agent).
     pub fn unregister(&self, id: &str) -> Option<Arc<dyn Agent>> {
-        self.agents.write().ok()?.remove(id)
+        self.write_agents().remove(id)
     }
 
     pub fn get(&self, id: &str) -> Option<Arc<dyn Agent>> {
-        self.agents.read().ok()?.get(id).cloned()
+        self.read_agents().get(id).cloned()
     }
 
     pub fn list(&self) -> Vec<AgentSummary> {
         let mut summaries = self
-            .agents
-            .read()
-            .map(|agents| {
-                agents
-                    .values()
-                    .map(|agent| AgentSummary {
-                        id: agent.id().to_string(),
-                        name: agent.name().to_string(),
-                        description: agent.description().to_string(),
-                        status: agent.status().to_string(),
-                    })
-                    .collect::<Vec<_>>()
+            .read_agents()
+            .values()
+            .map(|agent| AgentSummary {
+                id: agent.id().to_string(),
+                name: agent.name().to_string(),
+                description: agent.description().to_string(),
+                status: agent.status().to_string(),
             })
-            .unwrap_or_default();
+            .collect::<Vec<_>>();
 
         summaries.sort_by(|left, right| left.id.cmp(&right.id));
         summaries
@@ -82,6 +92,8 @@ impl AgentRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::stream::{self, StreamExt};
+    use std::panic::{self, AssertUnwindSafe};
 
     struct TempAgent;
 
@@ -98,8 +110,8 @@ mod tests {
             "Temporary testing agent"
         }
 
-        fn chat_chunks(&self, message: String) -> Vec<ChatChunk> {
-            vec![ChatChunk { content: message }]
+        fn chat_stream(&self, message: String) -> BoxStream<'static, ChatChunk> {
+            stream::iter(vec![ChatChunk { content: message }]).boxed()
         }
     }
 
@@ -120,6 +132,26 @@ mod tests {
                 status: "available".to_string(),
             }]
         );
+
+        let removed = registry.unregister("temp");
+        assert!(removed.is_some());
+        assert!(registry.list().is_empty());
+    }
+
+    #[test]
+    fn registry_recovers_after_lock_poisoning() {
+        let registry = AgentRegistry::new();
+        registry.register(Arc::new(TempAgent));
+
+        let inner = registry.agents.clone();
+        let _ = panic::catch_unwind(AssertUnwindSafe(move || {
+            let _guard = inner.write().unwrap();
+            panic!("poison lock for test");
+        }));
+
+        let summaries = registry.list();
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].id, "temp");
 
         let removed = registry.unregister("temp");
         assert!(removed.is_some());

--- a/crates/exomind-runtime/src/agent/mod.rs
+++ b/crates/exomind-runtime/src/agent/mod.rs
@@ -1,0 +1,128 @@
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+pub mod echo;
+
+/// Agent summary info (Agent 列表摘要信息).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AgentSummary {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub status: String,
+}
+
+/// Streaming chat chunk (流式聊天分片).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ChatChunk {
+    pub content: String,
+}
+
+/// Agent behavior contract (Agent 行为契约).
+pub trait Agent: Send + Sync {
+    fn id(&self) -> &'static str;
+    fn name(&self) -> &'static str;
+    fn description(&self) -> &'static str;
+
+    fn status(&self) -> &'static str {
+        "available"
+    }
+
+    fn chat_chunks(&self, message: String) -> Vec<ChatChunk>;
+}
+
+#[derive(Clone, Default)]
+pub struct AgentRegistry {
+    agents: Arc<RwLock<HashMap<String, Arc<dyn Agent>>>>,
+}
+
+impl AgentRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register an agent at runtime (运行时注册 Agent).
+    pub fn register(&self, agent: Arc<dyn Agent>) -> Option<Arc<dyn Agent>> {
+        let id = agent.id().to_string();
+        self.agents.write().ok()?.insert(id, agent)
+    }
+
+    /// Unregister by id at runtime (运行时注销 Agent).
+    pub fn unregister(&self, id: &str) -> Option<Arc<dyn Agent>> {
+        self.agents.write().ok()?.remove(id)
+    }
+
+    pub fn get(&self, id: &str) -> Option<Arc<dyn Agent>> {
+        self.agents.read().ok()?.get(id).cloned()
+    }
+
+    pub fn list(&self) -> Vec<AgentSummary> {
+        let mut summaries = self
+            .agents
+            .read()
+            .map(|agents| {
+                agents
+                    .values()
+                    .map(|agent| AgentSummary {
+                        id: agent.id().to_string(),
+                        name: agent.name().to_string(),
+                        description: agent.description().to_string(),
+                        status: agent.status().to_string(),
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        summaries.sort_by(|left, right| left.id.cmp(&right.id));
+        summaries
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TempAgent;
+
+    impl Agent for TempAgent {
+        fn id(&self) -> &'static str {
+            "temp"
+        }
+
+        fn name(&self) -> &'static str {
+            "Temp Agent"
+        }
+
+        fn description(&self) -> &'static str {
+            "Temporary testing agent"
+        }
+
+        fn chat_chunks(&self, message: String) -> Vec<ChatChunk> {
+            vec![ChatChunk { content: message }]
+        }
+    }
+
+    #[test]
+    fn registry_supports_runtime_register_and_unregister() {
+        let registry = AgentRegistry::new();
+        assert!(registry.list().is_empty());
+
+        let previous = registry.register(Arc::new(TempAgent));
+        assert!(previous.is_none());
+
+        assert_eq!(
+            registry.list(),
+            vec![AgentSummary {
+                id: "temp".to_string(),
+                name: "Temp Agent".to_string(),
+                description: "Temporary testing agent".to_string(),
+                status: "available".to_string(),
+            }]
+        );
+
+        let removed = registry.unregister("temp");
+        assert!(removed.is_some());
+        assert!(registry.list().is_empty());
+    }
+}

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -71,9 +71,31 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
+    use futures_util::stream::{self, BoxStream, StreamExt};
     use http_body_util::BodyExt;
     use serde_json::Value;
+    use std::sync::Arc;
     use tower::util::ServiceExt;
+
+    struct TempRouteAgent;
+
+    impl agent::Agent for TempRouteAgent {
+        fn id(&self) -> &'static str {
+            "temp-route"
+        }
+
+        fn name(&self) -> &'static str {
+            "Temp Route Agent"
+        }
+
+        fn description(&self) -> &'static str {
+            "用于路由注册/注销可见性测试"
+        }
+
+        fn chat_stream(&self, message: String) -> BoxStream<'static, agent::ChatChunk> {
+            stream::iter(vec![agent::ChatChunk { content: message }]).boxed()
+        }
+    }
 
     #[tokio::test]
     async fn health_endpoint_returns_ok_with_version() {
@@ -192,5 +214,83 @@ mod tests {
         let done_index = body_text.find(done_marker).unwrap();
 
         assert!(data_index < done_index);
+    }
+
+    #[tokio::test]
+    async fn unknown_agent_chat_returns_not_found() {
+        let response = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/agents/not-found/chat")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"message":"hello"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(StatusCode::NOT_FOUND, response.status());
+    }
+
+    #[tokio::test]
+    async fn agents_endpoint_reflects_runtime_register_and_unregister() {
+        let registry = agent::AgentRegistry::new();
+        registry.register(Arc::new(TempRouteAgent));
+
+        let router = routes::router().with_state(AppState {
+            registry: registry.clone(),
+        });
+
+        let first_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/agents")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(StatusCode::OK, first_response.status());
+        let first_body = first_response
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
+        let first_payload: Value = serde_json::from_slice(&first_body).unwrap();
+        assert_eq!(
+            first_payload,
+            serde_json::json!([
+                {
+                    "id": "temp-route",
+                    "name": "Temp Route Agent",
+                    "description": "用于路由注册/注销可见性测试",
+                    "status": "available"
+                }
+            ])
+        );
+
+        registry.unregister("temp-route");
+
+        let second_response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/agents")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(StatusCode::OK, second_response.status());
+        let second_body = second_response
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
+        let second_payload: Value = serde_json::from_slice(&second_body).unwrap();
+        assert_eq!(second_payload, serde_json::json!([]));
     }
 }

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -1,16 +1,13 @@
 use axum::{routing::get, Json, Router};
 use serde::Serialize;
 use std::env;
+use std::sync::Arc;
 use thiserror::Error;
 
+pub mod agent;
 pub mod routes;
 
 pub const RUNTIME_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-#[derive(Clone, Debug)]
-pub struct RuntimeState {
-    pub port: u16,
-}
 
 #[derive(Debug, Error)]
 pub enum PortConfigError {
@@ -34,11 +31,27 @@ pub fn configured_port_from_env() -> Result<u16, PortConfigError> {
 
 /// Build HTTP router (HTTP 路由构建入口).
 pub fn app(runtime_port: u16) -> Router {
-    Router::<RuntimeState>::new()
+    Router::new()
         .route("/health", get(health))
         .merge(routes::router())
-        .with_state(RuntimeState { port: runtime_port })
+        .with_state(AppState::new(runtime_port))
 }
+
+#[derive(Clone, Debug)]
+pub struct AppState {
+    pub port: u16,
+    pub registry: agent::AgentRegistry,
+}
+
+impl AppState {
+    fn new(port: u16) -> Self {
+        let registry = agent::AgentRegistry::new();
+        registry.register(Arc::new(agent::echo::EchoAgent::new()));
+        Self { port, registry }
+    }
+}
+
+pub type RuntimeState = AppState;
 
 #[derive(Debug, Serialize)]
 struct HealthResponse {
@@ -113,5 +126,71 @@ mod tests {
         assert!(payload["uptime_secs"].is_u64());
         assert_eq!(payload["version"], RUNTIME_VERSION);
         assert_eq!(payload["port"], serde_json::json!(TEST_PORT));
+    }
+
+    #[tokio::test]
+    async fn agents_endpoint_returns_echo_agent() {
+        const TEST_PORT: u16 = 3003;
+        let response = app(TEST_PORT)
+            .oneshot(
+                Request::builder()
+                    .uri("/agents")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(StatusCode::OK, response.status());
+
+        let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let payload: Value = serde_json::from_slice(&body_bytes).unwrap();
+
+        assert_eq!(
+            payload,
+            serde_json::json!([
+                {
+                    "id": "echo",
+                    "name": "Echo Agent",
+                    "description": "回显输入内容",
+                    "status": "available"
+                }
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn echo_chat_stream_returns_data_and_done() {
+        const TEST_PORT: u16 = 3003;
+        let response = app(TEST_PORT)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/agents/echo/chat")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"message":"hello"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(StatusCode::OK, response.status());
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|value| value.to_str().ok()),
+            Some("text/event-stream")
+        );
+
+        let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body_text = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+        let data_marker = r#"data: {"content":"Echo: hello"}"#;
+        let done_marker = "data: [DONE]";
+        let data_index = body_text.find(data_marker).unwrap();
+        let done_index = body_text.find(done_marker).unwrap();
+
+        assert!(data_index < done_index);
     }
 }

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -37,7 +37,7 @@ pub fn app(runtime_port: u16) -> Router {
         .with_state(AppState::new(runtime_port))
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct AppState {
     pub port: u16,
     pub registry: agent::AgentRegistry,
@@ -218,7 +218,8 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_agent_chat_returns_not_found() {
-        let response = app()
+        const TEST_PORT: u16 = 3003;
+        let response = app(TEST_PORT)
             .oneshot(
                 Request::builder()
                     .method("POST")
@@ -239,6 +240,7 @@ mod tests {
         registry.register(Arc::new(TempRouteAgent));
 
         let router = routes::router().with_state(AppState {
+            port: 3003,
             registry: registry.clone(),
         });
 

--- a/crates/exomind-runtime/src/routes/agents.rs
+++ b/crates/exomind-runtime/src/routes/agents.rs
@@ -1,0 +1,56 @@
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::sse::{Event, Sse};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use futures_util::stream;
+use serde::Deserialize;
+use std::convert::Infallible;
+
+use crate::agent::ChatChunk;
+use crate::AppState;
+
+#[derive(Debug, Deserialize)]
+struct ChatRequest {
+    message: String,
+}
+
+/// Agent routes (Agent 相关路由).
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/agents", get(list_agents))
+        .route("/agents/:id/chat", post(chat_with_agent))
+}
+
+async fn list_agents(State(state): State<AppState>) -> Json<Vec<crate::agent::AgentSummary>> {
+    Json(state.registry.list())
+}
+
+async fn chat_with_agent(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+    Json(payload): Json<ChatRequest>,
+) -> Result<Sse<impl futures_util::Stream<Item = Result<Event, Infallible>>>, StatusCode> {
+    let Some(agent) = state.registry.get(&id) else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+
+    let events = agent
+        .chat_chunks(payload.message)
+        .into_iter()
+        .map(|chunk: ChatChunk| {
+            serde_json::to_string(&chunk)
+                .map(|encoded| Event::default().data(encoded))
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let stream = stream::iter(
+        events
+            .into_iter()
+            .chain(std::iter::once(Event::default().data("[DONE]")))
+            .map(Ok::<Event, Infallible>),
+    );
+
+    Ok(Sse::new(stream))
+}

--- a/crates/exomind-runtime/src/routes/agents.rs
+++ b/crates/exomind-runtime/src/routes/agents.rs
@@ -3,7 +3,7 @@ use axum::http::StatusCode;
 use axum::response::sse::{Event, Sse};
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use futures_util::stream;
+use futures_util::stream::{self, StreamExt};
 use serde::Deserialize;
 use std::convert::Infallible;
 
@@ -35,22 +35,16 @@ async fn chat_with_agent(
         return Err(StatusCode::NOT_FOUND);
     };
 
-    let events = agent
-        .chat_chunks(payload.message)
-        .into_iter()
-        .map(|chunk: ChatChunk| {
-            serde_json::to_string(&chunk)
-                .map(|encoded| Event::default().data(encoded))
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let data_stream = agent.chat_stream(payload.message).map(|chunk: ChatChunk| {
+        // ChatChunk currently only contains strings, JSON serialization is expected infallible.
+        let encoded = serde_json::to_string(&chunk).expect("ChatChunk serialization failed");
+        Ok::<Event, Infallible>(Event::default().data(encoded))
+    });
 
-    let stream = stream::iter(
-        events
-            .into_iter()
-            .chain(std::iter::once(Event::default().data("[DONE]")))
-            .map(Ok::<Event, Infallible>),
-    );
+    let done_stream =
+        stream::once(async { Ok::<Event, Infallible>(Event::default().data("[DONE]")) });
+
+    let stream = data_stream.chain(done_stream);
 
     Ok(Sse::new(stream))
 }

--- a/crates/exomind-runtime/src/routes/mod.rs
+++ b/crates/exomind-runtime/src/routes/mod.rs
@@ -1,10 +1,13 @@
 use axum::{routing::get, Router};
 
-use crate::RuntimeState;
+use crate::AppState;
 
+pub mod agents;
 pub mod topology;
 
 /// Build route tree for runtime APIs（构建 runtime API 路由树）.
-pub fn router() -> Router<RuntimeState> {
-    Router::new().route("/topology", get(topology::get_topology))
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/topology", get(topology::get_topology))
+        .merge(agents::router())
 }


### PR DESCRIPTION
## Summary
- add Agent registry APIs (`register`/`unregister`) and built-in `echo` agent
- expose `GET /agents` and `POST /agents/:id/chat` SSE endpoint with `[DONE]` terminator
- fix review findings: recover from `RwLock` poisoning and switch chat response path to true streaming (stream，流式) instead of pre-collect buffering
- add tests for unknown agent `404`, runtime register/unregister visibility, and lock poisoning recovery

## Related
- Closes #201

## Test Evidence
- `cargo build -p exomind-runtime`
- `cargo test -p exomind-runtime`
- runtime smoke:
  - `GET /agents` returns echo list
  - `POST /agents/echo/chat` streams `data` then `data: [DONE]`