### PR TITLE
feat(agent-hub): 多主机聚合 + AgentsPage 真实 runtime 数据 (#201)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,6 +1034,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tower",
+ "tower-http",
 ]
 
 [[package]]

--- a/crates/exomind-runtime/Cargo.toml
+++ b/crates/exomind-runtime/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net"] }
 thiserror = "1"
 sysinfo = { version = "0.30", default-features = false }
+tower-http = { version = "0.6", features = ["cors"] }
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -1,8 +1,10 @@
 use axum::{routing::get, Json, Router};
+use axum::http::Method;
 use serde::Serialize;
 use std::env;
 use std::sync::Arc;
 use thiserror::Error;
+use tower_http::cors::{Any, CorsLayer};
 
 pub mod agent;
 pub mod routes;
@@ -31,9 +33,16 @@ pub fn configured_port_from_env() -> Result<u16, PortConfigError> {
 
 /// Build HTTP router (HTTP 路由构建入口).
 pub fn app(runtime_port: u16) -> Router {
+    // Enable CORS for browser-side host aggregation (允许浏览器跨端口访问 runtime).
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+        .allow_headers(Any);
+
     Router::new()
         .route("/health", get(health))
         .merge(routes::router())
+        .layer(cors)
         .with_state(AppState::new(runtime_port))
 }
 
@@ -178,6 +187,30 @@ mod tests {
                     "status": "available"
                 }
             ])
+        );
+    }
+
+    #[tokio::test]
+    async fn agents_endpoint_sets_cors_header_for_browser_fetch() {
+        const TEST_PORT: u16 = 3004;
+        let response = app(TEST_PORT)
+            .oneshot(
+                Request::builder()
+                    .uri("/agents")
+                    .header("origin", "http://127.0.0.1:1420")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(StatusCode::OK, response.status());
+        assert_eq!(
+            response
+                .headers()
+                .get("access-control-allow-origin")
+                .and_then(|value| value.to_str().ok()),
+            Some("*")
         );
     }
 

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -157,6 +157,8 @@ mod tests {
         assert!(payload["uptime_secs"].is_u64());
         assert_eq!(payload["version"], RUNTIME_VERSION);
         assert_eq!(payload["port"], serde_json::json!(TEST_PORT));
+        assert!(payload["total_memory_mb"].is_u64());
+        assert!(payload["used_memory_mb"].is_u64());
     }
 
     #[tokio::test]

--- a/crates/exomind-runtime/src/routes/topology.rs
+++ b/crates/exomind-runtime/src/routes/topology.rs
@@ -22,11 +22,14 @@ pub struct TopologyResponse {
     pub uptime_secs: u64,
     pub version: &'static str,
     pub port: u16,
+    pub total_memory_mb: u64,
+    pub used_memory_mb: u64,
 }
 
 pub async fn get_topology(State(state): State<RuntimeState>) -> Json<TopologyResponse> {
     // Cache mostly-static host identity data（缓存基本静态的主机身份信息）.
     let static_info = TOPOLOGY_STATIC_INFO.get_or_init(build_static_info);
+    let (total_memory_mb, used_memory_mb) = read_memory_stats_mb();
     Json(TopologyResponse {
         hostname: static_info.hostname.clone(),
         os: static_info.os.clone(),
@@ -34,6 +37,8 @@ pub async fn get_topology(State(state): State<RuntimeState>) -> Json<TopologyRes
         uptime_secs: System::uptime(),
         version: RUNTIME_VERSION,
         port: state.port,
+        total_memory_mb,
+        used_memory_mb,
     })
 }
 
@@ -62,4 +67,17 @@ fn read_arch() -> String {
     System::cpu_arch()
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| std::env::consts::ARCH.to_string())
+}
+
+fn read_memory_stats_mb() -> (u64, u64) {
+    // sysinfo v0.30 reports memory in bytes（sysinfo v0.30 的内存单位是 bytes）.
+    let mut system = System::new();
+    system.refresh_memory();
+    let total_memory_mb = bytes_to_mb(system.total_memory());
+    let used_memory_mb = bytes_to_mb(system.used_memory());
+    (total_memory_mb, used_memory_mb)
+}
+
+fn bytes_to_mb(bytes: u64) -> u64 {
+    bytes / (1024 * 1024)
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:e2e:issue198": "node Scripts/test/playwright-runner.cjs test tests/e2e/settings-desktop.issue198.test.ts --config tests/e2e/playwright.issue198.config.ts",
     "test:e2e:issue204": "node Scripts/test/playwright-runner.cjs test tests/e2e/agent-hub.issue204.test.ts --config tests/e2e/playwright.issue204.config.ts",
     "test:e2e:issue205": "node Scripts/test/playwright-runner.cjs test tests/e2e/agent-runtime-host.issue205.test.ts --config tests/e2e/playwright.issue205.config.ts",
+    "test:e2e:issue201": "node Scripts/test/playwright-runner.cjs test tests/e2e/agents-page.issue201.test.ts --config tests/e2e/playwright.issue201.config.ts",
     "test:e2e:issue243": "node Scripts/test/playwright-runner.cjs test tests/e2e/command-palette.issue243.test.ts --config tests/e2e/playwright.issue243.config.ts",
     "test:e2e:report": "node Scripts/test/playwright-runner.cjs test --reporter=html",
     "test:e2e:website": "node Scripts/test/playwright-runner.cjs test tests/e2e/website.dark-mode.test.ts tests/e2e/website.smoke.test.ts --config tests/e2e/playwright.website.config.ts",

--- a/src/lib/services/agent-hub.service.ts
+++ b/src/lib/services/agent-hub.service.ts
@@ -64,7 +64,6 @@ export class AgentHubServiceImpl implements AgentHubService {
 
     for (const host of aggregatedData.hosts) {
       const hostAgents = aggregatedData.agents.filter(a => a.hostId === host.id);
-      const topology = aggregatedData.topologies.get(host.id);
 
       // 构建设备卡片
       const cards = hostAgents.map(agent => ({

--- a/src/lib/types/runtime-topology.ts
+++ b/src/lib/types/runtime-topology.ts
@@ -9,4 +9,6 @@ export interface RuntimeTopologyResponse {
   uptime_secs: number; // 保持 snake_case 与 Rust JSON 契约一致（wire format alignment）
   version: string; // runtime 版本
   port: number; // runtime 监听端口
+  total_memory_mb?: number; // 总内存（MB）
+  used_memory_mb?: number; // 已用内存（MB）
 }

--- a/src/services/runtime-client.ts
+++ b/src/services/runtime-client.ts
@@ -1,0 +1,208 @@
+import type { RuntimeHostRecord } from '@/lib/types/agent-hub';
+import type { RuntimeTopologyResponse } from '@/lib/types/runtime-topology';
+
+export type RuntimeClientErrorCode = 'timeout' | 'network' | 'http' | 'invalid_payload';
+
+export interface RuntimeClientError {
+  code: RuntimeClientErrorCode;
+  message: string;
+  status?: number;
+}
+
+export type RuntimeClientResult<T> =
+  | {
+      ok: true;
+      data: T;
+    }
+  | {
+      ok: false;
+      error: RuntimeClientError;
+    };
+
+export interface RuntimeAgentSummary {
+  id: string;
+  name: string;
+  description: string;
+  status: string;
+}
+
+type RuntimeFetch = typeof fetch;
+
+export interface RuntimeClientOptions {
+  fetchImpl?: RuntimeFetch;
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 3500;
+
+function buildBaseUrl(host: RuntimeHostRecord): string {
+  return `http://${host.host}:${host.port}`;
+}
+
+function isTimeoutError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const message = error.message.toLowerCase();
+  return (
+    message.includes('aborterror')
+    || message.includes('aborted')
+    || message.includes('timeout')
+    || message.includes('signal is aborted')
+  );
+}
+
+function toNetworkError(error: unknown): RuntimeClientError {
+  if (isTimeoutError(error)) {
+    return {
+      code: 'timeout',
+      message: 'request timeout（请求超时）',
+    };
+  }
+  return {
+    code: 'network',
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parseRuntimeAgentSummary(value: unknown): RuntimeAgentSummary | null {
+  if (!isObjectRecord(value)) return null;
+  if (typeof value.id !== 'string') return null;
+  if (typeof value.name !== 'string') return null;
+
+  return {
+    id: value.id,
+    name: value.name,
+    description: typeof value.description === 'string' ? value.description : '',
+    status: typeof value.status === 'string' ? value.status : 'unknown',
+  };
+}
+
+function parseTopologyResponse(value: unknown): RuntimeTopologyResponse | null {
+  if (!isObjectRecord(value)) return null;
+  if (typeof value.hostname !== 'string') return null;
+  if (typeof value.os !== 'string') return null;
+  if (typeof value.arch !== 'string') return null;
+  if (typeof value.uptime_secs !== 'number') return null;
+  if (typeof value.version !== 'string') return null;
+  if (typeof value.port !== 'number') return null;
+
+  return {
+    hostname: value.hostname,
+    os: value.os,
+    arch: value.arch,
+    uptime_secs: value.uptime_secs,
+    version: value.version,
+    port: value.port,
+  };
+}
+
+export class RuntimeClient {
+  private readonly fetchImpl: RuntimeFetch;
+  private readonly timeoutMs: number;
+
+  constructor(options: RuntimeClientOptions = {}) {
+    this.fetchImpl = options.fetchImpl ?? ((input, init) => globalThis.fetch(input, init));
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  async getAgents(host: RuntimeHostRecord): Promise<RuntimeClientResult<RuntimeAgentSummary[]>> {
+    const response = await this.getJson(`${buildBaseUrl(host)}/agents`);
+    if (!response.ok) {
+      return response;
+    }
+
+    if (!Array.isArray(response.data)) {
+      return {
+        ok: false,
+        error: {
+          code: 'invalid_payload',
+          message: 'invalid /agents payload（/agents 响应格式无效）',
+        },
+      };
+    }
+
+    const agents: RuntimeAgentSummary[] = [];
+    for (const item of response.data) {
+      const parsed = parseRuntimeAgentSummary(item);
+      if (!parsed) {
+        return {
+          ok: false,
+          error: {
+            code: 'invalid_payload',
+            message: 'invalid agent item（agent 条目格式无效）',
+          },
+        };
+      }
+      agents.push(parsed);
+    }
+
+    return {
+      ok: true,
+      data: agents,
+    };
+  }
+
+  async getTopology(host: RuntimeHostRecord): Promise<RuntimeClientResult<RuntimeTopologyResponse>> {
+    const response = await this.getJson(`${buildBaseUrl(host)}/topology`);
+    if (!response.ok) {
+      return response;
+    }
+
+    const parsed = parseTopologyResponse(response.data);
+    if (!parsed) {
+      return {
+        ok: false,
+        error: {
+          code: 'invalid_payload',
+          message: 'invalid /topology payload（/topology 响应格式无效）',
+        },
+      };
+    }
+
+    return {
+      ok: true,
+      data: parsed,
+    };
+  }
+
+  private async getJson(url: string): Promise<RuntimeClientResult<unknown>> {
+    const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+    const timer = controller ? setTimeout(() => controller.abort(), this.timeoutMs) : null;
+
+    try {
+      const response = await this.fetchImpl(url, {
+        method: 'GET',
+        signal: controller?.signal,
+      });
+
+      if (!response.ok) {
+        return {
+          ok: false,
+          error: {
+            code: 'http',
+            message: `HTTP ${response.status}`,
+            status: response.status,
+          },
+        };
+      }
+
+      const data = await response.json();
+      return {
+        ok: true,
+        data,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        error: toNetworkError(error),
+      };
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
+  }
+}

--- a/src/services/runtime-client.ts
+++ b/src/services/runtime-client.ts
@@ -88,6 +88,8 @@ function parseTopologyResponse(value: unknown): RuntimeTopologyResponse | null {
   if (typeof value.uptime_secs !== 'number') return null;
   if (typeof value.version !== 'string') return null;
   if (typeof value.port !== 'number') return null;
+  if (value.total_memory_mb != null && typeof value.total_memory_mb !== 'number') return null;
+  if (value.used_memory_mb != null && typeof value.used_memory_mb !== 'number') return null;
 
   return {
     hostname: value.hostname,
@@ -96,6 +98,8 @@ function parseTopologyResponse(value: unknown): RuntimeTopologyResponse | null {
     uptime_secs: value.uptime_secs,
     version: value.version,
     port: value.port,
+    total_memory_mb: typeof value.total_memory_mb === 'number' ? value.total_memory_mb : undefined,
+    used_memory_mb: typeof value.used_memory_mb === 'number' ? value.used_memory_mb : undefined,
   };
 }
 

--- a/src/services/runtime-manager.ts
+++ b/src/services/runtime-manager.ts
@@ -49,6 +49,9 @@ function parseHostAddress(hostAddress: string): { host: string; port: number } {
   if (!raw) {
     throw new Error('host:port is required（必须输入 host:port）');
   }
+  if (raw.includes('://') || raw.includes('/') || raw.includes('?') || raw.includes('#')) {
+    throw new Error('invalid host:port format（host:port 格式错误）');
+  }
 
   const splitIndex = raw.lastIndexOf(':');
   if (splitIndex <= 0 || splitIndex === raw.length - 1) {

--- a/src/services/runtime-manager.ts
+++ b/src/services/runtime-manager.ts
@@ -1,0 +1,173 @@
+import type { RuntimeHostRecord } from '@/lib/types/agent-hub';
+import type { RuntimeTopologyResponse } from '@/lib/types/runtime-topology';
+import {
+  type AddRuntimeHostInput,
+  type RuntimeHostService,
+  getRuntimeHostService,
+} from '@/lib/services/runtime-host.service';
+import { RuntimeClient, type RuntimeAgentSummary } from './runtime-client';
+
+export type RuntimeHostConnectionState = 'online' | 'error' | 'offline';
+
+export interface RuntimeAggregatedAgent extends RuntimeAgentSummary {
+  sourceHostId: string;
+  sourceHostName: string;
+  sourceHostAddress: string;
+}
+
+export interface RuntimeHostSnapshot {
+  host: RuntimeHostRecord;
+  connectionState: RuntimeHostConnectionState;
+  agents: RuntimeAggregatedAgent[];
+  topology: RuntimeTopologyResponse | null;
+  error?: string;
+}
+
+export interface RuntimeManagerSnapshot {
+  updatedAt: string;
+  hosts: RuntimeHostSnapshot[];
+  agents: RuntimeAggregatedAgent[];
+}
+
+export interface RuntimeManagerOptions {
+  hostService?: Pick<RuntimeHostService, 'listHosts' | 'addHost' | 'removeHost'>;
+  runtimeClient?: Pick<RuntimeClient, 'getAgents' | 'getTopology'>;
+  now?: () => Date;
+}
+
+function mapErrorToConnectionState(errorCode: 'timeout' | 'network' | 'http' | 'invalid_payload'): RuntimeHostConnectionState {
+  if (errorCode === 'network') return 'offline';
+  return 'error';
+}
+
+function toIso(now: () => Date): string {
+  return now().toISOString();
+}
+
+function parseHostAddress(hostAddress: string): { host: string; port: number } {
+  const raw = hostAddress.trim();
+  if (!raw) {
+    throw new Error('host:port is required（必须输入 host:port）');
+  }
+
+  const splitIndex = raw.lastIndexOf(':');
+  if (splitIndex <= 0 || splitIndex === raw.length - 1) {
+    throw new Error('invalid host:port format（host:port 格式错误）');
+  }
+
+  const hostRaw = raw.slice(0, splitIndex).trim();
+  const portRaw = raw.slice(splitIndex + 1).trim();
+  const host = hostRaw.startsWith('[') && hostRaw.endsWith(']') ? hostRaw.slice(1, -1) : hostRaw;
+  const port = Number.parseInt(portRaw, 10);
+
+  if (!host) {
+    throw new Error('host is required（host 不能为空）');
+  }
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error('port must be 1-65535（端口需在 1-65535）');
+  }
+
+  return { host, port };
+}
+
+export class RuntimeManager {
+  private readonly hostService: Pick<RuntimeHostService, 'listHosts' | 'addHost' | 'removeHost'>;
+  private readonly runtimeClient: Pick<RuntimeClient, 'getAgents' | 'getTopology'>;
+  private readonly now: () => Date;
+
+  constructor(options: RuntimeManagerOptions = {}) {
+    this.hostService = options.hostService ?? getRuntimeHostService();
+    this.runtimeClient = options.runtimeClient ?? new RuntimeClient();
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async refreshSnapshot(): Promise<RuntimeManagerSnapshot> {
+    const hosts = await this.hostService.listHosts();
+    const hostSnapshots = await Promise.all(hosts.map((host) => this.buildHostSnapshot(host)));
+    const agents = hostSnapshots.flatMap((item) => item.agents);
+
+    return {
+      updatedAt: toIso(this.now),
+      hosts: hostSnapshots,
+      agents,
+    };
+  }
+
+  async retryHost(hostId: string): Promise<RuntimeHostSnapshot | null> {
+    const hosts = await this.hostService.listHosts();
+    const target = hosts.find((item) => item.id === hostId);
+    if (!target) return null;
+    return this.buildHostSnapshot(target);
+  }
+
+  async addHost(input: AddRuntimeHostInput): Promise<RuntimeHostRecord> {
+    return this.hostService.addHost(input);
+  }
+
+  async addHostFromAddress(hostAddress: string, name?: string): Promise<RuntimeHostRecord> {
+    const parsed = parseHostAddress(hostAddress);
+    return this.hostService.addHost({
+      name: name?.trim(),
+      host: parsed.host,
+      port: parsed.port,
+    });
+  }
+
+  async removeHost(hostId: string): Promise<void> {
+    await this.hostService.removeHost(hostId);
+  }
+
+  private async buildHostSnapshot(host: RuntimeHostRecord): Promise<RuntimeHostSnapshot> {
+    const [agentsResult, topologyResult] = await Promise.all([
+      this.runtimeClient.getAgents(host),
+      this.runtimeClient.getTopology(host),
+    ]);
+
+    if (!agentsResult.ok) {
+      return {
+        host,
+        connectionState: mapErrorToConnectionState(agentsResult.error.code),
+        agents: [],
+        topology: topologyResult.ok ? topologyResult.data : null,
+        error: agentsResult.error.message,
+      };
+    }
+
+    const nextAgents: RuntimeAggregatedAgent[] = agentsResult.data.map((agent) => ({
+      ...agent,
+      sourceHostId: host.id,
+      sourceHostName: host.name,
+      sourceHostAddress: `${host.host}:${host.port}`,
+    }));
+
+    if (!topologyResult.ok) {
+      return {
+        host,
+        connectionState: mapErrorToConnectionState(topologyResult.error.code),
+        agents: nextAgents,
+        topology: null,
+        error: topologyResult.error.message,
+      };
+    }
+
+    return {
+      host,
+      connectionState: 'online',
+      agents: nextAgents,
+      topology: topologyResult.data,
+    };
+  }
+}
+
+let runtimeManagerInstance: RuntimeManager | null = null;
+
+export function getRuntimeManager(): RuntimeManager {
+  if (!runtimeManagerInstance) {
+    runtimeManagerInstance = new RuntimeManager();
+  }
+  return runtimeManagerInstance;
+}
+
+export function resetRuntimeManagerForTests(): void {
+  runtimeManagerInstance = null;
+}

--- a/src/services/runtime-manager.ts
+++ b/src/services/runtime-manager.ts
@@ -20,6 +20,7 @@ export interface RuntimeHostSnapshot {
   connectionState: RuntimeHostConnectionState;
   agents: RuntimeAggregatedAgent[];
   topology: RuntimeTopologyResponse | null;
+  latencyMs?: number;
   error?: string;
 }
 
@@ -121,10 +122,15 @@ export class RuntimeManager {
   }
 
   private async buildHostSnapshot(host: RuntimeHostRecord): Promise<RuntimeHostSnapshot> {
-    const [agentsResult, topologyResult] = await Promise.all([
+    const topologyStartedAtMs = Date.now();
+    const [agentsResult, topologyEnvelope] = await Promise.all([
       this.runtimeClient.getAgents(host),
-      this.runtimeClient.getTopology(host),
+      this.runtimeClient.getTopology(host).then((result) => ({
+        result,
+        latencyMs: Math.max(1, Date.now() - topologyStartedAtMs),
+      })),
     ]);
+    const topologyResult = topologyEnvelope.result;
 
     if (!agentsResult.ok) {
       return {
@@ -132,6 +138,7 @@ export class RuntimeManager {
         connectionState: mapErrorToConnectionState(agentsResult.error.code),
         agents: [],
         topology: topologyResult.ok ? topologyResult.data : null,
+        latencyMs: topologyEnvelope.latencyMs,
         error: agentsResult.error.message,
       };
     }
@@ -149,6 +156,7 @@ export class RuntimeManager {
         connectionState: mapErrorToConnectionState(topologyResult.error.code),
         agents: nextAgents,
         topology: null,
+        latencyMs: topologyEnvelope.latencyMs,
         error: topologyResult.error.message,
       };
     }
@@ -158,6 +166,7 @@ export class RuntimeManager {
       connectionState: 'online',
       agents: nextAgents,
       topology: topologyResult.data,
+      latencyMs: topologyEnvelope.latencyMs,
     };
   }
 }

--- a/src/ui/app/pages/AgentsPage.tsx
+++ b/src/ui/app/pages/AgentsPage.tsx
@@ -2,6 +2,7 @@ import {
   AlarmClock,
   Bot,
   Brain,
+  CircleAlert,
   ChevronRight,
   Filter,
   List,
@@ -24,19 +25,23 @@ import type { LucideIcon } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { getAgentHubService } from '@/lib/services';
 import { getRuntimeControlService } from '@/lib/services/runtime-control.service';
-import { getRuntimeHostService } from '@/lib/services/runtime-host.service';
 import type {
-  AgentAddNodeOption,
   AgentDeviceGroup,
   AgentHubEdge,
   AgentHubListItem,
   AgentHubListSection,
+  AgentHubNodeStatus,
   AgentHubNode,
   AgentHubTopologyData,
   AgentHubViewMode,
   RuntimeHostRecord,
   RuntimeServiceStatus,
 } from '@/lib/types/agent-hub';
+import {
+  getRuntimeManager,
+  type RuntimeAggregatedAgent,
+  type RuntimeHostSnapshot,
+} from '@/services/runtime-manager';
 
 const VIEW_ITEMS: Array<{ id: AgentHubViewMode; icon: LucideIcon; label: string }> = [
   { id: 'topology', icon: Bot, label: '拓扑' },
@@ -51,6 +56,22 @@ const LIST_FILTERS = [
   { id: 'actor', label: 'Actor' },
   { id: 'output', label: '输出' },
 ] as const;
+
+type AddNodeOption = {
+  id: 'device';
+  title: string;
+  description: string;
+  tintColor: string;
+};
+
+const ADD_NODE_OPTIONS: AddNodeOption[] = [
+  {
+    id: 'device',
+    title: '添加设备',
+    description: '连接 exomind-rt 主机并聚合 Agent 列表',
+    tintColor: '#0D9488',
+  },
+];
 
 type TopologyLayoutItem = {
   x: number;
@@ -110,12 +131,50 @@ function getListItemIcon(item: AgentHubListItem): LucideIcon {
   return Waypoints;
 }
 
-function getAddOptionIcon(optionId: AgentAddNodeOption['id']): LucideIcon {
-  if (optionId === 'input') return Rss;
-  if (optionId === 'agent') return Brain;
-  if (optionId === 'actor') return AlarmClock;
-  if (optionId === 'output') return Send;
-  return Sparkles;
+function getAddOptionIcon(optionId: AddNodeOption['id']): LucideIcon {
+  if (optionId === 'device') return Monitor;
+  return Plus;
+}
+
+function mapRuntimeStatusToNodeStatus(status: string): AgentHubNodeStatus {
+  if (status === 'available' || status === 'running') return 'running';
+  if (status === 'busy') return 'warning';
+  if (status === 'error') return 'warning';
+  return 'idle';
+}
+
+function mapHostConnectionToRecordStatus(connectionState: RuntimeHostSnapshot['connectionState']): RuntimeHostRecord['status'] {
+  if (connectionState === 'online') return 'online';
+  if (connectionState === 'offline') return 'offline';
+  return 'warning';
+}
+
+function buildListSectionsFromRuntimeAgents(agents: RuntimeAggregatedAgent[]): AgentHubListSection[] {
+  const groupedByHost = new Map<string, RuntimeAggregatedAgent[]>();
+  for (const agent of agents) {
+    const key = JSON.stringify([agent.sourceHostId, agent.sourceHostName]);
+    const existing = groupedByHost.get(key) ?? [];
+    existing.push(agent);
+    groupedByHost.set(key, existing);
+  }
+
+  return Array.from(groupedByHost.entries()).map(([key, hostAgents], index) => {
+    const [hostId, hostName] = JSON.parse(key) as [string, string];
+    return {
+      id: `runtime-${hostId}-${index}`,
+      title: hostName || 'Runtime Host',
+      count: hostAgents.length,
+      items: hostAgents.map((agent) => ({
+        id: `${agent.sourceHostId}__${agent.id}`,
+        type: 'agent',
+        name: agent.name,
+        description: `来源 ${agent.sourceHostAddress}${agent.description ? ` · ${agent.description}` : ''}`,
+        status: mapRuntimeStatusToNodeStatus(agent.status),
+        icon: 'brain',
+        badgeText: agent.sourceHostName,
+      })),
+    };
+  });
 }
 
 function getDeviceTypeIcon(groupId: string): LucideIcon {
@@ -428,11 +487,17 @@ function TopologyView({
 
 function ListView({
   sections,
+  hostSnapshots,
+  onRetryHost,
   onItemNavigate,
 }: {
   sections: AgentHubListSection[];
+  hostSnapshots: RuntimeHostSnapshot[];
+  onRetryHost: (hostId: string) => Promise<void>;
   onItemNavigate: (path: string) => void;
 }) {
+  const problemHosts = hostSnapshots.filter((item) => item.connectionState !== 'online');
+
   return (
     <section data-testid="agent-list-view" className="space-y-4">
       <div className="flex gap-2 overflow-x-auto pb-1">
@@ -453,6 +518,57 @@ function ListView({
         })}
       </div>
 
+      {problemHosts.length > 0 && (
+        <article className="space-y-2 rounded-2xl border border-[#FECACA] bg-[#FEF2F2] p-3 dark:border-[#7F1D1D] dark:bg-[#2B1111]">
+          <div className="flex items-center gap-2 text-[#B91C1C] dark:text-[#FCA5A5]">
+            <CircleAlert size={14} />
+            <p className="text-xs font-semibold">连接异常主机</p>
+          </div>
+          <div className="space-y-2">
+            {problemHosts.map((item) => (
+              <div key={item.host.id} className="rounded-xl border border-[#FECACA] bg-white px-3 py-2 dark:border-[#7F1D1D] dark:bg-[#1C1917]">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="truncate text-xs font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{item.host.name}</p>
+                    <p className="truncate text-[11px] text-[#78716C] dark:text-[#A8A29E]">{item.host.host}:{item.host.port}</p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span
+                      data-testid={`runtime-host-status-${item.host.id}`}
+                      className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                        item.connectionState === 'offline'
+                          ? 'bg-[#EF444420] text-[#DC2626]'
+                          : 'bg-[#F59E0B20] text-[#D97706]'
+                      }`}
+                    >
+                      {item.connectionState}
+                    </span>
+                    <button
+                      type="button"
+                      data-testid={`runtime-host-probe-${item.host.id}`}
+                      onClick={() => {
+                        void onRetryHost(item.host.id);
+                      }}
+                      className="rounded bg-[#F5F0ED] px-2 py-1 text-[10px] text-[#57534E] dark:bg-[#292524] dark:text-[#D6D3D1]"
+                    >
+                      重试
+                    </button>
+                  </div>
+                </div>
+                {item.error && <p className="mt-1 text-[10px] text-[#DC2626]">{item.error}</p>}
+              </div>
+            ))}
+          </div>
+        </article>
+      )}
+
+      {sections.length === 0 && (
+        <article className="rounded-2xl border border-[#E7E5E4] bg-white px-4 py-6 text-center dark:border-[#292524] dark:bg-[#1C1917]">
+          <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">暂无可用 Agent</p>
+          <p className="mt-1 text-xs text-[#A8A29E]">请先添加 exomind-rt 主机并确认连接状态</p>
+        </article>
+      )}
+
       {sections.map((section) => (
         <article key={section.id} className="space-y-2">
           <div className="flex items-center justify-between">
@@ -468,11 +584,12 @@ function ListView({
                     type="button"
                     data-testid={`agent-list-item-${item.id}`}
                     onClick={() => {
+                      const runtimeAgentId = item.id.includes('__') ? item.id.split('__')[1] ?? item.id : item.id;
                       if (item.type === 'agent') {
-                        onItemNavigate(`/agents/agent/${item.id}`);
+                        onItemNavigate(`/agents/agent/${runtimeAgentId}`);
                       }
                       if (item.type === 'actor') {
-                        onItemNavigate(`/agents/actor/${item.id}`);
+                        onItemNavigate(`/agents/actor/${runtimeAgentId}`);
                       }
                     }}
                     className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left"
@@ -764,11 +881,11 @@ function DeviceView({
 function AddNodeSheet({
   options,
   onClose,
-  onNavigate,
+  onAddDevice,
 }: {
-  options: AgentAddNodeOption[];
+  options: AddNodeOption[];
   onClose: () => void;
-  onNavigate: (path: string) => void;
+  onAddDevice: () => void;
 }) {
   return (
     <>
@@ -806,9 +923,9 @@ function AddNodeSheet({
                 type="button"
                 data-testid={`agent-add-node-option-${option.id}`}
                 onClick={() => {
-                  if (option.id === 'market') {
+                  if (option.id === 'device') {
                     onClose();
-                    onNavigate('/agents/market');
+                    onAddDevice();
                   }
                 }}
                 className="flex w-full items-center justify-between rounded-2xl bg-[#FAF7F5] px-4 py-3 text-left dark:bg-[#292524]"
@@ -835,53 +952,221 @@ function AddNodeSheet({
   );
 }
 
+function RuntimeHostManagerSheet({
+  hostSnapshots,
+  runtimeHostName,
+  runtimeHostAddress,
+  runtimeHostError,
+  onRuntimeHostNameChange,
+  onRuntimeHostAddressChange,
+  onRuntimeHostAdd,
+  onRuntimeHostProbe,
+  onRuntimeHostRemove,
+  onClose,
+}: {
+  hostSnapshots: RuntimeHostSnapshot[];
+  runtimeHostName: string;
+  runtimeHostAddress: string;
+  runtimeHostError: string;
+  onRuntimeHostNameChange: (value: string) => void;
+  onRuntimeHostAddressChange: (value: string) => void;
+  onRuntimeHostAdd: () => Promise<void>;
+  onRuntimeHostProbe: (hostId: string) => Promise<void>;
+  onRuntimeHostRemove: (hostId: string) => Promise<void>;
+  onClose: () => void;
+}) {
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="agent-host-manager-overlay"
+        aria-label="关闭主机管理弹窗（Close Runtime Host Manager）"
+        className="absolute inset-0 z-20 bg-black/35"
+        onClick={onClose}
+      />
+      <section
+        data-testid="agent-host-manager-sheet"
+        className="absolute inset-x-0 bottom-0 z-30 rounded-t-[24px] bg-white pb-7 shadow-[0_-8px_28px_rgba(0,0,0,0.12)] dark:bg-[#1C1917] dark:shadow-[0_-8px_28px_rgba(0,0,0,0.45)]"
+      >
+        <div className="flex justify-center pt-2">
+          <div className="h-1 w-10 rounded bg-[#D6D3D1] dark:bg-[#57534E]" />
+        </div>
+        <div className="flex items-center justify-between px-5 py-3">
+          <h2 className="text-[18px] font-bold text-[#1C1917] dark:text-[#FAFAF9]">添加设备</h2>
+          <button
+            type="button"
+            data-testid="agent-host-manager-close"
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#A8A29E] dark:bg-[#292524] dark:text-[#78716C]"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="space-y-2 px-5">
+          <input
+            data-testid="runtime-host-name-input"
+            value={runtimeHostName}
+            onChange={(event) => onRuntimeHostNameChange(event.target.value)}
+            placeholder="Name（名称，可选）"
+            className="h-9 w-full rounded-lg border border-[#E7E5E4] bg-white px-3 text-xs text-[#1C1917] outline-none dark:border-[#292524] dark:bg-[#292524] dark:text-[#FAFAF9]"
+          />
+          <input
+            data-testid="runtime-host-address-input"
+            value={runtimeHostAddress}
+            onChange={(event) => onRuntimeHostAddressChange(event.target.value)}
+            placeholder="host:port（例如 127.0.0.1:1919）"
+            className="h-9 w-full rounded-lg border border-[#E7E5E4] bg-white px-3 text-xs text-[#1C1917] outline-none dark:border-[#292524] dark:bg-[#292524] dark:text-[#FAFAF9]"
+          />
+          <button
+            type="button"
+            data-testid="runtime-host-add-button"
+            onClick={() => {
+              void onRuntimeHostAdd();
+            }}
+            className="h-9 w-full rounded-lg bg-[#C75B3A] text-xs font-semibold text-white"
+          >
+            添加 exomind-rt
+          </button>
+        </div>
+
+        {runtimeHostError && (
+          <p className="mx-5 mt-2 rounded-md bg-[#EF444410] px-2 py-1 text-[11px] text-[#DC2626]">{runtimeHostError}</p>
+        )}
+
+        <div className="mt-3 space-y-2 px-5">
+          {hostSnapshots.map((item) => (
+            <div
+              key={item.host.id}
+              className="rounded-xl border border-[#E7E5E4] bg-[#FAF7F5] px-3 py-2 dark:border-[#292524] dark:bg-[#292524]"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="truncate text-xs font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{item.host.name}</p>
+                  <p className="truncate text-[11px] text-[#78716C] dark:text-[#A8A29E]">{item.host.host}:{item.host.port}</p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span
+                    data-testid={`runtime-host-status-${item.host.id}`}
+                    className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                      item.connectionState === 'online'
+                        ? 'bg-[#22C55E20] text-[#16A34A]'
+                        : item.connectionState === 'offline'
+                          ? 'bg-[#EF444420] text-[#DC2626]'
+                          : 'bg-[#F59E0B20] text-[#D97706]'
+                    }`}
+                  >
+                    {item.connectionState}
+                  </span>
+                  <button
+                    type="button"
+                    data-testid={`runtime-host-probe-${item.host.id}`}
+                    onClick={() => {
+                      void onRuntimeHostProbe(item.host.id);
+                    }}
+                    className="rounded bg-[#F5F0ED] px-2 py-1 text-[10px] text-[#57534E] dark:bg-[#1C1917] dark:text-[#D6D3D1]"
+                  >
+                    重试
+                  </button>
+                  <button
+                    type="button"
+                    data-testid={`runtime-host-remove-${item.host.id}`}
+                    onClick={() => {
+                      void onRuntimeHostRemove(item.host.id);
+                    }}
+                    className="rounded bg-[#FEE2E2] px-2 py-1 text-[10px] text-[#B91C1C] dark:bg-[#451A1A] dark:text-[#FCA5A5]"
+                  >
+                    删除
+                  </button>
+                </div>
+              </div>
+              {item.error && <p className="mt-1 text-[10px] text-[#DC2626]">{item.error}</p>}
+            </div>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}
+
 export function AgentsPage() {
   const [viewMode, setViewMode] = useState<AgentHubViewMode>('topology');
   const [topology, setTopology] = useState<AgentHubTopologyData>({ nodes: [], edges: [], selectedNodeId: null });
   const [listSections, setListSections] = useState<AgentHubListSection[]>([]);
   const [deviceGroups, setDeviceGroups] = useState<AgentDeviceGroup[]>([]);
+  const [runtimeHostSnapshots, setRuntimeHostSnapshots] = useState<RuntimeHostSnapshot[]>([]);
   const [runtimeHosts, setRuntimeHosts] = useState<RuntimeHostRecord[]>([]);
   const [runtimeServiceStatus, setRuntimeServiceStatus] = useState<RuntimeServiceStatus | null>(null);
   const [runtimeHostName, setRuntimeHostName] = useState('');
   const [runtimeHostAddress, setRuntimeHostAddress] = useState('');
   const [runtimeHostPort, setRuntimeHostPort] = useState('4077');
+  const [runtimeHostModalName, setRuntimeHostModalName] = useState('');
+  const [runtimeHostModalAddress, setRuntimeHostModalAddress] = useState('127.0.0.1:1919');
   const [runtimeHostError, setRuntimeHostError] = useState('');
-  const [addNodeOptions, setAddNodeOptions] = useState<AgentAddNodeOption[]>([]);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [sheetOpen, setSheetOpen] = useState(false);
+  const [hostManagerOpen, setHostManagerOpen] = useState(false);
+
+  const applyRuntimeSnapshot = (snapshot: { hosts: RuntimeHostSnapshot[]; agents: RuntimeAggregatedAgent[] }) => {
+    setRuntimeHostSnapshots(snapshot.hosts);
+    setListSections(buildListSectionsFromRuntimeAgents(snapshot.agents));
+    setRuntimeHosts(
+      snapshot.hosts.map((item) => ({
+        ...item.host,
+        status: mapHostConnectionToRecordStatus(item.connectionState),
+        lastError: item.error,
+      })),
+    );
+  };
+
+  const refreshRuntimeSnapshot = async () => {
+    const snapshot = await getRuntimeManager().refreshSnapshot();
+    applyRuntimeSnapshot(snapshot);
+  };
 
   useEffect(() => {
     let disposed = false;
     const service = getAgentHubService();
-    const runtimeHostService = getRuntimeHostService();
     const runtimeControlService = getRuntimeControlService();
+
     const load = async () => {
-      const [nextTopology, nextList, nextDevice, nextAddOptions, nextRuntimeHosts, nextRuntimeStatus] = await Promise.all([
+      const [nextTopology, nextDevice, nextRuntimeStatus, nextRuntimeSnapshot] = await Promise.all([
         service.getTopology(),
-        service.getListView(),
         service.getDeviceView(),
-        service.listAddNodeOptions(),
-        runtimeHostService.listHosts(),
         runtimeControlService.getStatus(),
+        getRuntimeManager().refreshSnapshot(),
       ]);
       if (disposed) return;
       setTopology(nextTopology);
       setSelectedNodeId(nextTopology.selectedNodeId ?? null);
-      setListSections(nextList);
       setDeviceGroups(nextDevice);
-      setAddNodeOptions(nextAddOptions);
-      setRuntimeHosts(nextRuntimeHosts);
       setRuntimeServiceStatus(nextRuntimeStatus);
+      applyRuntimeSnapshot(nextRuntimeSnapshot);
     };
+
+    const refreshInterval = setInterval(() => {
+      void (async () => {
+        try {
+          const nextRuntimeSnapshot = await getRuntimeManager().refreshSnapshot();
+          if (disposed) return;
+          applyRuntimeSnapshot(nextRuntimeSnapshot);
+        } catch {
+          // Ignore polling errors（轮询错误不打断页面渲染）
+        }
+      })();
+    }, 8000);
+
     void load();
+
     return () => {
       disposed = true;
+      clearInterval(refreshInterval);
     };
   }, []);
 
   const refreshRuntimeHosts = async () => {
-    const nextHosts = await getRuntimeHostService().listHosts();
-    setRuntimeHosts(nextHosts);
+    const nextSnapshot = await getRuntimeManager().refreshSnapshot();
+    applyRuntimeSnapshot(nextSnapshot);
   };
 
   const handleAddRuntimeHost = async () => {
@@ -898,7 +1183,7 @@ export function AgentsPage() {
 
     try {
       setRuntimeHostError('');
-      await getRuntimeHostService().addHost({
+      await getRuntimeManager().addHost({
         name: runtimeHostName.trim(),
         host,
         port,
@@ -911,11 +1196,34 @@ export function AgentsPage() {
     }
   };
 
+  const handleAddRuntimeHostFromManagerSheet = async () => {
+    try {
+      setRuntimeHostError('');
+      await getRuntimeManager().addHostFromAddress(runtimeHostModalAddress, runtimeHostModalName.trim());
+      setRuntimeHostModalName('');
+      await refreshRuntimeHosts();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setRuntimeHostError(message);
+    }
+  };
+
   const handleProbeRuntimeHost = async (hostId: string) => {
     try {
       setRuntimeHostError('');
-      const updated = await getRuntimeHostService().probeHost(hostId);
-      setRuntimeHosts((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
+      await getRuntimeManager().retryHost(hostId);
+      await refreshRuntimeHosts();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setRuntimeHostError(message);
+    }
+  };
+
+  const handleRemoveRuntimeHost = async (hostId: string) => {
+    try {
+      setRuntimeHostError('');
+      await getRuntimeManager().removeHost(hostId);
+      await refreshRuntimeHosts();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       setRuntimeHostError(message);
@@ -929,6 +1237,7 @@ export function AgentsPage() {
         port: 4077,
       });
       setRuntimeServiceStatus(status);
+      await refreshRuntimeSnapshot();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       setRuntimeServiceStatus({
@@ -944,6 +1253,7 @@ export function AgentsPage() {
     try {
       const status = await getRuntimeControlService().stopRuntime();
       setRuntimeServiceStatus(status);
+      await refreshRuntimeSnapshot();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       setRuntimeServiceStatus({
@@ -961,7 +1271,14 @@ export function AgentsPage() {
 
   const content = useMemo(() => {
     if (viewMode === 'list') {
-      return <ListView sections={listSections} onItemNavigate={navigateByPath} />;
+      return (
+        <ListView
+          sections={listSections}
+          hostSnapshots={runtimeHostSnapshots}
+          onRetryHost={handleProbeRuntimeHost}
+          onItemNavigate={navigateByPath}
+        />
+      );
     }
     if (viewMode === 'device') {
       return (
@@ -994,16 +1311,13 @@ export function AgentsPage() {
   }, [
     deviceGroups,
     listSections,
+    runtimeHostSnapshots,
     runtimeHosts,
     runtimeHostName,
     runtimeHostAddress,
     runtimeHostPort,
     runtimeHostError,
     runtimeServiceStatus,
-    handleAddRuntimeHost,
-    handleProbeRuntimeHost,
-    handleRuntimeStart,
-    handleRuntimeStop,
     selectedNodeId,
     topology,
     viewMode,
@@ -1040,9 +1354,24 @@ export function AgentsPage() {
 
       {sheetOpen && (
         <AddNodeSheet
-          options={addNodeOptions}
+          options={ADD_NODE_OPTIONS}
           onClose={() => setSheetOpen(false)}
-          onNavigate={navigateByPath}
+          onAddDevice={() => setHostManagerOpen(true)}
+        />
+      )}
+
+      {hostManagerOpen && (
+        <RuntimeHostManagerSheet
+          hostSnapshots={runtimeHostSnapshots}
+          runtimeHostName={runtimeHostModalName}
+          runtimeHostAddress={runtimeHostModalAddress}
+          runtimeHostError={runtimeHostError}
+          onRuntimeHostNameChange={setRuntimeHostModalName}
+          onRuntimeHostAddressChange={setRuntimeHostModalAddress}
+          onRuntimeHostAdd={handleAddRuntimeHostFromManagerSheet}
+          onRuntimeHostProbe={handleProbeRuntimeHost}
+          onRuntimeHostRemove={handleRemoveRuntimeHost}
+          onClose={() => setHostManagerOpen(false)}
         />
       )}
     </div>

--- a/src/ui/app/pages/AgentsPage.tsx
+++ b/src/ui/app/pages/AgentsPage.tsx
@@ -34,7 +34,6 @@ import type {
   AgentHubNode,
   AgentHubTopologyData,
   AgentHubViewMode,
-  RuntimeHostRecord,
   RuntimeServiceStatus,
 } from '@/lib/types/agent-hub';
 import {
@@ -143,10 +142,27 @@ function mapRuntimeStatusToNodeStatus(status: string): AgentHubNodeStatus {
   return 'idle';
 }
 
-function mapHostConnectionToRecordStatus(connectionState: RuntimeHostSnapshot['connectionState']): RuntimeHostRecord['status'] {
-  if (connectionState === 'online') return 'online';
-  if (connectionState === 'offline') return 'offline';
-  return 'warning';
+function formatHostUptime(uptimeSecs?: number): string {
+  if (!uptimeSecs || uptimeSecs <= 0) return '--';
+  const days = Math.floor(uptimeSecs / 86400);
+  const hours = Math.floor((uptimeSecs % 86400) / 3600);
+  const minutes = Math.floor((uptimeSecs % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+function formatHostMemory(usedMb?: number, totalMb?: number): string {
+  if (typeof usedMb !== 'number' || typeof totalMb !== 'number' || totalMb <= 0) return '--';
+  const usedGb = (usedMb / 1024).toFixed(1);
+  const totalGb = (totalMb / 1024).toFixed(1);
+  return `${usedGb} / ${totalGb} GB`;
+}
+
+function getHostStatusBadgeClass(connectionState: RuntimeHostSnapshot['connectionState']): string {
+  if (connectionState === 'online') return 'bg-[#22C55E20] text-[#16A34A]';
+  if (connectionState === 'offline') return 'bg-[#EF444420] text-[#DC2626]';
+  return 'bg-[#F59E0B20] text-[#D97706]';
 }
 
 function buildListSectionsFromRuntimeAgents(agents: RuntimeAggregatedAgent[]): AgentHubListSection[] {
@@ -622,34 +638,22 @@ function ListView({
 
 function DeviceView({
   groups,
-  runtimeHosts,
+  runtimeHostSnapshots,
   runtimeServiceStatus,
-  runtimeHostName,
-  runtimeHostAddress,
-  runtimeHostPort,
   runtimeHostError,
-  onRuntimeHostNameChange,
-  onRuntimeHostAddressChange,
-  onRuntimeHostPortChange,
-  onRuntimeHostAdd,
   onRuntimeHostProbe,
   onRuntimeStart,
   onRuntimeStop,
+  onOpenHostManager,
 }: {
   groups: AgentDeviceGroup[];
-  runtimeHosts: RuntimeHostRecord[];
+  runtimeHostSnapshots: RuntimeHostSnapshot[];
   runtimeServiceStatus: RuntimeServiceStatus | null;
-  runtimeHostName: string;
-  runtimeHostAddress: string;
-  runtimeHostPort: string;
   runtimeHostError: string;
-  onRuntimeHostNameChange: (value: string) => void;
-  onRuntimeHostAddressChange: (value: string) => void;
-  onRuntimeHostPortChange: (value: string) => void;
-  onRuntimeHostAdd: () => Promise<void>;
   onRuntimeHostProbe: (hostId: string) => Promise<void>;
   onRuntimeStart: () => Promise<void>;
   onRuntimeStop: () => Promise<void>;
+  onOpenHostManager: () => void;
 }) {
   const hostCard = groups.flatMap((group) => group.cards).find((card) => card.isHost) ?? groups[0]?.cards[0];
 
@@ -659,9 +663,21 @@ function DeviceView({
         data-testid="runtime-host-panel"
         className="space-y-3 rounded-2xl border border-[#E7E5E4] bg-white px-4 py-3 dark:border-[#292524] dark:bg-[#1C1917]"
       >
-        <div className="flex items-center justify-between">
-          <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">Runtime Hosts</h3>
-          <span className="text-[11px] text-[#A8A29E]">{runtimeHosts.length} 台</span>
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">Runtime 设备</h3>
+            <p className="text-[11px] text-[#A8A29E] dark:text-[#78716C]">
+              {runtimeHostSnapshots.length} 台在线配置
+            </p>
+          </div>
+          <button
+            type="button"
+            data-testid="runtime-host-manage-button"
+            onClick={onOpenHostManager}
+            className="rounded-lg bg-[#C75B3A] px-2.5 py-1 text-[11px] font-semibold text-white"
+          >
+            管理主机
+          </button>
         </div>
 
         <div className="rounded-xl border border-[#E7E5E4] bg-[#FAF7F5] px-3 py-2 dark:border-[#292524] dark:bg-[#292524]">
@@ -711,89 +727,105 @@ function DeviceView({
           </div>
         </div>
 
-        <div className="grid grid-cols-1 gap-2">
-          <input
-            data-testid="runtime-host-name-input"
-            value={runtimeHostName}
-            onChange={(event) => onRuntimeHostNameChange(event.target.value)}
-            placeholder="Name（名称）"
-            className="h-9 rounded-lg border border-[#E7E5E4] bg-white px-3 text-xs text-[#1C1917] outline-none dark:border-[#292524] dark:bg-[#292524] dark:text-[#FAFAF9]"
-          />
-          <div className="grid grid-cols-[1fr_96px] gap-2">
-            <input
-              data-testid="runtime-host-address-input"
-              value={runtimeHostAddress}
-              onChange={(event) => onRuntimeHostAddressChange(event.target.value)}
-              placeholder="IP / Host"
-              className="h-9 rounded-lg border border-[#E7E5E4] bg-white px-3 text-xs text-[#1C1917] outline-none dark:border-[#292524] dark:bg-[#292524] dark:text-[#FAFAF9]"
-            />
-            <input
-              data-testid="runtime-host-port-input"
-              value={runtimeHostPort}
-              onChange={(event) => onRuntimeHostPortChange(event.target.value)}
-              placeholder="Port"
-              className="h-9 rounded-lg border border-[#E7E5E4] bg-white px-3 text-xs text-[#1C1917] outline-none dark:border-[#292524] dark:bg-[#292524] dark:text-[#FAFAF9]"
-            />
-          </div>
-          <button
-            type="button"
-            data-testid="runtime-host-add-button"
-            onClick={() => {
-              void onRuntimeHostAdd();
-            }}
-            className="h-9 rounded-lg bg-[#C75B3A] text-xs font-semibold text-white"
-          >
-            添加 RuntimeHost
-          </button>
-        </div>
-
         {runtimeHostError && (
           <p className="rounded-md bg-[#EF444410] px-2 py-1 text-[11px] text-[#DC2626]">{runtimeHostError}</p>
         )}
 
         <div className="space-y-2">
-          {runtimeHosts.map((host) => (
+          {runtimeHostSnapshots.length === 0 && (
+            <div className="rounded-xl border border-dashed border-[#D6D3D1] bg-[#FAF7F5] px-3 py-3 text-[11px] text-[#78716C] dark:border-[#57534E] dark:bg-[#292524] dark:text-[#A8A29E]">
+              暂无 Runtime 设备，请点击「管理主机」添加 `host:port`。
+            </div>
+          )}
+          {runtimeHostSnapshots.map((item) => (
             <div
-              key={host.id}
-              className="rounded-xl border border-[#E7E5E4] bg-[#FAF7F5] px-3 py-2 dark:border-[#292524] dark:bg-[#292524]"
+              key={item.host.id}
+              data-testid={`runtime-host-device-card-${item.host.id}`}
+              className="rounded-xl border border-[#E7E5E4] bg-[#FAF7F5] px-3 py-2.5 dark:border-[#292524] dark:bg-[#292524]"
             >
               <div className="flex items-center justify-between gap-2">
-                <div className="min-w-0">
-                  <p className="truncate text-xs font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{host.name}</p>
-                  <p className="truncate text-[11px] text-[#78716C] dark:text-[#A8A29E]">{host.host}:{host.port}</p>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-[#0D948820] text-[#0D9488]">
+                      <Monitor size={13} />
+                    </div>
+                    <div className="min-w-0">
+                      <p className="truncate text-xs font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{item.host.name}</p>
+                      <p className="truncate text-[11px] text-[#78716C] dark:text-[#A8A29E]">
+                        {item.host.host}:{item.host.port}
+                      </p>
+                    </div>
+                  </div>
                 </div>
                 <div className="flex items-center gap-2">
                   <span
-                    data-testid={`runtime-host-status-${host.id}`}
-                    className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${
-                      host.status === 'online'
-                        ? 'bg-[#22C55E20] text-[#16A34A]'
-                        : host.status === 'offline'
-                          ? 'bg-[#EF444420] text-[#DC2626]'
-                          : host.status === 'warning'
-                            ? 'bg-[#F59E0B20] text-[#D97706]'
-                            : 'bg-[#E7E5E4] text-[#57534E]'
-                    }`}
+                    data-testid={`runtime-host-status-${item.host.id}`}
+                    className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${getHostStatusBadgeClass(item.connectionState)}`}
                   >
-                    {host.status}
+                    {item.connectionState}
                   </span>
                   <button
                     type="button"
-                    data-testid={`runtime-host-probe-${host.id}`}
+                    data-testid={`runtime-host-probe-${item.host.id}`}
                     onClick={() => {
-                      void onRuntimeHostProbe(host.id);
+                      void onRuntimeHostProbe(item.host.id);
                     }}
                     className="rounded bg-[#F5F0ED] px-2 py-1 text-[10px] text-[#57534E] dark:bg-[#1C1917] dark:text-[#D6D3D1]"
                   >
-                    探测
+                    重试
                   </button>
                 </div>
               </div>
-              {host.lastCheckedAt && (
-                <p className="mt-1 text-[10px] text-[#A8A29E]">last: {host.lastCheckedAt}</p>
+
+              <div className="mt-2 grid grid-cols-2 gap-2">
+                <div className="rounded-lg bg-white px-2 py-1.5 dark:bg-[#1C1917]">
+                  <p className="text-[10px] text-[#A8A29E]">设备名称</p>
+                  <p className="truncate text-[11px] font-medium text-[#1C1917] dark:text-[#FAFAF9]">
+                    {item.topology?.hostname ?? '--'}
+                  </p>
+                </div>
+                <div className="rounded-lg bg-white px-2 py-1.5 dark:bg-[#1C1917]">
+                  <p className="text-[10px] text-[#A8A29E]">系统</p>
+                  <p className="truncate text-[11px] font-medium text-[#1C1917] dark:text-[#FAFAF9]">
+                    {item.topology?.os ?? '--'}
+                  </p>
+                </div>
+                <div className="rounded-lg bg-white px-2 py-1.5 dark:bg-[#1C1917]">
+                  <p className="text-[10px] text-[#A8A29E]">架构</p>
+                  <p className="truncate text-[11px] font-medium text-[#1C1917] dark:text-[#FAFAF9]">
+                    {item.topology?.arch ?? '--'}
+                  </p>
+                </div>
+                <div className="rounded-lg bg-white px-2 py-1.5 dark:bg-[#1C1917]">
+                  <p className="text-[10px] text-[#A8A29E]">内存</p>
+                  <p className="truncate text-[11px] font-medium text-[#1C1917] dark:text-[#FAFAF9]">
+                    {formatHostMemory(item.topology?.used_memory_mb, item.topology?.total_memory_mb)}
+                  </p>
+                </div>
+                <div className="rounded-lg bg-white px-2 py-1.5 dark:bg-[#1C1917]">
+                  <p className="text-[10px] text-[#A8A29E]">延迟</p>
+                  <p className="truncate text-[11px] font-medium text-[#1C1917] dark:text-[#FAFAF9]">
+                    {item.latencyMs ? `${item.latencyMs} ms` : '--'}
+                  </p>
+                </div>
+                <div className="rounded-lg bg-white px-2 py-1.5 dark:bg-[#1C1917]">
+                  <p className="text-[10px] text-[#A8A29E]">在线时长</p>
+                  <p className="truncate text-[11px] font-medium text-[#1C1917] dark:text-[#FAFAF9]">
+                    {formatHostUptime(item.topology?.uptime_secs)}
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-2 flex flex-wrap items-center gap-2 text-[10px] text-[#78716C] dark:text-[#A8A29E]">
+                <span>runtime: {item.topology?.version ?? '--'}</span>
+                <span>port: {item.topology?.port ?? item.host.port}</span>
+              </div>
+
+              {item.host.lastCheckedAt && (
+                <p className="mt-1 text-[10px] text-[#A8A29E]">last: {item.host.lastCheckedAt}</p>
               )}
-              {host.lastError && (
-                <p className="mt-1 text-[10px] text-[#DC2626]">{host.lastError}</p>
+              {item.error && (
+                <p className="mt-1 text-[10px] text-[#DC2626]">{item.error}</p>
               )}
             </div>
           ))}
@@ -1095,11 +1127,7 @@ export function AgentsPage() {
   const [listSections, setListSections] = useState<AgentHubListSection[]>([]);
   const [deviceGroups, setDeviceGroups] = useState<AgentDeviceGroup[]>([]);
   const [runtimeHostSnapshots, setRuntimeHostSnapshots] = useState<RuntimeHostSnapshot[]>([]);
-  const [runtimeHosts, setRuntimeHosts] = useState<RuntimeHostRecord[]>([]);
   const [runtimeServiceStatus, setRuntimeServiceStatus] = useState<RuntimeServiceStatus | null>(null);
-  const [runtimeHostName, setRuntimeHostName] = useState('');
-  const [runtimeHostAddress, setRuntimeHostAddress] = useState('');
-  const [runtimeHostPort, setRuntimeHostPort] = useState('4077');
   const [runtimeHostModalName, setRuntimeHostModalName] = useState('');
   const [runtimeHostModalAddress, setRuntimeHostModalAddress] = useState('127.0.0.1:1919');
   const [runtimeHostError, setRuntimeHostError] = useState('');
@@ -1110,13 +1138,6 @@ export function AgentsPage() {
   const applyRuntimeSnapshot = (snapshot: { hosts: RuntimeHostSnapshot[]; agents: RuntimeAggregatedAgent[] }) => {
     setRuntimeHostSnapshots(snapshot.hosts);
     setListSections(buildListSectionsFromRuntimeAgents(snapshot.agents));
-    setRuntimeHosts(
-      snapshot.hosts.map((item) => ({
-        ...item.host,
-        status: mapHostConnectionToRecordStatus(item.connectionState),
-        lastError: item.error,
-      })),
-    );
   };
 
   const refreshRuntimeSnapshot = async () => {
@@ -1167,33 +1188,6 @@ export function AgentsPage() {
   const refreshRuntimeHosts = async () => {
     const nextSnapshot = await getRuntimeManager().refreshSnapshot();
     applyRuntimeSnapshot(nextSnapshot);
-  };
-
-  const handleAddRuntimeHost = async () => {
-    const host = runtimeHostAddress.trim();
-    const port = Number.parseInt(runtimeHostPort, 10);
-    if (!host) {
-      setRuntimeHostError('Host 不能为空');
-      return;
-    }
-    if (!Number.isInteger(port) || port <= 0) {
-      setRuntimeHostError('Port 非法');
-      return;
-    }
-
-    try {
-      setRuntimeHostError('');
-      await getRuntimeManager().addHost({
-        name: runtimeHostName.trim(),
-        host,
-        port,
-      });
-      setRuntimeHostName('');
-      await refreshRuntimeHosts();
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      setRuntimeHostError(message);
-    }
   };
 
   const handleAddRuntimeHostFromManagerSheet = async () => {
@@ -1284,19 +1278,13 @@ export function AgentsPage() {
       return (
         <DeviceView
           groups={deviceGroups}
-          runtimeHosts={runtimeHosts}
+          runtimeHostSnapshots={runtimeHostSnapshots}
           runtimeServiceStatus={runtimeServiceStatus}
-          runtimeHostName={runtimeHostName}
-          runtimeHostAddress={runtimeHostAddress}
-          runtimeHostPort={runtimeHostPort}
           runtimeHostError={runtimeHostError}
-          onRuntimeHostNameChange={setRuntimeHostName}
-          onRuntimeHostAddressChange={setRuntimeHostAddress}
-          onRuntimeHostPortChange={setRuntimeHostPort}
-          onRuntimeHostAdd={handleAddRuntimeHost}
           onRuntimeHostProbe={handleProbeRuntimeHost}
           onRuntimeStart={handleRuntimeStart}
           onRuntimeStop={handleRuntimeStop}
+          onOpenHostManager={() => setHostManagerOpen(true)}
         />
       );
     }
@@ -1312,10 +1300,6 @@ export function AgentsPage() {
     deviceGroups,
     listSections,
     runtimeHostSnapshots,
-    runtimeHosts,
-    runtimeHostName,
-    runtimeHostAddress,
-    runtimeHostPort,
     runtimeHostError,
     runtimeServiceStatus,
     selectedNodeId,

--- a/tests/e2e/agents-page.issue201.test.ts
+++ b/tests/e2e/agents-page.issue201.test.ts
@@ -1,0 +1,118 @@
+import { expect, test, type Page } from '@playwright/test';
+import { createServer, type Server } from 'node:http';
+
+const RUNTIME_HOST = '127.0.0.1';
+const RUNTIME_PORT = 4919;
+const RUNTIME_NAME = 'Runtime A';
+
+async function setupIssue201Flags(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('exomind:uiMode', 'new');
+    localStorage.setItem('exomind:agentPageEnabled', 'true');
+    localStorage.setItem('exomind:useMockData', 'true');
+  });
+}
+
+test.describe('Issue #201 AgentsPage runtime aggregation（真实 runtime 多主机聚合）', () => {
+  let runtimeServer: Server | null = null;
+
+  test.beforeAll(async () => {
+    runtimeServer = createServer((request, response) => {
+      const corsHeaders = {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Private-Network': 'true',
+      };
+      if (request.method === 'OPTIONS') {
+        response.writeHead(204, corsHeaders);
+        response.end();
+        return;
+      }
+
+      if (request.url === '/agents') {
+        response.writeHead(200, { 'Content-Type': 'application/json', ...corsHeaders });
+        response.end(JSON.stringify([
+          {
+            id: 'echo',
+            name: 'Echo Agent',
+            description: '回显输入内容',
+            status: 'available',
+          },
+        ]));
+        return;
+      }
+
+      if (request.url === '/topology') {
+        response.writeHead(200, { 'Content-Type': 'application/json', ...corsHeaders });
+        response.end(JSON.stringify({
+          hostname: 'local-runtime',
+          os: 'Windows 11',
+          arch: 'x86_64',
+          uptime_secs: 99,
+          version: '0.1.0',
+          port: RUNTIME_PORT,
+        }));
+        return;
+      }
+
+      if (request.url === '/health') {
+        response.writeHead(200, { 'Content-Type': 'application/json', ...corsHeaders });
+        response.end(JSON.stringify({ status: 'ok' }));
+        return;
+      }
+
+      response.writeHead(404, { 'Content-Type': 'application/json', ...corsHeaders });
+      response.end(JSON.stringify({ error: 'not_found' }));
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      runtimeServer?.once('error', reject);
+      runtimeServer?.listen(RUNTIME_PORT, RUNTIME_HOST, () => resolve());
+    });
+  });
+
+  test.afterAll(async () => {
+    if (!runtimeServer) return;
+    await new Promise<void>((resolve) => {
+      runtimeServer?.close(() => resolve());
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await setupIssue201Flags(page);
+  });
+
+  test('aggregates runtime list and switches to offline after server stop（聚合渲染并在服务关闭后显示 offline）', async ({ page }) => {
+    await page.goto('/agents');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('agent-add-node-button').click();
+    await page.getByTestId('agent-add-node-option-device').click();
+    await expect(page.getByTestId('agent-host-manager-sheet')).toBeVisible();
+
+    await page.getByTestId('runtime-host-name-input').fill(RUNTIME_NAME);
+    await page.getByTestId('runtime-host-address-input').fill(`${RUNTIME_HOST}:${RUNTIME_PORT}`);
+    await page.getByTestId('runtime-host-add-button').click();
+
+    const hostCard = page.locator('[data-testid="agent-host-manager-sheet"] div').filter({ hasText: RUNTIME_NAME }).first();
+    await expect(hostCard).toBeVisible();
+    await expect(hostCard.locator('[data-testid^="runtime-host-status-"]')).toHaveText('online');
+
+    await page.getByTestId('agent-host-manager-close').click();
+    await page.getByTestId('agent-view-toggle-list').click();
+    await expect(page.getByText('Echo Agent')).toBeVisible();
+    await expect(page.getByText(new RegExp(`来源 ${RUNTIME_HOST}:${RUNTIME_PORT}`))).toBeVisible();
+
+    await new Promise<void>((resolve) => {
+      runtimeServer?.close(() => resolve());
+    });
+    runtimeServer = null;
+
+    await page.getByTestId('agent-add-node-button').click();
+    await page.getByTestId('agent-add-node-option-device').click();
+    const offlineCard = page.locator('[data-testid="agent-host-manager-sheet"] div').filter({ hasText: RUNTIME_NAME }).first();
+    await offlineCard.getByRole('button', { name: '重试' }).click();
+    await expect(offlineCard.locator('[data-testid^="runtime-host-status-"]')).toHaveText('offline');
+  });
+});

--- a/tests/e2e/playwright.issue201.config.ts
+++ b/tests/e2e/playwright.issue201.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const WEB_PORT = 1432;
+const BASE_URL = `http://localhost:${WEB_PORT}`;
+
+export default defineConfig({
+  testDir: '.',
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    baseURL: BASE_URL,
+    trace: 'retain-on-failure',
+    launchOptions: {
+      channel: 'chrome',
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    },
+  ],
+  webServer: {
+    command: 'bun run dev',
+    cwd: '../..',
+    url: BASE_URL,
+    reuseExistingServer: true,
+    timeout: 180000,
+    env: {
+      ...process.env,
+      EXOMIND_WEB_PORT: String(WEB_PORT),
+      EXOMIND_HMR_PORT: '1433',
+      EXOMIND_POUCHDB_PORT: '7432',
+      EXOMIND_ASR_PORT: '2432',
+      VITE_SYNC_SERVER_URL: 'http://localhost:7432',
+      VITE_ASR_SERVER_URL: 'http://localhost:2432',
+    },
+  },
+});

--- a/tests/unit/services/runtime-client.issue201.test.ts
+++ b/tests/unit/services/runtime-client.issue201.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { RuntimeHostRecord } from '@/lib/types/agent-hub';
+import { RuntimeClient } from '@/services/runtime-client';
+
+const SAMPLE_HOST: RuntimeHostRecord = {
+  id: 'runtime-host-1',
+  name: 'Local Runtime',
+  host: '127.0.0.1',
+  port: 1919,
+  status: 'unknown',
+  createdAt: '2026-02-28T00:00:00.000Z',
+  updatedAt: '2026-02-28T00:00:00.000Z',
+};
+
+describe('runtime client issue-201（Runtime HTTP 客户端）', () => {
+  it('fetches agents from /agents（从 /agents 拉取 agent 列表）', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => [
+        {
+          id: 'echo',
+          name: 'Echo Agent',
+          description: '回显输入内容',
+          status: 'available',
+        },
+      ],
+    }));
+
+    const client = new RuntimeClient({ fetchImpl });
+    const result = await client.getAgents(SAMPLE_HOST);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]?.id).toBe('echo');
+    expect(result.data[0]?.name).toBe('Echo Agent');
+    expect(result.data[0]?.status).toBe('available');
+    expect(fetchImpl).toHaveBeenCalledWith('http://127.0.0.1:1919/agents', expect.any(Object));
+  });
+
+  it('returns timeout error for aborted request（请求中止时返回 timeout 错误）', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('AbortError: The operation was aborted');
+    });
+
+    const client = new RuntimeClient({ fetchImpl, timeoutMs: 10 });
+    const result = await client.getAgents(SAMPLE_HOST);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.error.code).toBe('timeout');
+  });
+
+  it('returns http error for non-2xx topology response（/topology 非 2xx 时返回 http 错误）', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: 'unavailable' }),
+    }));
+
+    const client = new RuntimeClient({ fetchImpl });
+    const result = await client.getTopology(SAMPLE_HOST);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.error.code).toBe('http');
+    expect(result.error.status).toBe(503);
+  });
+});

--- a/tests/unit/services/runtime-manager.issue201.test.ts
+++ b/tests/unit/services/runtime-manager.issue201.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { RuntimeHostRecord } from '@/lib/types/agent-hub';
+import { RuntimeManager } from '@/services/runtime-manager';
+
+const HOST_A: RuntimeHostRecord = {
+  id: 'host-a',
+  name: 'Host A',
+  host: '127.0.0.1',
+  port: 1919,
+  status: 'unknown',
+  createdAt: '2026-02-28T00:00:00.000Z',
+  updatedAt: '2026-02-28T00:00:00.000Z',
+};
+
+const HOST_B: RuntimeHostRecord = {
+  id: 'host-b',
+  name: 'Host B',
+  host: '192.168.1.22',
+  port: 2919,
+  status: 'unknown',
+  createdAt: '2026-02-28T00:00:00.000Z',
+  updatedAt: '2026-02-28T00:00:00.000Z',
+};
+
+describe('runtime manager issue-201（多主机聚合管理）', () => {
+  it('aggregates agents from multiple hosts with source labels（聚合多主机 agent 并标注来源）', async () => {
+    const hostService = {
+      listHosts: vi.fn(async () => [HOST_A, HOST_B]),
+      addHost: vi.fn(),
+      removeHost: vi.fn(),
+      probeHost: vi.fn(),
+      probeAllHosts: vi.fn(),
+    };
+    const runtimeClient = {
+      getAgents: vi.fn(async (host: RuntimeHostRecord) => {
+        if (host.id === 'host-a') {
+          return {
+            ok: true as const,
+            data: [{ id: 'echo', name: 'Echo Agent', description: 'ok', status: 'available' as const }],
+          };
+        }
+        return {
+          ok: true as const,
+          data: [{ id: 'daily', name: 'Daily Agent', description: 'summary', status: 'busy' as const }],
+        };
+      }),
+      getTopology: vi.fn(async () => ({
+        ok: true as const,
+        data: {
+          hostname: 'local',
+          os: 'windows',
+          arch: 'x86_64',
+          uptime_secs: 100,
+          version: '0.1.0',
+          port: 1919,
+        },
+      })),
+    };
+
+    const manager = new RuntimeManager({ hostService, runtimeClient });
+    const snapshot = await manager.refreshSnapshot();
+
+    expect(snapshot.agents).toHaveLength(2);
+    expect(snapshot.agents[0]?.sourceHostName).toBeDefined();
+    expect(snapshot.hosts.every((item) => item.connectionState === 'online')).toBe(true);
+  });
+
+  it('keeps offline host visible when request fails（请求失败时保留离线主机）', async () => {
+    const hostService = {
+      listHosts: vi.fn(async () => [HOST_A]),
+      addHost: vi.fn(),
+      removeHost: vi.fn(),
+      probeHost: vi.fn(),
+      probeAllHosts: vi.fn(),
+    };
+    const runtimeClient = {
+      getAgents: vi.fn(async () => ({
+        ok: false as const,
+        error: { code: 'network' as const, message: 'ECONNREFUSED' },
+      })),
+      getTopology: vi.fn(async () => ({
+        ok: false as const,
+        error: { code: 'network' as const, message: 'ECONNREFUSED' },
+      })),
+    };
+
+    const manager = new RuntimeManager({ hostService, runtimeClient });
+    const snapshot = await manager.refreshSnapshot();
+
+    expect(snapshot.agents).toHaveLength(0);
+    expect(snapshot.hosts).toHaveLength(1);
+    expect(snapshot.hosts[0]?.connectionState).toBe('offline');
+  });
+
+  it('parses host:port and forwards to host service（解析 host:port 并调用 hostService）', async () => {
+    const addHost = vi.fn(async () => HOST_A);
+    const hostService = {
+      listHosts: vi.fn(async () => [HOST_A]),
+      addHost,
+      removeHost: vi.fn(),
+      probeHost: vi.fn(),
+      probeAllHosts: vi.fn(),
+    };
+    const runtimeClient = {
+      getAgents: vi.fn(),
+      getTopology: vi.fn(),
+    };
+
+    const manager = new RuntimeManager({ hostService, runtimeClient });
+    await manager.addHostFromAddress('10.1.2.3:4077', 'LAN Runtime');
+
+    expect(addHost).toHaveBeenCalledWith({
+      name: 'LAN Runtime',
+      host: '10.1.2.3',
+      port: 4077,
+    });
+  });
+});

--- a/tests/unit/services/runtime-manager.issue201.test.ts
+++ b/tests/unit/services/runtime-manager.issue201.test.ts
@@ -115,4 +115,26 @@ describe('runtime manager issue-201（多主机聚合管理）', () => {
       port: 4077,
     });
   });
+
+  it('rejects full url input and requires plain host:port（拒绝完整 URL，仅接受 host:port）', async () => {
+    const addHost = vi.fn(async () => HOST_A);
+    const hostService = {
+      listHosts: vi.fn(async () => [HOST_A]),
+      addHost,
+      removeHost: vi.fn(),
+      probeHost: vi.fn(),
+      probeAllHosts: vi.fn(),
+    };
+    const runtimeClient = {
+      getAgents: vi.fn(),
+      getTopology: vi.fn(),
+    };
+
+    const manager = new RuntimeManager({ hostService, runtimeClient });
+
+    await expect(manager.addHostFromAddress('http://127.0.0.1:19424/health', 'Bad Input')).rejects.toThrow(
+      'invalid host:port format',
+    );
+    expect(addHost).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx
+++ b/tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx
@@ -59,7 +59,20 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
       host,
       connectionState: hostState[host.id] ?? 'offline',
       agents: [],
-      topology: null,
+      topology:
+        hostState[host.id] === 'online'
+          ? {
+              hostname: host.name,
+              os: 'Windows 11',
+              arch: 'x86_64',
+              uptime_secs: 3600,
+              version: '0.1.0',
+              port: host.port,
+              total_memory_mb: 16384,
+              used_memory_mb: 8192,
+            }
+          : null,
+      latencyMs: hostState[host.id] === 'online' ? 15 : undefined,
       error: hostState[host.id] === 'offline' ? 'ECONNREFUSED' : undefined,
     })),
   });
@@ -98,11 +111,26 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
       hostState[added.id] = 'offline';
       return added;
     });
+    runtimeManagerMocks.addHostFromAddress.mockImplementation(async (address: string, name?: string) => {
+      const [host, portRaw] = address.split(':');
+      const port = Number.parseInt(portRaw ?? '0', 10);
+      const added: RuntimeHostRecord = {
+        id: 'runtime-host-2',
+        name: name || `${host}:${port}`,
+        host: host ?? '',
+        port,
+        status: 'unknown',
+        createdAt: '2026-02-27T10:01:00.000Z',
+        updatedAt: '2026-02-27T10:01:00.000Z',
+      };
+      hosts = [...hosts, added];
+      hostState[added.id] = 'offline';
+      return added;
+    });
     runtimeManagerMocks.retryHost.mockImplementation(async (hostId: string) => {
       hostState[hostId] = 'online';
       return buildSnapshot().hosts.find((item) => item.host.id === hostId) ?? null;
     });
-    runtimeManagerMocks.addHostFromAddress.mockResolvedValue(null);
     runtimeManagerMocks.removeHost.mockResolvedValue(undefined);
 
     runtimeControlMocks.getStatus.mockResolvedValue({
@@ -123,7 +151,7 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
     });
   });
 
-  it('adds runtime host from device view form（设备页表单可新增 RuntimeHost）', async () => {
+  it('opens manager sheet from device view and adds runtime host（设备页可打开主机管理并新增 RuntimeHost）', async () => {
     render(<AgentsPage />);
     fireEvent.click(await screen.findByTestId('agent-view-toggle-device'));
 
@@ -132,18 +160,18 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
       expect(screen.getByText('Hope Desktop')).toBeInTheDocument();
     });
 
+    fireEvent.click(screen.getByTestId('runtime-host-manage-button'));
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-host-manager-sheet')).toBeInTheDocument();
+    });
+
     fireEvent.change(screen.getByTestId('runtime-host-name-input'), { target: { value: 'LAN Runner' } });
-    fireEvent.change(screen.getByTestId('runtime-host-address-input'), { target: { value: '192.168.1.33' } });
-    fireEvent.change(screen.getByTestId('runtime-host-port-input'), { target: { value: '9001' } });
+    fireEvent.change(screen.getByTestId('runtime-host-address-input'), { target: { value: '192.168.1.33:9001' } });
     fireEvent.click(screen.getByTestId('runtime-host-add-button'));
 
     await waitFor(() => {
-      expect(runtimeManagerMocks.addHost).toHaveBeenCalledWith({
-        name: 'LAN Runner',
-        host: '192.168.1.33',
-        port: 9001,
-      });
-      expect(screen.getByText('LAN Runner')).toBeInTheDocument();
+      expect(runtimeManagerMocks.addHostFromAddress).toHaveBeenCalledWith('192.168.1.33:9001', 'LAN Runner');
+      expect(screen.getAllByText('LAN Runner').length).toBeGreaterThan(0);
     });
   });
 

--- a/tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx
+++ b/tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx
@@ -6,17 +6,15 @@ import type { RuntimeHostRecord } from '@/lib/types/agent-hub';
 
 const agentHubMocks = vi.hoisted(() => ({
   getTopology: vi.fn(),
-  getListView: vi.fn(),
   getDeviceView: vi.fn(),
-  listAddNodeOptions: vi.fn(),
 }));
 
-const runtimeHostMocks = vi.hoisted(() => ({
-  listHosts: vi.fn(),
+const runtimeManagerMocks = vi.hoisted(() => ({
+  refreshSnapshot: vi.fn(),
   addHost: vi.fn(),
-  probeHost: vi.fn(),
+  addHostFromAddress: vi.fn(),
+  retryHost: vi.fn(),
   removeHost: vi.fn(),
-  probeAllHosts: vi.fn(),
 }));
 
 const runtimeControlMocks = vi.hoisted(() => ({
@@ -28,14 +26,12 @@ const runtimeControlMocks = vi.hoisted(() => ({
 vi.mock('@/lib/services', () => ({
   getAgentHubService: () => ({
     getTopology: agentHubMocks.getTopology,
-    getListView: agentHubMocks.getListView,
     getDeviceView: agentHubMocks.getDeviceView,
-    listAddNodeOptions: agentHubMocks.listAddNodeOptions,
   }),
 }));
 
-vi.mock('@/lib/services/runtime-host.service', () => ({
-  getRuntimeHostService: () => runtimeHostMocks,
+vi.mock('@/services/runtime-manager', () => ({
+  getRuntimeManager: () => runtimeManagerMocks,
 }));
 
 vi.mock('@/lib/services/runtime-control.service', () => ({
@@ -44,6 +40,29 @@ vi.mock('@/lib/services/runtime-control.service', () => ({
 
 describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）', () => {
   let hosts: RuntimeHostRecord[];
+  let hostState: Record<string, 'online' | 'offline' | 'error'>;
+
+  const buildSnapshot = () => ({
+    updatedAt: '2026-02-27T10:00:00.000Z',
+    agents: hosts
+      .filter((host) => hostState[host.id] === 'online')
+      .map((host) => ({
+        id: `agent-${host.id}`,
+        name: `Agent@${host.name}`,
+        description: 'Runtime Agent',
+        status: 'available',
+        sourceHostId: host.id,
+        sourceHostName: host.name,
+        sourceHostAddress: `${host.host}:${host.port}`,
+      })),
+    hosts: hosts.map((host) => ({
+      host,
+      connectionState: hostState[host.id] ?? 'offline',
+      agents: [],
+      topology: null,
+      error: hostState[host.id] === 'offline' ? 'ECONNREFUSED' : undefined,
+    })),
+  });
 
   beforeEach(() => {
     hosts = [
@@ -57,14 +76,15 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
         updatedAt: '2026-02-27T10:00:00.000Z',
       },
     ];
+    hostState = {
+      'runtime-host-1': 'offline',
+    };
 
     agentHubMocks.getTopology.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.topology);
-    agentHubMocks.getListView.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.listSections);
     agentHubMocks.getDeviceView.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.deviceGroups);
-    agentHubMocks.listAddNodeOptions.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.addNodeOptions);
 
-    runtimeHostMocks.listHosts.mockImplementation(async () => hosts);
-    runtimeHostMocks.addHost.mockImplementation(async (input: { name: string; host: string; port: number }) => {
+    runtimeManagerMocks.refreshSnapshot.mockImplementation(async () => buildSnapshot());
+    runtimeManagerMocks.addHost.mockImplementation(async (input: { name: string; host: string; port: number }) => {
       const added: RuntimeHostRecord = {
         id: 'runtime-host-2',
         name: input.name,
@@ -75,16 +95,15 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
         updatedAt: '2026-02-27T10:01:00.000Z',
       };
       hosts = [...hosts, added];
+      hostState[added.id] = 'offline';
       return added;
     });
-    runtimeHostMocks.probeHost.mockImplementation(async (hostId: string) => {
-      hosts = hosts.map((item) => (
-        item.id === hostId
-          ? { ...item, status: 'online', updatedAt: '2026-02-27T10:02:00.000Z', lastCheckedAt: '2026-02-27T10:02:00.000Z' }
-          : item
-      ));
-      return hosts.find((item) => item.id === hostId)!;
+    runtimeManagerMocks.retryHost.mockImplementation(async (hostId: string) => {
+      hostState[hostId] = 'online';
+      return buildSnapshot().hosts.find((item) => item.host.id === hostId) ?? null;
     });
+    runtimeManagerMocks.addHostFromAddress.mockResolvedValue(null);
+    runtimeManagerMocks.removeHost.mockResolvedValue(undefined);
 
     runtimeControlMocks.getStatus.mockResolvedValue({
       running: false,
@@ -119,7 +138,7 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
     fireEvent.click(screen.getByTestId('runtime-host-add-button'));
 
     await waitFor(() => {
-      expect(runtimeHostMocks.addHost).toHaveBeenCalledWith({
+      expect(runtimeManagerMocks.addHost).toHaveBeenCalledWith({
         name: 'LAN Runner',
         host: '192.168.1.33',
         port: 9001,
@@ -133,13 +152,13 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
     fireEvent.click(await screen.findByTestId('agent-view-toggle-device'));
 
     await waitFor(() => {
-      expect(screen.getByTestId('runtime-host-status-runtime-host-1')).toHaveTextContent('unknown');
+      expect(screen.getByTestId('runtime-host-status-runtime-host-1')).toHaveTextContent('offline');
     });
 
     fireEvent.click(screen.getByTestId('runtime-host-probe-runtime-host-1'));
 
     await waitFor(() => {
-      expect(runtimeHostMocks.probeHost).toHaveBeenCalledWith('runtime-host-1');
+      expect(runtimeManagerMocks.retryHost).toHaveBeenCalledWith('runtime-host-1');
       expect(screen.getByTestId('runtime-host-status-runtime-host-1')).toHaveTextContent('online');
     });
   });

--- a/tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
@@ -5,26 +5,77 @@ import { AGENT_HUB_MOCK_FIXTURE } from '@/lib/adapters/mock/fixtures/agent-hub';
 
 const serviceMocks = vi.hoisted(() => ({
   getTopology: vi.fn(),
-  getListView: vi.fn(),
   getDeviceView: vi.fn(),
-  listAddNodeOptions: vi.fn(),
+}));
+
+const runtimeManagerMocks = vi.hoisted(() => ({
+  refreshSnapshot: vi.fn(),
+  retryHost: vi.fn(),
+  addHost: vi.fn(),
+  addHostFromAddress: vi.fn(),
+  removeHost: vi.fn(),
+}));
+
+const runtimeControlMocks = vi.hoisted(() => ({
+  startRuntime: vi.fn(),
+  stopRuntime: vi.fn(),
+  getStatus: vi.fn(),
 }));
 
 vi.mock('@/lib/services', () => ({
   getAgentHubService: () => ({
     getTopology: serviceMocks.getTopology,
-    getListView: serviceMocks.getListView,
     getDeviceView: serviceMocks.getDeviceView,
-    listAddNodeOptions: serviceMocks.listAddNodeOptions,
   }),
+}));
+
+vi.mock('@/services/runtime-manager', () => ({
+  getRuntimeManager: () => runtimeManagerMocks,
+}));
+
+vi.mock('@/lib/services/runtime-control.service', () => ({
+  getRuntimeControlService: () => runtimeControlMocks,
 }));
 
 describe('agents page issue-204（主页面三视图与添加节点）', () => {
   beforeEach(() => {
     serviceMocks.getTopology.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.topology);
-    serviceMocks.getListView.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.listSections);
     serviceMocks.getDeviceView.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.deviceGroups);
-    serviceMocks.listAddNodeOptions.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.addNodeOptions);
+    runtimeControlMocks.getStatus.mockResolvedValue({
+      running: false,
+      host: '127.0.0.1',
+      port: 4077,
+    });
+    runtimeManagerMocks.refreshSnapshot.mockResolvedValue({
+      updatedAt: '2026-02-28T10:00:00.000Z',
+      agents: [
+        {
+          id: 'echo',
+          name: 'Echo Agent',
+          description: '回显输入内容',
+          status: 'available',
+          sourceHostId: 'host-a',
+          sourceHostName: '127.0.0.1:1919',
+          sourceHostAddress: '127.0.0.1:1919',
+        },
+      ],
+      hosts: [
+        {
+          host: {
+            id: 'host-a',
+            name: '127.0.0.1:1919',
+            host: '127.0.0.1',
+            port: 1919,
+            status: 'unknown',
+            createdAt: '2026-02-28T00:00:00.000Z',
+            updatedAt: '2026-02-28T00:00:00.000Z',
+          },
+          connectionState: 'online',
+          agents: [],
+          topology: null,
+        },
+      ],
+    });
   });
 
   it('switches topology/list/device views（支持拓扑/列表/设备切换）', async () => {
@@ -40,7 +91,7 @@ describe('agents page issue-204（主页面三视图与添加节点）', () => {
     fireEvent.click(screen.getByTestId('agent-view-toggle-list'));
     expect(screen.getByTestId('agent-list-view')).toBeInTheDocument();
     expect(screen.getByTestId('agent-list-filter-all')).toBeInTheDocument();
-    expect(screen.getByTestId('agent-list-item-agent-daily-chevron')).toBeInTheDocument();
+    expect(screen.getByText('Echo Agent')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('agent-view-toggle-device'));
     expect(screen.getByTestId('agent-device-view')).toBeInTheDocument();
     expect(screen.getByTestId('agent-device-overview-card')).toBeInTheDocument();
@@ -59,7 +110,7 @@ describe('agents page issue-204（主页面三视图与添加节点）', () => {
 
     fireEvent.click(screen.getByTestId('agent-add-node-button'));
     expect(screen.getByTestId('agent-add-node-sheet')).toBeInTheDocument();
-    expect(screen.getByText('从市场安装')).toBeInTheDocument();
+    expect(screen.getByText('添加设备')).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('agent-add-node-close'));
     expect(screen.queryByTestId('agent-add-node-sheet')).not.toBeInTheDocument();

--- a/tests/unit/ui/agent-hub/agents-page.runtime.issue201.test.tsx
+++ b/tests/unit/ui/agent-hub/agents-page.runtime.issue201.test.tsx
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { AgentsPage } from '@/ui/app/pages/AgentsPage';
+
+const runtimeManagerMocks = vi.hoisted(() => ({
+  refreshSnapshot: vi.fn(),
+  retryHost: vi.fn(),
+  addHostFromAddress: vi.fn(),
+  removeHost: vi.fn(),
+}));
+
+const runtimeControlMocks = vi.hoisted(() => ({
+  startRuntime: vi.fn(),
+  stopRuntime: vi.fn(),
+  getStatus: vi.fn(),
+}));
+
+vi.mock('@/services/runtime-manager', () => ({
+  getRuntimeManager: () => runtimeManagerMocks,
+}));
+
+vi.mock('@/lib/services/runtime-control.service', () => ({
+  getRuntimeControlService: () => runtimeControlMocks,
+}));
+
+describe('agents page runtime issue-201（AgentsPage 真实数据聚合）', () => {
+  beforeEach(() => {
+    runtimeControlMocks.getStatus.mockResolvedValue({
+      running: false,
+      host: '127.0.0.1',
+      port: 1919,
+    });
+
+    runtimeManagerMocks.refreshSnapshot.mockResolvedValue({
+      updatedAt: '2026-02-28T10:00:00.000Z',
+      agents: [
+        {
+          id: 'echo',
+          name: 'Echo Agent',
+          description: '回显输入内容',
+          status: 'available',
+          sourceHostId: 'host-a',
+          sourceHostName: '127.0.0.1:1919',
+          sourceHostAddress: '127.0.0.1:1919',
+        },
+      ],
+      hosts: [
+        {
+          host: {
+            id: 'host-a',
+            name: '127.0.0.1:1919',
+            host: '127.0.0.1',
+            port: 1919,
+            status: 'unknown',
+            createdAt: '2026-02-28T00:00:00.000Z',
+            updatedAt: '2026-02-28T00:00:00.000Z',
+          },
+          connectionState: 'online',
+          agents: [
+            {
+              id: 'echo',
+              name: 'Echo Agent',
+              description: '回显输入内容',
+              status: 'available',
+              sourceHostId: 'host-a',
+              sourceHostName: '127.0.0.1:1919',
+              sourceHostAddress: '127.0.0.1:1919',
+            },
+          ],
+          topology: null,
+        },
+        {
+          host: {
+            id: 'host-b',
+            name: '192.168.1.22:2919',
+            host: '192.168.1.22',
+            port: 2919,
+            status: 'unknown',
+            createdAt: '2026-02-28T00:00:00.000Z',
+            updatedAt: '2026-02-28T00:00:00.000Z',
+          },
+          connectionState: 'offline',
+          agents: [],
+          topology: null,
+          error: 'ECONNREFUSED',
+        },
+      ],
+    });
+  });
+
+  it('shows aggregated runtime agents with source host badge（聚合显示并标注来源主机）', async () => {
+    render(<AgentsPage />);
+    fireEvent.click(await screen.findByTestId('agent-view-toggle-list'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Echo Agent')).toBeInTheDocument();
+      expect(screen.getByText(/来源 127\.0\.0\.1:1919/)).toBeInTheDocument();
+    });
+  });
+
+  it('opens add-device flow from header button（右上角按钮触发添加设备流程）', async () => {
+    render(<AgentsPage />);
+
+    fireEvent.click(await screen.findByTestId('agent-add-node-button'));
+    expect(screen.getByTestId('agent-add-node-sheet')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('agent-add-node-option-device'));
+    expect(screen.getByTestId('agent-host-manager-sheet')).toBeInTheDocument();
+  });
+
+  it('supports retry and remove actions for host cards（支持主机重试与删除）', async () => {
+    runtimeManagerMocks.retryHost.mockResolvedValue(undefined);
+    runtimeManagerMocks.removeHost.mockResolvedValue(undefined);
+    render(<AgentsPage />);
+    fireEvent.click(await screen.findByTestId('agent-add-node-button'));
+    fireEvent.click(screen.getByTestId('agent-add-node-option-device'));
+
+    fireEvent.click(await screen.findByTestId('runtime-host-probe-host-b'));
+    fireEvent.click(screen.getByTestId('runtime-host-remove-host-b'));
+
+    await waitFor(() => {
+      expect(runtimeManagerMocks.retryHost).toHaveBeenCalledWith('host-b');
+      expect(runtimeManagerMocks.removeHost).toHaveBeenCalledWith('host-b');
+    });
+  });
+});


### PR DESCRIPTION
## 变更摘要
- 新增 src/services/runtime-client.ts：封装 exomind-rt HTTP 客户端（GET /agents、GET /topology），统一超时/网络/HTTP/响应格式错误处理。
- 新增 src/services/runtime-manager.ts：聚合多主机 runtime 数据，输出 host 连接状态（online/error/offline）与 agent 来源标注。
- 改造 src/ui/app/pages/AgentsPage.tsx：
  - 列表视图改为真实 runtime 聚合数据（每个 agent 标注来源主机）。
  - 右上角 + 弹层改为“添加设备”入口。
  - 新增主机管理弹层：支持 host:port 添加、删除、重试。
  - 连接失败/超时显示 error 样式与重试；主机离线显示 offline 且不隐藏。
- 增加并更新测试：
  - 单测：runtime client / runtime manager / AgentsPage runtime 流程
  - 回归：更新 issue204 / issue205 AgentsPage 相关单测以匹配新数据流
  - E2E：新增 issue201 用例（在线聚合 + 关闭服务后 offline）

## 验证记录
- unx vitest run tests/unit/services/runtime-client.issue201.test.ts tests/unit/services/runtime-manager.issue201.test.ts tests/unit/ui/agent-hub/agents-page.runtime.issue201.test.tsx
- unx vitest run tests/unit/ui/agent-hub/agents-page.issue204.test.tsx tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx tests/unit/ui/agent-hub/agents-page.runtime.issue201.test.tsx tests/unit/services/runtime-client.issue201.test.ts tests/unit/services/runtime-manager.issue201.test.ts
- unx tsc --noEmit
- un run test:e2e:issue201
- Playwright MCP 冒烟：已实测“添加节点 -> 添加设备 -> 添加 host:port -> 状态展示/重试”链路

Closes #201