### PR TITLE
feat(runtime): EXO-53 ClaudeAgent 会话生命周期管理与一致性修复 (Vibe Kanban)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,6 +1026,7 @@ name = "exomind-runtime"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "chrono",
  "futures-util",
  "http-body-util",
  "serde",

--- a/crates/exomind-runtime/Cargo.toml
+++ b/crates/exomind-runtime/Cargo.toml
@@ -14,6 +14,7 @@ path = "tests/bin/fake-claude-cli.rs"
 
 [dependencies]
 axum = "0.7"
+chrono = { version = "0.4", features = ["serde"] }
 futures-util = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/exomind-runtime/src/agent/claude.rs
+++ b/crates/exomind-runtime/src/agent/claude.rs
@@ -141,14 +141,14 @@ impl ClaudeAgent {
     }
 
     fn upsert_snapshot_from_session(&self, session: &ClaudeSession) {
-        let is_registered = self.lock_sessions().contains_key(&session.session_id);
-        if !is_registered {
-            self.remove_snapshot(&session.session_id);
-            return;
-        }
         let snapshot = SessionSnapshot::from_session(session);
-        self.lock_session_snapshots()
-            .insert(snapshot.session_id.clone(), snapshot);
+        let sessions = self.lock_sessions();
+        let mut snapshots = self.lock_session_snapshots();
+        if sessions.contains_key(&session.session_id) {
+            snapshots.insert(snapshot.session_id.clone(), snapshot);
+        } else {
+            snapshots.remove(&session.session_id);
+        }
     }
 
     fn remove_snapshot(&self, session_id: &str) {

--- a/crates/exomind-runtime/src/agent/claude.rs
+++ b/crates/exomind-runtime/src/agent/claude.rs
@@ -1,13 +1,14 @@
-use super::{Agent, ChatChunk, ChatRequest};
+use super::{Agent, ChatChunk, ChatRequest, SessionInfo};
+use chrono::{DateTime, SecondsFormat, Utc};
 use futures_util::stream::{self, BoxStream, StreamExt};
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::process::Stdio;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard};
 use std::time::Instant;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::{Mutex as AsyncMutex, mpsc};
 use uuid::Uuid;
 
 const MAX_CLAUDE_SESSIONS: usize = 64;
@@ -20,6 +21,16 @@ enum SessionStatus {
     Crashed,
 }
 
+impl SessionStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            SessionStatus::Idle => "idle",
+            SessionStatus::Processing => "processing",
+            SessionStatus::Crashed => "crashed",
+        }
+    }
+}
+
 /// Claude process session（Claude 子进程会话）.
 #[derive(Debug)]
 struct ClaudeSession {
@@ -30,6 +41,8 @@ struct ClaudeSession {
     stdout: BufReader<ChildStdout>,
     status: SessionStatus,
     created_at: Instant,
+    created_wall: DateTime<Utc>,
+    last_active: Instant,
     message_count: u64,
 }
 
@@ -54,14 +67,14 @@ enum ClaudeStreamEvent {
     Result,
 }
 
-type SharedClaudeSession = Arc<Mutex<ClaudeSession>>;
+type SharedClaudeSession = Arc<AsyncMutex<ClaudeSession>>;
 
 /// Built-in Claude agent (内置 Claude Agent，通过 Claude CLI 输出流式文本).
 #[derive(Debug, Clone)]
 pub struct ClaudeAgent {
     command: String,
     persistent_args: Vec<String>,
-    sessions: Arc<Mutex<HashMap<String, SharedClaudeSession>>>,
+    sessions: Arc<StdMutex<HashMap<String, SharedClaudeSession>>>,
 }
 
 impl ClaudeAgent {
@@ -73,7 +86,14 @@ impl ClaudeAgent {
         Self {
             command: command.into(),
             persistent_args,
-            sessions: Arc::new(Mutex::new(HashMap::new())),
+            sessions: Arc::new(StdMutex::new(HashMap::new())),
+        }
+    }
+
+    fn lock_sessions(&self) -> StdMutexGuard<'_, HashMap<String, SharedClaudeSession>> {
+        match self.sessions.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
         }
     }
 
@@ -91,7 +111,7 @@ impl ClaudeAgent {
     async fn handle_chat_request(&self, request: ChatRequest, sender: mpsc::Sender<ChatChunk>) {
         let normalized_session_id = normalize_session_id(request.session_id.as_deref());
         let existing_session = if let Some(session_id) = normalized_session_id.as_deref() {
-            self.find_session(session_id).await
+            self.find_session(session_id)
         } else {
             None
         };
@@ -100,7 +120,7 @@ impl ClaudeAgent {
             decide_session_action(normalized_session_id.as_deref(), existing_session.is_some());
 
         let (session_id, session_handle, needs_session_chunk) = match action {
-            SessionAction::CreateNew => match self.create_session().await {
+            SessionAction::CreateNew => match self.create_session() {
                 Ok(created) => (created.0, created.1, true),
                 Err(error_message) => {
                     emit_error_chunk(&sender, error_message).await;
@@ -130,12 +150,12 @@ impl ClaudeAgent {
         .await;
     }
 
-    async fn find_session(&self, session_id: &str) -> Option<SharedClaudeSession> {
-        self.sessions.lock().await.get(session_id).cloned()
+    fn find_session(&self, session_id: &str) -> Option<SharedClaudeSession> {
+        self.lock_sessions().get(session_id).cloned()
     }
 
-    async fn create_session(&self) -> Result<(String, SharedClaudeSession), String> {
-        self.evict_dead_sessions().await;
+    fn create_session(&self) -> Result<(String, SharedClaudeSession), String> {
+        self.evict_dead_sessions();
 
         let session_id = Uuid::new_v4().to_string();
         let mut child = Command::new(&self.command)
@@ -155,6 +175,7 @@ impl ClaudeAgent {
             .take()
             .ok_or_else(|| "Claude stdout 不可用".to_string())?;
 
+        let created_at = Instant::now();
         let mut session = ClaudeSession {
             session_id: session_id.clone(),
             claude_session_id: None,
@@ -162,11 +183,13 @@ impl ClaudeAgent {
             stdin,
             stdout: BufReader::new(stdout),
             status: SessionStatus::Idle,
-            created_at: Instant::now(),
+            created_at,
+            created_wall: Utc::now(),
+            last_active: created_at,
             message_count: 0,
         };
 
-        let mut sessions = self.sessions.lock().await;
+        let mut sessions = self.lock_sessions();
         if sessions.len() >= MAX_CLAUDE_SESSIONS {
             let _ = session.child.start_kill();
             return Err(format!(
@@ -174,7 +197,7 @@ impl ClaudeAgent {
             ));
         }
 
-        let shared_session = Arc::new(Mutex::new(session));
+        let shared_session = Arc::new(AsyncMutex::new(session));
         sessions.insert(session_id.clone(), shared_session.clone());
         Ok((session_id, shared_session))
     }
@@ -213,6 +236,7 @@ impl ClaudeAgent {
 
         session.status = SessionStatus::Processing;
         session.message_count += 1;
+        session.last_active = Instant::now();
 
         let input_line = build_stream_json_user_input(&message);
         if let Err(error) = write_user_input_line(&mut session.stdin, &input_line).await {
@@ -227,11 +251,13 @@ impl ClaudeAgent {
         loop {
             match read_next_stream_event(&mut session.stdout).await {
                 Ok(Some(ClaudeStreamEvent::System { claude_session_id })) => {
+                    session.last_active = Instant::now();
                     if let Some(value) = claude_session_id {
                         session.claude_session_id = Some(value);
                     }
                 }
                 Ok(Some(ClaudeStreamEvent::AssistantChunk { content })) => {
+                    session.last_active = Instant::now();
                     let chunk = ChatChunk {
                         content,
                         session_id: if pending_session_chunk {
@@ -248,6 +274,7 @@ impl ClaudeAgent {
                     }
                 }
                 Ok(Some(ClaudeStreamEvent::Result)) => {
+                    session.last_active = Instant::now();
                     if pending_session_chunk {
                         let _ = sender
                             .send(ChatChunk {
@@ -279,17 +306,18 @@ impl ClaudeAgent {
     }
 
     async fn cleanup_session(&self, session_id: &str) {
-        let removed = self.sessions.lock().await.remove(session_id);
+        let removed = self.lock_sessions().remove(session_id);
         if let Some(handle) = removed {
             let mut session = handle.lock().await;
             session.status = SessionStatus::Crashed;
+            session.last_active = Instant::now();
             let _ = session.child.start_kill();
         }
     }
 
-    async fn evict_dead_sessions(&self) {
+    fn evict_dead_sessions(&self) {
         let snapshots = {
-            let sessions = self.sessions.lock().await;
+            let sessions = self.lock_sessions();
             sessions
                 .iter()
                 .map(|(id, handle)| (id.clone(), handle.clone()))
@@ -312,7 +340,7 @@ impl ClaudeAgent {
             return;
         }
 
-        let mut sessions = self.sessions.lock().await;
+        let mut sessions = self.lock_sessions();
         for id in stale_ids {
             sessions.remove(&id);
         }
@@ -345,6 +373,97 @@ impl Agent for ClaudeAgent {
         })
         .boxed()
     }
+
+    fn list_sessions(&self) -> Vec<SessionInfo> {
+        self.evict_dead_sessions();
+
+        let session_handles = {
+            let sessions = self.lock_sessions();
+            sessions
+                .iter()
+                .map(|(id, handle)| (id.clone(), handle.clone()))
+                .collect::<Vec<_>>()
+        };
+
+        let mut sessions = session_handles
+            .into_iter()
+            .map(|(session_id, handle)| build_session_info_from_handle(&session_id, &handle))
+            .collect::<Vec<_>>();
+        sessions.sort_by(|left, right| left.session_id.cmp(&right.session_id));
+        sessions
+    }
+
+    fn get_session(&self, session_id: &str) -> Option<SessionInfo> {
+        self.evict_dead_sessions();
+        let handle = self.lock_sessions().get(session_id).cloned()?;
+        Some(build_session_info_from_handle(session_id, &handle))
+    }
+
+    fn close_session(&self, session_id: &str) -> bool {
+        let removed = self.lock_sessions().remove(session_id);
+        let Some(handle) = removed else {
+            return false;
+        };
+
+        if let Ok(mut session) = handle.try_lock() {
+            session.status = SessionStatus::Crashed;
+            session.last_active = Instant::now();
+            let _ = session.child.start_kill();
+        } else if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                let mut session = handle.lock().await;
+                session.status = SessionStatus::Crashed;
+                session.last_active = Instant::now();
+                let _ = session.child.start_kill();
+            });
+        }
+
+        true
+    }
+}
+
+fn build_session_info_from_handle(session_id: &str, handle: &SharedClaudeSession) -> SessionInfo {
+    match handle.try_lock() {
+        Ok(session) => build_session_info(&session),
+        Err(_) => build_locked_session_fallback_info(session_id),
+    }
+}
+
+fn build_session_info(session: &ClaudeSession) -> SessionInfo {
+    SessionInfo {
+        session_id: session.session_id.clone(),
+        status: session.status.as_str().to_string(),
+        created_at: format_utc_iso8601(session.created_wall),
+        last_active: format_utc_iso8601(compute_last_active_wall(session)),
+        message_count: session.message_count,
+        uptime_secs: session.created_at.elapsed().as_secs(),
+    }
+}
+
+fn build_locked_session_fallback_info(session_id: &str) -> SessionInfo {
+    let now = Utc::now();
+    let now_iso = format_utc_iso8601(now);
+    SessionInfo {
+        session_id: session_id.to_string(),
+        status: SessionStatus::Processing.as_str().to_string(),
+        created_at: now_iso.clone(),
+        last_active: now_iso,
+        message_count: 0,
+        uptime_secs: 0,
+    }
+}
+
+fn compute_last_active_wall(session: &ClaudeSession) -> DateTime<Utc> {
+    let since_created = session
+        .last_active
+        .saturating_duration_since(session.created_at);
+    let offset =
+        chrono::Duration::from_std(since_created).unwrap_or_else(|_| chrono::Duration::zero());
+    session.created_wall + offset
+}
+
+fn format_utc_iso8601(value: DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(SecondsFormat::Secs, true)
 }
 
 fn normalize_session_id(session_id: Option<&str>) -> Option<String> {
@@ -664,5 +783,23 @@ mod tests {
     fn decide_session_action_returns_create_for_empty_session_id() {
         let action = decide_session_action(normalize_session_id(Some("   ")).as_deref(), false);
         assert_eq!(action, SessionAction::CreateNew);
+    }
+
+    #[test]
+    fn list_sessions_returns_empty_initially() {
+        let agent = ClaudeAgent::with_command_and_args("unused-command", vec![]);
+        assert_eq!(agent.list_sessions(), Vec::new());
+    }
+
+    #[test]
+    fn get_session_returns_none_for_unknown() {
+        let agent = ClaudeAgent::with_command_and_args("unused-command", vec![]);
+        assert_eq!(agent.get_session("missing-session"), None);
+    }
+
+    #[test]
+    fn close_session_returns_false_for_unknown() {
+        let agent = ClaudeAgent::with_command_and_args("unused-command", vec![]);
+        assert!(!agent.close_session("missing-session"));
     }
 }

--- a/crates/exomind-runtime/src/agent/claude.rs
+++ b/crates/exomind-runtime/src/agent/claude.rs
@@ -141,6 +141,11 @@ impl ClaudeAgent {
     }
 
     fn upsert_snapshot_from_session(&self, session: &ClaudeSession) {
+        let is_registered = self.lock_sessions().contains_key(&session.session_id);
+        if !is_registered {
+            self.remove_snapshot(&session.session_id);
+            return;
+        }
         let snapshot = SessionSnapshot::from_session(session);
         self.lock_session_snapshots()
             .insert(snapshot.session_id.clone(), snapshot);

--- a/crates/exomind-runtime/src/agent/claude.rs
+++ b/crates/exomind-runtime/src/agent/claude.rs
@@ -67,6 +67,40 @@ enum ClaudeStreamEvent {
     Result,
 }
 
+#[derive(Debug, Clone)]
+struct SessionSnapshot {
+    session_id: String,
+    status: SessionStatus,
+    created_at: Instant,
+    created_wall: DateTime<Utc>,
+    last_active_wall: DateTime<Utc>,
+    message_count: u64,
+}
+
+impl SessionSnapshot {
+    fn from_session(session: &ClaudeSession) -> Self {
+        Self {
+            session_id: session.session_id.clone(),
+            status: session.status,
+            created_at: session.created_at,
+            created_wall: session.created_wall,
+            last_active_wall: compute_last_active_wall(session),
+            message_count: session.message_count,
+        }
+    }
+
+    fn to_session_info(&self) -> SessionInfo {
+        SessionInfo {
+            session_id: self.session_id.clone(),
+            status: self.status.as_str().to_string(),
+            created_at: format_utc_iso8601(self.created_wall),
+            last_active: format_utc_iso8601(self.last_active_wall),
+            message_count: self.message_count,
+            uptime_secs: self.created_at.elapsed().as_secs(),
+        }
+    }
+}
+
 type SharedClaudeSession = Arc<AsyncMutex<ClaudeSession>>;
 
 /// Built-in Claude agent (内置 Claude Agent，通过 Claude CLI 输出流式文本).
@@ -75,6 +109,7 @@ pub struct ClaudeAgent {
     command: String,
     persistent_args: Vec<String>,
     sessions: Arc<StdMutex<HashMap<String, SharedClaudeSession>>>,
+    session_snapshots: Arc<StdMutex<HashMap<String, SessionSnapshot>>>,
 }
 
 impl ClaudeAgent {
@@ -87,6 +122,7 @@ impl ClaudeAgent {
             command: command.into(),
             persistent_args,
             sessions: Arc::new(StdMutex::new(HashMap::new())),
+            session_snapshots: Arc::new(StdMutex::new(HashMap::new())),
         }
     }
 
@@ -95,6 +131,23 @@ impl ClaudeAgent {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         }
+    }
+
+    fn lock_session_snapshots(&self) -> StdMutexGuard<'_, HashMap<String, SessionSnapshot>> {
+        match self.session_snapshots.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    fn upsert_snapshot_from_session(&self, session: &ClaudeSession) {
+        let snapshot = SessionSnapshot::from_session(session);
+        self.lock_session_snapshots()
+            .insert(snapshot.session_id.clone(), snapshot);
+    }
+
+    fn remove_snapshot(&self, session_id: &str) {
+        self.lock_session_snapshots().remove(session_id);
     }
 
     fn spawn_streaming_task(&self, request: ChatRequest) -> mpsc::Receiver<ChatChunk> {
@@ -197,6 +250,8 @@ impl ClaudeAgent {
             ));
         }
 
+        self.lock_session_snapshots()
+            .insert(session_id.clone(), SessionSnapshot::from_session(&session));
         let shared_session = Arc::new(AsyncMutex::new(session));
         sessions.insert(session_id.clone(), shared_session.clone());
         Ok((session_id, shared_session))
@@ -237,10 +292,12 @@ impl ClaudeAgent {
         session.status = SessionStatus::Processing;
         session.message_count += 1;
         session.last_active = Instant::now();
+        self.upsert_snapshot_from_session(&session);
 
         let input_line = build_stream_json_user_input(&message);
         if let Err(error) = write_user_input_line(&mut session.stdin, &input_line).await {
             session.status = SessionStatus::Crashed;
+            self.upsert_snapshot_from_session(&session);
             drop(session);
             self.cleanup_session(&session_id).await;
             emit_error_chunk(&sender, format!("Claude 输入写入失败: {error}")).await;
@@ -255,9 +312,11 @@ impl ClaudeAgent {
                     if let Some(value) = claude_session_id {
                         session.claude_session_id = Some(value);
                     }
+                    self.upsert_snapshot_from_session(&session);
                 }
                 Ok(Some(ClaudeStreamEvent::AssistantChunk { content })) => {
                     session.last_active = Instant::now();
+                    self.upsert_snapshot_from_session(&session);
                     let chunk = ChatChunk {
                         content,
                         session_id: if pending_session_chunk {
@@ -270,6 +329,7 @@ impl ClaudeAgent {
 
                     if sender.send(chunk).await.is_err() {
                         session.status = SessionStatus::Idle;
+                        self.upsert_snapshot_from_session(&session);
                         return;
                     }
                 }
@@ -284,10 +344,12 @@ impl ClaudeAgent {
                             .await;
                     }
                     session.status = SessionStatus::Idle;
+                    self.upsert_snapshot_from_session(&session);
                     return;
                 }
                 Ok(None) => {
                     session.status = SessionStatus::Crashed;
+                    self.upsert_snapshot_from_session(&session);
                     let message = build_session_ended_error_message(&mut session);
                     drop(session);
                     self.cleanup_session(&session_id).await;
@@ -296,6 +358,7 @@ impl ClaudeAgent {
                 }
                 Err(error) => {
                     session.status = SessionStatus::Crashed;
+                    self.upsert_snapshot_from_session(&session);
                     drop(session);
                     self.cleanup_session(&session_id).await;
                     emit_error_chunk(&sender, format!("Claude 输出读取失败: {error}")).await;
@@ -307,6 +370,7 @@ impl ClaudeAgent {
 
     async fn cleanup_session(&self, session_id: &str) {
         let removed = self.lock_sessions().remove(session_id);
+        self.remove_snapshot(session_id);
         if let Some(handle) = removed {
             let mut session = handle.lock().await;
             session.status = SessionStatus::Crashed;
@@ -343,6 +407,7 @@ impl ClaudeAgent {
         let mut sessions = self.lock_sessions();
         for id in stale_ids {
             sessions.remove(&id);
+            self.remove_snapshot(&id);
         }
     }
 }
@@ -376,18 +441,10 @@ impl Agent for ClaudeAgent {
 
     fn list_sessions(&self) -> Vec<SessionInfo> {
         self.evict_dead_sessions();
-
-        let session_handles = {
-            let sessions = self.lock_sessions();
-            sessions
-                .iter()
-                .map(|(id, handle)| (id.clone(), handle.clone()))
-                .collect::<Vec<_>>()
-        };
-
-        let mut sessions = session_handles
-            .into_iter()
-            .map(|(session_id, handle)| build_session_info_from_handle(&session_id, &handle))
+        let mut sessions = self
+            .lock_session_snapshots()
+            .values()
+            .map(SessionSnapshot::to_session_info)
             .collect::<Vec<_>>();
         sessions.sort_by(|left, right| left.session_id.cmp(&right.session_id));
         sessions
@@ -395,8 +452,9 @@ impl Agent for ClaudeAgent {
 
     fn get_session(&self, session_id: &str) -> Option<SessionInfo> {
         self.evict_dead_sessions();
-        let handle = self.lock_sessions().get(session_id).cloned()?;
-        Some(build_session_info_from_handle(session_id, &handle))
+        self.lock_session_snapshots()
+            .get(session_id)
+            .map(SessionSnapshot::to_session_info)
     }
 
     fn close_session(&self, session_id: &str) -> bool {
@@ -404,6 +462,7 @@ impl Agent for ClaudeAgent {
         let Some(handle) = removed else {
             return false;
         };
+        self.remove_snapshot(session_id);
 
         if let Ok(mut session) = handle.try_lock() {
             session.status = SessionStatus::Crashed;
@@ -419,37 +478,6 @@ impl Agent for ClaudeAgent {
         }
 
         true
-    }
-}
-
-fn build_session_info_from_handle(session_id: &str, handle: &SharedClaudeSession) -> SessionInfo {
-    match handle.try_lock() {
-        Ok(session) => build_session_info(&session),
-        Err(_) => build_locked_session_fallback_info(session_id),
-    }
-}
-
-fn build_session_info(session: &ClaudeSession) -> SessionInfo {
-    SessionInfo {
-        session_id: session.session_id.clone(),
-        status: session.status.as_str().to_string(),
-        created_at: format_utc_iso8601(session.created_wall),
-        last_active: format_utc_iso8601(compute_last_active_wall(session)),
-        message_count: session.message_count,
-        uptime_secs: session.created_at.elapsed().as_secs(),
-    }
-}
-
-fn build_locked_session_fallback_info(session_id: &str) -> SessionInfo {
-    let now = Utc::now();
-    let now_iso = format_utc_iso8601(now);
-    SessionInfo {
-        session_id: session_id.to_string(),
-        status: SessionStatus::Processing.as_str().to_string(),
-        created_at: now_iso.clone(),
-        last_active: now_iso,
-        message_count: 0,
-        uptime_secs: 0,
     }
 }
 

--- a/crates/exomind-runtime/src/agent/mod.rs
+++ b/crates/exomind-runtime/src/agent/mod.rs
@@ -39,6 +39,17 @@ pub struct ChatRequest {
     pub session_id: Option<String>,
 }
 
+/// Session metadata（会话元信息）.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct SessionInfo {
+    pub session_id: String,
+    pub status: String,
+    pub created_at: String,
+    pub last_active: String,
+    pub message_count: u64,
+    pub uptime_secs: u64,
+}
+
 /// Agent behavior contract (Agent 行为契约).
 pub trait Agent: Send + Sync {
     fn id(&self) -> &'static str;
@@ -50,6 +61,18 @@ pub trait Agent: Send + Sync {
     }
 
     fn chat_stream(&self, request: ChatRequest) -> BoxStream<'static, ChatChunk>;
+
+    fn list_sessions(&self) -> Vec<SessionInfo> {
+        Vec::new()
+    }
+
+    fn get_session(&self, _session_id: &str) -> Option<SessionInfo> {
+        None
+    }
+
+    fn close_session(&self, _session_id: &str) -> bool {
+        false
+    }
 }
 
 #[derive(Clone, Default)]

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -36,7 +36,7 @@ pub fn app(runtime_port: u16) -> Router {
     // Enable CORS for browser-side host aggregation (允许浏览器跨端口访问 runtime).
     let cors = CorsLayer::new()
         .allow_origin(Any)
-        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+        .allow_methods([Method::GET, Method::POST, Method::DELETE, Method::OPTIONS])
         .allow_headers(Any);
 
     Router::new()
@@ -84,7 +84,9 @@ mod tests {
     use futures_util::stream::{self, BoxStream, StreamExt};
     use http_body_util::BodyExt;
     use serde_json::Value;
+    use std::collections::HashMap;
     use std::sync::Arc;
+    use std::sync::Mutex as StdMutex;
     use tower::util::ServiceExt;
 
     struct TempRouteAgent;
@@ -104,6 +106,69 @@ mod tests {
 
         fn chat_stream(&self, request: agent::ChatRequest) -> BoxStream<'static, agent::ChatChunk> {
             stream::iter(vec![agent::ChatChunk::content_only(request.message)]).boxed()
+        }
+    }
+
+    #[derive(Default)]
+    struct TempSessionAgent {
+        sessions: Arc<StdMutex<HashMap<String, agent::SessionInfo>>>,
+    }
+
+    impl TempSessionAgent {
+        fn new_with_one_session() -> Self {
+            let session = agent::SessionInfo {
+                session_id: "temp-session-1".to_string(),
+                status: "idle".to_string(),
+                created_at: "2026-02-28T10:30:00Z".to_string(),
+                last_active: "2026-02-28T10:35:00Z".to_string(),
+                message_count: 3,
+                uptime_secs: 300,
+            };
+
+            let mut sessions = HashMap::new();
+            sessions.insert(session.session_id.clone(), session);
+            Self {
+                sessions: Arc::new(StdMutex::new(sessions)),
+            }
+        }
+
+        fn lock_sessions(&self) -> std::sync::MutexGuard<'_, HashMap<String, agent::SessionInfo>> {
+            match self.sessions.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            }
+        }
+    }
+
+    impl agent::Agent for TempSessionAgent {
+        fn id(&self) -> &'static str {
+            "temp-session"
+        }
+
+        fn name(&self) -> &'static str {
+            "Temp Session Agent"
+        }
+
+        fn description(&self) -> &'static str {
+            "用于会话端点 JSON 结构测试"
+        }
+
+        fn chat_stream(&self, request: agent::ChatRequest) -> BoxStream<'static, agent::ChatChunk> {
+            stream::iter(vec![agent::ChatChunk::content_only(request.message)]).boxed()
+        }
+
+        fn list_sessions(&self) -> Vec<agent::SessionInfo> {
+            let mut sessions = self.lock_sessions().values().cloned().collect::<Vec<_>>();
+            sessions.sort_by(|left, right| left.session_id.cmp(&right.session_id));
+            sessions
+        }
+
+        fn get_session(&self, session_id: &str) -> Option<agent::SessionInfo> {
+            self.lock_sessions().get(session_id).cloned()
+        }
+
+        fn close_session(&self, session_id: &str) -> bool {
+            self.lock_sessions().remove(session_id).is_some()
         }
     }
 
@@ -274,6 +339,215 @@ mod tests {
             .unwrap();
 
         assert_eq!(StatusCode::NOT_FOUND, response.status());
+    }
+
+    #[tokio::test]
+    async fn sessions_endpoint_returns_empty_array_for_echo_agent() {
+        const TEST_PORT: u16 = 3005;
+        let response = app(TEST_PORT)
+            .oneshot(
+                Request::builder()
+                    .uri("/agents/echo/sessions")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(StatusCode::OK, response.status());
+        let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let payload: Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(payload, serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn unknown_agent_sessions_returns_not_found() {
+        const TEST_PORT: u16 = 3006;
+        let response = app(TEST_PORT)
+            .oneshot(
+                Request::builder()
+                    .uri("/agents/not-found/sessions")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(StatusCode::NOT_FOUND, response.status());
+    }
+
+    #[tokio::test]
+    async fn unknown_session_detail_returns_not_found() {
+        const TEST_PORT: u16 = 3007;
+        let response = app(TEST_PORT)
+            .oneshot(
+                Request::builder()
+                    .uri("/agents/echo/sessions/missing-session")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(StatusCode::NOT_FOUND, response.status());
+    }
+
+    #[tokio::test]
+    async fn close_unknown_session_returns_not_found() {
+        const TEST_PORT: u16 = 3008;
+        let response = app(TEST_PORT)
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/agents/echo/sessions/missing-session")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(StatusCode::NOT_FOUND, response.status());
+    }
+
+    #[tokio::test]
+    async fn session_endpoints_return_expected_json_payloads() {
+        let registry = agent::AgentRegistry::new();
+        registry.register(Arc::new(TempSessionAgent::new_with_one_session()));
+
+        let router = routes::router().with_state(AppState {
+            port: 3009,
+            registry: registry.clone(),
+        });
+
+        let list_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/agents/temp-session/sessions")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(StatusCode::OK, list_response.status());
+        let list_body = list_response
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
+        let list_payload: Value = serde_json::from_slice(&list_body).unwrap();
+        assert_eq!(
+            list_payload,
+            serde_json::json!([
+                {
+                    "session_id": "temp-session-1",
+                    "status": "idle",
+                    "created_at": "2026-02-28T10:30:00Z",
+                    "last_active": "2026-02-28T10:35:00Z",
+                    "message_count": 3,
+                    "uptime_secs": 300
+                }
+            ])
+        );
+
+        let get_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/agents/temp-session/sessions/temp-session-1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(StatusCode::OK, get_response.status());
+        let get_body = get_response.into_body().collect().await.unwrap().to_bytes();
+        let get_payload: Value = serde_json::from_slice(&get_body).unwrap();
+        assert_eq!(
+            get_payload,
+            serde_json::json!({
+                "session_id": "temp-session-1",
+                "status": "idle",
+                "created_at": "2026-02-28T10:30:00Z",
+                "last_active": "2026-02-28T10:35:00Z",
+                "message_count": 3,
+                "uptime_secs": 300
+            })
+        );
+
+        let delete_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/agents/temp-session/sessions/temp-session-1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(StatusCode::OK, delete_response.status());
+        let delete_body = delete_response
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
+        let delete_payload: Value = serde_json::from_slice(&delete_body).unwrap();
+        assert_eq!(
+            delete_payload,
+            serde_json::json!({
+                "status": "closed",
+                "session_id": "temp-session-1"
+            })
+        );
+
+        let after_close_response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/agents/temp-session/sessions/temp-session-1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(StatusCode::NOT_FOUND, after_close_response.status());
+    }
+
+    #[tokio::test]
+    async fn unknown_session_on_existing_agent_returns_not_found() {
+        let registry = agent::AgentRegistry::new();
+        registry.register(Arc::new(TempSessionAgent::new_with_one_session()));
+
+        let router = routes::router().with_state(AppState {
+            port: 3010,
+            registry,
+        });
+
+        let get_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/agents/temp-session/sessions/not-found")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(StatusCode::NOT_FOUND, get_response.status());
+
+        let delete_response = router
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/agents/temp-session/sessions/not-found")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(StatusCode::NOT_FOUND, delete_response.status());
     }
 
     #[tokio::test]

--- a/crates/exomind-runtime/src/routes/agents.rs
+++ b/crates/exomind-runtime/src/routes/agents.rs
@@ -4,11 +4,11 @@ use axum::response::sse::{Event, Sse};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use futures_util::stream::{self, StreamExt};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
 
 use crate::AppState;
-use crate::agent::{ChatChunk, ChatRequest};
+use crate::agent::{ChatChunk, ChatRequest, SessionInfo};
 
 #[derive(Debug, Deserialize)]
 struct ChatRequestPayload {
@@ -22,6 +22,11 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/agents", get(list_agents))
         .route("/agents/:id/chat", post(chat_with_agent))
+        .route("/agents/:id/sessions", get(list_sessions))
+        .route(
+            "/agents/:id/sessions/:sid",
+            get(get_session).delete(close_session),
+        )
 }
 
 async fn list_agents(State(state): State<AppState>) -> Json<Vec<crate::agent::AgentSummary>> {
@@ -57,4 +62,54 @@ async fn chat_with_agent(
     let stream = data_stream.chain(done_stream);
 
     Ok(Sse::new(stream))
+}
+
+#[derive(Debug, Serialize)]
+struct CloseSessionResponse {
+    status: String,
+    session_id: String,
+}
+
+async fn list_sessions(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+) -> Result<Json<Vec<SessionInfo>>, StatusCode> {
+    let Some(agent) = state.registry.get(&id) else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+
+    Ok(Json(agent.list_sessions()))
+}
+
+async fn get_session(
+    Path((id, sid)): Path<(String, String)>,
+    State(state): State<AppState>,
+) -> Result<Json<SessionInfo>, StatusCode> {
+    let Some(agent) = state.registry.get(&id) else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+
+    let Some(session) = agent.get_session(&sid) else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+
+    Ok(Json(session))
+}
+
+async fn close_session(
+    Path((id, sid)): Path<(String, String)>,
+    State(state): State<AppState>,
+) -> Result<Json<CloseSessionResponse>, StatusCode> {
+    let Some(agent) = state.registry.get(&id) else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+
+    if !agent.close_session(&sid) {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    Ok(Json(CloseSessionResponse {
+        status: "closed".to_string(),
+        session_id: sid,
+    }))
 }

--- a/crates/exomind-runtime/tests/bin/fake-claude-cli.rs
+++ b/crates/exomind-runtime/tests/bin/fake-claude-cli.rs
@@ -35,7 +35,13 @@ fn reply_for(message: &str, remembered_name: &mut Option<String>) -> String {
 }
 
 fn main() {
-    let exit_after_one_turn = std::env::args().any(|arg| arg == "--exit-after-one");
+    let args = std::env::args().collect::<Vec<_>>();
+    let exit_after_one_turn = args.iter().any(|arg| arg == "--exit-after-one");
+    let delay_ms = args
+        .iter()
+        .find_map(|arg| arg.strip_prefix("--delay-ms="))
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(0);
     let stdin = io::stdin();
     let mut stdout = io::stdout();
     let mut remembered_name: Option<String> = None;
@@ -77,6 +83,9 @@ fn main() {
 
         let _ = writeln!(stdout, "{system_event}");
         let _ = writeln!(stdout, "{assistant_event}");
+        if delay_ms > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+        }
         let _ = writeln!(stdout, "{result_event}");
         let _ = stdout.flush();
 

--- a/crates/exomind-runtime/tests/claude_persistent_streaming.rs
+++ b/crates/exomind-runtime/tests/claude_persistent_streaming.rs
@@ -151,3 +151,42 @@ async fn session_info_during_processing_keeps_real_message_count() {
     assert_eq!(after.status, "idle");
     assert_eq!(after.message_count, 1);
 }
+
+#[tokio::test]
+async fn close_processing_session_does_not_leave_ghost_snapshot() {
+    let agent = ClaudeAgent::with_command_and_args(
+        fake_cli_command_path(),
+        vec!["--delay-ms=1200".to_string()],
+    );
+
+    let mut stream = agent.chat_stream(ChatRequest {
+        message: "hello".to_string(),
+        session_id: None,
+    });
+
+    let first = stream
+        .next()
+        .await
+        .expect("first chunk should be available");
+    let session_id = first
+        .session_id
+        .clone()
+        .expect("first chunk should include session_id");
+
+    assert!(
+        agent.close_session(&session_id),
+        "close_session should succeed for active session"
+    );
+    assert_eq!(
+        agent.get_session(&session_id),
+        None,
+        "session snapshot should be removed immediately after close"
+    );
+
+    let _rest = stream.collect::<Vec<_>>().await;
+    assert_eq!(
+        agent.get_session(&session_id),
+        None,
+        "session snapshot should not reappear after in-flight turn exits"
+    );
+}

--- a/crates/exomind-runtime/tests/claude_persistent_streaming.rs
+++ b/crates/exomind-runtime/tests/claude_persistent_streaming.rs
@@ -1,6 +1,7 @@
 use exomind_runtime::agent::claude::ClaudeAgent;
 use exomind_runtime::agent::{Agent, ChatRequest};
 use futures_util::StreamExt;
+use std::time::Duration;
 
 fn fake_cli_command_path() -> String {
     env!("CARGO_BIN_EXE_fake-claude-cli").to_string()
@@ -103,4 +104,50 @@ async fn returns_error_after_reusing_session_with_exited_process() {
             .any(|chunk| chunk.content.contains("会话不存在")),
         "third_chunks={third_chunks:?}"
     );
+}
+
+#[tokio::test]
+async fn session_info_during_processing_keeps_real_message_count() {
+    let agent = ClaudeAgent::with_command_and_args(
+        fake_cli_command_path(),
+        vec!["--delay-ms=800".to_string()],
+    );
+
+    let mut stream = agent.chat_stream(ChatRequest {
+        message: "hello".to_string(),
+        session_id: None,
+    });
+
+    let first = stream
+        .next()
+        .await
+        .expect("first chunk should be available");
+    let session_id = first
+        .session_id
+        .clone()
+        .expect("first chunk should include session_id");
+
+    let during_processing = agent
+        .get_session(&session_id)
+        .expect("session should exist while processing");
+    assert_eq!(during_processing.status, "processing");
+    assert_eq!(
+        during_processing.message_count, 1,
+        "message_count should reflect current turn"
+    );
+
+    std::thread::sleep(Duration::from_millis(250));
+    let later_processing = agent
+        .get_session(&session_id)
+        .expect("session should still exist before result event");
+    assert_eq!(later_processing.status, "processing");
+    assert_eq!(later_processing.message_count, 1);
+    assert_eq!(later_processing.created_at, during_processing.created_at);
+
+    let _rest = stream.collect::<Vec<_>>().await;
+    let after = agent
+        .get_session(&session_id)
+        .expect("session should still exist after turn");
+    assert_eq!(after.status, "idle");
+    assert_eq!(after.message_count, 1);
 }

--- a/docs/development/exomind-runtime-agents-api.md
+++ b/docs/development/exomind-runtime-agents-api.md
@@ -12,10 +12,13 @@
 - 默认路由（Routes，路由）:
   - `GET /agents`
   - `POST /agents/:id/chat`
+  - `GET /agents/:id/sessions`
+  - `GET /agents/:id/sessions/:sid`
+  - `DELETE /agents/:id/sessions/:sid`
 - 当前内置 Agent（Built-in Agents，内置 Agent）:
   - `claude`
   - `echo`
-- CORS（跨域）: 允许任意来源（`*`）、`GET/POST/OPTIONS`
+- CORS（跨域）: 允许任意来源（`*`）、`GET/POST/DELETE/OPTIONS`
 
 ---
 
@@ -114,10 +117,93 @@ data: [DONE]
 
 ---
 
-## 5. 状态码与错误（Status Codes & Errors，状态码与错误）
+## 5. `GET /agents/:id/sessions`
 
-- `200 OK`: 成功建立 SSE 流
-- `404 Not Found`: `:id` 对应 Agent 不存在
+### 5.1 作用（Purpose，用途）
+
+返回指定 Agent 的所有活跃会话列表。
+
+### 5.2 响应示例（Response Example，响应示例）
+
+```json
+[
+  {
+    "session_id": "a1b2c3d4-...",
+    "status": "idle",
+    "created_at": "2026-02-28T10:30:00Z",
+    "last_active": "2026-02-28T10:35:00Z",
+    "message_count": 3,
+    "uptime_secs": 300
+  }
+]
+```
+
+### 5.3 状态码（Status Codes，状态码）
+
+- `200 OK`: 返回 JSON 数组（可能为空 `[]`）
+- `404 Not Found`: Agent 不存在
+
+---
+
+## 6. `GET /agents/:id/sessions/:sid`
+
+### 6.1 作用（Purpose，用途）
+
+返回指定会话的详细信息。
+
+### 6.2 响应示例（Response Example，响应示例）
+
+```json
+{
+  "session_id": "a1b2c3d4-...",
+  "status": "idle",
+  "created_at": "2026-02-28T10:30:00Z",
+  "last_active": "2026-02-28T10:35:00Z",
+  "message_count": 3,
+  "uptime_secs": 300
+}
+```
+
+### 6.3 状态码（Status Codes，状态码）
+
+- `200 OK`: 返回 JSON 对象
+- `404 Not Found`: Agent 或 Session 不存在
+
+---
+
+## 7. `DELETE /agents/:id/sessions/:sid`
+
+### 7.1 作用（Purpose，用途）
+
+关闭指定会话，终止 Claude 子进程并清理资源。
+
+### 7.2 响应示例（Response Example，响应示例）
+
+```json
+{
+  "status": "closed",
+  "session_id": "a1b2c3d4-..."
+}
+```
+
+### 7.3 状态码（Status Codes，状态码）
+
+- `200 OK`: 会话已关闭
+- `404 Not Found`: Agent 或 Session 不存在
+
+---
+
+## 8. 状态码与错误（Status Codes & Errors，状态码与错误）
+
+- `200 OK`:
+  - `GET /agents`
+  - `POST /agents/:id/chat`（成功建立 SSE 流）
+  - `GET /agents/:id/sessions`
+  - `GET /agents/:id/sessions/:sid`
+  - `DELETE /agents/:id/sessions/:sid`
+- `404 Not Found`:
+  - `:id` 对应 Agent 不存在
+  - `:sid` 对应 Session 不存在（`GET/DELETE /agents/:id/sessions/:sid`）
 - `400 Bad Request`: 请求 JSON 非法（例如格式错误）
 
 说明:
@@ -126,9 +212,9 @@ data: [DONE]
 
 ---
 
-## 6. 联调示例（Examples，示例）
+## 9. 联调示例（Examples，示例）
 
-### 6.1 cURL（PowerShell）首轮创建会话
+### 9.1 cURL（PowerShell）首轮创建会话
 
 ```powershell
 $enc = New-Object System.Text.UTF8Encoding($false)
@@ -147,7 +233,7 @@ data: {"content":"...","session_id":"<uuid>"}
 data: [DONE]
 ```
 
-### 6.2 cURL（PowerShell）复用同一会话
+### 9.2 cURL（PowerShell）复用同一会话
 
 ```powershell
 $sid = "<首轮返回的 session_id>"
@@ -162,7 +248,7 @@ curl.exe -N -X POST "http://127.0.0.1:1919/agents/claude/chat" `
 
 ---
 
-## 7. Reqable 使用要点（Reqable Tips，Reqable 要点）
+## 10. Reqable 使用要点（Reqable Tips，Reqable 要点）
 
 1. Method（方法）: `POST`
 2. URL: `http://127.0.0.1:<port>/agents/claude/chat`
@@ -176,9 +262,10 @@ curl.exe -N -X POST "http://127.0.0.1:1919/agents/claude/chat" `
 
 ---
 
-## 8. 代码对应（Source Mapping，代码映射）
+## 11. 代码对应（Source Mapping，代码映射）
 
 - 路由与 SSE 封装: `crates/exomind-runtime/src/routes/agents.rs`
-- `ChatChunk` / `ChatRequest` 结构: `crates/exomind-runtime/src/agent/mod.rs`
+- `ChatChunk` / `ChatRequest` / `SessionInfo` 结构: `crates/exomind-runtime/src/agent/mod.rs`
 - Claude 会话管理与复用逻辑: `crates/exomind-runtime/src/agent/claude.rs`
+- CORS 方法配置（含 `DELETE`）: `crates/exomind-runtime/src/lib.rs`
 

--- a/src-tauri/src/commands/device_commands.rs
+++ b/src-tauri/src/commands/device_commands.rs
@@ -37,4 +37,3 @@ pub fn get_device_id(app: AppHandle) -> Result<String, String> {
     fs::write(&path, &generated).map_err(|err| format!("failed to persist device id: {err}"))?;
     Ok(generated)
 }
-

--- a/src-tauri/src/commands/eventlog_commands.rs
+++ b/src-tauri/src/commands/eventlog_commands.rs
@@ -49,7 +49,13 @@ fn sanitize_user_id(user_id: Option<&str>) -> String {
     }
 
     raw.chars()
-        .map(|ch| if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' { ch } else { '_' })
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
         .collect()
 }
 
@@ -84,7 +90,8 @@ fn read_events(path: &Path) -> Result<Vec<EventRecord>, String> {
         return Ok(Vec::new());
     }
 
-    let raw = fs::read_to_string(path).map_err(|err| format!("failed to read eventlog file: {err}"))?;
+    let raw =
+        fs::read_to_string(path).map_err(|err| format!("failed to read eventlog file: {err}"))?;
     if raw.trim().is_empty() {
         return Ok(Vec::new());
     }
@@ -103,7 +110,8 @@ fn read_checkpoint(path: &Path) -> Result<Option<MirrorCheckpoint>, String> {
         return Ok(None);
     }
 
-    let raw = fs::read_to_string(path).map_err(|err| format!("failed to read checkpoint file: {err}"))?;
+    let raw =
+        fs::read_to_string(path).map_err(|err| format!("failed to read checkpoint file: {err}"))?;
     if raw.trim().is_empty() {
         return Ok(None);
     }
@@ -135,8 +143,7 @@ fn sort_events_desc(events: &mut [EventRecord]) {
 
 fn sort_events_asc(events: &mut [EventRecord]) {
     events.sort_by(|left, right| {
-        left
-            .timestamp
+        left.timestamp
             .cmp(&right.timestamp)
             .then_with(|| left.id.cmp(&right.id))
     });
@@ -146,8 +153,7 @@ fn latest_event_id(events: &[EventRecord]) -> Option<String> {
     events
         .iter()
         .max_by(|left, right| {
-            left
-                .timestamp
+            left.timestamp
                 .cmp(&right.timestamp)
                 .then_with(|| left.id.cmp(&right.id))
         })
@@ -182,7 +188,8 @@ fn rebuild_markdown(paths: &EventLogPaths, events: &[EventRecord]) -> Result<(),
         markdown.push_str(&format_event_markdown(event));
     }
 
-    fs::write(&paths.mirror, markdown).map_err(|err| format!("failed to write markdown mirror: {err}"))?;
+    fs::write(&paths.mirror, markdown)
+        .map_err(|err| format!("failed to write markdown mirror: {err}"))?;
     let checkpoint_event = ordered.last().map(|event| event.id.clone());
     write_checkpoint(&paths.checkpoint, checkpoint_event)
 }
@@ -196,7 +203,8 @@ fn count_mirrored_events(path: &Path) -> Result<usize, String> {
         return Ok(0);
     }
 
-    let raw = fs::read_to_string(path).map_err(|err| format!("failed to read markdown mirror: {err}"))?;
+    let raw =
+        fs::read_to_string(path).map_err(|err| format!("failed to read markdown mirror: {err}"))?;
     Ok(raw
         .lines()
         .filter(|line| line.trim_start().starts_with("event_id: "))
@@ -212,7 +220,11 @@ pub fn eventlog_list(app: AppHandle, user_id: Option<String>) -> Result<Vec<Even
 }
 
 #[tauri::command]
-pub fn eventlog_append(app: AppHandle, user_id: Option<String>, event: EventRecord) -> Result<(), String> {
+pub fn eventlog_append(
+    app: AppHandle,
+    user_id: Option<String>,
+    event: EventRecord,
+) -> Result<(), String> {
     let paths = resolve_eventlog_paths(&app, user_id.as_deref())?;
     let mut events = read_events(&paths.events)?;
 
@@ -228,7 +240,11 @@ pub fn eventlog_append(app: AppHandle, user_id: Option<String>, event: EventReco
 }
 
 #[tauri::command]
-pub fn eventlog_get(app: AppHandle, user_id: Option<String>, id: String) -> Result<Option<EventRecord>, String> {
+pub fn eventlog_get(
+    app: AppHandle,
+    user_id: Option<String>,
+    id: String,
+) -> Result<Option<EventRecord>, String> {
     let paths = resolve_eventlog_paths(&app, user_id.as_deref())?;
     let events = read_events(&paths.events)?;
     Ok(events.into_iter().find(|event| event.id == id))
@@ -242,7 +258,10 @@ pub fn eventlog_clear(app: AppHandle, user_id: Option<String>) -> Result<(), Str
 }
 
 #[tauri::command]
-pub fn eventlog_mirror_status(app: AppHandle, user_id: Option<String>) -> Result<MirrorStatus, String> {
+pub fn eventlog_mirror_status(
+    app: AppHandle,
+    user_id: Option<String>,
+) -> Result<MirrorStatus, String> {
     let paths = resolve_eventlog_paths(&app, user_id.as_deref())?;
     let events = read_events(&paths.events)?;
     let checkpoint = read_checkpoint(&paths.checkpoint)?;
@@ -266,7 +285,10 @@ pub fn eventlog_mirror_status(app: AppHandle, user_id: Option<String>) -> Result
 }
 
 #[tauri::command]
-pub fn eventlog_rebuild_markdown(app: AppHandle, user_id: Option<String>) -> Result<MirrorStatus, String> {
+pub fn eventlog_rebuild_markdown(
+    app: AppHandle,
+    user_id: Option<String>,
+) -> Result<MirrorStatus, String> {
     let paths = resolve_eventlog_paths(&app, user_id.as_deref())?;
     let events = read_events(&paths.events)?;
     sync_markdown_mirror(&paths, &events)?;

--- a/src-tauri/src/commands/file_commands.rs
+++ b/src-tauri/src/commands/file_commands.rs
@@ -428,7 +428,10 @@ where
         message: format!("导入文件不是 UTF-8 文本: {}", e),
     })?;
 
-    Ok(PickedJsonFile { path: display, content })
+    Ok(PickedJsonFile {
+        path: display,
+        content,
+    })
 }
 
 /// 导出所有消息到 Markdown 文件
@@ -682,7 +685,10 @@ mod tests {
         .expect("url variant should be readable");
 
         assert!(read_uri);
-        assert_eq!(picked.path, "content://com.android.providers.downloads/doc/42");
+        assert_eq!(
+            picked.path,
+            "content://com.android.providers.downloads/doc/42"
+        );
         assert!(picked.content.contains("\"version\":1"));
     }
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,8 +1,8 @@
 //! 命令模块导出
 //! 导出所有 Tauri 命令
 
-pub mod ws_commands;
-pub mod file_commands;
 pub mod device_commands;
 pub mod eventlog_commands;
+pub mod file_commands;
 pub mod runtime_commands;
+pub mod ws_commands;

--- a/src-tauri/src/commands/runtime_commands.rs
+++ b/src-tauri/src/commands/runtime_commands.rs
@@ -38,13 +38,21 @@ pub struct RuntimeServiceStatus {
     pub error: Option<String>,
 }
 
-fn lock_or_error<'a, T>(mutex: &'a Mutex<T>, label: &str) -> Result<std::sync::MutexGuard<'a, T>, String> {
+fn lock_or_error<'a, T>(
+    mutex: &'a Mutex<T>,
+    label: &str,
+) -> Result<std::sync::MutexGuard<'a, T>, String> {
     mutex
         .lock()
         .map_err(|_| format!("failed to lock runtime state: {label}"))
 }
 
-fn current_status(state: &Arc<RuntimeProcessState>, running: bool, pid: Option<u32>, error: Option<String>) -> Result<RuntimeServiceStatus, String> {
+fn current_status(
+    state: &Arc<RuntimeProcessState>,
+    running: bool,
+    pid: Option<u32>,
+    error: Option<String>,
+) -> Result<RuntimeServiceStatus, String> {
     let host = lock_or_error(&state.host, "host")?.clone();
     let port = *lock_or_error(&state.port, "port")?;
     let started_at = lock_or_error(&state.started_at, "started_at")?.clone();
@@ -153,13 +161,16 @@ fn is_valid_host(host: &str) -> bool {
 }
 
 fn resolve_runtime_entry_path() -> Result<PathBuf, String> {
-    let base_dir = std::env::current_dir()
-        .map_err(|_error| {
-            #[cfg(debug_assertions)]
-            { format!("failed to resolve current directory: {_error}") }
-            #[cfg(not(debug_assertions))]
-            { "failed to resolve current directory".to_string() }
-        })?;
+    let base_dir = std::env::current_dir().map_err(|_error| {
+        #[cfg(debug_assertions)]
+        {
+            format!("failed to resolve current directory: {_error}")
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            "failed to resolve current directory".to_string()
+        }
+    })?;
     resolve_runtime_entry_path_from_base(&base_dir)
 }
 
@@ -170,7 +181,10 @@ pub fn runtime_service_start(
     host: Option<String>,
     port: Option<u16>,
 ) -> Result<RuntimeServiceStatus, String> {
-    let runtime_host = host.unwrap_or_else(|| "127.0.0.1".to_string()).trim().to_string();
+    let runtime_host = host
+        .unwrap_or_else(|| "127.0.0.1".to_string())
+        .trim()
+        .to_string();
     if runtime_host.is_empty() {
         return Err("runtime host is required".to_string());
     }
@@ -215,7 +229,9 @@ pub fn runtime_service_start(
 }
 
 #[tauri::command]
-pub fn runtime_service_stop(state: State<'_, Arc<RuntimeProcessState>>) -> Result<RuntimeServiceStatus, String> {
+pub fn runtime_service_stop(
+    state: State<'_, Arc<RuntimeProcessState>>,
+) -> Result<RuntimeServiceStatus, String> {
     let mut child_guard = lock_or_error(&state.child, "child")?;
 
     if let Some(process) = child_guard.as_mut() {
@@ -231,7 +247,9 @@ pub fn runtime_service_stop(state: State<'_, Arc<RuntimeProcessState>>) -> Resul
 }
 
 #[tauri::command]
-pub fn runtime_service_status(state: State<'_, Arc<RuntimeProcessState>>) -> Result<RuntimeServiceStatus, String> {
+pub fn runtime_service_status(
+    state: State<'_, Arc<RuntimeProcessState>>,
+) -> Result<RuntimeServiceStatus, String> {
     let mut child_guard = lock_or_error(&state.child, "child")?;
     let (running, pid) = refresh_child_running_state(&mut child_guard)?;
 
@@ -268,8 +286,11 @@ mod tests {
         fs::create_dir_all(&server_dir).expect("should create server directory");
         fs::write(&entry, "// runtime server").expect("should create runtime entry");
 
-        let resolved = resolve_runtime_entry_path_from_base(&src_tauri).expect("should resolve runtime entry");
-        let expected = entry.canonicalize().expect("should canonicalize expected entry");
+        let resolved =
+            resolve_runtime_entry_path_from_base(&src_tauri).expect("should resolve runtime entry");
+        let expected = entry
+            .canonicalize()
+            .expect("should canonicalize expected entry");
         assert_eq!(resolved, expected);
 
         let _ = fs::remove_dir_all(&root);
@@ -281,7 +302,8 @@ mod tests {
         let src_tauri = root.join("src-tauri");
         fs::create_dir_all(&src_tauri).expect("should create src-tauri directory");
 
-        let resolved = resolve_runtime_entry_path_from_base(&src_tauri).expect("should fallback to manifest root server path");
+        let resolved = resolve_runtime_entry_path_from_base(&src_tauri)
+            .expect("should fallback to manifest root server path");
         assert!(resolved.ends_with(PathBuf::from("server").join("agent-runtime-server.js")));
         assert!(resolved.exists());
 

--- a/src-tauri/src/commands/ws_commands.rs
+++ b/src-tauri/src/commands/ws_commands.rs
@@ -1,15 +1,15 @@
 //! WebSocket 客户端命令
 //! 用于连接远程 WebSocket 服务器（手机端连接电脑端）
 
+use futures::{SinkExt, StreamExt};
+use std::collections::HashSet;
+use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Runtime, State};
 use tokio::sync::Mutex;
-use std::sync::Arc;
-use std::collections::HashSet;
-use tungstenite::{Message};
-use tokio_tungstenite::{connect_async, WebSocketStream};
-use futures::{SinkExt, StreamExt};
-use url::Url;
 use tokio_tungstenite::MaybeTlsStream;
+use tokio_tungstenite::{connect_async, WebSocketStream};
+use tungstenite::Message;
+use url::Url;
 
 /// WebSocket 连接状态
 #[derive(Debug, Clone)]
@@ -115,7 +115,8 @@ pub async fn ws_send<R: Runtime>(
         ConnectionState::Connected(_) => {
             let mut stream_guard = client_state.stream.lock().await;
             if let Some(ref mut ws_stream) = *stream_guard {
-                ws_stream.send(Message::Text(message))
+                ws_stream
+                    .send(Message::Text(message))
                     .await
                     .map_err(|e| format!("Send failed: {}", e))?;
                 return Ok(());


### PR DESCRIPTION
## 背景与目标

本 PR 对应 EXO-53，目标是为 `ClaudeAgent` 增加会话生命周期管理能力：
- 支持查询会话列表
- 支持查询单个会话状态
- 支持手动关闭会话

在实现过程中，额外修复了会话元数据在并发场景下的一致性问题，避免监控信息失真和“幽灵会话”残留。

## 主要变更

### 1) Agent 能力扩展（trait 扩展，接口扩展）
- 在 `crates/exomind-runtime/src/agent/mod.rs` 新增 `SessionInfo`（会话信息）结构。
- 为 `Agent` trait 增加默认方法：
  - `list_sessions()`（列出会话）
  - `get_session()`（查询会话）
  - `close_session()`（关闭会话）

### 2) Claude 会话管理实现
- 在 `crates/exomind-runtime/src/agent/claude.rs` 中：
  - 增加 wall-clock 时间字段（`created_wall`）与活跃时间跟踪。
  - 实现 `list/get/close` 三个会话方法。
  - 新增 `SessionSnapshot`（会话快照）机制，解决处理中 `try_lock` 失败时元数据失真问题。
  - 修复关闭处理中会话后快照可能被重新写入导致的“幽灵会话”问题。

### 3) Runtime 路由与 API
- 在 `crates/exomind-runtime/src/routes/agents.rs` 新增端点：
  - `GET /agents/:id/sessions`
  - `GET /agents/:id/sessions/:sid`
  - `DELETE /agents/:id/sessions/:sid`
- 在 `crates/exomind-runtime/src/lib.rs` 放开 CORS 方法以支持 `DELETE`。

### 4) 文档与依赖
- 在 `docs/development/exomind-runtime-agents-api.md` 补充新端点说明、状态码、代码映射。
- 在 `crates/exomind-runtime/Cargo.toml` 增加 `chrono` 依赖（用于时间序列化）。

### 5) 测试覆盖
- 新增/扩展测试覆盖：
  - 空会话、未知会话、未知 agent 的 404/空返回场景。
  - 处理中读取会话信息时 `message_count` 与 `created_at` 的真实性与稳定性。
  - 关闭处理中会话后不应残留快照（防幽灵会话）。
- 扩展 `fake-claude-cli` 支持 `--delay-ms`，用于稳定复现并发场景。

## 为什么这样改

原始目标是提供会话管理 API；但在并发场景下，如果直接依赖 `try_lock` 读取会话，可能出现：
- `created_at` 被伪造为当前时间
- `message_count/uptime` 失真
- 关闭中的会话在快照层“复活”

因此本 PR 在满足 EXO-53 功能目标的同时，补上了会话元数据一致性保障，确保 API 在实际运行和监控场景可用、可信。

## 重要实现细节

- `SessionSnapshot`（会话快照）作为会话可观测状态的稳定来源，避免高并发下直接读取会话主锁带来的错误回退。
- 快照写入前检查会话是否仍在活跃注册表中，防止 close 后被异步流程重新登记。
- `close_session` 维持 best-effort 终止语义，并确保对外查询层不再返回已关闭会话。

## 验证结果（本地）

已执行：
- `cargo fmt`
- `cargo test -p exomind-runtime`
- `cargo build -p exomind-runtime`

结果：全部通过。

## 备注

- 本分支中 `src-tauri/src/commands/*` 的若干格式化改动来自同批提交历史，和 EXO-53 运行时会话功能无直接耦合；本次 PR 描述聚焦 runtime 会话生命周期能力与一致性修复。

This PR was written using [Vibe Kanban](https://vibekanban.com)