### PR TITLE
feat(runtime): 内嵌 exomind-runtime 到 Tauri（M1：lib 化 + setup 自动启动 + invoke 快速通道）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,6 +1000,7 @@ version = "0.3.3"
 dependencies = [
  "async-trait",
  "chrono",
+ "exomind-runtime",
  "futures",
  "futures-util",
  "parking_lot",

--- a/Scripts/dev/tauri-wrapper.ps1
+++ b/Scripts/dev/tauri-wrapper.ps1
@@ -266,25 +266,28 @@ if ($TauriArgs -and $TauriArgs.Count -ge 2 -and $TauriArgs[0] -eq "android" -and
 # Run tauri CLI (执行 tauri 命令)
 $exitCode = 0
 $tempConfigPath = $null
-if ($TauriArgs -and $TauriArgs.Count -gt 0) {
-  # Inject --config to override devUrl when port differs from default
-  # (端口非默认值时，通过 --config 覆盖 devUrl)
-  if ($isTauriDev -and $env:EXOMIND_WEB_PORT -and $env:EXOMIND_WEB_PORT -ne "1420") {
-    $tempConfigPath = Join-Path $env:TEMP ("exomind-tauri-dev-config-{0}.json" -f [Guid]::NewGuid().ToString("N"))
-    $devUrlOverride = '{"build":{"devUrl":"http://localhost:' + $env:EXOMIND_WEB_PORT + '"}}'
-    Write-TextUtf8NoBom -Path $tempConfigPath -Content $devUrlOverride
-    & tauri @TauriArgs --config $tempConfigPath
+try {
+  if ($TauriArgs -and $TauriArgs.Count -gt 0) {
+    # Inject --config to override devUrl when port differs from default
+    # (端口非默认值时，通过 --config 覆盖 devUrl)
+    if ($isTauriDev -and $env:EXOMIND_WEB_PORT -and $env:EXOMIND_WEB_PORT -ne "1420") {
+      $tempConfigPath = Join-Path $env:TEMP ("exomind-tauri-dev-config-{0}.json" -f [Guid]::NewGuid().ToString("N"))
+      $devUrlOverride = '{"build":{"devUrl":"http://localhost:' + $env:EXOMIND_WEB_PORT + '"}}'
+      Write-TextUtf8NoBom -Path $tempConfigPath -Content $devUrlOverride
+      & tauri @TauriArgs --config $tempConfigPath
+    } else {
+      & tauri @TauriArgs
+    }
   } else {
-    & tauri @TauriArgs
+    & tauri
   }
-} else {
-  & tauri
+  $exitCode = $LASTEXITCODE
+} finally {
+  if ($tempConfigPath -and (Test-Path -LiteralPath $tempConfigPath)) {
+    Remove-Item -LiteralPath $tempConfigPath -Force -ErrorAction SilentlyContinue
+  }
 }
-$exitCode = $LASTEXITCODE
 
-if ($tempConfigPath -and (Test-Path -LiteralPath $tempConfigPath)) {
-  Remove-Item -LiteralPath $tempConfigPath -Force -ErrorAction SilentlyContinue
-}
 
 # Patch again for `tauri android init`-like flows (初始化后再次补权限与 cleartext 配置)
 if ($TauriArgs -and $TauriArgs.Count -ge 2 -and $TauriArgs[0] -eq "android") {

--- a/Scripts/dev/tauri-wrapper.ps1
+++ b/Scripts/dev/tauri-wrapper.ps1
@@ -264,12 +264,16 @@ if ($TauriArgs -and $TauriArgs.Count -ge 2 -and $TauriArgs[0] -eq "android" -and
 }
 
 # Run tauri CLI (执行 tauri 命令)
+$exitCode = 0
+$tempConfigPath = $null
 if ($TauriArgs -and $TauriArgs.Count -gt 0) {
   # Inject --config to override devUrl when port differs from default
   # (端口非默认值时，通过 --config 覆盖 devUrl)
   if ($isTauriDev -and $env:EXOMIND_WEB_PORT -and $env:EXOMIND_WEB_PORT -ne "1420") {
+    $tempConfigPath = Join-Path $env:TEMP ("exomind-tauri-dev-config-{0}.json" -f [Guid]::NewGuid().ToString("N"))
     $devUrlOverride = '{"build":{"devUrl":"http://localhost:' + $env:EXOMIND_WEB_PORT + '"}}'
-    & tauri @TauriArgs --config $devUrlOverride
+    Write-TextUtf8NoBom -Path $tempConfigPath -Content $devUrlOverride
+    & tauri @TauriArgs --config $tempConfigPath
   } else {
     & tauri @TauriArgs
   }
@@ -277,6 +281,10 @@ if ($TauriArgs -and $TauriArgs.Count -gt 0) {
   & tauri
 }
 $exitCode = $LASTEXITCODE
+
+if ($tempConfigPath -and (Test-Path -LiteralPath $tempConfigPath)) {
+  Remove-Item -LiteralPath $tempConfigPath -Force -ErrorAction SilentlyContinue
+}
 
 # Patch again for `tauri android init`-like flows (初始化后再次补权限与 cleartext 配置)
 if ($TauriArgs -and $TauriArgs.Count -ge 2 -and $TauriArgs[0] -eq "android") {

--- a/crates/exomind-runtime/Cargo.toml
+++ b/crates/exomind-runtime/Cargo.toml
@@ -18,7 +18,7 @@ chrono = { version = "0.4", features = ["serde"] }
 futures-util = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "process", "sync"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "process", "sync", "signal"] }
 thiserror = "1"
 sysinfo = { version = "0.30", default-features = false }
 tower-http = { version = "0.6", features = ["cors"] }

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -2,8 +2,14 @@ use axum::http::Method;
 use axum::{Json, Router, routing::get};
 use serde::Serialize;
 use std::env;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::process::Stdio;
 use std::sync::Arc;
 use thiserror::Error;
+use tokio::process::{Child, Command};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
 use tower_http::cors::{Any, CorsLayer};
 
 use signal::SignalPool;
@@ -13,6 +19,7 @@ pub mod routes;
 pub mod signal;
 
 pub const RUNTIME_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const DEFAULT_RT_PORT: u16 = 1949;
 
 #[derive(Debug, Error)]
 pub enum PortConfigError {
@@ -21,16 +28,321 @@ pub enum PortConfigError {
 }
 
 /// Read EXOMIND_RT_PORT from env (从环境变量读取运行端口).
-/// Missing value means `0` (缺省时用 0，让系统分配随机可用端口).
+/// Missing value means `1949`（缺省时用 1949）.
+/// `0` means random available port（0 表示随机可用端口）.
 pub fn configured_port_from_env() -> Result<u16, PortConfigError> {
     match env::var("EXOMIND_RT_PORT") {
         Ok(raw) => raw
             .parse::<u16>()
             .map_err(|_| PortConfigError::InvalidPort { raw }),
-        Err(env::VarError::NotPresent) => Ok(0),
+        Err(env::VarError::NotPresent) => Ok(DEFAULT_RT_PORT),
         Err(env::VarError::NotUnicode(_)) => Err(PortConfigError::InvalidPort {
             raw: "<non-unicode>".to_string(),
         }),
+    }
+}
+
+/// Read EXOMIND_RT_BIND from env（读取绑定地址，默认 127.0.0.1）.
+pub fn configured_bind_host_from_env() -> String {
+    env::var("EXOMIND_RT_BIND").unwrap_or_else(|_| "127.0.0.1".to_string())
+}
+
+/// Runtime startup options（运行时启动选项）.
+#[derive(Debug, Clone)]
+pub struct RuntimeStartOptions {
+    /// bind host（绑定地址）.
+    pub bind_host: String,
+    /// bind port（绑定端口）. `0` means random available port.
+    pub port: u16,
+    /// spawn built-in rust actors（是否拉起内置 Rust Actor）.
+    pub spawn_builtin_actors: bool,
+    /// spawn ts agents (reviewer/classifier)（是否拉起 TS Agent）.
+    pub spawn_ts_agents: bool,
+    /// command to run TS agents（启动 TS Agent 的命令）.
+    pub ts_agent_command: String,
+    /// project root used for spawning TS agents（TS Agent 工作目录）.
+    pub ts_agent_workdir: Option<PathBuf>,
+}
+
+impl Default for RuntimeStartOptions {
+    fn default() -> Self {
+        let spawn_ts_agents = env::var("EXOMIND_RT_DISABLE_TS_AGENTS")
+            .map(|value| {
+                let value = value.to_ascii_lowercase();
+                !(value == "1" || value == "true" || value == "yes")
+            })
+            .unwrap_or(true);
+
+        Self {
+            bind_host: configured_bind_host_from_env(),
+            port: configured_port_from_env().unwrap_or(DEFAULT_RT_PORT),
+            spawn_builtin_actors: true,
+            spawn_ts_agents,
+            ts_agent_command: env::var("EXOMIND_RT_AGENT_CMD")
+                .unwrap_or_else(|_| "bun".to_string()),
+            ts_agent_workdir: None,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum RuntimeStartError {
+    #[error("invalid bind address: {raw}")]
+    InvalidBindAddress {
+        raw: String,
+        #[source]
+        source: std::net::AddrParseError,
+    },
+    #[error("failed to bind runtime listener on {bind_addr}: {source}")]
+    BindListener {
+        bind_addr: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to read listener local address: {0}")]
+    ReadLocalAddr(#[source] std::io::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum RuntimeStopError {
+    #[error("runtime server task join failed: {0}")]
+    JoinServerTask(#[source] tokio::task::JoinError),
+    #[error("runtime server returned IO error: {0}")]
+    ServerIo(#[source] std::io::Error),
+    #[error("failed to stop ts agent `{agent}`: {source}")]
+    KillTsAgent {
+        agent: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+#[derive(Debug)]
+struct TsAgentProcess {
+    name: String,
+    child: Child,
+}
+
+/// Runtime handle（运行句柄）.
+pub struct RuntimeHandle {
+    local_addr: SocketAddr,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    server_task: Option<JoinHandle<std::io::Result<()>>>,
+    actor_tasks: Vec<JoinHandle<()>>,
+    ts_agents: Vec<TsAgentProcess>,
+}
+
+impl RuntimeHandle {
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    pub fn host(&self) -> String {
+        self.local_addr.ip().to_string()
+    }
+
+    pub fn port(&self) -> u16 {
+        self.local_addr.port()
+    }
+
+    /// Graceful shutdown（优雅停止）.
+    pub async fn stop(&mut self) -> Result<(), RuntimeStopError> {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+
+        for task in &self.actor_tasks {
+            task.abort();
+        }
+        while let Some(task) = self.actor_tasks.pop() {
+            let _ = task.await;
+        }
+
+        for agent in &mut self.ts_agents {
+            match agent.child.try_wait() {
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    agent
+                        .child
+                        .kill()
+                        .await
+                        .map_err(|source| RuntimeStopError::KillTsAgent {
+                            agent: agent.name.clone(),
+                            source,
+                        })?;
+                    let _ = agent.child.wait().await;
+                }
+                Err(source) => {
+                    return Err(RuntimeStopError::KillTsAgent {
+                        agent: agent.name.clone(),
+                        source,
+                    });
+                }
+            }
+        }
+        self.ts_agents.clear();
+
+        if let Some(server_task) = self.server_task.take() {
+            match server_task.await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => return Err(RuntimeStopError::ServerIo(error)),
+                Err(error) => return Err(RuntimeStopError::JoinServerTask(error)),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for RuntimeHandle {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        for task in self.actor_tasks.drain(..) {
+            task.abort();
+        }
+        for agent in &mut self.ts_agents {
+            let _ = agent.child.start_kill();
+        }
+        if let Some(server_task) = self.server_task.take() {
+            server_task.abort();
+        }
+    }
+}
+
+/// Start runtime with env defaults（按环境变量默认值启动）.
+pub async fn start() -> Result<RuntimeHandle, RuntimeStartError> {
+    start_with_options(RuntimeStartOptions::default()).await
+}
+
+/// Start runtime with explicit options（按显式参数启动）.
+pub async fn start_with_options(
+    options: RuntimeStartOptions,
+) -> Result<RuntimeHandle, RuntimeStartError> {
+    let bind_addr_raw = format!("{}:{}", options.bind_host, options.port);
+    let bind_addr: SocketAddr =
+        bind_addr_raw
+            .parse()
+            .map_err(|source| RuntimeStartError::InvalidBindAddress {
+                raw: bind_addr_raw.clone(),
+                source,
+            })?;
+
+    let listener = tokio::net::TcpListener::bind(bind_addr)
+        .await
+        .map_err(|source| RuntimeStartError::BindListener {
+            bind_addr: bind_addr_raw.clone(),
+            source,
+        })?;
+    let local_addr = listener
+        .local_addr()
+        .map_err(RuntimeStartError::ReadLocalAddr)?;
+
+    let state = AppState::new(local_addr.port());
+
+    let mut actor_tasks = Vec::new();
+    if options.spawn_builtin_actors {
+        actor_tasks.push(signal::actors::task_actor::spawn_task_actor(Arc::clone(
+            &state.signal_pool,
+        )));
+        actor_tasks.push(signal::actors::eventlog_actor::spawn_eventlog_actor(Arc::clone(
+            &state.signal_pool,
+        )));
+    }
+
+    let ts_agents = if options.spawn_ts_agents {
+        spawn_default_ts_agents(local_addr.port(), &options).await
+    } else {
+        Vec::new()
+    };
+
+    let app = app_with_state(state);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let server_task = tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+    });
+
+    Ok(RuntimeHandle {
+        local_addr,
+        shutdown_tx: Some(shutdown_tx),
+        server_task: Some(server_task),
+        actor_tasks,
+        ts_agents,
+    })
+}
+
+async fn spawn_default_ts_agents(port: u16, options: &RuntimeStartOptions) -> Vec<TsAgentProcess> {
+    const REVIEWER_ENTRY: &str = "packages/ts-agent-cli/agents/reviewer/index.ts";
+    const CLASSIFIER_ENTRY: &str = "packages/ts-agent-cli/agents/classifier/index.ts";
+    let project_root = resolve_project_root(options);
+    let rt_url = format!("http://127.0.0.1:{port}");
+
+    let mut out = Vec::new();
+    if let Some(proc) = try_spawn_ts_agent(
+        "reviewer",
+        REVIEWER_ENTRY,
+        &project_root,
+        &options.ts_agent_command,
+        &rt_url,
+    ) {
+        out.push(proc);
+    }
+    if let Some(proc) = try_spawn_ts_agent(
+        "classifier",
+        CLASSIFIER_ENTRY,
+        &project_root,
+        &options.ts_agent_command,
+        &rt_url,
+    ) {
+        out.push(proc);
+    }
+    out
+}
+
+fn resolve_project_root(options: &RuntimeStartOptions) -> PathBuf {
+    if let Some(path) = &options.ts_agent_workdir {
+        return path.clone();
+    }
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .and_then(|path| path.parent())
+        .map(|path| path.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn try_spawn_ts_agent(
+    name: &str,
+    entry: &str,
+    project_root: &PathBuf,
+    cmd: &str,
+    rt_url: &str,
+) -> Option<TsAgentProcess> {
+    let mut command = Command::new(cmd);
+    command
+        .arg("run")
+        .arg(entry)
+        .current_dir(project_root)
+        .env("EXOMIND_RT_URL", rt_url)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    match command.spawn() {
+        Ok(child) => Some(TsAgentProcess {
+            name: name.to_string(),
+            child,
+        }),
+        Err(error) => {
+            eprintln!("exomind-rt: failed to spawn ts agent `{name}`: {error}");
+            None
+        }
     }
 }
 

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -126,10 +126,21 @@ struct TsAgentProcess {
 /// Runtime handle（运行句柄）.
 pub struct RuntimeHandle {
     local_addr: SocketAddr,
+    signal_pool: Arc<SignalPool>,
     shutdown_tx: Option<oneshot::Sender<()>>,
     server_task: Option<JoinHandle<std::io::Result<()>>>,
     actor_tasks: Vec<JoinHandle<()>>,
     ts_agents: Vec<TsAgentProcess>,
+}
+
+/// Publish request for in-process fast path（进程内快速发布请求）.
+#[derive(Debug, Clone)]
+pub struct RuntimePublishRequest {
+    pub topic: String,
+    pub source: Option<String>,
+    pub payload: serde_json::Value,
+    pub trace_id: Option<String>,
+    pub origin_host_id: Option<String>,
 }
 
 impl RuntimeHandle {
@@ -143,6 +154,33 @@ impl RuntimeHandle {
 
     pub fn port(&self) -> u16 {
         self.local_addr.port()
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.server_task
+            .as_ref()
+            .map(|task| !task.is_finished())
+            .unwrap_or(false)
+    }
+
+    /// Publish a signal directly via in-process SignalPool（进程内直发）.
+    pub fn publish_signal(&self, request: RuntimePublishRequest) -> String {
+        let event_id = uuid::Uuid::new_v4().to_string();
+        let event = signal::types::SignalEvent {
+            schema_version: 1,
+            id: event_id.clone(),
+            topic: request.topic,
+            ts: chrono::Utc::now().timestamp_millis() as u64,
+            source: request.source.unwrap_or_else(|| "tauri:invoke".to_string()),
+            origin_host_id: request
+                .origin_host_id
+                .unwrap_or_else(|| "local".to_string()),
+            hop: 0,
+            trace_id: request.trace_id,
+            payload: request.payload,
+        };
+        self.signal_pool.publish(event);
+        event_id
     }
 
     /// Graceful shutdown（优雅停止）.
@@ -240,6 +278,7 @@ pub async fn start_with_options(
         .map_err(RuntimeStartError::ReadLocalAddr)?;
 
     let state = AppState::new(local_addr.port());
+    let signal_pool = Arc::clone(&state.signal_pool);
 
     let mut actor_tasks = Vec::new();
     if options.spawn_builtin_actors {
@@ -269,6 +308,7 @@ pub async fn start_with_options(
 
     Ok(RuntimeHandle {
         local_addr,
+        signal_pool,
         shutdown_tx: Some(shutdown_tx),
         server_task: Some(server_task),
         actor_tasks,

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -80,7 +80,7 @@ impl Default for RuntimeStartOptions {
             spawn_ts_agents,
             ts_agent_command: env::var("EXOMIND_RT_AGENT_CMD")
                 .unwrap_or_else(|_| "bun".to_string()),
-            ts_agent_workdir: None,
+            ts_agent_workdir: env::var("EXOMIND_RT_AGENT_WORKDIR").ok().map(PathBuf::from),
         }
     }
 }
@@ -163,8 +163,16 @@ impl RuntimeHandle {
             .unwrap_or(false)
     }
 
-    /// Publish a signal directly via in-process SignalPool（进程内直发）.
-    pub fn publish_signal(&self, request: RuntimePublishRequest) -> String {
+    /// Clone underlying SignalPool Arc（克隆底层 SignalPool 引用）.
+    pub fn clone_signal_pool(&self) -> Arc<SignalPool> {
+        Arc::clone(&self.signal_pool)
+    }
+
+    /// Publish via a provided SignalPool（在指定 SignalPool 上发布）.
+    pub fn publish_signal_to_pool(
+        signal_pool: &SignalPool,
+        request: RuntimePublishRequest,
+    ) -> String {
         let event_id = uuid::Uuid::new_v4().to_string();
         let event = signal::types::SignalEvent {
             schema_version: 1,
@@ -179,8 +187,13 @@ impl RuntimeHandle {
             trace_id: request.trace_id,
             payload: request.payload,
         };
-        self.signal_pool.publish(event);
+        signal_pool.publish(event);
         event_id
+    }
+
+    /// Publish a signal directly via in-process SignalPool（进程内直发）.
+    pub fn publish_signal(&self, request: RuntimePublishRequest) -> String {
+        Self::publish_signal_to_pool(&self.signal_pool, request)
     }
 
     /// Graceful shutdown（优雅停止）.
@@ -285,13 +298,13 @@ pub async fn start_with_options(
         actor_tasks.push(signal::actors::task_actor::spawn_task_actor(Arc::clone(
             &state.signal_pool,
         )));
-        actor_tasks.push(signal::actors::eventlog_actor::spawn_eventlog_actor(Arc::clone(
-            &state.signal_pool,
-        )));
+        actor_tasks.push(signal::actors::eventlog_actor::spawn_eventlog_actor(
+            Arc::clone(&state.signal_pool),
+        ));
     }
 
     let ts_agents = if options.spawn_ts_agents {
-        spawn_default_ts_agents(local_addr.port(), &options).await
+        spawn_default_ts_agents(local_addr.port(), &options)
     } else {
         Vec::new()
     };
@@ -316,7 +329,7 @@ pub async fn start_with_options(
     })
 }
 
-async fn spawn_default_ts_agents(port: u16, options: &RuntimeStartOptions) -> Vec<TsAgentProcess> {
+fn spawn_default_ts_agents(port: u16, options: &RuntimeStartOptions) -> Vec<TsAgentProcess> {
     const REVIEWER_ENTRY: &str = "packages/ts-agent-cli/agents/reviewer/index.ts";
     const CLASSIFIER_ENTRY: &str = "packages/ts-agent-cli/agents/classifier/index.ts";
     let project_root = resolve_project_root(options);
@@ -349,6 +362,10 @@ fn resolve_project_root(options: &RuntimeStartOptions) -> PathBuf {
         return path.clone();
     }
 
+    if let Ok(cwd) = env::current_dir() {
+        return cwd;
+    }
+
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     manifest_dir
         .parent()
@@ -372,7 +389,7 @@ fn try_spawn_ts_agent(
         .env("EXOMIND_RT_URL", rt_url)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .stderr(Stdio::inherit());
 
     match command.spawn() {
         Ok(child) => Some(TsAgentProcess {
@@ -396,7 +413,13 @@ pub fn app_with_state(state: AppState) -> Router {
     // Enable CORS for browser-side host aggregation (允许浏览器跨端口访问 runtime).
     let cors = CorsLayer::new()
         .allow_origin(Any)
-        .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE, Method::OPTIONS])
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
         .allow_headers(Any);
 
     Router::new()

--- a/crates/exomind-runtime/src/main.rs
+++ b/crates/exomind-runtime/src/main.rs
@@ -1,30 +1,9 @@
-use std::net::SocketAddr;
-use std::sync::Arc;
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let port = exomind_runtime::configured_port_from_env()?;
+    let mut handle = exomind_runtime::start().await?;
+    println!("exomind-rt listening on http://{}", handle.local_addr());
 
-    // 支持环境变量 EXOMIND_RT_BIND 指定绑定地址，默认 127.0.0.1
-    // 例如：EXOMIND_RT_BIND=0.0.0.0 允许局域网访问
-    let bind_host = std::env::var("EXOMIND_RT_BIND").unwrap_or_else(|_| "127.0.0.1".to_string());
-    let bind_addr: SocketAddr = format!("{bind_host}:{port}").parse()?;
-
-    let listener = tokio::net::TcpListener::bind(bind_addr).await?;
-    let local_addr = listener.local_addr()?;
-
-    let state = exomind_runtime::AppState::new(local_addr.port());
-
-    // Spawn in-process actors
-    let _task_actor = exomind_runtime::signal::actors::task_actor::spawn_task_actor(
-        Arc::clone(&state.signal_pool),
-    );
-    let _eventlog_actor = exomind_runtime::signal::actors::eventlog_actor::spawn_eventlog_actor(
-        Arc::clone(&state.signal_pool),
-    );
-
-    println!("exomind-rt listening on http://{local_addr}");
-
-    axum::serve(listener, exomind_runtime::app_with_state(state)).await?;
+    tokio::signal::ctrl_c().await?;
+    handle.stop().await?;
     Ok(())
 }

--- a/crates/exomind-runtime/tests/runtime_startup.rs
+++ b/crates/exomind-runtime/tests/runtime_startup.rs
@@ -1,0 +1,53 @@
+//! runtime_startup.rs - Runtime startup contract tests（运行时启动契约测试）
+//!
+//! TDD RED phase:
+//! - default port should be 1949（默认端口应为 1949）
+//! - port=0 means random assign（端口 0 表示随机分配）
+//! - runtime can start/stop via lib API（可通过库 API 启停）
+
+use exomind_runtime::{
+    configured_port_from_env, start_with_options, RuntimeStartOptions, DEFAULT_RT_PORT,
+};
+use std::sync::Mutex;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+#[test]
+fn configured_port_defaults_to_1949_when_env_missing() {
+    let _guard = ENV_LOCK.lock().expect("env lock should be available");
+    // SAFETY: tests guard env mutation with a global mutex（用全局锁保护环境变量修改）
+    unsafe {
+        std::env::remove_var("EXOMIND_RT_PORT");
+    }
+    let port = configured_port_from_env().expect("port should parse");
+    assert_eq!(port, DEFAULT_RT_PORT);
+    assert_eq!(port, 1949);
+}
+
+#[test]
+fn configured_port_accepts_zero_for_random_assignment() {
+    let _guard = ENV_LOCK.lock().expect("env lock should be available");
+    // SAFETY: tests guard env mutation with a global mutex（用全局锁保护环境变量修改）
+    unsafe {
+        std::env::set_var("EXOMIND_RT_PORT", "0");
+    }
+    let port = configured_port_from_env().expect("port should parse");
+    assert_eq!(port, 0);
+}
+
+#[tokio::test]
+async fn start_with_port_zero_binds_a_random_available_port() {
+    let mut handle = start_with_options(RuntimeStartOptions {
+        bind_host: "127.0.0.1".to_string(),
+        port: 0,
+        spawn_ts_agents: false,
+        ..Default::default()
+    })
+    .await
+    .expect("runtime should start");
+
+    assert!(handle.port() > 0);
+    assert_eq!(handle.host(), "127.0.0.1");
+
+    handle.stop().await.expect("runtime should stop");
+}

--- a/crates/exomind-runtime/tests/runtime_ts_agents.rs
+++ b/crates/exomind-runtime/tests/runtime_ts_agents.rs
@@ -1,0 +1,112 @@
+//! runtime_ts_agents.rs - TS agent autostart integration（TS Agent 自启动集成测试）
+
+use exomind_runtime::{RuntimeStartOptions, start_with_options};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn make_temp_root(prefix: &str) -> PathBuf {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}-{now}-{}", std::process::id()))
+}
+
+fn write_agent_script(path: &PathBuf, suffix: &str) {
+    let content = format!(
+        r#"
+import {{ writeFileSync }} from "node:fs";
+const marker = process.env["EXOMIND_RT_AGENT_MARKER"];
+const rtUrl = process.env["EXOMIND_RT_URL"] ?? "";
+if (marker) {{
+  writeFileSync(`${{marker}}-{suffix}.txt`, rtUrl, "utf-8");
+}}
+setInterval(() => {{}}, 500);
+"#
+    );
+    fs::write(path, content).expect("should write agent script");
+}
+
+async fn wait_until_file_exists(path: &PathBuf, timeout_ms: u64) -> bool {
+    let started = std::time::Instant::now();
+    while started.elapsed() < Duration::from_millis(timeout_ms) {
+        if path.exists() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    false
+}
+
+#[tokio::test]
+async fn runtime_spawns_reviewer_and_classifier_with_rt_url() {
+    let _guard = ENV_LOCK.lock().expect("env lock should be available");
+
+    let root = make_temp_root("rt-ts-agents");
+    let reviewer = root.join("packages/ts-agent-cli/agents/reviewer/index.ts");
+    let classifier = root.join("packages/ts-agent-cli/agents/classifier/index.ts");
+    fs::create_dir_all(
+        reviewer
+            .parent()
+            .expect("reviewer parent should exist"),
+    )
+    .expect("should create reviewer directory");
+    fs::create_dir_all(
+        classifier
+            .parent()
+            .expect("classifier parent should exist"),
+    )
+    .expect("should create classifier directory");
+    write_agent_script(&reviewer, "reviewer");
+    write_agent_script(&classifier, "classifier");
+
+    let marker_base = root.join("marker").to_string_lossy().to_string();
+    // SAFETY: tests guard env mutation with a global mutex（用全局锁保护环境变量修改）
+    unsafe {
+        std::env::set_var("EXOMIND_RT_AGENT_MARKER", &marker_base);
+    }
+
+    let mut handle = start_with_options(RuntimeStartOptions {
+        bind_host: "127.0.0.1".to_string(),
+        port: 0,
+        spawn_builtin_actors: false,
+        spawn_ts_agents: true,
+        ts_agent_command: "bun".to_string(),
+        ts_agent_workdir: Some(root.clone()),
+    })
+    .await
+    .expect("runtime should start with ts agents");
+
+    let expected_url = format!("http://127.0.0.1:{}", handle.port());
+    let reviewer_marker = PathBuf::from(format!("{marker_base}-reviewer.txt"));
+    let classifier_marker = PathBuf::from(format!("{marker_base}-classifier.txt"));
+
+    assert!(
+        wait_until_file_exists(&reviewer_marker, 8_000).await,
+        "reviewer marker should be created"
+    );
+    assert!(
+        wait_until_file_exists(&classifier_marker, 8_000).await,
+        "classifier marker should be created"
+    );
+
+    let reviewer_url =
+        fs::read_to_string(&reviewer_marker).expect("should read reviewer marker content");
+    let classifier_url =
+        fs::read_to_string(&classifier_marker).expect("should read classifier marker content");
+    assert_eq!(reviewer_url, expected_url);
+    assert_eq!(classifier_url, expected_url);
+
+    handle.stop().await.expect("runtime should stop cleanly");
+
+    // SAFETY: tests guard env mutation with a global mutex（用全局锁保护环境变量修改）
+    unsafe {
+        std::env::remove_var("EXOMIND_RT_AGENT_MARKER");
+    }
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/docs/plans/2026-03-04-m1-embedded-runtime-pr-comment.md
+++ b/docs/plans/2026-03-04-m1-embedded-runtime-pr-comment.md
@@ -1,0 +1,38 @@
+## M1 方案确认（exomind-runtime 内嵌 Tauri）
+
+### 一、目标（Goal，目标）
+- 将 `exomind-runtime` 从外部 Bun 进程改为 Tauri 进程内嵌（in-process runtime，进程内运行时）。
+- `SignalPool` 在 Tauri 进程内运行，前端能力保持可用，优先保障桌面端验证链路。
+- 保持可替换传输层（transport channel，可替换通道）：`invoke` 高频优先，HTTP 可降级。
+
+### 二、关键决策（Decisions，决策）
+- **默认 RT 端口**：`1947`（支持 `EXOMIND_RT_PORT=0` 随机端口）。
+- **M1.1**：`crates/exomind-runtime` 保持 `lib.rs` 为核心导出，`main.rs` 仅作为 thin wrapper（薄包装）。
+- **M1.2**：`src-tauri/src/lib.rs` 的 `setup()` 中自动启动 RT（`tokio::spawn`）。
+- **M1.3**：默认加入 `invoke` 高频桥接（如 signal publish），并保留 HTTP fallback（降级）。
+- **M1.4**：RT 启动后自动拉起 TS Agent 子进程：`reviewer` + `classifier`，并注入 `EXOMIND_RT_URL`。
+
+### 三、验收链路（Acceptance Chain，验收路径）
+1. 启动桌面端：
+   - `cargo tauri dev`
+2. 验证健康检查：
+   - `curl http://127.0.0.1:1947/health` 返回 `status=ok`
+3. 验证 SignalPool：
+   - publish → route → SSE/history 可观测
+4. 验证回归：
+   - `cargo test -p exomind-runtime`
+   - `bun run build`
+   - 相关 Vitest/Playwright 用例通过
+5. 验证前端功能不回退：
+   - EventLog / Tasks / Agent Chat 可正常使用
+
+### 四、风险与降级（Risk & Fallback，风险与降级）
+- 若内嵌复杂度超预期（截止 14:00 未跑通）：
+  - 降级为 Tauri spawn `exomind-rt.exe` 二进制（不再依赖 Bun server 脚本）。
+  - 前端接口保持兼容，确保本轮可交付。
+
+### 五、提交与评审策略（Commit & Review，提交与评审）
+- 按 TDD 执行：先失败测试（RED）→ 最小实现（GREEN）→ 重构（REFACTOR）。
+- 每个任务一个独立 commit（便于 PR squash merge）。
+- 每个里程碑输出测试证据与评审结论，并同步到 PR 评论。
+

--- a/docs/plans/2026-03-04-m1-embedded-runtime-pr-comment.md
+++ b/docs/plans/2026-03-04-m1-embedded-runtime-pr-comment.md
@@ -6,7 +6,7 @@
 - 保持可替换传输层（transport channel，可替换通道）：`invoke` 高频优先，HTTP 可降级。
 
 ### 二、关键决策（Decisions，决策）
-- **默认 RT 端口**：`1947`（支持 `EXOMIND_RT_PORT=0` 随机端口）。
+- **默认 RT 端口**：`1949`（支持 `EXOMIND_RT_PORT=0` 随机端口）。
 - **M1.1**：`crates/exomind-runtime` 保持 `lib.rs` 为核心导出，`main.rs` 仅作为 thin wrapper（薄包装）。
 - **M1.2**：`src-tauri/src/lib.rs` 的 `setup()` 中自动启动 RT（`tokio::spawn`）。
 - **M1.3**：默认加入 `invoke` 高频桥接（如 signal publish），并保留 HTTP fallback（降级）。
@@ -16,7 +16,7 @@
 1. 启动桌面端：
    - `cargo tauri dev`
 2. 验证健康检查：
-   - `curl http://127.0.0.1:1947/health` 返回 `status=ok`
+   - `curl http://127.0.0.1:1949/health` 返回 `status=ok`
 3. 验证 SignalPool：
    - publish → route → SSE/history 可观测
 4. 验证回归：
@@ -35,4 +35,5 @@
 - 按 TDD 执行：先失败测试（RED）→ 最小实现（GREEN）→ 重构（REFACTOR）。
 - 每个任务一个独立 commit（便于 PR squash merge）。
 - 每个里程碑输出测试证据与评审结论，并同步到 PR 评论。
+
 

--- a/docs/plans/2026-03-04-m1-embedded-runtime-tauri-plan.md
+++ b/docs/plans/2026-03-04-m1-embedded-runtime-tauri-plan.md
@@ -1,0 +1,415 @@
+# M1 Embedded Runtime in Tauri Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 把 `exomind-runtime` 从外部进程模式改成 Tauri 进程内嵌运行（in-process runtime，进程内运行时），并交付 `invoke 高频桥接 + HTTP fallback（降级）`。
+
+**Architecture:** `crates/exomind-runtime` 提供可复用 `lib` 启动入口（start API，启动接口）与句柄（handle，运行句柄）；`src-tauri` 在 `setup()` 内 `tokio::spawn` 启动 RT；前端保持现有 HTTP 调用链不破坏，同时新增 `invoke` 快速通道用于高频 publish。RT 默认端口统一为 `1947`，并允许 `port=0` 随机分配。
+
+**Tech Stack:** Rust (axum/tokio/tauri), TypeScript (React/Vitest/Playwright), Bun (TS Agent 子进程), GitHub CLI (`gh`)
+
+---
+
+## Scope / Non-Scope（范围 / 非范围）
+
+- Scope（本轮包含）
+  - M1.1 crate 重构为可复用 lib + thin `main.rs`
+  - M1.2 Tauri `setup()` 内嵌 RT 启动
+  - M1.3 `invoke` 高频桥接 + HTTP fallback
+  - M1.4 TS `reviewer + classifier` 随 RT 启动与退出
+  - 端口默认改为 `1947`（并支持随机端口）
+- Non-Scope（本轮不包含）
+  - 全面替换前端所有 HTTP 调用为 invoke（只改高频 publish）
+  - Web-only WASM 正式交付（仅保留兼容路径与后续接口）
+
+---
+
+### Task 1: Freeze Contracts + Baseline Verification（冻结契约与基线验证）
+
+**Files:**
+- Modify: `artifacts/pr-comments/2026-03-04-m1-plan-comment.md`
+- Modify: `docs/plans/2026-03-04-m1-embedded-runtime-tauri-plan.md`
+- Verify: `crates/exomind-runtime/`, `src-tauri/`, `src/lib/services/`
+
+**Step 1: Create plan comment markdown（先写方案评论）**
+
+```md
+## M1 方案与验收链路
+- 默认端口: 1947（可设置 0 随机）
+- 内嵌模式: Tauri setup() 启动 RT
+- 高频 publish: invoke 优先，HTTP 降级
+```
+
+**Step 2: Baseline tests before implementation（编码前基线测试）**
+
+Run:
+```powershell
+cargo test -p exomind-runtime
+bun run build
+```
+
+Expected:
+- 当前分支全部通过或记录明确失败点（若已有历史失败需注明与本任务无关）
+
+**Step 3: Commit plan artifacts**
+
+Run:
+```powershell
+git add docs/plans/2026-03-04-m1-embedded-runtime-tauri-plan.md artifacts/pr-comments/2026-03-04-m1-plan-comment.md
+git commit -m "docs: add M1 embedded runtime implementation plan and PR comment draft"
+```
+
+---
+
+### Task 2: Runtime lib entrypoint（Runtime 库入口）TDD
+
+**Files:**
+- Modify: `crates/exomind-runtime/src/lib.rs`
+- Modify: `crates/exomind-runtime/src/main.rs`
+- Create: `crates/exomind-runtime/tests/runtime_startup.test.rs`（若仓库命名风格要求可改名）
+- Modify: `crates/exomind-runtime/Cargo.toml`（必要时补 feature/deps）
+
+**Step 1: Write failing tests（先写失败测试）**
+
+Test targets:
+- `start_with_options()` 返回可观察句柄（startup handle，启动句柄）
+- 默认端口为 `1947`
+- `port=0` 时可随机端口，且可通过 `local_addr` 读取实际端口
+- actor（`task_actor` / `eventlog_actor`）随 runtime 启动
+
+**Step 2: Run test to verify RED（确认失败）**
+
+Run:
+```powershell
+cargo test -p exomind-runtime runtime_startup -- --nocapture
+```
+
+Expected:
+- FAIL，失败原因是 `start` API 尚未实现或行为不符
+
+**Step 3: Minimal implementation（最小实现）**
+
+Implementation outline:
+```rust
+pub struct RuntimeHandle { /* server task + actor task + ts agent process handles */ }
+pub struct RuntimeStartOptions { pub host: String, pub port: u16, ... }
+pub async fn start_with_options(opts: RuntimeStartOptions) -> Result<RuntimeHandle, RuntimeError>;
+```
+
+**Step 4: Re-run targeted tests（确认转绿）**
+
+Run:
+```powershell
+cargo test -p exomind-runtime runtime_startup -- --nocapture
+```
+
+Expected:
+- PASS
+
+**Step 5: Keep binary thin wrapper（保持 main 精简）**
+- `main.rs` 仅解析 env + 调 `start_with_options()` + `wait()`
+
+**Step 6: Commit**
+
+Run:
+```powershell
+git add crates/exomind-runtime/src/lib.rs crates/exomind-runtime/src/main.rs crates/exomind-runtime/tests/runtime_startup.test.rs crates/exomind-runtime/Cargo.toml
+git commit -m "feat(runtime): expose reusable start API and thin binary wrapper"
+```
+
+---
+
+### Task 3: Embed runtime in Tauri setup()（Tauri 内嵌启动）TDD
+
+**Files:**
+- Modify: `Cargo.toml`（workspace deps，可选）
+- Modify: `src-tauri/Cargo.toml`
+- Modify: `src-tauri/src/lib.rs`
+- Create/Modify: `src-tauri/src/runtime_embed.rs`（如需解耦）
+- Test: `tests/unit/tauri/runtime-commands.issue205.test.ts`（契约保持）
+
+**Step 1: Write failing Rust/TS tests（先写失败测试）**
+
+Test targets:
+- Tauri app `setup()` 会自动拉起 RT（无需调用 start command）
+- setup 后状态可读（host/port/running）
+
+**Step 2: Verify RED**
+
+Run:
+```powershell
+bun test tests/unit/tauri/runtime-commands.issue205.test.ts
+```
+
+Expected:
+- FAIL（旧行为是手动按钮启动）
+
+**Step 3: Implement setup embedding（实现 setup 内嵌）**
+- `src-tauri/Cargo.toml` 引入 `exomind-runtime`（workspace dependency，工作区依赖）
+- `setup()` 中 `tokio::spawn` 启动 runtime，默认 `127.0.0.1:1947`
+- 支持 `EXOMIND_RT_PORT=0` 随机端口，并把实际端口写入共享状态
+
+**Step 4: Verify GREEN**
+
+Run:
+```powershell
+bun test tests/unit/tauri/runtime-commands.issue205.test.ts
+```
+
+Expected:
+- PASS
+
+**Step 5: Commit**
+
+Run:
+```powershell
+git add Cargo.toml src-tauri/Cargo.toml src-tauri/src/lib.rs src-tauri/src/runtime_embed.rs tests/unit/tauri/runtime-commands.issue205.test.ts
+git commit -m "feat(tauri): start embedded exomind-runtime in setup hook"
+```
+
+---
+
+### Task 4: Replace runtime commands semantics（命令语义迁移）TDD
+
+**Files:**
+- Modify: `src-tauri/src/commands/runtime_commands.rs`
+- Modify: `src-tauri/src/lib.rs`
+- Modify: `src/lib/adapters/tauri-runtime-adapter.ts`
+- Modify: `src/lib/services/runtime-control.service.ts`（如需）
+- Modify: `tests/unit/services/runtime-control.service.issue205.test.ts`
+- Modify: `tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx`
+
+**Step 1: Write failing tests**
+
+Targets:
+- `runtime_service_start` 在内嵌模式下幂等（idempotent，重复调用不重复启动）
+- `runtime_service_status` 返回 setup 已启动状态
+- `runtime_service_stop` 可控关闭（仅桌面端）
+- 默认端口改为 `1947`
+
+**Step 2: Verify RED**
+
+Run:
+```powershell
+bun test tests/unit/services/runtime-control.service.issue205.test.ts tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx
+```
+
+**Step 3: Implement command migration**
+- 去掉 `spawn bun server/agent-runtime-server.js`
+- 命令改为控制/查询内嵌 runtime handle
+- 维持前端接口不变（API 兼容）
+
+**Step 4: Verify GREEN**
+
+Run:
+```powershell
+bun test tests/unit/services/runtime-control.service.issue205.test.ts tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx
+```
+
+**Step 5: Commit**
+
+Run:
+```powershell
+git add src-tauri/src/commands/runtime_commands.rs src-tauri/src/lib.rs src/lib/adapters/tauri-runtime-adapter.ts src/lib/services/runtime-control.service.ts tests/unit/services/runtime-control.service.issue205.test.ts tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx
+git commit -m "refactor(runtime): migrate runtime control commands to embedded mode"
+```
+
+---
+
+### Task 5: Invoke bridge + HTTP fallback（高频桥接 + 降级）TDD
+
+**Files:**
+- Modify: `src-tauri/src/commands/mod.rs`
+- Create: `src-tauri/src/commands/signal_commands.rs`
+- Modify: `src-tauri/src/lib.rs`
+- Modify: `src/lib/services/signal-stream.service.ts`
+- Modify: `src/lib/services/timeblock.service.ts`
+- Test: `tests/unit/services/signal-stream.service.test.ts`
+
+**Step 1: Write failing tests**
+
+Targets:
+- 在 Tauri 环境优先 `invoke('signal_publish_fast')`
+- invoke 失败时自动 fallback 到 HTTP `POST /signals/publish`
+- 非 Tauri 环境保持 HTTP 行为
+
+**Step 2: Verify RED**
+
+Run:
+```powershell
+bun test tests/unit/services/signal-stream.service.test.ts
+```
+
+**Step 3: Implement minimal bridge**
+- Rust command 直接调用 `signal_pool.publish`
+- TS publish 流程：`invoke -> catch -> fetch`
+
+**Step 4: Verify GREEN**
+
+Run:
+```powershell
+bun test tests/unit/services/signal-stream.service.test.ts
+```
+
+**Step 5: Commit**
+
+Run:
+```powershell
+git add src-tauri/src/commands/mod.rs src-tauri/src/commands/signal_commands.rs src-tauri/src/lib.rs src/lib/services/signal-stream.service.ts src/lib/services/timeblock.service.ts tests/unit/services/signal-stream.service.test.ts
+git commit -m "feat(signal): add invoke fast-path with HTTP fallback for publish"
+```
+
+---
+
+### Task 6: TS agents auto-spawn with runtime（TS Agent 自启动）TDD
+
+**Files:**
+- Modify: `crates/exomind-runtime/src/lib.rs`（或拆到 `runtime/agents.rs`）
+- Modify: `packages/ts-agent-cli/agents/classifier/index.ts`（默认端口文案）
+- Modify: `packages/ts-agent-cli/agents/reviewer/index.ts`（默认端口文案）
+- Create/Modify: `crates/exomind-runtime/tests/runtime_agents_spawn.test.rs`
+
+**Step 1: Write failing tests**
+
+Targets:
+- runtime 启动时 spawn `classifier` + `reviewer`
+- 进程环境变量带 `EXOMIND_RT_URL=http://127.0.0.1:<port>`
+- runtime 停止时子进程同步退出
+
+**Step 2: Verify RED**
+
+Run:
+```powershell
+cargo test -p exomind-runtime runtime_agents_spawn -- --nocapture
+```
+
+**Step 3: Implement spawn/teardown**
+- `tokio::process::Command` 拉起 Bun 子进程
+- 进程句柄纳入 `RuntimeHandle`
+- 失败隔离（spawn 一个失败不应导致主服务崩溃）
+
+**Step 4: Verify GREEN**
+
+Run:
+```powershell
+cargo test -p exomind-runtime runtime_agents_spawn -- --nocapture
+```
+
+**Step 5: Commit**
+
+Run:
+```powershell
+git add crates/exomind-runtime/src/lib.rs crates/exomind-runtime/tests/runtime_agents_spawn.test.rs packages/ts-agent-cli/agents/classifier/index.ts packages/ts-agent-cli/agents/reviewer/index.ts
+git commit -m "feat(runtime): auto-spawn reviewer and classifier with embedded runtime"
+```
+
+---
+
+### Task 7: End-to-end verification + PR update（端到端验收 + PR 更新）
+
+**Files:**
+- Modify: `artifacts/pr-comments/2026-03-04-m1-test-evidence.md`
+- Modify: `artifacts/pr-comments/2026-03-04-m1-review-result.md`
+- Modify: `README.md` / `docs/development/*.md`（如端口或运行命令有变化）
+
+**Step 1: Run required verification chain**
+
+Run:
+```powershell
+cargo test -p exomind-runtime
+bun test tests/unit/tauri/runtime-commands.issue205.test.ts
+bun test tests/unit/services/runtime-control.service.issue205.test.ts
+bun test tests/unit/services/signal-stream.service.test.ts
+bun run build
+```
+
+Expected:
+- 全部通过；若有非本任务失败项，列入 PR comment 的 “Known Issues（已知问题）”
+
+**Step 2: Desktop runtime smoke（桌面端冒烟）**
+
+Run:
+```powershell
+cargo tauri dev
+curl http://127.0.0.1:1947/health
+curl http://127.0.0.1:1947/signals/history?limit=1
+```
+
+Expected:
+- `health` 返回 `status=ok`
+- SignalPool 接口可用
+
+**Step 3: Playwright validation（在用户启动 dev server 后执行）**
+
+Run:
+```powershell
+bunx playwright test -c tests/e2e/playwright.signal-pool.config.ts
+```
+
+**Step 4: PR comment + description update**
+
+Run:
+```powershell
+gh pr comment <PR_NUMBER> --body-file artifacts/pr-comments/2026-03-04-m1-test-evidence.md
+gh pr comment <PR_NUMBER> --body-file artifacts/pr-comments/2026-03-04-m1-review-result.md
+gh pr edit <PR_NUMBER> --body-file artifacts/pr-comments/2026-03-04-m1-pr-description.md
+```
+
+**Step 5: Request review and record review result**
+- 发起代码评审（code review，代码审查）
+- 修复 Critical/Important 问题后再次附证据
+
+**Step 6: Final commit(s)**
+
+Run:
+```powershell
+git add artifacts/pr-comments README.md docs/development
+git commit -m "docs: add M1 verification evidence and review summary"
+```
+
+---
+
+## Runtime Env + Startup Commands（运行环境变量与启动命令）
+
+### Desktop preferred validation（桌面端优先）
+
+```powershell
+# Runtime (RT) default port（默认端口）
+$env:EXOMIND_RT_PORT='1947'
+$env:EXOMIND_RT_BIND='127.0.0.1'
+
+# Optional random port（随机端口，可选）
+# $env:EXOMIND_RT_PORT='0'
+
+# TS agent runtime URL（供 reviewer/classifier 使用）
+$env:EXOMIND_RT_URL='http://127.0.0.1:1947'
+
+# Start desktop app
+cargo tauri dev
+```
+
+### Web mode note（Web 模式说明）
+
+- 本轮优先验证桌面端。
+- Web-only 路径后续可通过 WASM/runtime adapter 演进；本轮保持 HTTP 路由兼容，不阻塞 UI Summary 信号链路。
+
+---
+
+## Rollback / Downgrade（降级方案）
+
+若 14:00 前内嵌链路仍不稳定：
+- 启用降级：Tauri 侧改为 spawn `exomind-rt.exe`（不再 spawn Bun JS server）。
+- 仍保留同一 API 契约：`/health`, `/signals/*`, `/agents/*`，确保前端与测试不改或少改。
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/plans/2026-03-04-m1-embedded-runtime-tauri-plan.md`.  
+Two execution options:
+
+1. **Subagent-Driven (this session)** - I dispatch fresh subagent per task, review between tasks, fast iteration.
+2. **Parallel Session (separate)** - Open new session with executing-plans, batch execution with checkpoints.
+
+Which approach?
+

--- a/docs/plans/2026-03-04-m1-embedded-runtime-tauri-plan.md
+++ b/docs/plans/2026-03-04-m1-embedded-runtime-tauri-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** 把 `exomind-runtime` 从外部进程模式改成 Tauri 进程内嵌运行（in-process runtime，进程内运行时），并交付 `invoke 高频桥接 + HTTP fallback（降级）`。
 
-**Architecture:** `crates/exomind-runtime` 提供可复用 `lib` 启动入口（start API，启动接口）与句柄（handle，运行句柄）；`src-tauri` 在 `setup()` 内 `tokio::spawn` 启动 RT；前端保持现有 HTTP 调用链不破坏，同时新增 `invoke` 快速通道用于高频 publish。RT 默认端口统一为 `1947`，并允许 `port=0` 随机分配。
+**Architecture:** `crates/exomind-runtime` 提供可复用 `lib` 启动入口（start API，启动接口）与句柄（handle，运行句柄）；`src-tauri` 在 `setup()` 内 `tokio::spawn` 启动 RT；前端保持现有 HTTP 调用链不破坏，同时新增 `invoke` 快速通道用于高频 publish。RT 默认端口统一为 `1949`，并允许 `port=0` 随机分配。
 
 **Tech Stack:** Rust (axum/tokio/tauri), TypeScript (React/Vitest/Playwright), Bun (TS Agent 子进程), GitHub CLI (`gh`)
 
@@ -17,7 +17,7 @@
   - M1.2 Tauri `setup()` 内嵌 RT 启动
   - M1.3 `invoke` 高频桥接 + HTTP fallback
   - M1.4 TS `reviewer + classifier` 随 RT 启动与退出
-  - 端口默认改为 `1947`（并支持随机端口）
+  - 端口默认改为 `1949`（并支持随机端口）
 - Non-Scope（本轮不包含）
   - 全面替换前端所有 HTTP 调用为 invoke（只改高频 publish）
   - Web-only WASM 正式交付（仅保留兼容路径与后续接口）
@@ -35,7 +35,7 @@
 
 ```md
 ## M1 方案与验收链路
-- 默认端口: 1947（可设置 0 随机）
+- 默认端口: 1949（可设置 0 随机）
 - 内嵌模式: Tauri setup() 启动 RT
 - 高频 publish: invoke 优先，HTTP 降级
 ```
@@ -73,7 +73,7 @@ git commit -m "docs: add M1 embedded runtime implementation plan and PR comment 
 
 Test targets:
 - `start_with_options()` 返回可观察句柄（startup handle，启动句柄）
-- 默认端口为 `1947`
+- 默认端口为 `1949`
 - `port=0` 时可随机端口，且可通过 `local_addr` 读取实际端口
 - actor（`task_actor` / `eventlog_actor`）随 runtime 启动
 
@@ -146,7 +146,7 @@ Expected:
 
 **Step 3: Implement setup embedding（实现 setup 内嵌）**
 - `src-tauri/Cargo.toml` 引入 `exomind-runtime`（workspace dependency，工作区依赖）
-- `setup()` 中 `tokio::spawn` 启动 runtime，默认 `127.0.0.1:1947`
+- `setup()` 中 `tokio::spawn` 启动 runtime，默认 `127.0.0.1:1949`
 - 支持 `EXOMIND_RT_PORT=0` 随机端口，并把实际端口写入共享状态
 
 **Step 4: Verify GREEN**
@@ -185,7 +185,7 @@ Targets:
 - `runtime_service_start` 在内嵌模式下幂等（idempotent，重复调用不重复启动）
 - `runtime_service_status` 返回 setup 已启动状态
 - `runtime_service_stop` 可控关闭（仅桌面端）
-- 默认端口改为 `1947`
+- 默认端口改为 `1949`
 
 **Step 2: Verify RED**
 
@@ -331,8 +331,8 @@ Expected:
 Run:
 ```powershell
 cargo tauri dev
-curl http://127.0.0.1:1947/health
-curl http://127.0.0.1:1947/signals/history?limit=1
+curl http://127.0.0.1:1949/health
+curl http://127.0.0.1:1949/signals/history?limit=1
 ```
 
 Expected:
@@ -375,14 +375,14 @@ git commit -m "docs: add M1 verification evidence and review summary"
 
 ```powershell
 # Runtime (RT) default port（默认端口）
-$env:EXOMIND_RT_PORT='1947'
+$env:EXOMIND_RT_PORT='1949'
 $env:EXOMIND_RT_BIND='127.0.0.1'
 
 # Optional random port（随机端口，可选）
 # $env:EXOMIND_RT_PORT='0'
 
 # TS agent runtime URL（供 reviewer/classifier 使用）
-$env:EXOMIND_RT_URL='http://127.0.0.1:1947'
+$env:EXOMIND_RT_URL='http://127.0.0.1:1949'
 
 # Start desktop app
 cargo tauri dev
@@ -412,4 +412,5 @@ Two execution options:
 2. **Parallel Session (separate)** - Open new session with executing-plans, batch execution with checkpoints.
 
 Which approach?
+
 

--- a/docs/plans/2026-03-04-m1-final-pr-comment.md
+++ b/docs/plans/2026-03-04-m1-final-pr-comment.md
@@ -1,0 +1,92 @@
+## M1 完成汇报：exomind-runtime 内嵌 Tauri（含评审闭环）
+
+### 1. 方案与实现范围（Plan → Execute）
+- M1.1：`exomind-runtime` 完成 lib 化，`main.rs` 变 thin wrapper。
+- M1.2：Tauri `setup()` 自动内嵌启动 Runtime，替代外部 bun 子进程启动链路。
+- M1.3：新增 `invoke` 高频通道 `signal_publish_fast`，保留 HTTP fallback。
+- M1.4：Runtime 启动后自动拉起 TS agents（reviewer/classifier）。
+- 端口策略：默认 `1949`；`EXOMIND_RT_PORT=0` 允许随机端口（auto port）。
+
+### 2. 关键提交（按里程碑）
+- `29b9696` feat(runtime): add reusable startup API and default port 1949
+- `5931edb` feat(tauri): embed runtime with invoke fast publish and port 1949 defaults
+- `433759c` docs(plan): align M1 runtime default port to 1949
+- `6334f51` fix(tauri): honor RT env defaults and harden embedded runtime start race
+- `592e14d` fix(runtime): address review findings for fast publish and agent startup
+
+### 3. 自动化测试证据（Verification）
+已执行并通过：
+
+```powershell
+cargo test -p exomind-runtime
+cargo check -p exomind
+bun run test -- tests/unit/tauri/runtime-embedded.m1.test.ts tests/unit/services/signal-stream-fast-publish.m1.test.ts tests/unit/tauri/runtime-commands.issue205.test.ts tests/unit/services/runtime-control.service.issue205.test.ts tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
+bun run build
+```
+
+结果摘要：
+- Rust runtime 测试：`88 passed, 0 failed`
+- Tauri crate check：通过
+- 相关 Vitest：`17 passed, 0 failed`
+- 前端构建：通过
+
+### 4. 桌面端实测证据（cargo tauri dev）
+验证链路：
+1. 启动 `cargo tauri dev --no-watch`
+2. `GET http://127.0.0.1:1949/health` 返回 `{"status":"ok","version":"0.1.0"}`
+3. `POST /signals/publish` 返回 `accepted=true`
+4. 关闭进程后再次访问 health，确认端口下线（`POST_STOP_HEALTH=down`）
+
+### 5. Playwright 自动化
+通过（与信号池链路直接相关）：
+
+```powershell
+# 启动 exomind-rt 后执行
+bunx playwright test tests/e2e/signal-pool-classification.test.ts --config playwright.config.ts --reporter=line
+```
+
+结果：`4 passed`
+
+已记录的现有失败（非本次 M1 新增）：
+- `bun run test:e2e:issue204`：1/3 fail（断言文案 `从市场安装` 不存在）
+- `bun run test:e2e:issue205`：1/1 fail（`page.goto('/agents')` 超时）
+
+### 6. Subagent 评审结果与修复
+已使用子代理做审查（`sonnet` + `gpt-5.1`），审查重点为生命周期、并发、端口一致性、快速通道可靠性。
+
+子代理重点意见（已修复）：
+- `signal_publish_fast` 持锁过久（高频发布串行化风险）
+  - 修复：提取 `SignalPool` clone 后释放锁再发布（`592e14d`）
+- `setup()` 路径写死导致 env 覆盖（`EXOMIND_RT_PORT=0` 无法生效）
+  - 修复：`setup()` 改为 `ensure_runtime_started(None, None)`，遵循 env/default（`6334f51`）
+- 并发启动竞争（start race）误报失败
+  - 修复：启动失败后加短轮询重查运行状态（`6334f51` / `592e14d`）
+- TS agent 目录与日志可观测性
+  - 修复：支持 `EXOMIND_RT_AGENT_WORKDIR`，默认回退 `current_dir`；agent `stderr` 改为 `inherit`（`592e14d`）
+
+当前结论：
+- M1 验收主链路已跑通，未发现阻塞本里程碑合并的问题。
+
+### 7. 手工复测命令（给 Reviewer / QA）
+```powershell
+# 可选：显式指定（默认就是 1949）
+$env:EXOMIND_RT_PORT='1949'
+$env:EXOMIND_RT_BIND='127.0.0.1'
+$env:EXOMIND_RT_URL='http://127.0.0.1:1949'
+
+# 可选：随机端口模式（0=random）
+# $env:EXOMIND_RT_PORT='0'
+
+# 可选：TS agent 工作目录（建议在桌面调试时设置）
+$env:EXOMIND_RT_AGENT_WORKDIR='D:\project\exomind'
+
+# 启动桌面端（自动内嵌 RT）
+cargo tauri dev --no-watch
+
+# 健康检查（默认端口）
+curl http://127.0.0.1:1949/health
+
+# 发布信号
+curl -X POST http://127.0.0.1:1949/signals/publish -H "Content-Type: application/json" -d "{\"topic\":\"manual.smoke\",\"source\":\"qa\",\"payload\":{\"text\":\"hello\"}}"
+```
+

--- a/docs/plans/2026-03-04-m1-review-followup-comment.md
+++ b/docs/plans/2026-03-04-m1-review-followup-comment.md
@@ -1,0 +1,32 @@
+## M1 评审闭环补充（Subagent Review Follow-up）
+
+### 初审结论（子代理）
+- 子代理初审指出的高优先项：
+  1. `signal_publish_fast` 持锁范围过大（高频串行化风险）
+  2. `setup()` 固定 host/port，覆盖 env（`EXOMIND_RT_PORT=0` 语义不生效）
+  3. 并发启动竞争下可能误报失败（start race）
+  4. TS agent 启动目录与日志可观测性不足
+
+### 已修复提交
+- `6334f51`：`setup` 改为 `ensure_runtime_started(None, None)`，遵循 env/default；补充启动竞争重查逻辑
+- `592e14d`：快速发布改为先 clone `SignalPool` 再发布（缩小锁范围）；支持 `EXOMIND_RT_AGENT_WORKDIR`；`stderr` 继承便于诊断
+
+### 复核结果（合并门禁）
+- 复核结论：**未发现阻塞合并问题**（M1 范围内）。
+- 残余风险（非阻塞）：
+  - 现有 `issue204/issue205` Playwright 用例仍有历史性失败，需要单独 issue 处理；
+  - 端口常量在 TS 侧仍可进一步收敛为单一常量源（技术债优化项）。
+
+### 复核后再验证（已执行）
+```powershell
+cargo test -p exomind-runtime
+cargo check -p exomind
+bun run test -- tests/unit/tauri/runtime-embedded.m1.test.ts tests/unit/services/signal-stream-fast-publish.m1.test.ts tests/unit/tauri/runtime-commands.issue205.test.ts tests/unit/services/runtime-control.service.issue205.test.ts tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
+bun run build
+```
+
+以及桌面端启动链路：
+- `cargo tauri dev --no-watch` → `http://127.0.0.1:1949/health` 返回 OK
+- publish 成功
+- 关闭后端口下线
+

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,4 +39,5 @@ rand = "0.8"
 uuid = { version = "1", features = ["v4", "serde"] }
 tauri-plugin-mcp-bridge= "0.8"
 thiserror = "1"
+exomind-runtime = { path = "../crates/exomind-runtime" }
 

--- a/src-tauri/src/commands/runtime_commands.rs
+++ b/src-tauri/src/commands/runtime_commands.rs
@@ -8,6 +8,7 @@ use exomind_runtime::{
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
 use tauri::State;
+use tokio::time::{sleep, Duration};
 
 struct RuntimeInner {
     handle: Option<RuntimeHandle>,
@@ -148,10 +149,13 @@ pub async fn ensure_runtime_started(
         Ok(handle) => handle,
         Err(error) => {
             // Handle startup race gracefully（处理并发启动竞争）.
-            if let Ok(status) = runtime_status_snapshot(state.clone()) {
-                if status.running {
-                    return Ok(status);
+            for _ in 0..10 {
+                if let Ok(status) = runtime_status_snapshot(state.clone()) {
+                    if status.running {
+                        return Ok(status);
+                    }
                 }
+                sleep(Duration::from_millis(25)).await;
             }
 
             let message = format!("failed to start embedded runtime: {error}");
@@ -175,11 +179,7 @@ pub async fn ensure_runtime_started(
 pub async fn ensure_runtime_stopped(
     state: Arc<RuntimeProcessState>,
 ) -> Result<RuntimeServiceStatus, String> {
-    let mut handle = {
-        let mut inner = lock_or_error(&state)?;
-        inner.started_at = None;
-        inner.handle.take()
-    };
+    let mut handle = { lock_or_error(&state)?.handle.take() };
 
     if let Some(runtime) = handle.as_mut() {
         runtime
@@ -243,22 +243,28 @@ pub fn signal_publish_fast(
     state: State<'_, Arc<RuntimeProcessState>>,
     request: SignalPublishFastRequest,
 ) -> Result<SignalPublishFastResponse, String> {
-    let inner = lock_or_error(state.inner())?;
-    let handle = inner
-        .handle
-        .as_ref()
-        .ok_or_else(|| "embedded runtime not running".to_string())?;
-    if !handle.is_running() {
-        return Err("embedded runtime is not running".to_string());
-    }
+    let signal_pool = {
+        let inner = lock_or_error(state.inner())?;
+        let handle = inner
+            .handle
+            .as_ref()
+            .ok_or_else(|| "embedded runtime not running".to_string())?;
+        if !handle.is_running() {
+            return Err("embedded runtime is not running".to_string());
+        }
+        handle.clone_signal_pool()
+    };
 
-    let event_id = handle.publish_signal(RuntimePublishRequest {
-        topic: request.topic,
-        source: request.source,
-        payload: request.payload,
-        trace_id: request.trace_id,
-        origin_host_id: request.origin_host_id,
-    });
+    let event_id = RuntimeHandle::publish_signal_to_pool(
+        &signal_pool,
+        RuntimePublishRequest {
+            topic: request.topic,
+            source: request.source,
+            payload: request.payload,
+            trace_id: request.trace_id,
+            origin_host_id: request.origin_host_id,
+        },
+    );
 
     Ok(SignalPublishFastResponse {
         accepted: true,

--- a/src-tauri/src/commands/runtime_commands.rs
+++ b/src-tauri/src/commands/runtime_commands.rs
@@ -1,28 +1,36 @@
-//! Runtime 服务命令
-//! 提供桌面端 Agent Runtime 的启动、停止与状态查询
+//! Runtime 服务命令（embedded mode，内嵌模式）
+//! 提供桌面端 Runtime 的启动、停止与状态查询。
 
 use chrono::Utc;
-use serde::Serialize;
-use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use exomind_runtime::{
+    DEFAULT_RT_PORT, RuntimeHandle, RuntimePublishRequest, RuntimeStartOptions, start_with_options,
+};
+use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
-use tauri::{AppHandle, State};
+use tauri::State;
 
-#[derive(Default)]
+struct RuntimeInner {
+    handle: Option<RuntimeHandle>,
+    host: String,
+    port: u16,
+    started_at: Option<String>,
+    last_error: Option<String>,
+}
+
 pub struct RuntimeProcessState {
-    pub child: Mutex<Option<Child>>,
-    pub host: Mutex<String>,
-    pub port: Mutex<u16>,
-    pub started_at: Mutex<Option<String>>,
+    inner: Mutex<RuntimeInner>,
 }
 
 impl RuntimeProcessState {
     pub fn new() -> Self {
         Self {
-            child: Mutex::new(None),
-            host: Mutex::new("127.0.0.1".to_string()),
-            port: Mutex::new(4077),
-            started_at: Mutex::new(None),
+            inner: Mutex::new(RuntimeInner {
+                handle: None,
+                host: "127.0.0.1".to_string(),
+                port: DEFAULT_RT_PORT,
+                started_at: None,
+                last_error: None,
+            }),
         }
     }
 }
@@ -38,103 +46,38 @@ pub struct RuntimeServiceStatus {
     pub error: Option<String>,
 }
 
-fn lock_or_error<'a, T>(
-    mutex: &'a Mutex<T>,
-    label: &str,
-) -> Result<std::sync::MutexGuard<'a, T>, String> {
-    mutex
+#[derive(Debug, Deserialize)]
+pub struct SignalPublishFastRequest {
+    pub topic: String,
+    pub source: Option<String>,
+    pub payload: serde_json::Value,
+    pub trace_id: Option<String>,
+    pub origin_host_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SignalPublishFastResponse {
+    pub accepted: bool,
+    pub event_id: String,
+}
+
+fn lock_or_error<'a>(
+    state: &'a Arc<RuntimeProcessState>,
+) -> Result<std::sync::MutexGuard<'a, RuntimeInner>, String> {
+    state
+        .inner
         .lock()
-        .map_err(|_| format!("failed to lock runtime state: {label}"))
+        .map_err(|_| "failed to lock runtime state".to_string())
 }
 
-fn current_status(
-    state: &Arc<RuntimeProcessState>,
-    running: bool,
-    pid: Option<u32>,
-    error: Option<String>,
-) -> Result<RuntimeServiceStatus, String> {
-    let host = lock_or_error(&state.host, "host")?.clone();
-    let port = *lock_or_error(&state.port, "port")?;
-    let started_at = lock_or_error(&state.started_at, "started_at")?.clone();
-
-    Ok(RuntimeServiceStatus {
+fn compose_status(inner: &RuntimeInner, running: bool, error: Option<String>) -> RuntimeServiceStatus {
+    RuntimeServiceStatus {
         running,
-        host,
-        port,
-        pid,
-        started_at,
-        error,
-    })
-}
-
-fn refresh_child_running_state(child: &mut Option<Child>) -> Result<(bool, Option<u32>), String> {
-    if let Some(process) = child.as_mut() {
-        match process.try_wait() {
-            Ok(Some(_)) => {
-                *child = None;
-                Ok((false, None))
-            }
-            Ok(None) => Ok((true, Some(process.id()))),
-            Err(error) => Err(format!("runtime process status check failed: {error}")),
-        }
-    } else {
-        Ok((false, None))
-    }
-}
-
-fn runtime_entry_candidates(base_dir: &Path) -> Vec<PathBuf> {
-    let mut candidates = Vec::new();
-    let mut push_candidate = |path: PathBuf| {
-        if !candidates.iter().any(|item| item == &path) {
-            candidates.push(path);
-        }
-    };
-
-    push_candidate(base_dir.join("server").join("agent-runtime-server.js"));
-
-    if let Some(parent) = base_dir.parent() {
-        push_candidate(parent.join("server").join("agent-runtime-server.js"));
-    }
-
-    let manifest_parent = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .map(|path| path.to_path_buf());
-    if let Some(root) = manifest_parent {
-        push_candidate(root.join("server").join("agent-runtime-server.js"));
-    }
-
-    candidates
-}
-
-fn resolve_runtime_entry_path_from_base(base_dir: &Path) -> Result<PathBuf, String> {
-    // Canonicalize base_dir to prevent path traversal
-    let canonical_base = base_dir
-        .canonicalize()
-        .map_err(|e| format!("failed to canonicalize base directory: {e}"))?;
-
-    let candidates = runtime_entry_candidates(&canonical_base);
-    for path in &candidates {
-        if path.exists() {
-            // Canonicalize resolved path to eliminate any remaining .. components
-            let canonical = path
-                .canonicalize()
-                .map_err(|e| format!("failed to canonicalize runtime entry path: {e}"))?;
-            return Ok(canonical);
-        }
-    }
-
-    #[cfg(debug_assertions)]
-    {
-        let searched = candidates
-            .iter()
-            .map(|item| item.to_string_lossy().to_string())
-            .collect::<Vec<String>>()
-            .join(" | ");
-        Err(format!("runtime entry not found: {searched}"))
-    }
-    #[cfg(not(debug_assertions))]
-    {
-        Err("runtime entry not found".to_string())
+        host: inner.host.clone(),
+        port: inner.port,
+        pid: running.then_some(std::process::id()),
+        started_at: inner.started_at.clone(),
+        error: error.or_else(|| inner.last_error.clone()),
     }
 }
 
@@ -160,24 +103,8 @@ fn is_valid_host(host: &str) -> bool {
     })
 }
 
-fn resolve_runtime_entry_path() -> Result<PathBuf, String> {
-    let base_dir = std::env::current_dir().map_err(|_error| {
-        #[cfg(debug_assertions)]
-        {
-            format!("failed to resolve current directory: {_error}")
-        }
-        #[cfg(not(debug_assertions))]
-        {
-            "failed to resolve current directory".to_string()
-        }
-    })?;
-    resolve_runtime_entry_path_from_base(&base_dir)
-}
-
-#[tauri::command]
-pub fn runtime_service_start(
-    _app: AppHandle,
-    state: State<'_, Arc<RuntimeProcessState>>,
+pub async fn ensure_runtime_started(
+    state: Arc<RuntimeProcessState>,
     host: Option<String>,
     port: Option<u16>,
 ) -> Result<RuntimeServiceStatus, String> {
@@ -188,128 +115,139 @@ pub fn runtime_service_start(
     if runtime_host.is_empty() {
         return Err("runtime host is required".to_string());
     }
-
     if !is_valid_host(&runtime_host) {
         return Err("invalid host format: must be a valid IP address or hostname".to_string());
     }
+    let runtime_port = port.unwrap_or(DEFAULT_RT_PORT);
 
-    let runtime_port = port.unwrap_or(4077);
-    if runtime_port == 0 {
-        return Err("runtime port must be greater than 0".to_string());
+    // Fast path: already running（快速路径：已在运行）
+    {
+        let mut inner = lock_or_error(&state)?;
+        let running_snapshot = inner
+            .handle
+            .as_ref()
+            .and_then(|handle| handle.is_running().then(|| (handle.host(), handle.port())));
+        if let Some((host, port)) = running_snapshot {
+            inner.host = host;
+            inner.port = port;
+            return Ok(compose_status(&inner, true, None));
+        }
     }
 
-    let mut child_guard = lock_or_error(&state.child, "child")?;
-    let (running, pid) = refresh_child_running_state(&mut child_guard)?;
-    if running {
-        return current_status(&state.inner().clone(), true, pid, None);
+    let mut options = RuntimeStartOptions::default();
+    options.bind_host = runtime_host;
+    options.port = runtime_port;
+
+    let handle = start_with_options(options)
+        .await
+        .map_err(|error| format!("failed to start embedded runtime: {error}"))?;
+    let started_host = handle.host();
+    let started_port = handle.port();
+
+    let mut inner = lock_or_error(&state)?;
+    inner.host = started_host;
+    inner.port = started_port;
+    inner.started_at = Some(Utc::now().to_rfc3339());
+    inner.last_error = None;
+    inner.handle = Some(handle);
+    Ok(compose_status(&inner, true, None))
+}
+
+pub async fn ensure_runtime_stopped(
+    state: Arc<RuntimeProcessState>,
+) -> Result<RuntimeServiceStatus, String> {
+    let mut handle = {
+        let mut inner = lock_or_error(&state)?;
+        inner.started_at = None;
+        inner.handle.take()
+    };
+
+    if let Some(runtime) = handle.as_mut() {
+        runtime
+            .stop()
+            .await
+            .map_err(|error| format!("failed to stop embedded runtime: {error}"))?;
     }
 
-    let script_path = resolve_runtime_entry_path()?;
+    let mut inner = lock_or_error(&state)?;
+    inner.started_at = None;
+    Ok(compose_status(&inner, false, None))
+}
 
-    let child = Command::new("bun")
-        .arg(script_path.to_string_lossy().to_string())
-        .arg("--host")
-        .arg(runtime_host.clone())
-        .arg("--port")
-        .arg(runtime_port.to_string())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .stdin(Stdio::null())
-        .spawn()
-        .map_err(|error| format!("failed to start runtime process: {error}"))?;
+pub fn runtime_status_snapshot(
+    state: Arc<RuntimeProcessState>,
+) -> Result<RuntimeServiceStatus, String> {
+    let mut inner = lock_or_error(&state)?;
+    let running_snapshot = inner
+        .handle
+        .as_ref()
+        .and_then(|handle| handle.is_running().then(|| (handle.host(), handle.port())));
 
-    let pid = Some(child.id());
-    *child_guard = Some(child);
+    let running = if let Some((host, port)) = running_snapshot {
+        inner.host = host;
+        inner.port = port;
+        true
+    } else {
+        inner.started_at = None;
+        false
+    };
 
-    *lock_or_error(&state.host, "host")? = runtime_host.clone();
-    *lock_or_error(&state.port, "port")? = runtime_port;
-    *lock_or_error(&state.started_at, "started_at")? = Some(Utc::now().to_rfc3339());
-
-    current_status(&state.inner().clone(), true, pid, None)
+    Ok(compose_status(&inner, running, None))
 }
 
 #[tauri::command]
-pub fn runtime_service_stop(
+pub async fn runtime_service_start(
+    state: State<'_, Arc<RuntimeProcessState>>,
+    host: Option<String>,
+    port: Option<u16>,
+) -> Result<RuntimeServiceStatus, String> {
+    ensure_runtime_started(state.inner().clone(), host, port).await
+}
+
+#[tauri::command]
+pub async fn runtime_service_stop(
     state: State<'_, Arc<RuntimeProcessState>>,
 ) -> Result<RuntimeServiceStatus, String> {
-    let mut child_guard = lock_or_error(&state.child, "child")?;
-
-    if let Some(process) = child_guard.as_mut() {
-        process
-            .kill()
-            .map_err(|error| format!("failed to stop runtime process: {error}"))?;
-        let _ = process.wait();
-    }
-    *child_guard = None;
-    *lock_or_error(&state.started_at, "started_at")? = None;
-
-    current_status(&state.inner().clone(), false, None, None)
+    ensure_runtime_stopped(state.inner().clone()).await
 }
 
 #[tauri::command]
 pub fn runtime_service_status(
     state: State<'_, Arc<RuntimeProcessState>>,
 ) -> Result<RuntimeServiceStatus, String> {
-    let mut child_guard = lock_or_error(&state.child, "child")?;
-    let (running, pid) = refresh_child_running_state(&mut child_guard)?;
+    runtime_status_snapshot(state.inner().clone())
+}
 
-    if !running {
-        *lock_or_error(&state.started_at, "started_at")? = None;
+#[tauri::command]
+pub fn signal_publish_fast(
+    state: State<'_, Arc<RuntimeProcessState>>,
+    request: SignalPublishFastRequest,
+) -> Result<SignalPublishFastResponse, String> {
+    let inner = lock_or_error(state.inner())?;
+    let handle = inner
+        .handle
+        .as_ref()
+        .ok_or_else(|| "embedded runtime not running".to_string())?;
+    if !handle.is_running() {
+        return Err("embedded runtime is not running".to_string());
     }
 
-    current_status(&state.inner().clone(), running, pid, None)
+    let event_id = handle.publish_signal(RuntimePublishRequest {
+        topic: request.topic,
+        source: request.source,
+        payload: request.payload,
+        trace_id: request.trace_id,
+        origin_host_id: request.origin_host_id,
+    });
+
+    Ok(SignalPublishFastResponse {
+        accepted: true,
+        event_id,
+    })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_runtime_entry_path_from_base;
-    use std::fs;
-    use std::path::PathBuf;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    fn make_temp_root(prefix: &str) -> PathBuf {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time should be after unix epoch")
-            .as_nanos();
-        std::env::temp_dir().join(format!("{prefix}-{now}-{}", std::process::id()))
-    }
-
-    #[test]
-    fn resolve_runtime_entry_uses_project_root_server_when_cwd_is_src_tauri() {
-        let root = make_temp_root("runtime-entry-success");
-        let src_tauri = root.join("src-tauri");
-        let server_dir = root.join("server");
-        let entry = server_dir.join("agent-runtime-server.js");
-
-        fs::create_dir_all(&src_tauri).expect("should create src-tauri directory");
-        fs::create_dir_all(&server_dir).expect("should create server directory");
-        fs::write(&entry, "// runtime server").expect("should create runtime entry");
-
-        let resolved =
-            resolve_runtime_entry_path_from_base(&src_tauri).expect("should resolve runtime entry");
-        let expected = entry
-            .canonicalize()
-            .expect("should canonicalize expected entry");
-        assert_eq!(resolved, expected);
-
-        let _ = fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn resolve_runtime_entry_falls_back_to_manifest_root() {
-        let root = make_temp_root("runtime-entry-missing");
-        let src_tauri = root.join("src-tauri");
-        fs::create_dir_all(&src_tauri).expect("should create src-tauri directory");
-
-        let resolved = resolve_runtime_entry_path_from_base(&src_tauri)
-            .expect("should fallback to manifest root server path");
-        assert!(resolved.ends_with(PathBuf::from("server").join("agent-runtime-server.js")));
-        assert!(resolved.exists());
-
-        let _ = fs::remove_dir_all(&root);
-    }
-
     #[test]
     fn is_valid_host_accepts_ipv4() {
         assert!(super::is_valid_host("127.0.0.1"));

--- a/src-tauri/src/commands/runtime_commands.rs
+++ b/src-tauri/src/commands/runtime_commands.rs
@@ -3,7 +3,7 @@
 
 use chrono::Utc;
 use exomind_runtime::{
-    DEFAULT_RT_PORT, RuntimeHandle, RuntimePublishRequest, RuntimeStartOptions, start_with_options,
+    start_with_options, RuntimeHandle, RuntimePublishRequest, RuntimeStartOptions, DEFAULT_RT_PORT,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, Mutex};
@@ -70,7 +70,11 @@ fn lock_or_error<'a>(
         .map_err(|_| "failed to lock runtime state".to_string())
 }
 
-fn compose_status(inner: &RuntimeInner, running: bool, error: Option<String>) -> RuntimeServiceStatus {
+fn compose_status(
+    inner: &RuntimeInner,
+    running: bool,
+    error: Option<String>,
+) -> RuntimeServiceStatus {
     RuntimeServiceStatus {
         running,
         host: inner.host.clone(),
@@ -108,17 +112,22 @@ pub async fn ensure_runtime_started(
     host: Option<String>,
     port: Option<u16>,
 ) -> Result<RuntimeServiceStatus, String> {
+    let mut options = RuntimeStartOptions::default();
     let runtime_host = host
-        .unwrap_or_else(|| "127.0.0.1".to_string())
-        .trim()
-        .to_string();
+        .map(|value| value.trim().to_string())
+        .unwrap_or_else(|| options.bind_host.clone());
+
     if runtime_host.is_empty() {
         return Err("runtime host is required".to_string());
     }
     if !is_valid_host(&runtime_host) {
         return Err("invalid host format: must be a valid IP address or hostname".to_string());
     }
-    let runtime_port = port.unwrap_or(DEFAULT_RT_PORT);
+
+    options.bind_host = runtime_host;
+    if let Some(runtime_port) = port {
+        options.port = runtime_port;
+    }
 
     // Fast path: already running（快速路径：已在运行）
     {
@@ -130,17 +139,27 @@ pub async fn ensure_runtime_started(
         if let Some((host, port)) = running_snapshot {
             inner.host = host;
             inner.port = port;
+            inner.last_error = None;
             return Ok(compose_status(&inner, true, None));
         }
     }
 
-    let mut options = RuntimeStartOptions::default();
-    options.bind_host = runtime_host;
-    options.port = runtime_port;
+    let handle = match start_with_options(options).await {
+        Ok(handle) => handle,
+        Err(error) => {
+            // Handle startup race gracefully（处理并发启动竞争）.
+            if let Ok(status) = runtime_status_snapshot(state.clone()) {
+                if status.running {
+                    return Ok(status);
+                }
+            }
 
-    let handle = start_with_options(options)
-        .await
-        .map_err(|error| format!("failed to start embedded runtime: {error}"))?;
+            let message = format!("failed to start embedded runtime: {error}");
+            let mut inner = lock_or_error(&state)?;
+            inner.last_error = Some(message.clone());
+            return Err(message);
+        }
+    };
     let started_host = handle.host();
     let started_port = handle.port();
 
@@ -171,6 +190,7 @@ pub async fn ensure_runtime_stopped(
 
     let mut inner = lock_or_error(&state)?;
     inner.started_at = None;
+    inner.last_error = None;
     Ok(compose_status(&inner, false, None))
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,7 +12,8 @@ use commands::file_commands::{
     list_files, pick_json_file, read_file, read_file_binary, save_json_file, write_file,
 };
 use commands::runtime_commands::{
-    runtime_service_start, runtime_service_status, runtime_service_stop, RuntimeProcessState,
+    ensure_runtime_started, runtime_service_start, runtime_service_status, runtime_service_stop,
+    signal_publish_fast, RuntimeProcessState,
 };
 use commands::ws_commands::{ws_connect, ws_disconnect, ws_get_state, ws_send, WsClientState};
 
@@ -25,6 +26,7 @@ fn greet(name: &str) -> String {
 pub fn run() {
     let ws_client_state = std::sync::Arc::new(WsClientState::default());
     let runtime_process_state = std::sync::Arc::new(RuntimeProcessState::new());
+    let runtime_process_state_for_setup = runtime_process_state.clone();
 
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_fs::init())
@@ -33,6 +35,21 @@ pub fn run() {
         .plugin(tauri_plugin_clipboard_manager::init())
         .manage(ws_client_state.clone())
         .manage(runtime_process_state.clone())
+        .setup(move |_app| {
+            let runtime_state = runtime_process_state_for_setup.clone();
+            tauri::async_runtime::spawn(async move {
+                if let Err(error) = ensure_runtime_started(
+                    runtime_state,
+                    Some("127.0.0.1".to_string()),
+                    Some(exomind_runtime::DEFAULT_RT_PORT),
+                )
+                .await
+                {
+                    eprintln!("[tauri/setup] failed to auto-start embedded runtime: {error}");
+                }
+            });
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             greet,
             // WebSocket 客户端命令
@@ -63,6 +80,7 @@ pub fn run() {
             runtime_service_start,
             runtime_service_stop,
             runtime_service_status,
+            signal_publish_fast,
         ]);
 
     #[cfg(debug_assertions)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,13 +38,7 @@ pub fn run() {
         .setup(move |_app| {
             let runtime_state = runtime_process_state_for_setup.clone();
             tauri::async_runtime::spawn(async move {
-                if let Err(error) = ensure_runtime_started(
-                    runtime_state,
-                    Some("127.0.0.1".to_string()),
-                    Some(exomind_runtime::DEFAULT_RT_PORT),
-                )
-                .await
-                {
+                if let Err(error) = ensure_runtime_started(runtime_state, None, None).await {
                     eprintln!("[tauri/setup] failed to auto-start embedded runtime: {error}");
                 }
             });

--- a/src/lib/adapters/tauri-runtime-adapter.ts
+++ b/src/lib/adapters/tauri-runtime-adapter.ts
@@ -5,7 +5,7 @@ import type { RuntimeServiceStatus } from '@/lib/types/agent-hub';
 const DEFAULT_RUNTIME_STATUS: RuntimeServiceStatus = {
   running: false,
   host: '127.0.0.1',
-  port: 4077,
+  port: 1949,
   error: 'tauri runtime control only',
 };
 

--- a/src/lib/services/signal-stream.service.ts
+++ b/src/lib/services/signal-stream.service.ts
@@ -7,6 +7,7 @@
 
 import type { RuntimeHostRecord } from '@/lib/types/agent-hub';
 import type { SignalEvent, PublishRequest, PublishResponse } from '@/lib/types/signal-pool';
+import { invoke, isTauri } from '@tauri-apps/api/core';
 
 // ── 配置 ─────────────────────────────────────────────────────
 
@@ -80,6 +81,16 @@ export class SignalStreamService {
 
   /** Publish a signal to the RT. */
   async publish(request: PublishRequest): Promise<PublishResponse> {
+    // Prefer Tauri invoke fast-path（优先走 Tauri invoke 快速通道）
+    if (await isTauri()) {
+      try {
+        return await invoke<PublishResponse>('signal_publish_fast', { request });
+      } catch (error) {
+        console.warn('[SignalStream] invoke publish failed, fallback to HTTP:', error);
+      }
+    }
+
+    // HTTP fallback（HTTP 降级路径）
     const url = `${this.baseUrl}/signals/publish`;
     const response = await fetch(url, {
       method: 'POST',

--- a/src/ui/app/pages/AgentsPage.tsx
+++ b/src/ui/app/pages/AgentsPage.tsx
@@ -695,7 +695,7 @@ function DeviceView({
             </span>
           </div>
           <p className="mt-1 text-[10px] text-[#A8A29E]">
-            {runtimeServiceStatus?.host ?? '127.0.0.1'}:{runtimeServiceStatus?.port ?? 4077}
+            {runtimeServiceStatus?.host ?? '127.0.0.1'}:{runtimeServiceStatus?.port ?? 1949}
           </p>
           {runtimeServiceStatus?.pid && (
             <p className="mt-1 text-[10px] text-[#A8A29E]">pid: {runtimeServiceStatus.pid}</p>
@@ -1228,7 +1228,7 @@ export function AgentsPage() {
     try {
       const status = await getRuntimeControlService().startRuntime({
         host: '127.0.0.1',
-        port: 4077,
+        port: 1949,
       });
       setRuntimeServiceStatus(status);
       await refreshRuntimeSnapshot();
@@ -1237,7 +1237,7 @@ export function AgentsPage() {
       setRuntimeServiceStatus({
         running: false,
         host: '127.0.0.1',
-        port: 4077,
+        port: 1949,
         error: message,
       });
     }
@@ -1253,7 +1253,7 @@ export function AgentsPage() {
       setRuntimeServiceStatus({
         running: false,
         host: '127.0.0.1',
-        port: 4077,
+        port: 1949,
         error: message,
       });
     }

--- a/tests/unit/services/runtime-control.service.issue205.test.ts
+++ b/tests/unit/services/runtime-control.service.issue205.test.ts
@@ -5,13 +5,13 @@ import { RuntimeControlServiceImpl } from '@/lib/services/runtime-control.servic
 function createMockRuntimePort(overrides: Partial<IRuntimePort> = {}): IRuntimePort {
   return {
     startRuntime: vi.fn().mockResolvedValue({
-      running: true, host: '127.0.0.1', port: 4077, pid: 9527,
+      running: true, host: '127.0.0.1', port: 1949, pid: 9527,
     }),
     stopRuntime: vi.fn().mockResolvedValue({
-      running: false, host: '127.0.0.1', port: 4077,
+      running: false, host: '127.0.0.1', port: 1949,
     }),
     getStatus: vi.fn().mockResolvedValue({
-      running: true, host: '127.0.0.1', port: 4077, pid: 9527,
+      running: true, host: '127.0.0.1', port: 1949, pid: 9527,
     }),
     ...overrides,
   };
@@ -21,9 +21,9 @@ describe('runtime control service issue-205（Runtime 启停服务）', () => {
   it('delegates startRuntime to port（委托 port 启动运行时）', async () => {
     const port = createMockRuntimePort();
     const service = new RuntimeControlServiceImpl(port);
-    const status = await service.startRuntime({ host: '127.0.0.1', port: 4077 });
+    const status = await service.startRuntime({ host: '127.0.0.1', port: 1949 });
 
-    expect(port.startRuntime).toHaveBeenCalledWith({ host: '127.0.0.1', port: 4077 });
+    expect(port.startRuntime).toHaveBeenCalledWith({ host: '127.0.0.1', port: 1949 });
     expect(status.running).toBe(true);
     expect(status.pid).toBe(9527);
   });
@@ -44,10 +44,10 @@ describe('runtime control service issue-205（Runtime 启停服务）', () => {
   it('works with non-tauri port implementation（兼容非 Tauri 实现）', async () => {
     const port = createMockRuntimePort({
       startRuntime: vi.fn().mockResolvedValue({
-        running: false, host: '127.0.0.1', port: 4077, error: 'not supported',
+        running: false, host: '127.0.0.1', port: 1949, error: 'not supported',
       }),
       getStatus: vi.fn().mockResolvedValue({
-        running: false, host: '127.0.0.1', port: 4077, error: 'not supported',
+        running: false, host: '127.0.0.1', port: 1949, error: 'not supported',
       }),
     });
     const service = new RuntimeControlServiceImpl(port);

--- a/tests/unit/services/signal-stream-fast-publish.m1.test.ts
+++ b/tests/unit/services/signal-stream-fast-publish.m1.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SignalStreamService } from '@/lib/services/signal-stream.service';
+import type { PublishRequest } from '@/lib/types/signal-pool';
+
+const tauriMocks = vi.hoisted(() => ({
+  isTauri: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: tauriMocks.isTauri,
+  invoke: tauriMocks.invoke,
+}));
+
+function createService() {
+  return new SignalStreamService({
+    host: {
+      id: 'local',
+      name: 'Local RT',
+      host: '127.0.0.1',
+      port: 1949,
+      status: 'unknown',
+      createdAt: '2026-03-04T00:00:00.000Z',
+      updatedAt: '2026-03-04T00:00:00.000Z',
+      isLocal: true,
+    },
+    agentId: 'ui',
+  });
+}
+
+const requestPayload: PublishRequest = {
+  topic: 'user.input.text',
+  source: 'frontend:test',
+  payload: { text: 'hello' },
+};
+
+describe('signal stream fast publish m1（invoke 高频桥接）', () => {
+  beforeEach(() => {
+    tauriMocks.isTauri.mockReset();
+    tauriMocks.invoke.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('uses invoke fast-path in tauri（Tauri 环境优先 invoke）', async () => {
+    tauriMocks.isTauri.mockResolvedValue(true);
+    tauriMocks.invoke.mockResolvedValue({
+      accepted: true,
+      event_id: 'evt-fast-1',
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const service = createService();
+    const response = await service.publish(requestPayload);
+
+    expect(tauriMocks.invoke).toHaveBeenCalledWith('signal_publish_fast', { request: requestPayload });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(response.accepted).toBe(true);
+    expect(response.event_id).toBe('evt-fast-1');
+  });
+
+  it('falls back to HTTP when invoke fails（invoke 失败降级到 HTTP）', async () => {
+    tauriMocks.isTauri.mockResolvedValue(true);
+    tauriMocks.invoke.mockRejectedValue(new Error('invoke unavailable'));
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ accepted: true, event_id: 'evt-http-1' }),
+    } as unknown as Response);
+
+    const service = createService();
+    const response = await service.publish(requestPayload);
+
+    expect(tauriMocks.invoke).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith('http://127.0.0.1:1949/signals/publish', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(requestPayload),
+    });
+    expect(response.event_id).toBe('evt-http-1');
+  });
+
+  it('uses HTTP directly in non-tauri（非 Tauri 直接走 HTTP）', async () => {
+    tauriMocks.isTauri.mockResolvedValue(false);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ accepted: true, event_id: 'evt-http-2' }),
+    } as unknown as Response);
+
+    const service = createService();
+    const response = await service.publish(requestPayload);
+
+    expect(tauriMocks.invoke).not.toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(response.event_id).toBe('evt-http-2');
+  });
+});

--- a/tests/unit/tauri/runtime-commands.issue205.test.ts
+++ b/tests/unit/tauri/runtime-commands.issue205.test.ts
@@ -10,14 +10,16 @@ describe('tauri runtime commands issue-205（Tauri Runtime 命令注册）', () 
     expect(tauriLib).toContain('runtime_service_start');
     expect(tauriLib).toContain('runtime_service_stop');
     expect(tauriLib).toContain('runtime_service_status');
+    expect(tauriLib).toContain('signal_publish_fast');
   });
 
   it('defines runtime service commands in rust source（Rust 源码定义 runtime 命令）', () => {
     const runtimeCommands = readFileSync('src-tauri/src/commands/runtime_commands.rs', 'utf-8');
 
     expect(runtimeCommands).toContain('#[tauri::command]');
-    expect(runtimeCommands).toContain('pub fn runtime_service_start');
-    expect(runtimeCommands).toContain('pub fn runtime_service_stop');
+    expect(runtimeCommands).toContain('pub async fn runtime_service_start');
+    expect(runtimeCommands).toContain('pub async fn runtime_service_stop');
     expect(runtimeCommands).toContain('pub fn runtime_service_status');
+    expect(runtimeCommands).toContain('pub fn signal_publish_fast');
   });
 });

--- a/tests/unit/tauri/runtime-embedded.m1.test.ts
+++ b/tests/unit/tauri/runtime-embedded.m1.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('runtime embedded startup m1（Runtime 内嵌启动约束）', () => {
+  it('starts runtime in tauri setup hook（在 setup 钩子自动启动运行时）', () => {
+    const tauriLib = readFileSync('src-tauri/src/lib.rs', 'utf-8');
+    expect(tauriLib).toContain('.setup(');
+    expect(tauriLib).toMatch(/runtime.*start/i);
+  });
+
+  it('runtime commands no longer spawn bun server script（不再通过 bun 脚本拉起 runtime）', () => {
+    const runtimeCommands = readFileSync('src-tauri/src/commands/runtime_commands.rs', 'utf-8');
+    expect(runtimeCommands).not.toContain('agent-runtime-server.js');
+    expect(runtimeCommands).not.toContain('Command::new("bun")');
+    expect(runtimeCommands).toContain('start_with_options');
+  });
+});

--- a/tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx
+++ b/tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx
@@ -83,7 +83,7 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
         id: 'runtime-host-1',
         name: 'Hope Desktop',
         host: '127.0.0.1',
-        port: 4077,
+        port: 1949,
         status: 'unknown',
         createdAt: '2026-02-27T10:00:00.000Z',
         updatedAt: '2026-02-27T10:00:00.000Z',
@@ -136,18 +136,18 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
     runtimeControlMocks.getStatus.mockResolvedValue({
       running: false,
       host: '127.0.0.1',
-      port: 4077,
+      port: 1949,
     });
     runtimeControlMocks.startRuntime.mockResolvedValue({
       running: true,
       host: '127.0.0.1',
-      port: 4077,
+      port: 1949,
       pid: 9527,
     });
     runtimeControlMocks.stopRuntime.mockResolvedValue({
       running: false,
       host: '127.0.0.1',
-      port: 4077,
+      port: 1949,
     });
   });
 
@@ -203,7 +203,7 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
     await waitFor(() => {
       expect(runtimeControlMocks.startRuntime).toHaveBeenCalledWith({
         host: '127.0.0.1',
-        port: 4077,
+        port: 1949,
       });
       expect(screen.getByTestId('runtime-local-status')).toHaveTextContent('running');
     });

--- a/tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
@@ -44,7 +44,7 @@ describe('agents page issue-204（主页面三视图与添加节点）', () => {
     runtimeControlMocks.getStatus.mockResolvedValue({
       running: false,
       host: '127.0.0.1',
-      port: 4077,
+      port: 1949,
     });
     runtimeManagerMocks.refreshSnapshot.mockResolvedValue({
       updatedAt: '2026-02-28T10:00:00.000Z',


### PR DESCRIPTION
## 背景与目标（Background / Goal）
本 PR 完成 M1：将 `exomind-runtime` 从外部进程模式改为 **Tauri 内嵌运行（in-process）**，实现：
- `SignalPool` 在 Tauri 进程内运行
- `exomind-runtime` 作为核心 `lib` 可复用（一次编写，多端复用）
- 传输层采用 `invoke` 高频通道 + HTTP 降级通道
- 默认端口统一为 `1949`，并支持 `EXOMIND_RT_PORT=0` 随机端口

---

## 变更范围（Scope）

### M1.1 `exomind-runtime` crate 重构为 `lib`
- `crates/exomind-runtime/src/lib.rs`
  - 新增可复用启动 API：`start()` / `start_with_options()`
  - 新增 `RuntimeHandle` 生命周期管理（start/stop/is_running）
  - 新增默认端口常量 `DEFAULT_RT_PORT = 1949`
  - 支持 `EXOMIND_RT_PORT=0` 随机端口
  - 支持 RT 启动后自动拉起 TS agents（reviewer/classifier）
- `crates/exomind-runtime/src/main.rs`
  - 改为 thin wrapper：仅调用 `start()` 并在 `ctrl_c` 后 `stop()`

### M1.2 Tauri `setup()` 内嵌启动 Runtime
- `src-tauri/src/lib.rs`
  - 在 `setup()` 中自动启动 embedded runtime
  - 启动参数改为遵循 env/default（不再硬编码覆盖）
- `src-tauri/src/commands/runtime_commands.rs`
  - `runtime_service_start/stop/status` 改为内嵌模式
  - 不再 spawn 外部 bun runtime 进程

### M1.3 `invoke` 高频桥接 + HTTP fallback
- `src-tauri/src/commands/runtime_commands.rs`
  - 新增 `signal_publish_fast`（Tauri invoke 快速发布）
- `src/lib/services/signal-stream.service.ts`
  - 发布策略：`isTauri() -> invoke('signal_publish_fast') -> HTTP fallback`

### M1.4 TS agents 随 RT 启动
- `crates/exomind-runtime/src/lib.rs`
  - runtime 启动后自动拉起 reviewer/classifier
  - 注入 `EXOMIND_RT_URL`
  - 支持 `EXOMIND_RT_AGENT_WORKDIR`

---

## 关键修复（Review-driven Fixes）
本 PR 在实现后又完成了一轮评审闭环修复：
- 修复 `setup()` 覆盖 env 的问题（保证 `EXOMIND_RT_PORT=0` 语义生效）
- 缩小 `signal_publish_fast` 持锁范围，避免高频路径串行化
- 增强并发启动竞争（start race）场景下的幂等处理
- 增强 TS agent 启动目录与错误可观测性（`stderr` 继承）

---

## 默认端口策略（Port Policy）
- 默认：`1949`
- 随机端口：`EXOMIND_RT_PORT=0`

---

## 验证与测试证据（Verification）

### 已通过
```powershell
cargo test -p exomind-runtime
cargo check -p exomind
bun run test -- tests/unit/tauri/runtime-embedded.m1.test.ts tests/unit/services/signal-stream-fast-publish.m1.test.ts tests/unit/tauri/runtime-commands.issue205.test.ts tests/unit/services/runtime-control.service.issue205.test.ts tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
bun run build
```

### 桌面端链路实测通过
- `cargo tauri dev --no-watch` 启动后，`GET /health` 返回 OK
- `POST /signals/publish` 返回 `accepted=true`
- 关闭进程后端口下线

### Playwright
- 通过：`signal-pool-classification.test.ts`（4 passed）
- 已知历史失败（非本 PR 新引入）：
  - `test:e2e:issue204`（文案断言差异）
  - `test:e2e:issue205`（`goto('/agents')` 超时）

---

## 人工验收步骤（Manual QA）
```powershell
# 默认端口模式
$env:EXOMIND_RT_PORT='1949'
$env:EXOMIND_RT_BIND='127.0.0.1'
$env:EXOMIND_RT_URL='http://127.0.0.1:1949'
$env:EXOMIND_RT_AGENT_WORKDIR='D:\project\exomind'

cargo tauri dev --no-watch
curl http://127.0.0.1:1949/health
curl -X POST http://127.0.0.1:1949/signals/publish -H "Content-Type: application/json" -d "{\"topic\":\"manual.smoke\",\"source\":\"qa\",\"payload\":{\"text\":\"hello\"}}"
```

```powershell
# 随机端口模式
$env:EXOMIND_RT_PORT='0'
$env:EXOMIND_RT_BIND='127.0.0.1'
$env:EXOMIND_RT_AGENT_WORKDIR='D:\project\exomind'
cargo tauri dev --no-watch
```

---

## 对前端行为影响（Compatibility）
- 现有前端 HTTP 调用链保留，迁移为渐进式
- 高频发布场景优先走 invoke，不可用时自动降级 HTTP
- EventLog / Tasks / Agent Chat 现有主链路不做破坏性改动

---

## 提交说明（Commits in this PR）
- feat(runtime): lib 化 + startup API + 默认端口 1949
- feat(tauri): setup 内嵌启动 + invoke fast publish
- fix(tauri/runtime): 评审驱动修复（env 覆盖、并发启动、锁粒度、agent workdir/logging）
- docs(pr): 方案、测试证据、评审闭环评论