### PR TITLE
feat(runtime): EXO-50 Claude CLI 多轮会话持久化与流式测试

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,6 +1035,7 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/exomind-runtime/Cargo.toml
+++ b/crates/exomind-runtime/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-uti
 thiserror = "1"
 sysinfo = { version = "0.30", default-features = false }
 tower-http = { version = "0.6", features = ["cors"] }
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/crates/exomind-runtime/Cargo.toml
+++ b/crates/exomind-runtime/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2024"
 name = "exomind-rt"
 path = "src/main.rs"
 
+[[bin]]
+name = "fake-claude-cli"
+path = "tests/bin/fake-claude-cli.rs"
+
 [dependencies]
 axum = "0.7"
 futures-util = "0.3"

--- a/crates/exomind-runtime/Cargo.toml
+++ b/crates/exomind-runtime/Cargo.toml
@@ -2,6 +2,7 @@
 name = "exomind-runtime"
 version = "0.1.0"
 edition = "2024"
+default-run = "exomind-rt"
 
 [[bin]]
 name = "exomind-rt"

--- a/crates/exomind-runtime/src/agent/claude.rs
+++ b/crates/exomind-runtime/src/agent/claude.rs
@@ -10,6 +10,8 @@ use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::{Mutex, mpsc};
 use uuid::Uuid;
 
+const MAX_CLAUDE_SESSIONS: usize = 64;
+
 /// Session status（会话状态）.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SessionStatus {
@@ -29,6 +31,13 @@ struct ClaudeSession {
     status: SessionStatus,
     created_at: Instant,
     message_count: u64,
+}
+
+impl Drop for ClaudeSession {
+    fn drop(&mut self) {
+        // Best-effort process termination（尽力终止子进程，避免僵尸/泄漏）.
+        let _ = self.child.start_kill();
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -60,10 +69,7 @@ impl ClaudeAgent {
         Self::with_command_and_args("claude", build_claude_persistent_args())
     }
 
-    pub fn with_command_and_args(
-        command: impl Into<String>,
-        persistent_args: Vec<String>,
-    ) -> Self {
+    pub fn with_command_and_args(command: impl Into<String>, persistent_args: Vec<String>) -> Self {
         Self {
             command: command.into(),
             persistent_args,
@@ -90,7 +96,8 @@ impl ClaudeAgent {
             None
         };
 
-        let action = decide_session_action(normalized_session_id.as_deref(), existing_session.is_some());
+        let action =
+            decide_session_action(normalized_session_id.as_deref(), existing_session.is_some());
 
         let (session_id, session_handle, needs_session_chunk) = match action {
             SessionAction::CreateNew => match self.create_session().await {
@@ -128,6 +135,8 @@ impl ClaudeAgent {
     }
 
     async fn create_session(&self) -> Result<(String, SharedClaudeSession), String> {
+        self.evict_dead_sessions().await;
+
         let session_id = Uuid::new_v4().to_string();
         let mut child = Command::new(&self.command)
             .args(&self.persistent_args)
@@ -146,7 +155,7 @@ impl ClaudeAgent {
             .take()
             .ok_or_else(|| "Claude stdout 不可用".to_string())?;
 
-        let session = ClaudeSession {
+        let mut session = ClaudeSession {
             session_id: session_id.clone(),
             claude_session_id: None,
             child,
@@ -157,11 +166,16 @@ impl ClaudeAgent {
             message_count: 0,
         };
 
+        let mut sessions = self.sessions.lock().await;
+        if sessions.len() >= MAX_CLAUDE_SESSIONS {
+            let _ = session.child.start_kill();
+            return Err(format!(
+                "Claude 会话数已达上限({MAX_CLAUDE_SESSIONS})，请复用已有会话"
+            ));
+        }
+
         let shared_session = Arc::new(Mutex::new(session));
-        self.sessions
-            .lock()
-            .await
-            .insert(session_id.clone(), shared_session.clone());
+        sessions.insert(session_id.clone(), shared_session.clone());
         Ok((session_id, shared_session))
     }
 
@@ -175,8 +189,24 @@ impl ClaudeAgent {
     ) {
         let mut session = session_handle.lock().await;
 
-        if let Err(error_message) = ensure_session_ready_for_turn(&mut session) {
+        match session.status {
+            SessionStatus::Idle => {}
+            SessionStatus::Processing => {
+                emit_error_chunk(&sender, "Claude 会话正在处理中，请稍后重试".to_string()).await;
+                return;
+            }
+            SessionStatus::Crashed => {
+                drop(session);
+                self.cleanup_session(&session_id).await;
+                emit_error_chunk(&sender, "Claude 会话已崩溃，请新建会话".to_string()).await;
+                return;
+            }
+        }
+
+        if let Err(error_message) = ensure_session_process_alive(&mut session) {
             session.status = SessionStatus::Crashed;
+            drop(session);
+            self.cleanup_session(&session_id).await;
             emit_error_chunk(&sender, error_message).await;
             return;
         }
@@ -187,6 +217,8 @@ impl ClaudeAgent {
         let input_line = build_stream_json_user_input(&message);
         if let Err(error) = write_user_input_line(&mut session.stdin, &input_line).await {
             session.status = SessionStatus::Crashed;
+            drop(session);
+            self.cleanup_session(&session_id).await;
             emit_error_chunk(&sender, format!("Claude 输入写入失败: {error}")).await;
             return;
         }
@@ -230,15 +262,59 @@ impl ClaudeAgent {
                 Ok(None) => {
                     session.status = SessionStatus::Crashed;
                     let message = build_session_ended_error_message(&mut session);
+                    drop(session);
+                    self.cleanup_session(&session_id).await;
                     emit_error_chunk(&sender, message).await;
                     return;
                 }
                 Err(error) => {
                     session.status = SessionStatus::Crashed;
+                    drop(session);
+                    self.cleanup_session(&session_id).await;
                     emit_error_chunk(&sender, format!("Claude 输出读取失败: {error}")).await;
                     return;
                 }
             }
+        }
+    }
+
+    async fn cleanup_session(&self, session_id: &str) {
+        let removed = self.sessions.lock().await.remove(session_id);
+        if let Some(handle) = removed {
+            let mut session = handle.lock().await;
+            session.status = SessionStatus::Crashed;
+            let _ = session.child.start_kill();
+        }
+    }
+
+    async fn evict_dead_sessions(&self) {
+        let snapshots = {
+            let sessions = self.sessions.lock().await;
+            sessions
+                .iter()
+                .map(|(id, handle)| (id.clone(), handle.clone()))
+                .collect::<Vec<_>>()
+        };
+
+        let mut stale_ids = Vec::new();
+        for (id, handle) in snapshots {
+            if let Ok(mut session) = handle.try_lock() {
+                let dead = matches!(session.status, SessionStatus::Crashed)
+                    || matches!(session.child.try_wait(), Ok(Some(_)) | Err(_));
+                if dead {
+                    let _ = session.child.start_kill();
+                    stale_ids.push(id);
+                }
+            }
+        }
+
+        if stale_ids.is_empty() {
+            return;
+        }
+
+        let mut sessions = self.sessions.lock().await;
+        for id in stale_ids {
+            sessions.remove(&id);
         }
     }
 }
@@ -290,13 +366,7 @@ fn decide_session_action(session_id: Option<&str>, has_existing_session: bool) -
     }
 }
 
-fn ensure_session_ready_for_turn(session: &mut ClaudeSession) -> Result<(), String> {
-    match session.status {
-        SessionStatus::Idle => {}
-        SessionStatus::Processing => return Err("Claude 会话正在处理中，请稍后重试".to_string()),
-        SessionStatus::Crashed => return Err("Claude 会话已崩溃，请新建会话".to_string()),
-    }
-
+fn ensure_session_process_alive(session: &mut ClaudeSession) -> Result<(), String> {
     match session.child.try_wait() {
         Ok(Some(status)) => Err(build_exit_status_error_message(status.code())),
         Ok(None) => Ok(()),
@@ -515,7 +585,10 @@ mod tests {
         let chunks = collect_chunks_from_mock_stdout(mock_stdout);
         assert_eq!(
             chunks,
-            vec![ChatChunk::content_only("你好"), ChatChunk::content_only("！")]
+            vec![
+                ChatChunk::content_only("你好"),
+                ChatChunk::content_only("！")
+            ]
         );
     }
 

--- a/crates/exomind-runtime/src/agent/claude.rs
+++ b/crates/exomind-runtime/src/agent/claude.rs
@@ -1,33 +1,236 @@
-use super::{Agent, ChatChunk};
+use super::{Agent, ChatChunk, ChatRequest};
 use futures_util::stream::{self, BoxStream, StreamExt};
-use serde_json::Value;
+use serde_json::{Value, json};
+use std::collections::HashMap;
 use std::process::Stdio;
-use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::Command;
-use tokio::sync::mpsc;
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::sync::{Mutex, mpsc};
+use uuid::Uuid;
+
+/// Session status（会话状态）.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionStatus {
+    Idle,
+    Processing,
+    Crashed,
+}
+
+/// Claude process session（Claude 子进程会话）.
+#[derive(Debug)]
+struct ClaudeSession {
+    session_id: String,
+    claude_session_id: Option<String>,
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    status: SessionStatus,
+    created_at: Instant,
+    message_count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SessionAction {
+    CreateNew,
+    Reuse { session_id: String },
+    Missing { session_id: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ClaudeStreamEvent {
+    System { claude_session_id: Option<String> },
+    AssistantChunk { content: String },
+    Result,
+}
+
+type SharedClaudeSession = Arc<Mutex<ClaudeSession>>;
 
 /// Built-in Claude agent (内置 Claude Agent，通过 Claude CLI 输出流式文本).
 #[derive(Debug, Clone)]
 pub struct ClaudeAgent {
     command: String,
+    sessions: Arc<Mutex<HashMap<String, SharedClaudeSession>>>,
 }
 
 impl ClaudeAgent {
     pub fn new() -> Self {
         Self {
             command: "claude".to_string(),
+            sessions: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
-    fn spawn_streaming_task(&self, message: String) -> mpsc::Receiver<ChatChunk> {
+    fn spawn_streaming_task(&self, request: ChatRequest) -> mpsc::Receiver<ChatChunk> {
         let (sender, receiver) = mpsc::channel(64);
-        let command = self.command.clone();
+        let agent = self.clone();
 
         tokio::spawn(async move {
-            stream_claude_stdout(command, message, sender).await;
+            agent.handle_chat_request(request, sender).await;
         });
 
         receiver
+    }
+
+    async fn handle_chat_request(&self, request: ChatRequest, sender: mpsc::Sender<ChatChunk>) {
+        let normalized_session_id = normalize_session_id(request.session_id.as_deref());
+        let existing_session = if let Some(session_id) = normalized_session_id.as_deref() {
+            self.find_session(session_id).await
+        } else {
+            None
+        };
+
+        let action = decide_session_action(normalized_session_id.as_deref(), existing_session.is_some());
+
+        let (session_id, session_handle, needs_session_chunk) = match action {
+            SessionAction::CreateNew => match self.create_session().await {
+                Ok(created) => (created.0, created.1, true),
+                Err(error_message) => {
+                    emit_error_chunk(&sender, error_message).await;
+                    return;
+                }
+            },
+            SessionAction::Reuse { session_id } => {
+                let Some(handle) = existing_session else {
+                    emit_error_chunk(&sender, format!("Claude 会话不存在: {session_id}")).await;
+                    return;
+                };
+                (session_id, handle, false)
+            }
+            SessionAction::Missing { session_id } => {
+                emit_error_chunk(&sender, format!("Claude 会话不存在: {session_id}")).await;
+                return;
+            }
+        };
+
+        self.process_turn(
+            session_id,
+            session_handle,
+            request.message,
+            needs_session_chunk,
+            sender,
+        )
+        .await;
+    }
+
+    async fn find_session(&self, session_id: &str) -> Option<SharedClaudeSession> {
+        self.sessions.lock().await.get(session_id).cloned()
+    }
+
+    async fn create_session(&self) -> Result<(String, SharedClaudeSession), String> {
+        let session_id = Uuid::new_v4().to_string();
+        let mut child = Command::new(&self.command)
+            .args(build_claude_persistent_args())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|error| format!("Claude 启动失败: {error}"))?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "Claude stdin 不可用".to_string())?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "Claude stdout 不可用".to_string())?;
+
+        let session = ClaudeSession {
+            session_id: session_id.clone(),
+            claude_session_id: None,
+            child,
+            stdin,
+            stdout: BufReader::new(stdout),
+            status: SessionStatus::Idle,
+            created_at: Instant::now(),
+            message_count: 0,
+        };
+
+        let shared_session = Arc::new(Mutex::new(session));
+        self.sessions
+            .lock()
+            .await
+            .insert(session_id.clone(), shared_session.clone());
+        Ok((session_id, shared_session))
+    }
+
+    async fn process_turn(
+        &self,
+        session_id: String,
+        session_handle: SharedClaudeSession,
+        message: String,
+        needs_session_chunk: bool,
+        sender: mpsc::Sender<ChatChunk>,
+    ) {
+        let mut session = session_handle.lock().await;
+
+        if let Err(error_message) = ensure_session_ready_for_turn(&mut session) {
+            session.status = SessionStatus::Crashed;
+            emit_error_chunk(&sender, error_message).await;
+            return;
+        }
+
+        session.status = SessionStatus::Processing;
+        session.message_count += 1;
+
+        let input_line = build_stream_json_user_input(&message);
+        if let Err(error) = write_user_input_line(&mut session.stdin, &input_line).await {
+            session.status = SessionStatus::Crashed;
+            emit_error_chunk(&sender, format!("Claude 输入写入失败: {error}")).await;
+            return;
+        }
+
+        let mut pending_session_chunk = needs_session_chunk;
+        loop {
+            match read_next_stream_event(&mut session.stdout).await {
+                Ok(Some(ClaudeStreamEvent::System { claude_session_id })) => {
+                    if let Some(value) = claude_session_id {
+                        session.claude_session_id = Some(value);
+                    }
+                }
+                Ok(Some(ClaudeStreamEvent::AssistantChunk { content })) => {
+                    let chunk = ChatChunk {
+                        content,
+                        session_id: if pending_session_chunk {
+                            pending_session_chunk = false;
+                            Some(session_id.clone())
+                        } else {
+                            None
+                        },
+                    };
+
+                    if sender.send(chunk).await.is_err() {
+                        session.status = SessionStatus::Idle;
+                        return;
+                    }
+                }
+                Ok(Some(ClaudeStreamEvent::Result)) => {
+                    if pending_session_chunk {
+                        let _ = sender
+                            .send(ChatChunk {
+                                content: String::new(),
+                                session_id: Some(session_id.clone()),
+                            })
+                            .await;
+                    }
+                    session.status = SessionStatus::Idle;
+                    return;
+                }
+                Ok(None) => {
+                    session.status = SessionStatus::Crashed;
+                    let message = build_session_ended_error_message(&mut session);
+                    emit_error_chunk(&sender, message).await;
+                    return;
+                }
+                Err(error) => {
+                    session.status = SessionStatus::Crashed;
+                    emit_error_chunk(&sender, format!("Claude 输出读取失败: {error}")).await;
+                    return;
+                }
+            }
+        }
     }
 }
 
@@ -50,8 +253,8 @@ impl Agent for ClaudeAgent {
         "通过 Claude Code CLI 提供流式对话"
     }
 
-    fn chat_stream(&self, message: String) -> BoxStream<'static, ChatChunk> {
-        let receiver = self.spawn_streaming_task(message);
+    fn chat_stream(&self, request: ChatRequest) -> BoxStream<'static, ChatChunk> {
+        let receiver = self.spawn_streaming_task(request);
         stream::unfold(receiver, |mut receiver| async move {
             receiver.recv().await.map(|chunk| (chunk, receiver))
         })
@@ -59,70 +262,103 @@ impl Agent for ClaudeAgent {
     }
 }
 
-async fn stream_claude_stdout(command: String, message: String, sender: mpsc::Sender<ChatChunk>) {
-    let args = build_claude_args(&message);
-    let mut child = match Command::new(&command)
-        .args(&args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        Ok(child) => child,
-        Err(error) => {
-            emit_error_chunk(&sender, format!("Claude 启动失败: {error}")).await;
-            return;
-        }
-    };
+fn normalize_session_id(session_id: Option<&str>) -> Option<String> {
+    session_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
 
-    let Some(stdout) = child.stdout.take() else {
-        emit_error_chunk(&sender, "Claude stdout 不可用".to_string()).await;
-        return;
-    };
+fn decide_session_action(session_id: Option<&str>, has_existing_session: bool) -> SessionAction {
+    match session_id {
+        Some(value) if has_existing_session => SessionAction::Reuse {
+            session_id: value.to_string(),
+        },
+        Some(value) => SessionAction::Missing {
+            session_id: value.to_string(),
+        },
+        None => SessionAction::CreateNew,
+    }
+}
 
-    let mut lines = BufReader::new(stdout).lines();
-
-    loop {
-        match lines.next_line().await {
-            Ok(Some(line)) => {
-                if let Some(chunk) = parse_stream_json_line(&line) {
-                    if sender.send(chunk).await.is_err() {
-                        break;
-                    }
-                }
-            }
-            Ok(None) => break,
-            Err(error) => {
-                emit_error_chunk(&sender, format!("Claude 输出读取失败: {error}")).await;
-                break;
-            }
-        }
+fn ensure_session_ready_for_turn(session: &mut ClaudeSession) -> Result<(), String> {
+    match session.status {
+        SessionStatus::Idle => {}
+        SessionStatus::Processing => return Err("Claude 会话正在处理中，请稍后重试".to_string()),
+        SessionStatus::Crashed => return Err("Claude 会话已崩溃，请新建会话".to_string()),
     }
 
-    match child.wait().await {
-        Ok(status) => {
-            if !status.success() {
-                emit_error_chunk(&sender, build_exit_status_error_message(status.code())).await;
-            }
+    match session.child.try_wait() {
+        Ok(Some(status)) => Err(build_exit_status_error_message(status.code())),
+        Ok(None) => Ok(()),
+        Err(error) => Err(format!("Claude 进程状态检查失败: {error}")),
+    }
+}
+
+async fn write_user_input_line(stdin: &mut ChildStdin, line: &str) -> std::io::Result<()> {
+    stdin.write_all(line.as_bytes()).await?;
+    stdin.write_all(b"\n").await?;
+    stdin.flush().await
+}
+
+async fn read_next_stream_event(
+    stdout: &mut BufReader<ChildStdout>,
+) -> std::io::Result<Option<ClaudeStreamEvent>> {
+    loop {
+        let mut line = String::new();
+        let read_bytes = stdout.read_line(&mut line).await?;
+        if read_bytes == 0 {
+            return Ok(None);
         }
-        Err(error) => {
-            emit_error_chunk(&sender, format!("Claude 进程等待失败: {error}")).await;
+
+        let normalized_line = line.trim();
+        if normalized_line.is_empty() {
+            continue;
+        }
+
+        if let Some(event) = parse_stream_event_line(normalized_line) {
+            return Ok(Some(event));
         }
     }
 }
 
 async fn emit_error_chunk(sender: &mpsc::Sender<ChatChunk>, message: String) {
-    let _ = sender.send(ChatChunk { content: message }).await;
+    let _ = sender.send(ChatChunk::content_only(message)).await;
 }
 
-fn build_claude_args(message: &str) -> Vec<String> {
+fn build_claude_persistent_args() -> Vec<String> {
     vec![
         "-p".to_string(),
+        "--input-format".to_string(),
+        "stream-json".to_string(),
         "--output-format".to_string(),
         "stream-json".to_string(),
         "--verbose".to_string(),
         "--dangerously-skip-permissions".to_string(),
-        message.to_string(),
     ]
+}
+
+fn build_stream_json_user_input(message: &str) -> String {
+    json!({
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": message
+        }
+    })
+    .to_string()
+}
+
+fn build_session_ended_error_message(session: &mut ClaudeSession) -> String {
+    let uptime_seconds = session.created_at.elapsed().as_secs();
+    match session.child.try_wait() {
+        Ok(Some(status)) => build_exit_status_error_message(status.code()),
+        Ok(None) => format!(
+            "Claude 输出流提前结束，会话已中断: {}（运行 {} 秒）",
+            session.session_id, uptime_seconds
+        ),
+        Err(error) => format!("Claude 进程状态检查失败: {error}"),
+    }
 }
 
 fn build_exit_status_error_message(code: Option<i32>) -> String {
@@ -132,16 +368,43 @@ fn build_exit_status_error_message(code: Option<i32>) -> String {
     }
 }
 
-fn parse_stream_json_line(line: &str) -> Option<ChatChunk> {
+fn parse_stream_event_line(line: &str) -> Option<ClaudeStreamEvent> {
     let event: Value = serde_json::from_str(line).ok()?;
     let event_type = event.get("type").and_then(Value::as_str)?;
 
-    if event_type != "text" && event_type != "assistant" {
-        return None;
+    match event_type {
+        "text" | "assistant" => {
+            let content = extract_text_content(&event)?;
+            Some(ClaudeStreamEvent::AssistantChunk { content })
+        }
+        "system" => Some(ClaudeStreamEvent::System {
+            claude_session_id: extract_claude_session_id(&event),
+        }),
+        "result" => Some(ClaudeStreamEvent::Result),
+        _ => None,
     }
+}
 
-    let content = extract_text_content(&event)?;
-    Some(ChatChunk { content })
+#[cfg(test)]
+fn parse_stream_json_line(line: &str) -> Option<ChatChunk> {
+    match parse_stream_event_line(line)? {
+        ClaudeStreamEvent::AssistantChunk { content } => Some(ChatChunk::content_only(content)),
+        _ => None,
+    }
+}
+
+fn extract_claude_session_id(event: &Value) -> Option<String> {
+    event
+        .get("session_id")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .or_else(|| {
+            event
+                .get("session")
+                .and_then(|session| session.get("id"))
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        })
 }
 
 fn extract_text_content(event: &Value) -> Option<String> {
@@ -191,22 +454,6 @@ mod tests {
     }
 
     #[test]
-    fn build_claude_args_includes_verbose_for_print_stream_json() {
-        let args = build_claude_args("你好");
-        assert_eq!(
-            args,
-            vec![
-                "-p".to_string(),
-                "--output-format".to_string(),
-                "stream-json".to_string(),
-                "--verbose".to_string(),
-                "--dangerously-skip-permissions".to_string(),
-                "你好".to_string(),
-            ]
-        );
-    }
-
-    #[test]
     fn build_exit_status_error_message_with_code() {
         assert_eq!(
             build_exit_status_error_message(Some(7)),
@@ -226,24 +473,14 @@ mod tests {
     fn parse_stream_json_line_accepts_text_event() {
         let line = r#"{"type":"text","text":"你好"}"#;
         let chunk = parse_stream_json_line(line);
-        assert_eq!(
-            chunk,
-            Some(ChatChunk {
-                content: "你好".to_string()
-            })
-        );
+        assert_eq!(chunk, Some(ChatChunk::content_only("你好")));
     }
 
     #[test]
     fn parse_stream_json_line_accepts_assistant_event() {
         let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"有"},{"type":"text","text":"什么"}]}}"#;
         let chunk = parse_stream_json_line(line);
-        assert_eq!(
-            chunk,
-            Some(ChatChunk {
-                content: "有什么".to_string()
-            })
-        );
+        assert_eq!(chunk, Some(ChatChunk::content_only("有什么")));
     }
 
     #[test]
@@ -269,14 +506,79 @@ mod tests {
         let chunks = collect_chunks_from_mock_stdout(mock_stdout);
         assert_eq!(
             chunks,
+            vec![ChatChunk::content_only("你好"), ChatChunk::content_only("！")]
+        );
+    }
+
+    #[test]
+    fn build_claude_persistent_args_uses_stream_json_input_and_output() {
+        let args = build_claude_persistent_args();
+        assert_eq!(
+            args,
             vec![
-                ChatChunk {
-                    content: "你好".to_string()
-                },
-                ChatChunk {
-                    content: "！".to_string()
-                }
+                "-p".to_string(),
+                "--input-format".to_string(),
+                "stream-json".to_string(),
+                "--output-format".to_string(),
+                "stream-json".to_string(),
+                "--verbose".to_string(),
+                "--dangerously-skip-permissions".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn build_stream_json_user_input_returns_json_line_payload() {
+        let line = build_stream_json_user_input("你好，我叫小明");
+        assert_eq!(
+            line,
+            r#"{"message":{"content":"你好，我叫小明","role":"user"},"type":"user"}"#.to_string()
+        );
+    }
+
+    #[test]
+    fn parse_stream_event_line_extracts_system_session_id() {
+        let event =
+            parse_stream_event_line(r#"{"type":"system","session_id":"claude-session-123"}"#);
+        assert_eq!(
+            event,
+            Some(ClaudeStreamEvent::System {
+                claude_session_id: Some("claude-session-123".to_string())
+            })
+        );
+    }
+
+    #[test]
+    fn parse_stream_event_line_detects_result_event() {
+        let event = parse_stream_event_line(r#"{"type":"result","stop_reason":"end_turn"}"#);
+        assert_eq!(event, Some(ClaudeStreamEvent::Result));
+    }
+
+    #[test]
+    fn decide_session_action_returns_reuse_for_existing_session() {
+        let action = decide_session_action(Some("exo-session-1"), true);
+        assert_eq!(
+            action,
+            SessionAction::Reuse {
+                session_id: "exo-session-1".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn decide_session_action_returns_missing_for_unknown_session() {
+        let action = decide_session_action(Some("exo-session-404"), false);
+        assert_eq!(
+            action,
+            SessionAction::Missing {
+                session_id: "exo-session-404".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn decide_session_action_returns_create_for_empty_session_id() {
+        let action = decide_session_action(normalize_session_id(Some("   ")).as_deref(), false);
+        assert_eq!(action, SessionAction::CreateNew);
     }
 }

--- a/crates/exomind-runtime/src/agent/claude.rs
+++ b/crates/exomind-runtime/src/agent/claude.rs
@@ -412,6 +412,7 @@ fn build_claude_persistent_args() -> Vec<String> {
         "stream-json".to_string(),
         "--output-format".to_string(),
         "stream-json".to_string(),
+        "--replay-user-messages".to_string(),
         "--verbose".to_string(),
         "--dangerously-skip-permissions".to_string(),
     ]
@@ -603,6 +604,7 @@ mod tests {
                 "stream-json".to_string(),
                 "--output-format".to_string(),
                 "stream-json".to_string(),
+                "--replay-user-messages".to_string(),
                 "--verbose".to_string(),
                 "--dangerously-skip-permissions".to_string(),
             ]

--- a/crates/exomind-runtime/src/agent/claude.rs
+++ b/crates/exomind-runtime/src/agent/claude.rs
@@ -51,13 +51,22 @@ type SharedClaudeSession = Arc<Mutex<ClaudeSession>>;
 #[derive(Debug, Clone)]
 pub struct ClaudeAgent {
     command: String,
+    persistent_args: Vec<String>,
     sessions: Arc<Mutex<HashMap<String, SharedClaudeSession>>>,
 }
 
 impl ClaudeAgent {
     pub fn new() -> Self {
+        Self::with_command_and_args("claude", build_claude_persistent_args())
+    }
+
+    pub fn with_command_and_args(
+        command: impl Into<String>,
+        persistent_args: Vec<String>,
+    ) -> Self {
         Self {
-            command: "claude".to_string(),
+            command: command.into(),
+            persistent_args,
             sessions: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -121,7 +130,7 @@ impl ClaudeAgent {
     async fn create_session(&self) -> Result<(String, SharedClaudeSession), String> {
         let session_id = Uuid::new_v4().to_string();
         let mut child = Command::new(&self.command)
-            .args(build_claude_persistent_args())
+            .args(&self.persistent_args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())

--- a/crates/exomind-runtime/src/agent/echo.rs
+++ b/crates/exomind-runtime/src/agent/echo.rs
@@ -1,4 +1,4 @@
-use super::{Agent, ChatChunk};
+use super::{Agent, ChatChunk, ChatRequest};
 use futures_util::stream::{self, BoxStream, StreamExt};
 
 /// Built-in echo agent (内置回显 Agent).
@@ -24,10 +24,11 @@ impl Agent for EchoAgent {
         "回显输入内容"
     }
 
-    fn chat_stream(&self, message: String) -> BoxStream<'static, ChatChunk> {
-        stream::iter(vec![ChatChunk {
-            content: format!("Echo: {message}"),
-        }])
+    fn chat_stream(&self, request: ChatRequest) -> BoxStream<'static, ChatChunk> {
+        stream::iter(vec![ChatChunk::content_only(format!(
+            "Echo: {}",
+            request.message
+        ))])
         .boxed()
     }
 }

--- a/crates/exomind-runtime/src/agent/mod.rs
+++ b/crates/exomind-runtime/src/agent/mod.rs
@@ -19,6 +19,24 @@ pub struct AgentSummary {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ChatChunk {
     pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+impl ChatChunk {
+    pub fn content_only(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            session_id: None,
+        }
+    }
+}
+
+/// Chat request payload (聊天请求载荷).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChatRequest {
+    pub message: String,
+    pub session_id: Option<String>,
 }
 
 /// Agent behavior contract (Agent 行为契约).
@@ -31,7 +49,7 @@ pub trait Agent: Send + Sync {
         "available"
     }
 
-    fn chat_stream(&self, message: String) -> BoxStream<'static, ChatChunk>;
+    fn chat_stream(&self, request: ChatRequest) -> BoxStream<'static, ChatChunk>;
 }
 
 #[derive(Clone, Default)]
@@ -111,8 +129,8 @@ mod tests {
             "Temporary testing agent"
         }
 
-        fn chat_stream(&self, message: String) -> BoxStream<'static, ChatChunk> {
-            stream::iter(vec![ChatChunk { content: message }]).boxed()
+        fn chat_stream(&self, request: ChatRequest) -> BoxStream<'static, ChatChunk> {
+            stream::iter(vec![ChatChunk::content_only(request.message)]).boxed()
         }
     }
 

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -102,8 +102,8 @@ mod tests {
             "用于路由注册/注销可见性测试"
         }
 
-        fn chat_stream(&self, message: String) -> BoxStream<'static, agent::ChatChunk> {
-            stream::iter(vec![agent::ChatChunk { content: message }]).boxed()
+        fn chat_stream(&self, request: agent::ChatRequest) -> BoxStream<'static, agent::ChatChunk> {
+            stream::iter(vec![agent::ChatChunk::content_only(request.message)]).boxed()
         }
     }
 

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -1,5 +1,5 @@
 use axum::http::Method;
-use axum::{routing::get, Json, Router};
+use axum::{Json, Router, routing::get};
 use serde::Serialize;
 use std::env;
 use std::sync::Arc;

--- a/crates/exomind-runtime/src/routes/agents.rs
+++ b/crates/exomind-runtime/src/routes/agents.rs
@@ -7,8 +7,8 @@ use futures_util::stream::{self, StreamExt};
 use serde::Deserialize;
 use std::convert::Infallible;
 
-use crate::agent::{ChatChunk, ChatRequest};
 use crate::AppState;
+use crate::agent::{ChatChunk, ChatRequest};
 
 #[derive(Debug, Deserialize)]
 struct ChatRequestPayload {

--- a/crates/exomind-runtime/src/routes/agents.rs
+++ b/crates/exomind-runtime/src/routes/agents.rs
@@ -7,12 +7,14 @@ use futures_util::stream::{self, StreamExt};
 use serde::Deserialize;
 use std::convert::Infallible;
 
-use crate::agent::ChatChunk;
+use crate::agent::{ChatChunk, ChatRequest};
 use crate::AppState;
 
 #[derive(Debug, Deserialize)]
-struct ChatRequest {
+struct ChatRequestPayload {
     message: String,
+    #[serde(default)]
+    session_id: Option<String>,
 }
 
 /// Agent routes (Agent 相关路由).
@@ -29,13 +31,21 @@ async fn list_agents(State(state): State<AppState>) -> Json<Vec<crate::agent::Ag
 async fn chat_with_agent(
     Path(id): Path<String>,
     State(state): State<AppState>,
-    Json(payload): Json<ChatRequest>,
+    Json(payload): Json<ChatRequestPayload>,
 ) -> Result<Sse<impl futures_util::Stream<Item = Result<Event, Infallible>>>, StatusCode> {
     let Some(agent) = state.registry.get(&id) else {
         return Err(StatusCode::NOT_FOUND);
     };
 
-    let data_stream = agent.chat_stream(payload.message).map(|chunk: ChatChunk| {
+    let request = ChatRequest {
+        message: payload.message,
+        session_id: payload
+            .session_id
+            .map(|session| session.trim().to_string())
+            .filter(|session| !session.is_empty()),
+    };
+
+    let data_stream = agent.chat_stream(request).map(|chunk: ChatChunk| {
         // ChatChunk currently only contains strings, JSON serialization is expected infallible.
         let encoded = serde_json::to_string(&chunk).expect("ChatChunk serialization failed");
         Ok::<Event, Infallible>(Event::default().data(encoded))

--- a/crates/exomind-runtime/src/routes/mod.rs
+++ b/crates/exomind-runtime/src/routes/mod.rs
@@ -1,4 +1,4 @@
-use axum::{routing::get, Router};
+use axum::{Router, routing::get};
 
 use crate::AppState;
 

--- a/crates/exomind-runtime/src/routes/topology.rs
+++ b/crates/exomind-runtime/src/routes/topology.rs
@@ -58,7 +58,7 @@ fn read_hostname() -> String {
 
 fn read_os() -> String {
     System::long_os_version()
-        .or_else(|| System::name())
+        .or_else(System::name)
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| std::env::consts::OS.to_string())
 }

--- a/crates/exomind-runtime/src/routes/topology.rs
+++ b/crates/exomind-runtime/src/routes/topology.rs
@@ -1,9 +1,9 @@
-use axum::{extract::State, Json};
+use axum::{Json, extract::State};
 use serde::Serialize;
 use std::sync::OnceLock;
 use sysinfo::System;
 
-use crate::{RuntimeState, RUNTIME_VERSION};
+use crate::{RUNTIME_VERSION, RuntimeState};
 
 #[derive(Debug, Clone)]
 struct TopologyStaticInfo {

--- a/crates/exomind-runtime/tests/bin/fake-claude-cli.rs
+++ b/crates/exomind-runtime/tests/bin/fake-claude-cli.rs
@@ -1,0 +1,87 @@
+use serde_json::{Value, json};
+use std::io::{self, BufRead, Write};
+
+fn extract_user_content(line: &str) -> String {
+    let payload: Value = match serde_json::from_str(line) {
+        Ok(value) => value,
+        Err(_) => return String::new(),
+    };
+
+    payload
+        .get("message")
+        .and_then(|message| message.get("content"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string()
+}
+
+fn reply_for(message: &str, remembered_name: &mut Option<String>) -> String {
+    let normalized = message.to_lowercase();
+
+    if let Some(index) = normalized.find("my name is ") {
+        let name = message[(index + "my name is ".len())..].trim().to_string();
+        *remembered_name = Some(name.clone());
+        return format!("hi {name}");
+    }
+
+    if normalized.contains("what is my name") {
+        return remembered_name
+            .as_ref()
+            .map(|name| format!("your name is {name}"))
+            .unwrap_or_else(|| "unknown".to_string());
+    }
+
+    format!("echo:{message}")
+}
+
+fn main() {
+    let exit_after_one_turn = std::env::args().any(|arg| arg == "--exit-after-one");
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+    let mut remembered_name: Option<String> = None;
+    let mut turns = 0usize;
+
+    for line in stdin.lock().lines() {
+        let raw_line = match line {
+            Ok(value) => value,
+            Err(_) => break,
+        };
+
+        if raw_line.trim().is_empty() {
+            continue;
+        }
+
+        turns += 1;
+        let message = extract_user_content(&raw_line);
+        let reply = reply_for(&message, &mut remembered_name);
+
+        let system_event = json!({
+            "type": "system",
+            "session_id": "fake-claude-session"
+        });
+        let assistant_event = json!({
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": reply
+                    }
+                ]
+            }
+        });
+        let result_event = json!({
+            "type": "result",
+            "subtype": "success"
+        });
+
+        let _ = writeln!(stdout, "{system_event}");
+        let _ = writeln!(stdout, "{assistant_event}");
+        let _ = writeln!(stdout, "{result_event}");
+        let _ = stdout.flush();
+
+        if exit_after_one_turn && turns >= 1 {
+            break;
+        }
+    }
+}

--- a/crates/exomind-runtime/tests/claude_persistent_streaming.rs
+++ b/crates/exomind-runtime/tests/claude_persistent_streaming.rs
@@ -1,0 +1,84 @@
+use exomind_runtime::agent::claude::ClaudeAgent;
+use exomind_runtime::agent::{Agent, ChatRequest};
+use futures_util::StreamExt;
+
+fn fake_cli_command_path() -> String {
+    env!("CARGO_BIN_EXE_fake-claude-cli").to_string()
+}
+
+#[tokio::test]
+async fn reuses_same_session_and_keeps_conversation_context() {
+    let agent = ClaudeAgent::with_command_and_args(fake_cli_command_path(), vec![]);
+
+    let first_chunks = agent
+        .chat_stream(ChatRequest {
+            message: "hello my name is xiaoming".to_string(),
+            session_id: None,
+        })
+        .collect::<Vec<_>>()
+        .await;
+
+    assert!(
+        first_chunks.iter().any(|chunk| chunk.content.contains("xiaoming")),
+        "first_chunks={first_chunks:?}"
+    );
+
+    let session_id = first_chunks
+        .iter()
+        .find_map(|chunk| chunk.session_id.clone())
+        .expect("first turn should include session_id");
+
+    let second_chunks = agent
+        .chat_stream(ChatRequest {
+            message: "what is my name?".to_string(),
+            session_id: Some(session_id),
+        })
+        .collect::<Vec<_>>()
+        .await;
+
+    assert!(
+        second_chunks
+            .iter()
+            .any(|chunk| chunk.content.contains("xiaoming")),
+        "second_chunks={second_chunks:?}"
+    );
+    assert!(
+        second_chunks.iter().all(|chunk| chunk.session_id.is_none()),
+        "reused turn should not mint a new session_id: {second_chunks:?}"
+    );
+}
+
+#[tokio::test]
+async fn returns_error_after_reusing_session_with_exited_process() {
+    let agent = ClaudeAgent::with_command_and_args(
+        fake_cli_command_path(),
+        vec!["--exit-after-one".to_string()],
+    );
+
+    let first_chunks = agent
+        .chat_stream(ChatRequest {
+            message: "hello my name is xiaoming".to_string(),
+            session_id: None,
+        })
+        .collect::<Vec<_>>()
+        .await;
+    let session_id = first_chunks
+        .iter()
+        .find_map(|chunk| chunk.session_id.clone())
+        .expect("first turn should include session_id");
+
+    let second_chunks = agent
+        .chat_stream(ChatRequest {
+            message: "what is my name?".to_string(),
+            session_id: Some(session_id),
+        })
+        .collect::<Vec<_>>()
+        .await;
+
+    assert!(
+        second_chunks
+            .iter()
+            .any(|chunk| chunk.content.contains("退出码") || chunk.content.contains("提前结束")),
+        "second_chunks={second_chunks:?}"
+    );
+}

--- a/crates/exomind-runtime/tests/claude_persistent_streaming.rs
+++ b/crates/exomind-runtime/tests/claude_persistent_streaming.rs
@@ -19,7 +19,9 @@ async fn reuses_same_session_and_keeps_conversation_context() {
         .await;
 
     assert!(
-        first_chunks.iter().any(|chunk| chunk.content.contains("xiaoming")),
+        first_chunks
+            .iter()
+            .any(|chunk| chunk.content.contains("xiaoming")),
         "first_chunks={first_chunks:?}"
     );
 
@@ -80,5 +82,25 @@ async fn returns_error_after_reusing_session_with_exited_process() {
             .iter()
             .any(|chunk| chunk.content.contains("退出码") || chunk.content.contains("提前结束")),
         "second_chunks={second_chunks:?}"
+    );
+
+    let third_chunks = agent
+        .chat_stream(ChatRequest {
+            message: "what is my name?".to_string(),
+            session_id: Some(
+                first_chunks
+                    .iter()
+                    .find_map(|chunk| chunk.session_id.clone())
+                    .expect("first turn should include session_id"),
+            ),
+        })
+        .collect::<Vec<_>>()
+        .await;
+
+    assert!(
+        third_chunks
+            .iter()
+            .any(|chunk| chunk.content.contains("会话不存在")),
+        "third_chunks={third_chunks:?}"
     );
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,14 @@
 
 ---
 
+### 1.4 开发与运行文档
+
+| 文档 | 职责 |
+|------|------|
+| [development/exomind-runtime-agents-api.md](./development/exomind-runtime-agents-api.md) | Runtime Agent HTTP/SSE 接口说明（含 `session_id` 复用） |
+
+---
+
 ## 二、软件工程文档规范
 
 本项目遵循软件工程最佳实践，文档分为以下层次：

--- a/docs/development/exomind-runtime-agents-api.md
+++ b/docs/development/exomind-runtime-agents-api.md
@@ -1,0 +1,184 @@
+# ExoMind Runtime Agents API（运行时 Agent 接口）
+
+> 适用范围（Scope，范围）: `crates/exomind-runtime`
+>  
+> 目标（Goal，目标）: 基于当前代码，给出可直接联调的接口说明。
+
+---
+
+## 1. 基础信息（Basics，基础）
+
+- Base URL（基础地址）: `http://127.0.0.1:<EXOMIND_RT_PORT>`
+- 默认路由（Routes，路由）:
+  - `GET /agents`
+  - `POST /agents/:id/chat`
+- 当前内置 Agent（Built-in Agents，内置 Agent）:
+  - `claude`
+  - `echo`
+- CORS（跨域）: 允许任意来源（`*`）、`GET/POST/OPTIONS`
+
+---
+
+## 2. `GET /agents`
+
+### 2.1 作用（Purpose，用途）
+
+返回当前可用 Agent 列表（包含 `id/name/description/status`）。
+
+### 2.2 响应示例（Response Example，响应示例）
+
+```json
+[
+  {
+    "id": "claude",
+    "name": "Claude Agent",
+    "description": "通过 Claude Code CLI 提供流式对话",
+    "status": "available"
+  },
+  {
+    "id": "echo",
+    "name": "Echo Agent",
+    "description": "回显输入内容",
+    "status": "available"
+  }
+]
+```
+
+---
+
+## 3. `POST /agents/:id/chat`
+
+### 3.1 请求体（Request Body，请求体）
+
+`Content-Type: application/json`
+
+```json
+{
+  "message": "你好",
+  "session_id": "optional-session-id"
+}
+```
+
+字段说明（Field Notes，字段说明）:
+
+- `message`（必填）: 用户输入文本
+- `session_id`（可选）: 会话复用 ID（前后空格会被 `trim`）
+
+### 3.2 响应类型（Response Type，响应类型）
+
+`text/event-stream`（SSE，服务端事件流）
+
+服务端按事件推送（每条 `data:` 一行），最后固定输出:
+
+```text
+data: [DONE]
+```
+
+### 3.3 数据片段结构（ChatChunk，聊天分片）
+
+每个 `data:` 行的 JSON 结构：
+
+```json
+{
+  "content": "分片文本",
+  "session_id": "optional-on-first-turn"
+}
+```
+
+注意（Notes，注意）:
+
+- `session_id` 仅在“新建会话”的首轮返回（可能在首个文本分片里出现）。
+- 复用会话时，后续分片通常不再带 `session_id`。
+- `session_id` 为 `Option` 字段，为空时不会出现在 JSON 中。
+
+---
+
+## 4. Claude 会话语义（Claude Session Semantics，会话语义）
+
+以下行为仅针对 `id=claude`:
+
+1. 不传 `session_id`:
+   - 新建 Claude 子进程会话（Persistent Process，持久进程）
+   - 返回新的 ExoMind `session_id`
+2. 传入存在的 `session_id`:
+   - 复用同一个 Claude 子进程
+   - 保持多轮上下文
+3. 传入不存在/已失效 `session_id`:
+   - 流中返回错误文本分片：`Claude 会话不存在: <id>`
+4. 并发同会话请求:
+   - 若会话在 `Processing`，返回：`Claude 会话正在处理中，请稍后重试`
+5. 资源上限:
+   - 最多 64 个 Claude 会话（`MAX_CLAUDE_SESSIONS = 64`）
+6. 结束标志:
+   - 每一轮都以 `data: [DONE]` 结束
+
+---
+
+## 5. 状态码与错误（Status Codes & Errors，状态码与错误）
+
+- `200 OK`: 成功建立 SSE 流
+- `404 Not Found`: `:id` 对应 Agent 不存在
+- `400 Bad Request`: 请求 JSON 非法（例如格式错误）
+
+说明:
+
+- `claude` 的多数运行时错误（如会话不存在、进程退出）通过 SSE `content` 分片返回，而不是切换 HTTP 状态码。
+
+---
+
+## 6. 联调示例（Examples，示例）
+
+### 6.1 cURL（PowerShell）首轮创建会话
+
+```powershell
+$enc = New-Object System.Text.UTF8Encoding($false)
+$tmp1 = Join-Path $env:TEMP "exo-chat-1.json"
+[System.IO.File]::WriteAllText($tmp1, '{"message":"你好，我叫小明"}', $enc)
+
+curl.exe -N -X POST "http://127.0.0.1:1919/agents/claude/chat" `
+  -H "content-type: application/json" `
+  --data-binary "@$tmp1"
+```
+
+预期会出现（示意）:
+
+```text
+data: {"content":"...","session_id":"<uuid>"}
+data: [DONE]
+```
+
+### 6.2 cURL（PowerShell）复用同一会话
+
+```powershell
+$sid = "<首轮返回的 session_id>"
+$enc = New-Object System.Text.UTF8Encoding($false)
+$tmp2 = Join-Path $env:TEMP "exo-chat-2.json"
+[System.IO.File]::WriteAllText($tmp2, ('{"message":"我叫什么名字？","session_id":"' + $sid + '"}'), $enc)
+
+curl.exe -N -X POST "http://127.0.0.1:1919/agents/claude/chat" `
+  -H "content-type: application/json" `
+  --data-binary "@$tmp2"
+```
+
+---
+
+## 7. Reqable 使用要点（Reqable Tips，Reqable 要点）
+
+1. Method（方法）: `POST`
+2. URL: `http://127.0.0.1:<port>/agents/claude/chat`
+3. Header（请求头）: `content-type: application/json`
+4. Body（JSON）:
+   - 首轮: `{"message":"你好，我叫小明"}`
+   - 次轮: `{"message":"我叫什么名字？","session_id":"<首轮session_id>"}`
+5. 响应查看（Response，响应）:
+   - 以 SSE 文本形式查看 `data:` 行
+   - 确认最后有 `data: [DONE]`
+
+---
+
+## 8. 代码对应（Source Mapping，代码映射）
+
+- 路由与 SSE 封装: `crates/exomind-runtime/src/routes/agents.rs`
+- `ChatChunk` / `ChatRequest` 结构: `crates/exomind-runtime/src/agent/mod.rs`
+- Claude 会话管理与复用逻辑: `crates/exomind-runtime/src/agent/claude.rs`
+


### PR DESCRIPTION
## 背景 / Background\n实现 EXO-50：Runtime 需要支持 Claude CLI 在 stream-json 模式下保持子进程持续运行，并复用会话完成多轮对话。\n\n## 主要改动 / Changes\n- 在 ClaudeAgent 中引入持久会话池（session map），支持按 session_id 复用进程。\n- 保持子进程 stdin/stdout 持续打开，按 esult 事件作为每轮边界。\n- 首轮返回 session_id，后续轮复用该会话。\n- 新增可注入命令参数构造器 with_command_and_args（用于测试与可控启动）。\n- 新增集成测试：\n  - euses_same_session_and_keeps_conversation_context\n  - eturns_error_after_reusing_session_with_exited_process\n- 新增 ake-claude-cli 测试二进制，模拟持续 stdin/stdout 流事件。\n- 修复 clippy 审查问题（outes/topology.rs 中 edundant closure）。\n\n## 验证 / Verification\n- cargo test -p exomind-runtime ✅\n- cargo clippy -p exomind-runtime --all-targets -- -D warnings ✅\n- cargo build -p exomind-runtime ✅\n- cargo build ✅\n- un run build ✅\n\n## DoD 对照 / DoD Checklist\n- [x] 运行时可完成 Claude CLI 流式输入输出（持续会话、多轮复用）\n- [x] 首轮返回 session_id\n- [x] 后续轮可复用会话并保留上下文\n- [x] 子进程退出可检测并返回错误\n- [x] 自动化测试覆盖会话复用与异常路径\n\n## 风险与后续 / Risks & Follow-up\n- 真实 Claude CLI 的完整线上冒烟受本地策略环境影响；本 PR 使用稳定的 fake CLI 集成测试保证协议与会话复用行为。