### PR TITLE
fix(mcp): 修复 #303 日期过滤时区偏移问题

### DIFF
--- a/packages/mcp/src/tools/tools-timeblock.ts
+++ b/packages/mcp/src/tools/tools-timeblock.ts
@@ -52,15 +52,24 @@ function formatTimeBlock(block: TimeBlock): Record<string, unknown> {
 }
 
 function filterByDate(blocks: TimeBlock[], dateString: string): TimeBlock[] {
-  const day = new Date(dateString);
-  if (Number.isNaN(day.getTime())) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateString);
+  if (!match) {
     throw new Error('date must be a valid date string (e.g. 2026-02-13)');
   }
 
-  const start = new Date(day);
-  start.setHours(0, 0, 0, 0);
-  const end = new Date(day);
-  end.setHours(23, 59, 59, 999);
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const start = new Date(year, month - 1, day, 0, 0, 0, 0);
+  if (
+    Number.isNaN(start.getTime()) ||
+    start.getFullYear() !== year ||
+    start.getMonth() !== month - 1 ||
+    start.getDate() !== day
+  ) {
+    throw new Error('date must be a valid date string (e.g. 2026-02-13)');
+  }
+  const end = new Date(year, month - 1, day, 23, 59, 59, 999);
 
   const startMs = start.getTime();
   const endMs = end.getTime();

--- a/packages/mcp/test/mcp-environment.test.ts
+++ b/packages/mcp/test/mcp-environment.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'vitest';
 import { createMcpEnvironment } from '../src/utils/mcp-environment';
 import { RemoteEventLogPort } from '../src/ports/remote-eventlog-port';
 import { WebEventLogStorageAdapter } from '../../../src/lib/adapters/web-eventlog-storage';
@@ -63,4 +63,3 @@ function restoreEnv(snapshot: Record<string, string | undefined>): void {
     }
   }
 }
-

--- a/packages/mcp/test/tool-registry.test.ts
+++ b/packages/mcp/test/tool-registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'vitest';
 import { createToolRegistryWithDependencies } from '../src/tools/tool-registry';
 import type { EventLogService } from '../../../src/lib/services/eventlog.service';
 import type { TimeBlockService } from '../../../src/lib/services/timeblock.service';
@@ -84,6 +84,76 @@ describe('MCP tool registry', () => {
     expect(blocksParsed.count).toBe(1);
     expect(blocksParsed.blocks[0].name).toBe('Focus');
   });
+
+  test('exomind_get_blocks date filter uses local calendar date', async () => {
+    const previousTz = process.env.TZ;
+    process.env.TZ = 'America/Los_Angeles';
+    try {
+      const startTime = new Date('2026-02-13T10:00:00-08:00').getTime();
+      const midnightStart = new Date('2026-02-13T00:00:00-08:00').getTime();
+      const previousDayLate = new Date('2026-02-12T23:59:59.999-08:00').getTime();
+      const nextDayStart = new Date('2026-02-14T00:00:00-08:00').getTime();
+      const timeBlockService = createFakeTimeBlockServiceWithBlocks([
+        {
+          id: 'b1',
+          name: 'LA Focus',
+          startId: 's1',
+          endId: 'e1',
+          note: undefined,
+          tags: new Set(),
+          startTime,
+          endTime: startTime + 30 * 60 * 1000,
+        },
+        {
+          id: 'b2',
+          name: 'LA Midnight Start',
+          startId: 's2',
+          endId: 'e2',
+          note: undefined,
+          tags: new Set(),
+          startTime: midnightStart,
+          endTime: midnightStart + 15 * 60 * 1000,
+        },
+        {
+          id: 'b3',
+          name: 'LA Previous Day',
+          startId: 's3',
+          endId: 'e3',
+          note: undefined,
+          tags: new Set(),
+          startTime: previousDayLate,
+          endTime: previousDayLate + 5 * 60 * 1000,
+        },
+        {
+          id: 'b4',
+          name: 'LA Next Day',
+          startId: 's4',
+          endId: 'e4',
+          note: undefined,
+          tags: new Set(),
+          startTime: nextDayStart,
+          endTime: nextDayStart + 10 * 60 * 1000,
+        },
+      ]);
+      const registry = createToolRegistryWithDependencies({
+        eventLogService: createFakeEventLogService(),
+        timeBlockService,
+      });
+
+      const blocks = await registry.callTool('exomind_get_blocks', { date: '2026-02-13' });
+      const parsed = parseToolText(blocks);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.count).toBe(2);
+      expect(parsed.blocks.map((block: { id: string }) => block.id).sort()).toEqual(['b1', 'b2']);
+    } finally {
+      if (previousTz === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = previousTz;
+      }
+    }
+  });
 });
 
 function createFakeEventLogService(): EventLogService {
@@ -168,3 +238,26 @@ function createFakeTimeBlockService(): TimeBlockService {
   };
 }
 
+function createFakeTimeBlockServiceWithBlocks(source: TimeBlock[]): TimeBlockService {
+  const blocks = [...source];
+  return {
+    async loadTimeBlocks() {
+      return [...blocks];
+    },
+    async loadActiveBlock() {
+      return null;
+    },
+    async startBlock() {
+      throw new Error('not implemented for this test');
+    },
+    async pauseBlock() {},
+    async resumeBlock() {},
+    async endBlock() {
+      return null;
+    },
+    async updateElapsed() {},
+    onBlockChange() {
+      return () => undefined;
+    },
+  };
+}

--- a/tests/unit/settings/settings-export-runtime.issue222.test.tsx
+++ b/tests/unit/settings/settings-export-runtime.issue222.test.tsx
@@ -45,6 +45,11 @@ vi.mock('@/config/agent-page-enabled', () => ({
   setAgentPageEnabled: vi.fn(),
 }));
 
+vi.mock('@/config/desktop-adaptive', () => ({
+  getDesktopAdaptiveEnabled: () => false,
+  setDesktopAdaptiveEnabled: vi.fn(),
+}));
+
 vi.mock('@/config/mock-data', () => ({
   getUseMockDataEnabled: () => false,
   setUseMockDataEnabled: vi.fn(),

--- a/tests/unit/settings/settings-input-section.issue199.test.tsx
+++ b/tests/unit/settings/settings-input-section.issue199.test.tsx
@@ -4,8 +4,26 @@ import '../components/settings/setup-settings-mocks.tsx';
 import { SettingsPage } from '@/ui/app/pages/SettingsPage';
 import { setVoiceTranscriptSendMode } from '@/config/voice-transcript-send-mode';
 
+vi.mock('@/config/desktop-adaptive', () => ({
+  getDesktopAdaptiveEnabled: () => false,
+  setDesktopAdaptiveEnabled: vi.fn(),
+}));
+
 describe('SettingsPage input section（输入分组语音配置）', () => {
   beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
     const storage = window.localStorage as Partial<Storage>;
     if (typeof storage.removeItem === 'function') {
       storage.removeItem('moss_api_key');

--- a/tests/unit/settings/settings-timer-card.issue182.test.tsx
+++ b/tests/unit/settings/settings-timer-card.issue182.test.tsx
@@ -38,6 +38,11 @@ vi.mock('@/config/developer-mode', () => ({
   setDeveloperModeEnabled: vi.fn(),
 }));
 
+vi.mock('@/config/desktop-adaptive', () => ({
+  getDesktopAdaptiveEnabled: () => false,
+  setDesktopAdaptiveEnabled: vi.fn(),
+}));
+
 vi.mock('@/ui/pages/UserManagePage', () => ({
   UserManagePage: () => <div data-testid="user-manage-page-mock">UserManagePage</div>,
 }));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,7 +18,10 @@ export default defineConfig({
     environment: 'happy-dom',
     maxWorkers: isTermuxRuntime ? 1 : undefined,
     minWorkers: isTermuxRuntime ? 1 : undefined,
-    include: ['tests/**/*.{test,spec}.{ts,tsx}'],
+    include: [
+      'tests/**/*.{test,spec}.{ts,tsx}',
+      'packages/mcp/test/**/*.{test,spec}.{ts,tsx}',
+    ],
     exclude: [...configDefaults.exclude, 'tests/e2e/**'],
     setupFiles: ['tests/setup.ts'],
     globals: true,


### PR DESCRIPTION
## 背景
- 修复 Issue #303：`exomind_get_blocks` 按日期过滤在时区场景下可能返回空结果。

## 实现内容
- 重写日期解析逻辑，避免 `new Date('YYYY-MM-DD')` 的隐式时区解析。
- 显式解析 `YYYY-MM-DD` 并构造本地日界（00:00:00.000 ~ 23:59:59.999）。
- 增强 MCP 测试覆盖：
  - 同日命中
  - 00:00 边界命中
  - 前一日/后一日边界排除

## 代码变更
- `packages/mcp/src/tools/tools-timeblock.ts`
- `packages/mcp/test/tool-registry.test.ts`
- `packages/mcp/test/mcp-environment.test.ts`
- `vitest.config.ts`
- `tests/unit/settings/settings-export-runtime.issue222.test.tsx`
- `tests/unit/settings/settings-input-section.issue199.test.tsx`
- `tests/unit/settings/settings-timer-card.issue182.test.tsx`

## 验证
- `npx vitest run packages/mcp/test/tool-registry.test.ts packages/mcp/test/mcp-environment.test.ts`
- `npx vitest run`
  - 结果：`156 passed | 5 skipped (161 files)`

## 关联
- Closes #303
