### PR TITLE
feat(runtime): 支持 Claude Token 成本统计与 /agents/:id/stats 端点

### DIFF
--- a/crates/exomind-runtime/src/agent/claude.rs
+++ b/crates/exomind-runtime/src/agent/claude.rs
@@ -1,5 +1,6 @@
 use super::{Agent, ChatChunk, ChatRequest};
 use futures_util::stream::{self, BoxStream, StreamExt};
+use serde::Serialize;
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::process::Stdio;
@@ -11,6 +12,54 @@ use tokio::sync::{Mutex, mpsc};
 use uuid::Uuid;
 
 const MAX_CLAUDE_SESSIONS: usize = 64;
+
+/// Token usage snapshot（Token 用量快照）.
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+struct TokenUsage {
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_read_tokens: u64,
+    cache_write_tokens: u64,
+}
+
+impl TokenUsage {
+    fn accumulate(&mut self, other: &TokenUsage) {
+        self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
+        self.cache_read_tokens = self
+            .cache_read_tokens
+            .saturating_add(other.cache_read_tokens);
+        self.cache_write_tokens = self
+            .cache_write_tokens
+            .saturating_add(other.cache_write_tokens);
+    }
+
+    fn estimated_cost_usd(&self) -> f64 {
+        const PER_MILLION_INPUT_USD: f64 = 3.0;
+        const PER_MILLION_OUTPUT_USD: f64 = 15.0;
+        const PER_MILLION_CACHE_READ_USD: f64 = 0.30;
+        const PER_MILLION_CACHE_WRITE_USD: f64 = 3.75;
+
+        (self.input_tokens as f64 * PER_MILLION_INPUT_USD
+            + self.output_tokens as f64 * PER_MILLION_OUTPUT_USD
+            + self.cache_read_tokens as f64 * PER_MILLION_CACHE_READ_USD
+            + self.cache_write_tokens as f64 * PER_MILLION_CACHE_WRITE_USD)
+            / 1_000_000.0
+    }
+}
+
+/// Claude stats payload（Claude 统计响应载荷）.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+struct ClaudeAgentStats {
+    session_id: Option<String>,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_read_tokens: u64,
+    cache_write_tokens: u64,
+    message_count: u64,
+    uptime_secs: u64,
+    total_cost_usd: f64,
+}
 
 /// Session status（会话状态）.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -31,6 +80,8 @@ struct ClaudeSession {
     status: SessionStatus,
     created_at: Instant,
     message_count: u64,
+    token_usage: TokenUsage,
+    total_cost_usd: f64,
 }
 
 impl Drop for ClaudeSession {
@@ -47,11 +98,18 @@ enum SessionAction {
     Missing { session_id: String },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 enum ClaudeStreamEvent {
-    System { claude_session_id: Option<String> },
-    AssistantChunk { content: String },
-    Result,
+    System {
+        claude_session_id: Option<String>,
+    },
+    AssistantChunk {
+        content: String,
+    },
+    Result {
+        usage: Option<TokenUsage>,
+        total_cost_usd: Option<f64>,
+    },
 }
 
 type SharedClaudeSession = Arc<Mutex<ClaudeSession>>;
@@ -164,6 +222,8 @@ impl ClaudeAgent {
             status: SessionStatus::Idle,
             created_at: Instant::now(),
             message_count: 0,
+            token_usage: TokenUsage::default(),
+            total_cost_usd: 0.0,
         };
 
         let mut sessions = self.sessions.lock().await;
@@ -177,6 +237,43 @@ impl ClaudeAgent {
         let shared_session = Arc::new(Mutex::new(session));
         sessions.insert(session_id.clone(), shared_session.clone());
         Ok((session_id, shared_session))
+    }
+
+    async fn collect_stats(&self, session_id: Option<&str>) -> Option<ClaudeAgentStats> {
+        let target_sessions = {
+            let sessions = self.sessions.lock().await;
+            match session_id {
+                Some(id) => {
+                    let handle = sessions.get(id)?.clone();
+                    vec![handle]
+                }
+                None => sessions.values().cloned().collect::<Vec<_>>(),
+            }
+        };
+
+        let mut usage = TokenUsage::default();
+        let mut message_count = 0_u64;
+        let mut uptime_secs = 0_u64;
+        let mut total_cost_usd = 0.0_f64;
+
+        for handle in target_sessions {
+            let session = handle.lock().await;
+            usage.accumulate(&session.token_usage);
+            message_count = message_count.saturating_add(session.message_count);
+            uptime_secs = uptime_secs.saturating_add(session.created_at.elapsed().as_secs());
+            total_cost_usd += session.total_cost_usd;
+        }
+
+        Some(ClaudeAgentStats {
+            session_id: session_id.map(ToString::to_string),
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+            cache_read_tokens: usage.cache_read_tokens,
+            cache_write_tokens: usage.cache_write_tokens,
+            message_count,
+            uptime_secs,
+            total_cost_usd,
+        })
     }
 
     async fn process_turn(
@@ -247,7 +344,17 @@ impl ClaudeAgent {
                         return;
                     }
                 }
-                Ok(Some(ClaudeStreamEvent::Result)) => {
+                Ok(Some(ClaudeStreamEvent::Result {
+                    usage,
+                    total_cost_usd,
+                })) => {
+                    let turn_cost_usd = resolve_turn_cost_usd(usage.as_ref(), total_cost_usd);
+
+                    if let Some(turn_usage) = usage {
+                        session.token_usage.accumulate(&turn_usage);
+                    }
+                    session.total_cost_usd += turn_cost_usd;
+
                     if pending_session_chunk {
                         let _ = sender
                             .send(ChatChunk {
@@ -344,6 +451,16 @@ impl Agent for ClaudeAgent {
             receiver.recv().await.map(|chunk| (chunk, receiver))
         })
         .boxed()
+    }
+
+    fn stats(
+        &self,
+        session_id: Option<String>,
+    ) -> futures_util::future::BoxFuture<'_, Option<Value>> {
+        Box::pin(async move {
+            let stats = self.collect_stats(session_id.as_deref()).await?;
+            serde_json::to_value(stats).ok()
+        })
     }
 }
 
@@ -460,7 +577,10 @@ fn parse_stream_event_line(line: &str) -> Option<ClaudeStreamEvent> {
         "system" => Some(ClaudeStreamEvent::System {
             claude_session_id: extract_claude_session_id(&event),
         }),
-        "result" => Some(ClaudeStreamEvent::Result),
+        "result" => Some(ClaudeStreamEvent::Result {
+            usage: extract_token_usage(&event),
+            total_cost_usd: extract_total_cost_usd(&event),
+        }),
         _ => None,
     }
 }
@@ -520,6 +640,35 @@ fn extract_text_content(event: &Value) -> Option<String> {
     }
 
     None
+}
+
+fn extract_total_cost_usd(event: &Value) -> Option<f64> {
+    event.get("total_cost_usd").and_then(Value::as_f64)
+}
+
+fn extract_token_usage(event: &Value) -> Option<TokenUsage> {
+    let usage = event.get("usage")?;
+    Some(TokenUsage {
+        input_tokens: read_u64_field(usage, &["input_tokens"]),
+        output_tokens: read_u64_field(usage, &["output_tokens"]),
+        cache_read_tokens: read_u64_field(usage, &["cache_read_input_tokens", "cache_read_tokens"]),
+        cache_write_tokens: read_u64_field(
+            usage,
+            &["cache_creation_input_tokens", "cache_write_tokens"],
+        ),
+    })
+}
+
+fn read_u64_field(value: &Value, keys: &[&str]) -> u64 {
+    keys.iter()
+        .find_map(|key| value.get(key).and_then(Value::as_u64))
+        .unwrap_or(0)
+}
+
+fn resolve_turn_cost_usd(usage: Option<&TokenUsage>, total_cost_usd: Option<f64>) -> f64 {
+    total_cost_usd
+        .or_else(|| usage.map(TokenUsage::estimated_cost_usd))
+        .unwrap_or(0.0)
 }
 
 #[cfg(test)]
@@ -635,7 +784,107 @@ mod tests {
     #[test]
     fn parse_stream_event_line_detects_result_event() {
         let event = parse_stream_event_line(r#"{"type":"result","stop_reason":"end_turn"}"#);
-        assert_eq!(event, Some(ClaudeStreamEvent::Result));
+        assert_eq!(
+            event,
+            Some(ClaudeStreamEvent::Result {
+                usage: None,
+                total_cost_usd: None,
+            })
+        );
+    }
+
+    #[test]
+    fn token_usage_accumulate_adds_all_fields() {
+        let mut total = TokenUsage {
+            input_tokens: 10,
+            output_tokens: 20,
+            cache_read_tokens: 30,
+            cache_write_tokens: 40,
+        };
+        let delta = TokenUsage {
+            input_tokens: 1,
+            output_tokens: 2,
+            cache_read_tokens: 3,
+            cache_write_tokens: 4,
+        };
+
+        total.accumulate(&delta);
+
+        assert_eq!(
+            total,
+            TokenUsage {
+                input_tokens: 11,
+                output_tokens: 22,
+                cache_read_tokens: 33,
+                cache_write_tokens: 44,
+            }
+        );
+    }
+
+    #[test]
+    fn token_usage_estimated_cost_usd_uses_claude_3_5_sonnet_pricing() {
+        let usage = TokenUsage {
+            input_tokens: 1_000_000,
+            output_tokens: 1_000_000,
+            cache_read_tokens: 1_000_000,
+            cache_write_tokens: 1_000_000,
+        };
+
+        let cost = usage.estimated_cost_usd();
+        let expected = 3.0 + 15.0 + 0.30 + 3.75;
+        assert!((cost - expected).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_stream_event_line_extracts_result_usage_and_cost() {
+        let line = r#"{
+            "type":"result",
+            "usage":{
+                "input_tokens":1250,
+                "output_tokens":340,
+                "cache_creation_input_tokens":200,
+                "cache_read_input_tokens":500
+            },
+            "total_cost_usd":0.042
+        }"#;
+        let event = parse_stream_event_line(line);
+
+        assert_eq!(
+            event,
+            Some(ClaudeStreamEvent::Result {
+                usage: Some(TokenUsage {
+                    input_tokens: 1250,
+                    output_tokens: 340,
+                    cache_read_tokens: 500,
+                    cache_write_tokens: 200,
+                }),
+                total_cost_usd: Some(0.042),
+            })
+        );
+    }
+
+    #[test]
+    fn resolve_turn_cost_usd_prioritizes_cli_reported_cost() {
+        let usage = TokenUsage {
+            input_tokens: 1_000_000,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+        };
+        let resolved = resolve_turn_cost_usd(Some(&usage), Some(0.5));
+        assert!((resolved - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn resolve_turn_cost_usd_falls_back_to_estimation() {
+        let usage = TokenUsage {
+            input_tokens: 1_000_000,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+        };
+        let resolved = resolve_turn_cost_usd(Some(&usage), None);
+        assert!((resolved - 3.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/crates/exomind-runtime/src/agent/claude.rs
+++ b/crates/exomind-runtime/src/agent/claude.rs
@@ -52,6 +52,7 @@ impl TokenUsage {
 #[derive(Debug, Clone, Serialize, PartialEq)]
 struct ClaudeAgentStats {
     session_id: Option<String>,
+    session_count: u64,
     input_tokens: u64,
     output_tokens: u64,
     cache_read_tokens: u64,
@@ -251,6 +252,7 @@ impl ClaudeAgent {
             }
         };
 
+        let session_count = target_sessions.len() as u64;
         let mut usage = TokenUsage::default();
         let mut message_count = 0_u64;
         let mut uptime_secs = 0_u64;
@@ -266,6 +268,7 @@ impl ClaudeAgent {
 
         Some(ClaudeAgentStats {
             session_id: session_id.map(ToString::to_string),
+            session_count,
             input_tokens: usage.input_tokens,
             output_tokens: usage.output_tokens,
             cache_read_tokens: usage.cache_read_tokens,

--- a/crates/exomind-runtime/src/agent/mod.rs
+++ b/crates/exomind-runtime/src/agent/mod.rs
@@ -1,5 +1,7 @@
+use futures_util::future::BoxFuture;
 use futures_util::stream::BoxStream;
 use serde::Serialize;
+use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
@@ -50,6 +52,10 @@ pub trait Agent: Send + Sync {
     }
 
     fn chat_stream(&self, request: ChatRequest) -> BoxStream<'static, ChatChunk>;
+
+    fn stats(&self, _session_id: Option<String>) -> BoxFuture<'_, Option<Value>> {
+        Box::pin(async { None })
+    }
 }
 
 #[derive(Clone, Default)]

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -297,6 +297,7 @@ mod tests {
             payload,
             serde_json::json!({
                 "session_id": null,
+                "session_count": 0,
                 "input_tokens": 0,
                 "output_tokens": 0,
                 "cache_read_tokens": 0,

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -277,6 +277,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn claude_stats_endpoint_returns_default_zero_snapshot() {
+        const TEST_PORT: u16 = 3005;
+        let response = app(TEST_PORT)
+            .oneshot(
+                Request::builder()
+                    .uri("/agents/claude/stats")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(StatusCode::OK, response.status());
+
+        let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let payload: Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(
+            payload,
+            serde_json::json!({
+                "session_id": null,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "message_count": 0,
+                "uptime_secs": 0,
+                "total_cost_usd": 0.0
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn claude_stats_endpoint_returns_not_found_for_unknown_session_id() {
+        const TEST_PORT: u16 = 3006;
+        let response = app(TEST_PORT)
+            .oneshot(
+                Request::builder()
+                    .uri("/agents/claude/stats?session_id=session-404")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(StatusCode::NOT_FOUND, response.status());
+    }
+
+    #[tokio::test]
     async fn agents_endpoint_reflects_runtime_register_and_unregister() {
         let registry = agent::AgentRegistry::new();
         registry.register(Arc::new(TempRouteAgent));

--- a/crates/exomind-runtime/src/routes/agents.rs
+++ b/crates/exomind-runtime/src/routes/agents.rs
@@ -1,10 +1,11 @@
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::sse::{Event, Sse};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use futures_util::stream::{self, StreamExt};
 use serde::Deserialize;
+use serde_json::Value as JsonValue;
 use std::convert::Infallible;
 
 use crate::AppState;
@@ -17,11 +18,18 @@ struct ChatRequestPayload {
     session_id: Option<String>,
 }
 
+#[derive(Debug, Deserialize, Default)]
+struct AgentStatsQuery {
+    #[serde(default)]
+    session_id: Option<String>,
+}
+
 /// Agent routes (Agent 相关路由).
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/agents", get(list_agents))
         .route("/agents/:id/chat", post(chat_with_agent))
+        .route("/agents/:id/stats", get(agent_stats))
 }
 
 async fn list_agents(State(state): State<AppState>) -> Json<Vec<crate::agent::AgentSummary>> {
@@ -57,4 +65,25 @@ async fn chat_with_agent(
     let stream = data_stream.chain(done_stream);
 
     Ok(Sse::new(stream))
+}
+
+async fn agent_stats(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+    Query(query): Query<AgentStatsQuery>,
+) -> Result<Json<JsonValue>, StatusCode> {
+    let Some(agent) = state.registry.get(&id) else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+
+    let session_id = query
+        .session_id
+        .map(|session| session.trim().to_string())
+        .filter(|session| !session.is_empty());
+
+    let Some(stats) = agent.stats(session_id).await else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+
+    Ok(Json(stats))
 }

--- a/crates/exomind-runtime/tests/bin/fake-claude-cli.rs
+++ b/crates/exomind-runtime/tests/bin/fake-claude-cli.rs
@@ -72,7 +72,14 @@ fn main() {
         });
         let result_event = json!({
             "type": "result",
-            "subtype": "success"
+            "subtype": "success",
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 20,
+                "cache_read_input_tokens": 10
+            },
+            "total_cost_usd": 0.001
         });
 
         let _ = writeln!(stdout, "{system_event}");

--- a/crates/exomind-runtime/tests/claude_persistent_streaming.rs
+++ b/crates/exomind-runtime/tests/claude_persistent_streaming.rs
@@ -1,6 +1,7 @@
 use exomind_runtime::agent::claude::ClaudeAgent;
 use exomind_runtime::agent::{Agent, ChatRequest};
 use futures_util::StreamExt;
+use serde_json::Value;
 
 fn fake_cli_command_path() -> String {
     env!("CARGO_BIN_EXE_fake-claude-cli").to_string()
@@ -103,4 +104,67 @@ async fn returns_error_after_reusing_session_with_exited_process() {
             .any(|chunk| chunk.content.contains("会话不存在")),
         "third_chunks={third_chunks:?}"
     );
+}
+
+#[tokio::test]
+async fn accumulates_usage_stats_from_result_events() {
+    let agent = ClaudeAgent::with_command_and_args(fake_cli_command_path(), vec![]);
+
+    let first_chunks = agent
+        .chat_stream(ChatRequest {
+            message: "hello my name is xiaoming".to_string(),
+            session_id: None,
+        })
+        .collect::<Vec<_>>()
+        .await;
+    let session_id = first_chunks
+        .iter()
+        .find_map(|chunk| chunk.session_id.clone())
+        .expect("first turn should include session_id");
+
+    let _second_chunks = agent
+        .chat_stream(ChatRequest {
+            message: "what is my name?".to_string(),
+            session_id: Some(session_id.clone()),
+        })
+        .collect::<Vec<_>>()
+        .await;
+
+    let stats_value = agent
+        .stats(Some(session_id))
+        .await
+        .expect("stats should be available for existing session");
+
+    let session_id_value = stats_value
+        .get("session_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(!session_id_value.is_empty());
+    assert_eq!(
+        stats_value.get("input_tokens").and_then(Value::as_u64),
+        Some(200)
+    );
+    assert_eq!(
+        stats_value.get("output_tokens").and_then(Value::as_u64),
+        Some(100)
+    );
+    assert_eq!(
+        stats_value
+            .get("cache_write_tokens")
+            .and_then(Value::as_u64),
+        Some(40)
+    );
+    assert_eq!(
+        stats_value.get("cache_read_tokens").and_then(Value::as_u64),
+        Some(20)
+    );
+    assert_eq!(
+        stats_value.get("message_count").and_then(Value::as_u64),
+        Some(2)
+    );
+    let total_cost_usd = stats_value
+        .get("total_cost_usd")
+        .and_then(Value::as_f64)
+        .unwrap_or_default();
+    assert!((total_cost_usd - 0.002).abs() < 1e-12);
 }

--- a/crates/exomind-runtime/tests/claude_persistent_streaming.rs
+++ b/crates/exomind-runtime/tests/claude_persistent_streaming.rs
@@ -141,6 +141,10 @@ async fn accumulates_usage_stats_from_result_events() {
         .unwrap_or_default();
     assert!(!session_id_value.is_empty());
     assert_eq!(
+        stats_value.get("session_count").and_then(Value::as_u64),
+        Some(1)
+    );
+    assert_eq!(
         stats_value.get("input_tokens").and_then(Value::as_u64),
         Some(200)
     );
@@ -167,4 +171,43 @@ async fn accumulates_usage_stats_from_result_events() {
         .and_then(Value::as_f64)
         .unwrap_or_default();
     assert!((total_cost_usd - 0.002).abs() < 1e-12);
+}
+
+#[tokio::test]
+async fn returns_aggregated_stats_with_session_count_for_all_sessions() {
+    let agent = ClaudeAgent::with_command_and_args(fake_cli_command_path(), vec![]);
+
+    let _first_chunks = agent
+        .chat_stream(ChatRequest {
+            message: "hello my name is xiaoming".to_string(),
+            session_id: None,
+        })
+        .collect::<Vec<_>>()
+        .await;
+
+    let _second_chunks = agent
+        .chat_stream(ChatRequest {
+            message: "hello my name is xiaohong".to_string(),
+            session_id: None,
+        })
+        .collect::<Vec<_>>()
+        .await;
+
+    let summary_stats = agent
+        .stats(None)
+        .await
+        .expect("summary stats should be available");
+
+    assert_eq!(
+        summary_stats.get("session_id").and_then(Value::as_str),
+        None
+    );
+    assert_eq!(
+        summary_stats.get("session_count").and_then(Value::as_u64),
+        Some(2)
+    );
+    assert_eq!(
+        summary_stats.get("message_count").and_then(Value::as_u64),
+        Some(2)
+    );
 }


### PR DESCRIPTION
## 变更概览（What）
本 PR 在 `exomind-runtime` 中补齐了 Claude 运行时的 Token 用量统计与查询能力，核心改动如下：
1. 扩展 `Agent` trait（接口，trait）新增 `stats`（统计）方法，默认返回 `None`，避免影响其他 Agent。
2. 改造 `ClaudeStreamEvent::Result`（结果事件）为结构化变体，解析 `usage`（用量）与 `total_cost_usd`（总成本）。
3. 在 `ClaudeSession`（会话）中新增并累加 Token/成本统计字段。
4. 新增 `GET /agents/:id/stats` 路由，支持 `session_id` 查询单会话，不传则返回活跃会话汇总。
5. 汇总响应新增 `session_count`（会话数量），便于监控面板直接展示。
6. 更新 `fake-claude-cli` 测试桩，使 `result` 事件输出 `usage` 与 `total_cost_usd`，补齐集成测试覆盖。

## 变更动机（Why）
EXO-51 的目标是让运行时能够从 Claude CLI 的 `result` 事件中提取并累加 Token 用量，提供可观测、可查询的统计端点。此前 `result` 事件是空标记，导致用量与成本信息被丢弃，无法支持后续监控与健康分析。

## 关键实现细节（Implementation Details）
1. 成本计算策略：优先使用 CLI 返回的 `total_cost_usd`（实际成本）；若缺失则按 Claude 3.5 Sonnet 定价做 `estimated_cost_usd`（估算成本）回退。
2. 线程安全（thread safety，线程安全）：在会话锁（`Mutex`）作用域内写入统计，在读取统计时逐会话加锁读取，避免并发读写竞争。
3. 兼容性策略：`Agent::stats` 提供默认实现，`echo` 等未实现统计的 Agent 行为保持不变。
4. API 行为：
   - `GET /agents/claude/stats?session_id=<id>` 返回该会话统计；会话不存在返回 `404`。
   - `GET /agents/claude/stats` 返回所有活跃会话汇总，并带 `session_count`。

## 测试与验证（Verification）
1. 新增/更新单元测试与集成测试，覆盖：
   - `TokenUsage` 累加与成本估算。
   - `result` 事件解析 `usage + total_cost_usd`。
   - 单会话统计、汇总统计（含 `session_count`）与 `404` 场景。
2. 本地验证命令：
   - `cargo test -p exomind-runtime`（在 Windows 可执行文件占用场景下使用独立 `--target-dir` 完成验证）。

This PR was written using [Vibe Kanban](https://vibekanban.com)