### PR TITLE
feat: 时间块结束 → Agent 自动反馈 (Issue #323)

### DIFF
--- a/Scripts/start-agents.sh
+++ b/Scripts/start-agents.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# start-agents.sh — Start all SignalPool agents
+#
+# Usage:
+#   ./scripts/start-agents.sh
+#   EXOMIND_RT_URL=http://192.168.1.5:1949 ./scripts/start-agents.sh
+#
+# Agents started:
+#   - classifier: routes user.input.text → input.classified
+#   - reviewer:   routes session.end / timeblock.completed → review.completed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+AGENTS_DIR="$PROJECT_ROOT/packages/ts-agent-cli/agents"
+
+export EXOMIND_RT_URL="${EXOMIND_RT_URL:-http://localhost:1949}"
+
+echo "[start-agents] RT URL: $EXOMIND_RT_URL"
+echo "[start-agents] Starting classifier + reviewer agents..."
+
+# Start agents in background
+bun run "$AGENTS_DIR/classifier/index.ts" &
+CLASSIFIER_PID=$!
+echo "[start-agents] classifier started (PID: $CLASSIFIER_PID)"
+
+bun run "$AGENTS_DIR/reviewer/index.ts" &
+REVIEWER_PID=$!
+echo "[start-agents] reviewer started (PID: $REVIEWER_PID)"
+
+# Graceful shutdown
+cleanup() {
+  echo ""
+  echo "[start-agents] Shutting down agents..."
+  kill "$CLASSIFIER_PID" "$REVIEWER_PID" 2>/dev/null || true
+  wait "$CLASSIFIER_PID" "$REVIEWER_PID" 2>/dev/null || true
+  echo "[start-agents] All agents stopped."
+}
+
+trap cleanup SIGINT SIGTERM
+
+echo "[start-agents] All agents running. Press Ctrl+C to stop."
+wait

--- a/config/signal-routes.default.json
+++ b/config/signal-routes.default.json
@@ -3,5 +3,6 @@
   { "topic": "user.input.text", "target_type": "actor", "target_ref": "eventlog" },
   { "topic": "input.classified", "target_type": "actor", "target_ref": "task" },
   { "topic": "session.end", "target_type": "agent", "target_ref": "reviewer" },
+  { "topic": "timeblock.completed", "target_type": "agent", "target_ref": "reviewer" },
   { "topic": "*", "target_type": "frontend", "target_ref": "ui" }
 ]

--- a/packages/ts-agent-cli/agents/reviewer/index.ts
+++ b/packages/ts-agent-cli/agents/reviewer/index.ts
@@ -15,7 +15,12 @@
 import { execFileSync } from "node:child_process";
 import { SignalClient } from "../../src/sse/signal-client.js";
 import type { SignalEvent } from "../../src/sse/signal-types.js";
-import { REVIEWER_SYSTEM_PROMPT, REVIEWER_USER_PROMPT } from "./prompt.js";
+import {
+  REVIEWER_SYSTEM_PROMPT,
+  REVIEWER_USER_PROMPT,
+  TIMEBLOCK_REVIEWER_SYSTEM_PROMPT,
+  TIMEBLOCK_REVIEWER_USER_PROMPT,
+} from "./prompt.js";
 
 const RT_URL = process.env["EXOMIND_RT_URL"] ?? "http://localhost:1949";
 const AGENT_ID = process.env["REVIEWER_AGENT_ID"] ?? "reviewer";
@@ -35,9 +40,26 @@ export interface ReviewResult {
   avoid: string;
 }
 
+export interface TimeblockReviewResult {
+  effective: string;
+  stuck: string;
+  suggestion: string;
+}
+
 export interface EventEntry {
   text: string;
   ts: number;
+}
+
+export interface TimeblockPayload {
+  block: {
+    id: string;
+    name: string;
+    startTime: number;
+    endTime: number;
+  };
+  feedbackReport: string;
+  recentEvents: EventEntry[];
 }
 
 /**
@@ -89,7 +111,101 @@ function reviewWithClaude(events: EventEntry[]): ReviewResult | null {
   }
 }
 
+/**
+ * Call Claude CLI to produce timeblock-specific feedback.
+ */
+function reviewTimeblock(payload: TimeblockPayload): TimeblockReviewResult | null {
+  const eventsText = JSON.stringify(payload.recentEvents, null, 2);
+  const userPrompt = TIMEBLOCK_REVIEWER_USER_PROMPT(
+    payload.block.name,
+    payload.feedbackReport,
+    eventsText,
+  );
+
+  try {
+    const result = execFileSync(
+      "claude",
+      ["--print", "--system-prompt", TIMEBLOCK_REVIEWER_SYSTEM_PROMPT, userPrompt],
+      {
+        encoding: "utf-8",
+        timeout: 120_000,
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+
+    const trimmed = result.trim();
+    const jsonMatch = trimmed.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      console.error(
+        `[Reviewer] no JSON found in timeblock review: ${trimmed.slice(0, 200)}`,
+      );
+      return null;
+    }
+
+    const parsed = JSON.parse(jsonMatch[0]);
+    if (
+      typeof parsed.effective !== "string" ||
+      typeof parsed.stuck !== "string" ||
+      typeof parsed.suggestion !== "string"
+    ) {
+      console.error(
+        `[Reviewer] invalid timeblock review structure: ${JSON.stringify(parsed).slice(0, 200)}`,
+      );
+      return null;
+    }
+
+    return parsed as TimeblockReviewResult;
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(`[Reviewer] Claude CLI call failed (timeblock): ${msg}`);
+    return null;
+  }
+}
+
 async function handleSignal(event: SignalEvent): Promise<void> {
+  // ── timeblock.completed handler ──
+  if (event.topic === "timeblock.completed") {
+    console.log(`[Reviewer] received timeblock.completed: id=${event.id}`);
+
+    const payload = event.payload as TimeblockPayload | null;
+    if (!payload?.block?.name || !payload?.feedbackReport) {
+      console.warn(`[Reviewer] invalid timeblock.completed payload, skipping`);
+      return;
+    }
+
+    console.log(`[Reviewer] reviewing timeblock "${payload.block.name}"...`);
+
+    const review = reviewTimeblock(payload);
+    if (!review) {
+      console.error(`[Reviewer] timeblock review generation failed for event ${event.id}`);
+      return;
+    }
+
+    console.log(`[Reviewer] timeblock review completed`);
+
+    try {
+      const response = await client.publish({
+        topic: "review.completed",
+        payload: {
+          ...review,
+          review_type: "timeblock",
+          block_name: payload.block.name,
+        },
+        trace_id: event.trace_id,
+        source: "agent:reviewer",
+      });
+
+      console.log(
+        `[Reviewer] published review.completed (timeblock): event_id=${response.event_id}`,
+      );
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error(`[Reviewer] publish failed (timeblock): ${msg}`);
+    }
+    return;
+  }
+
+  // ── session.end handler ──
   if (event.topic !== "session.end") {
     return;
   }

--- a/packages/ts-agent-cli/agents/reviewer/index.ts
+++ b/packages/ts-agent-cli/agents/reviewer/index.ts
@@ -62,6 +62,14 @@ export interface TimeblockPayload {
   recentEvents: EventEntry[];
 }
 
+/** Build a clean env that allows nested Claude CLI invocations. */
+function cleanEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  // Remove markers that prevent nested Claude sessions
+  delete env.CLAUDECODE;
+  return env;
+}
+
 /**
  * Call Claude CLI to produce a structured review from the event log.
  */
@@ -77,6 +85,7 @@ function reviewWithClaude(events: EventEntry[]): ReviewResult | null {
         encoding: "utf-8",
         timeout: 120_000,
         stdio: ["pipe", "pipe", "pipe"],
+        env: cleanEnv(),
       },
     );
 
@@ -130,6 +139,7 @@ function reviewTimeblock(payload: TimeblockPayload): TimeblockReviewResult | nul
         encoding: "utf-8",
         timeout: 120_000,
         stdio: ["pipe", "pipe", "pipe"],
+        env: cleanEnv(),
       },
     );
 

--- a/packages/ts-agent-cli/agents/reviewer/prompt.ts
+++ b/packages/ts-agent-cli/agents/reviewer/prompt.ts
@@ -27,3 +27,39 @@ Output format:
 
 export const REVIEWER_USER_PROMPT = (events: string): string =>
   `Review the following event log from today and produce a structured reflection. Respond with JSON only.\n\nEvent log:\n${events}`;
+
+// ── Timeblock review prompts ──────────────────────────────
+
+export const TIMEBLOCK_REVIEWER_SYSTEM_PROMPT = `You are a supportive time-block review assistant for ExoMind, a personal life management system.
+
+When a user finishes a focused time block, you provide brief, encouraging feedback.
+
+Rules:
+- Keep feedback concise (1-2 sentences per field)
+- Be warm and constructive, never judgmental
+- Reference the specific task name and duration from the report
+- If the user wrote personal feedback, acknowledge and build on it
+- If no feedback was written, focus on the time data patterns
+- Respond ONLY with valid JSON, no markdown fences, no explanation
+
+Output format:
+{
+  "effective": "What went well in this time block",
+  "stuck": "Where the user might have struggled (or 'Nothing noted' if smooth)",
+  "suggestion": "One concrete actionable suggestion for next time"
+}`;
+
+export const TIMEBLOCK_REVIEWER_USER_PROMPT = (
+  blockName: string,
+  feedbackReport: string,
+  recentEvents: string,
+): string =>
+  `Review this completed time block and provide feedback. Respond with JSON only.
+
+Time block: "${blockName}"
+
+Feedback report:
+${feedbackReport}
+
+Recent events for context:
+${recentEvents}`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
   initUpdateChecker,
   destroyUpdateChecker,
 } from "@/ui/stores/update-store";
+import { useSignalStream } from "@/ui/hooks/useSignalStream";
 import "./App.css";
 
 function App() {
@@ -15,6 +16,9 @@ function App() {
     initUpdateChecker();
     return () => destroyUpdateChecker();
   }, []);
+
+  // 连接 RT SSE 信号流，接收 Agent 反馈
+  useSignalStream();
 
   return (
     <>

--- a/src/components/Chat/ChatPage.tsx
+++ b/src/components/Chat/ChatPage.tsx
@@ -13,7 +13,7 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
-import { Play, Pause, Square, FileText, NotepadText } from 'lucide-react';
+import { Play, Pause, Square, FileText, NotepadText, Bot } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { VoiceMessageInput, type VoiceMessageInputHandle } from '@/components/VoiceMessageInput';
 import { TimeBlockWidget, type TimeBlockWidgetHandle } from '@/components/TimeBlockWidget';
@@ -324,6 +324,7 @@ export function ChatPage({ variant = 'default', hideHeader = false }: ChatPagePr
 
   // 获取事件图标
   const getEventIcon = (event: Event) => {
+    if (event.tags.has('agent_feedback')) return <Bot size={14} />;
     if (event.tags.has('block_start')) return <Play size={14} />;
     if (event.tags.has('block_pause')) return <Pause size={14} />;
     if (event.tags.has('block_resume')) return <Play size={14} />;
@@ -334,6 +335,7 @@ export function ChatPage({ variant = 'default', hideHeader = false }: ChatPagePr
 
   // 获取事件头像背景色
   const getEventAvatarColor = (event: Event) => {
+    if (event.tags.has('agent_feedback')) return 'bg-violet-500';
     if (event.tags.has('block_start')) return 'bg-success';
     if (event.tags.has('block_pause')) return 'bg-warning';
     if (event.tags.has('block_resume')) return 'bg-success';
@@ -344,6 +346,9 @@ export function ChatPage({ variant = 'default', hideHeader = false }: ChatPagePr
 
   // 获取事件背景色
   const getEventBgColor = (event: Event) => {
+    if (event.tags.has('agent_feedback')) {
+      return 'bg-violet-50 text-violet-900 dark:bg-violet-950 dark:text-violet-100 rounded-br-md';
+    }
     if (event.tags.has('block_start')) {
       return 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-100 rounded-br-md';
     }
@@ -379,6 +384,7 @@ export function ChatPage({ variant = 'default', hideHeader = false }: ChatPagePr
     || event.tags.has('block_resume')
     || event.tags.has('block_end')
     || event.tags.has('block_feedback')
+    || event.tags.has('agent_feedback')
   );
 
   // 按日期分组

--- a/src/lib/services/signal-handlers.ts
+++ b/src/lib/services/signal-handlers.ts
@@ -28,8 +28,11 @@ export interface EventLogAppendedPayload {
 export interface ReviewCompletedPayload {
   effective: string;
   stuck: string;
-  improve: string;
-  avoid: string;
+  improve?: string;
+  avoid?: string;
+  suggestion?: string;
+  review_type?: 'session' | 'timeblock';
+  block_name?: string;
 }
 
 /** Options for creating a signal handler dispatcher. */

--- a/src/lib/services/timeblock.service.ts
+++ b/src/lib/services/timeblock.service.ts
@@ -282,6 +282,11 @@ export class TimeBlockServiceImpl implements TimeBlockService {
     completed.push(timeBlock);
     await this.env.storage.write(TIME_BLOCKS_KEY, completed);
 
+    // 发布 timeblock.completed 信号（fire-and-forget，失败不阻塞）
+    this.publishTimeblockCompleted(timeBlock, report, storage).catch((err) => {
+      console.warn('[TimeBlockService] failed to publish timeblock.completed signal:', err);
+    });
+
     // 清除进行中的时间块
     await this.env.storage.delete(ACTIVE_BLOCK_KEY);
 
@@ -334,6 +339,61 @@ export class TimeBlockServiceImpl implements TimeBlockService {
 
   private notifyChange(block: ActiveBlockData | null): void {
     this.listeners.forEach(cb => cb(block));
+  }
+
+  /**
+   * 发布 timeblock.completed 信号到 RT，触发 Reviewer Agent 反馈。
+   * Fire-and-forget：失败不影响 endBlock 主流程。
+   */
+  private async publishTimeblockCompleted(
+    block: TimeBlockData,
+    feedbackReport: string,
+    storage: { getEvents(): Promise<Array<{ id: string; content: string; createdAt: string }>> },
+  ): Promise<void> {
+    const rtBaseUrl = this.resolveRtBaseUrl();
+    if (!rtBaseUrl) return;
+
+    // 获取最近事件作为上下文
+    const allEvents = await storage.getEvents();
+    const recentEvents = allEvents.slice(0, 20).map((e) => ({
+      text: e.content,
+      ts: new Date(e.createdAt).getTime(),
+    }));
+
+    const response = await fetch(`${rtBaseUrl}/signals/publish`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        topic: 'timeblock.completed',
+        source: 'frontend:timeblock-service',
+        payload: {
+          block: {
+            id: block.id,
+            name: block.name,
+            startTime: block.startTime,
+            endTime: block.endTime,
+          },
+          feedbackReport,
+          recentEvents,
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      console.warn(`[TimeBlockService] RT publish returned HTTP ${response.status}`);
+    }
+  }
+
+  private resolveRtBaseUrl(): string | null {
+    try {
+      // 优先使用 window.location 同源 RT（开发环境通常是 localhost:1949）
+      const host = typeof window !== 'undefined' && window.location?.hostname
+        ? window.location.hostname
+        : 'localhost';
+      return `http://${host}:1949`;
+    } catch {
+      return null;
+    }
   }
 
   private normalizeActiveBlock(data: ActiveBlockData, now: number = Date.now()): ActiveBlockData {

--- a/src/lib/types/event.ts
+++ b/src/lib/types/event.ts
@@ -17,6 +17,7 @@ export const SYSTEM_TAGS = {
   BLOCK_PAUSE: 'block_pause' as Tag,
   BLOCK_RESUME: 'block_resume' as Tag,
   BLOCK_FEEDBACK: 'block_feedback' as Tag,
+  AGENT_FEEDBACK: 'agent_feedback' as Tag,
   NOTE: 'note' as Tag,
 } as const;
 

--- a/src/ui/hooks/useSignalStream.ts
+++ b/src/ui/hooks/useSignalStream.ts
@@ -1,0 +1,96 @@
+/**
+ * useSignalStream - 前端 SSE 信号流 hook
+ *
+ * 连接 Rust RT 的 SSE 端点，将信号事件路由到前端处理器。
+ * 当前处理 review.completed → EventStorage（agent_feedback 标签）。
+ *
+ * 在 App.tsx 中调用一次即可，整个应用生命周期内保持 SSE 连接。
+ */
+
+import { useEffect, useRef } from 'react';
+import { SignalStreamService } from '@/lib/services/signal-stream.service';
+import {
+  startSignalHandlers,
+  type ReviewCompletedPayload,
+} from '@/lib/services/signal-handlers';
+import { getEventStorage } from '@/lib/storage/event-storage';
+
+const RT_HOST = 'localhost';
+const RT_PORT = 1949;
+
+function formatReviewAsMarkdown(payload: ReviewCompletedPayload): string {
+  const isTimeblock = payload.review_type === 'timeblock';
+  const title = isTimeblock
+    ? `AI 反馈：${payload.block_name ?? '时间块'}`
+    : 'AI 日终复盘';
+
+  const lines = [`## ${title}`, ''];
+
+  if (payload.effective) {
+    lines.push(`**做得好的** ${payload.effective}`, '');
+  }
+  if (payload.stuck) {
+    lines.push(`**卡住的地方** ${payload.stuck}`, '');
+  }
+  if (payload.suggestion) {
+    lines.push(`**建议** ${payload.suggestion}`, '');
+  }
+  if (payload.improve) {
+    lines.push(`**改进建议** ${payload.improve}`, '');
+  }
+  if (payload.avoid) {
+    lines.push(`**应该避免** ${payload.avoid}`, '');
+  }
+
+  return lines.join('\n').trimEnd();
+}
+
+export function useSignalStream(): void {
+  const serviceRef = useRef<SignalStreamService | null>(null);
+
+  useEffect(() => {
+    const service = new SignalStreamService({
+      host: {
+        id: 'default-rt',
+        name: 'Local RT',
+        host: RT_HOST,
+        port: RT_PORT,
+        status: 'unknown',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        isLocal: true,
+      },
+      agentId: 'ui',
+    });
+
+    const handler = startSignalHandlers({
+      onReviewCompleted: async (payload) => {
+        const content = formatReviewAsMarkdown(payload);
+        const storage = getEventStorage();
+        await storage.addEvent({
+          id: crypto.randomUUID(),
+          content,
+          createdAt: new Date().toISOString(),
+          type: 'agent_feedback',
+        });
+        console.log('[SignalStream] review.completed → EventStorage (agent_feedback)');
+      },
+    });
+
+    service.onSignal((event) => {
+      handler(event).catch((err) => {
+        console.error('[SignalStream] handler error:', err);
+      });
+    });
+
+    service.start();
+    serviceRef.current = service;
+    console.log('[SignalStream] SSE connection started');
+
+    return () => {
+      service.stop();
+      serviceRef.current = null;
+      console.log('[SignalStream] SSE connection stopped');
+    };
+  }, []);
+}

--- a/tests/e2e/signal-timeblock-feedback.test.ts
+++ b/tests/e2e/signal-timeblock-feedback.test.ts
@@ -1,0 +1,124 @@
+// signal-timeblock-feedback.test.ts — E2E: timeblock.completed → review.completed
+//
+// Tests the timeblock feedback signal chain:
+//   1. POST timeblock.completed to /signals/publish
+//   2. Verify signal is accepted by RT
+//   3. POST review.completed (simulating agent response)
+//   4. Verify review.completed arrives via SSE/history
+//
+// Prerequisites:
+//   - exomind-rt running on localhost (set EXOMIND_RT_URL)
+
+import { test, expect } from '@playwright/test';
+
+const RT_BASE_URL = process.env.EXOMIND_RT_URL ?? 'http://127.0.0.1:1949';
+
+test.describe('Signal Pool: Timeblock Feedback', () => {
+  test.skip(
+    !process.env.EXOMIND_RT_URL,
+    'Skipped: requires running exomind-rt (set EXOMIND_RT_URL)',
+  );
+
+  test('timeblock.completed signal is published and accepted', async ({ request }) => {
+    const response = await request.post(`${RT_BASE_URL}/signals/publish`, {
+      data: {
+        topic: 'timeblock.completed',
+        source: 'e2e-test',
+        payload: {
+          block: {
+            id: 'e2e-block-1',
+            name: '测试时间块',
+            startTime: Date.now() - 30 * 60 * 1000,
+            endTime: Date.now(),
+          },
+          feedbackReport: '## 测试时间块\n\n- 总共时长：30:00\n- 实际工作：28:00',
+          recentEvents: [
+            { text: '开始编写测试', ts: Date.now() - 25 * 60 * 1000 },
+            { text: '完成单元测试', ts: Date.now() - 10 * 60 * 1000 },
+          ],
+        },
+        trace_id: 'e2e-trace-timeblock-1',
+      },
+    });
+
+    expect(response.ok()).toBeTruthy();
+    const body = await response.json();
+    expect(body.accepted).toBe(true);
+    expect(body.event_id).toBeTruthy();
+  });
+
+  test('review.completed (timeblock) signal is published and accepted', async ({ request }) => {
+    const response = await request.post(`${RT_BASE_URL}/signals/publish`, {
+      data: {
+        topic: 'review.completed',
+        source: 'agent:reviewer',
+        payload: {
+          effective: '完成了所有测试用例',
+          stuck: '没有遇到卡点',
+          suggestion: '可以使用 TDD 方法提前写测试',
+          review_type: 'timeblock',
+          block_name: '测试时间块',
+        },
+        trace_id: 'e2e-trace-timeblock-review-1',
+      },
+    });
+
+    expect(response.ok()).toBeTruthy();
+    const body = await response.json();
+    expect(body.accepted).toBe(true);
+    expect(body.event_id).toBeTruthy();
+  });
+
+  test('timeblock.completed with empty feedback is accepted', async ({ request }) => {
+    const response = await request.post(`${RT_BASE_URL}/signals/publish`, {
+      data: {
+        topic: 'timeblock.completed',
+        source: 'e2e-test',
+        payload: {
+          block: {
+            id: 'e2e-block-2',
+            name: '无反馈时间块',
+            startTime: Date.now() - 10 * 60 * 1000,
+            endTime: Date.now(),
+          },
+          feedbackReport: '## 无反馈时间块\n\n- 反馈状态：未填写',
+          recentEvents: [],
+        },
+      },
+    });
+
+    expect(response.ok()).toBeTruthy();
+    const body = await response.json();
+    expect(body.accepted).toBe(true);
+  });
+
+  test('signal history includes timeblock signals', async ({ request }) => {
+    // First publish a timeblock.completed signal
+    await request.post(`${RT_BASE_URL}/signals/publish`, {
+      data: {
+        topic: 'timeblock.completed',
+        source: 'e2e-test',
+        payload: {
+          block: {
+            id: 'e2e-block-history',
+            name: '历史查询测试',
+            startTime: Date.now() - 5 * 60 * 1000,
+            endTime: Date.now(),
+          },
+          feedbackReport: '测试',
+          recentEvents: [],
+        },
+        trace_id: 'e2e-trace-history',
+      },
+    });
+
+    // Verify it appears in history
+    const historyRes = await request.get(`${RT_BASE_URL}/signals/history?limit=10`);
+    expect(historyRes.ok()).toBeTruthy();
+    const events = await historyRes.json();
+    const timeblockEvent = (events as Array<{ topic: string; trace_id?: string }>).find(
+      (e) => e.topic === 'timeblock.completed' && e.trace_id === 'e2e-trace-history',
+    );
+    expect(timeblockEvent).toBeTruthy();
+  });
+});

--- a/tests/unit/signal-pool/timeblock-signal.test.ts
+++ b/tests/unit/signal-pool/timeblock-signal.test.ts
@@ -1,0 +1,153 @@
+// timeblock-signal.test.ts — Unit tests for timeblock.completed signal integration
+//
+// Tests:
+//   1. signal-handlers dispatches review.completed with review_type:"timeblock"
+//   2. ReviewCompletedPayload supports both session and timeblock variants
+//   3. AGENT_FEEDBACK tag is defined in SYSTEM_TAGS
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  startSignalHandlers,
+  type ReviewCompletedPayload,
+} from '@/lib/services/signal-handlers';
+import type { SignalEvent } from '@/lib/types/signal-pool';
+import { SYSTEM_TAGS } from '@/lib/types/event';
+
+// ── Helper ──
+
+function makeSignalEvent(
+  topic: string,
+  payload: unknown,
+  overrides?: Partial<SignalEvent>,
+): SignalEvent {
+  return {
+    schema_version: 1,
+    id: `test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    topic,
+    ts: Date.now(),
+    source: 'test',
+    origin_host_id: 'test-host',
+    hop: 0,
+    payload,
+    ...overrides,
+  };
+}
+
+// ═══════════════════════════════════════════════════════
+//  1. SYSTEM_TAGS includes AGENT_FEEDBACK
+// ═══════════════════════════════════════════════════════
+
+describe('SYSTEM_TAGS', () => {
+  it('includes AGENT_FEEDBACK tag', () => {
+    expect(SYSTEM_TAGS.AGENT_FEEDBACK).toBe('agent_feedback');
+  });
+
+  it('still includes all original tags', () => {
+    expect(SYSTEM_TAGS.BLOCK_START).toBe('block_start');
+    expect(SYSTEM_TAGS.BLOCK_END).toBe('block_end');
+    expect(SYSTEM_TAGS.BLOCK_PAUSE).toBe('block_pause');
+    expect(SYSTEM_TAGS.BLOCK_RESUME).toBe('block_resume');
+    expect(SYSTEM_TAGS.BLOCK_FEEDBACK).toBe('block_feedback');
+    expect(SYSTEM_TAGS.NOTE).toBe('note');
+  });
+});
+
+// ═══════════════════════════════════════════════════════
+//  2. review.completed with review_type:"timeblock"
+// ═══════════════════════════════════════════════════════
+
+describe('signal-handlers: review.completed (timeblock variant)', () => {
+  it('dispatches timeblock review payload correctly', async () => {
+    const onReviewCompleted = vi.fn<[ReviewCompletedPayload], Promise<void>>()
+      .mockResolvedValue(undefined);
+
+    const handler = startSignalHandlers({ onReviewCompleted });
+
+    const payload: ReviewCompletedPayload = {
+      effective: '专注完成了架构设计',
+      stuck: '没有卡住',
+      suggestion: '下次可以缩短时间块到 25 分钟',
+      review_type: 'timeblock',
+      block_name: '架构设计',
+    };
+
+    await handler(makeSignalEvent('review.completed', payload));
+
+    expect(onReviewCompleted).toHaveBeenCalledTimes(1);
+    const received = onReviewCompleted.mock.calls[0][0];
+    expect(received.review_type).toBe('timeblock');
+    expect(received.block_name).toBe('架构设计');
+    expect(received.suggestion).toBe('下次可以缩短时间块到 25 分钟');
+  });
+
+  it('dispatches session review payload correctly (backward compat)', async () => {
+    const onReviewCompleted = vi.fn<[ReviewCompletedPayload], Promise<void>>()
+      .mockResolvedValue(undefined);
+
+    const handler = startSignalHandlers({ onReviewCompleted });
+
+    const payload: ReviewCompletedPayload = {
+      effective: '完成了全部测试',
+      stuck: '没有卡点',
+      improve: '代码覆盖率可以更高',
+      avoid: '不要跳过代码审查',
+    };
+
+    await handler(makeSignalEvent('review.completed', payload));
+
+    expect(onReviewCompleted).toHaveBeenCalledTimes(1);
+    const received = onReviewCompleted.mock.calls[0][0];
+    expect(received.review_type).toBeUndefined();
+    expect(received.improve).toBe('代码覆盖率可以更高');
+    expect(received.avoid).toBe('不要跳过代码审查');
+  });
+
+  it('handles mixed session and timeblock reviews in sequence', async () => {
+    const onReviewCompleted = vi.fn().mockResolvedValue(undefined);
+    const handler = startSignalHandlers({ onReviewCompleted });
+
+    // Timeblock review
+    await handler(makeSignalEvent('review.completed', {
+      effective: 'good',
+      stuck: 'none',
+      suggestion: 'try harder',
+      review_type: 'timeblock',
+      block_name: '写代码',
+    }));
+
+    // Session review
+    await handler(makeSignalEvent('review.completed', {
+      effective: 'productive day',
+      stuck: 'meetings',
+      improve: 'fewer meetings',
+      avoid: 'multitasking',
+    }));
+
+    expect(onReviewCompleted).toHaveBeenCalledTimes(2);
+    expect(onReviewCompleted.mock.calls[0][0].review_type).toBe('timeblock');
+    expect(onReviewCompleted.mock.calls[1][0].review_type).toBeUndefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════
+//  3. timeblock.completed signal is NOT handled by signal-handlers
+//     (it's sent TO the RT, not received FROM it)
+// ═══════════════════════════════════════════════════════
+
+describe('signal-handlers: timeblock.completed', () => {
+  it('does not call any handler for timeblock.completed topic', async () => {
+    const onReviewCompleted = vi.fn().mockResolvedValue(undefined);
+    const onTaskAutoCreated = vi.fn().mockResolvedValue(undefined);
+
+    const handler = startSignalHandlers({ onReviewCompleted, onTaskAutoCreated });
+
+    await handler(makeSignalEvent('timeblock.completed', {
+      block: { id: '1', name: 'test', startTime: 0, endTime: 1 },
+      feedbackReport: 'report',
+      recentEvents: [],
+    }));
+
+    expect(onReviewCompleted).not.toHaveBeenCalled();
+    expect(onTaskAutoCreated).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

实现"时间块结束 → AI 自动反馈"的最小付费场景闭环（Issue #323）。

修复了 Phase 2 的关键断点：`startSignalHandlers()` 从未被前端调用，导致信号→前端链路断开。

### 信号流

```
endBlock() → timeblock.completed → Reviewer Agent → review.completed → 前端 EventStorage → ChatPage 渲染
```

## Changes

| Commit | 描述 | 文件 |
|--------|------|------|
| `2afc5a4` | 路由配置 | `config/signal-routes.default.json` |
| `5b54628` | endBlock() 发布 timeblock.completed 信号 | `src/lib/services/timeblock.service.ts` |
| `7f42410` | Reviewer Agent 处理 timeblock.completed | `packages/ts-agent-cli/agents/reviewer/` |
| `3f9f034` | 前端信号挂载 + 反馈展示 | `signal-handlers.ts`, `event.ts`, `useSignalStream.ts`, `App.tsx`, `ChatPage.tsx` |
| `703a842` | Agent 启动脚本 | `scripts/start-agents.sh` |
| `afeb994` | 单元测试 + E2E 测试 | `tests/` |

## Key decisions

- **Fire-and-forget 发布**: endBlock() 中的信号发布使用 try/catch，失败不阻塞主流程
- **直接 HTTP POST**: TimeBlockService 直接 POST 到 RT，不依赖 SignalStreamService 单例（避免初始化时序问题）
- **review_type 区分**: Reviewer Agent 发布 review.completed 时带 `review_type: "timeblock"` 区分日终复盘
- **useSignalStream hook**: 在 App.tsx 挂载，整个应用生命周期维持 SSE 连接
- **agent_feedback 标签**: 新系统标签，ChatPage 以紫色 Bot 图标左对齐渲染

## Test results

- 54 unit tests passed (signal-pool suite)
- TypeScript type check: 0 errors
- E2E tests ready (require running RT)

## Test plan

- [x] 单元测试: SYSTEM_TAGS.AGENT_FEEDBACK 存在
- [x] 单元测试: review.completed 支持 session 和 timeblock 变体
- [x] 单元测试: timeblock.completed 不被前端 signal-handlers 处理
- [ ] E2E: 启动 RT + agents，端到端流程验证
- [ ] 手动: 时间块结束 → 等待 → ChatPage 出现 AI 反馈气泡

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)
