### PR TITLE
feat(agent-hub): 桌面端布局适配 + 右侧栏占位符清理 (#354)

### DIFF
--- a/src/ui/app/pages/AgentsPage.tsx
+++ b/src/ui/app/pages/AgentsPage.tsx
@@ -7,6 +7,7 @@ import {
   List,
   Mail,
   MessageCircle,
+  MessageSquare,
   Monitor,
   Plus,
   Rocket,
@@ -1858,6 +1859,8 @@ export function AgentsPage() {
           const node = signalGraph.nodes.find((n) => n.id === nodeId);
           if (node?.type === 'agent') openAgentDetail(nodeId);
           else if (node?.type === 'actor') openActorDetail(nodeId);
+          else openSignalDetail(nodeId);
+          // TODO(issue-354-mobile-sheet): <lg 视口点击节点后改为底部详情 Sheet。
         }}
         onClearSelection={() => {
           setSelectedNodeId(null);
@@ -1986,13 +1989,13 @@ export function AgentsPage() {
       {/* 主内容区：桌面端三栏（内容区 + 右侧栏），移动端单栏 */}
       <div className="flex flex-1 overflow-hidden">
         {/* 内容区 */}
-        <div className="flex-1 overflow-auto px-5 pb-[calc(env(safe-area-inset-bottom,0px)+108px)] pt-2">
+        <div className="flex-1 overflow-auto px-5 pb-[calc(env(safe-area-inset-bottom,0px)+108px)] pt-2 lg:pb-6">
           {content}
         </div>
 
         {/* 右侧栏：桌面端固定 380px，CLOSED 时不渲染 */}
         {rightPanel.state !== 'CLOSED' && (
-          <aside className="hidden w-[380px] shrink-0 border-l border-[#292524] bg-[#1C1917] md:flex md:flex-col">
+          <aside className="hidden w-[380px] shrink-0 border-l border-[#292524] bg-[#1C1917] lg:flex lg:flex-col">
             <div className="flex items-center justify-between border-b border-[#292524] px-4 py-3">
               <span className="flex items-center gap-2 text-sm font-medium text-[#FAFAF9]">
                 {(rightPanel.state === 'AGENT_DETAIL' || rightPanel.state === 'ACTOR_DETAIL') && (() => {
@@ -2178,51 +2181,106 @@ export function AgentsPage() {
               )}
               {rightPanel.state === 'SIGNAL_DETAIL' && (
                 <div className="flex flex-col gap-3 p-4">
-                  <div className="flex flex-col gap-1">
-                    <p className="text-xs font-medium text-[#A8A29E]">节点 ID</p>
-                    <p className="font-mono text-sm text-[#FAFAF9]">
-                      {rightPanel.signalId ?? '—'}
-                    </p>
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <p className="text-xs font-medium text-[#A8A29E]">最近信号路由</p>
-                    {signalRoutes
-                      .filter((r) =>
-                        r.target_ref === rightPanel.signalId ||
-                        r.topic.includes(rightPanel.signalId ?? '')
-                      )
-                      .slice(0, 5)
-                      .map((r) => (
-                        <div
-                          key={r.id}
-                          className="flex items-center gap-2 rounded-[6px] bg-[#292524] px-3 py-2"
-                        >
-                          <span
-                            className={`h-1.5 w-1.5 rounded-full ${r.enabled ? 'bg-[#22C55E]' : 'bg-[#57534E]'}`}
-                          />
-                          <span className="flex-1 truncate font-mono text-xs text-[#D6D3D1]">
-                            {r.topic}
-                          </span>
-                          <span className="shrink-0 text-[10px] text-[#78716C]">
-                            → {r.target_type}
-                          </span>
+                  {(() => {
+                    const nodeId = rightPanel.signalId;
+                    const normalizedNodeId = nodeId?.includes(':')
+                      ? nodeId.split(':').slice(1).join(':')
+                      : nodeId;
+                    const routeMatchKey = normalizedNodeId ?? nodeId ?? '';
+                    const node =
+                      (nodeId ? signalGraph.nodes.find((n) => n.id === nodeId) : null) ??
+                      (normalizedNodeId
+                        ? signalGraph.nodes.find(
+                            (n) => n.label === normalizedNodeId || n.id.endsWith(`:${normalizedNodeId}`)
+                          )
+                        : null);
+                    const relatedRoutes = routeMatchKey
+                      ? signalRoutes.filter(
+                          (r) =>
+                            r.target_ref === routeMatchKey || r.topic.includes(routeMatchKey)
+                        )
+                      : [];
+                    const incomingCount = routeMatchKey
+                      ? signalRoutes.filter((r) => r.target_ref === routeMatchKey).length
+                      : 0;
+                    const outgoingCount = routeMatchKey
+                      ? signalRoutes.filter((r) => r.topic.includes(routeMatchKey)).length
+                      : 0;
+
+                    return (
+                      <>
+                        <div className="flex flex-col gap-1">
+                          <p className="text-xs font-medium text-[#A8A29E]">节点 ID</p>
+                          <p className="font-mono text-sm text-[#FAFAF9]">{nodeId ?? '—'}</p>
                         </div>
-                      ))}
-                    {signalRoutes.filter((r) =>
-                      r.target_ref === rightPanel.signalId ||
-                      r.topic.includes(rightPanel.signalId ?? '')
-                    ).length === 0 && (
-                      <p className="text-xs text-[#57534E]">无关联路由</p>
-                    )}
-                  </div>
-                  <p className="text-[10px] text-[#57534E]">
-                    完整 Signal History 面板将在后续版本实现
-                  </p>
+
+                        {node && (
+                          <div className="flex flex-col gap-3">
+                            <div className="flex items-center gap-2">
+                              <span
+                                className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                                  node.type === 'agent'
+                                    ? 'bg-[#CCFBF1] text-[#0D9488]'
+                                    : node.type === 'actor'
+                                      ? 'bg-[#FEF3C7] text-[#B45309]'
+                                      : node.type === 'topic'
+                                        ? 'bg-[#FFEDD5] text-[#EA580C]'
+                                        : 'bg-[#DBEAFE] text-[#1D4ED8]'
+                                }`}
+                              >
+                                {node.type}
+                              </span>
+                              <span className="text-xs text-[#78716C]">状态：{node.status}</span>
+                            </div>
+                            <div className="flex gap-4">
+                              <div className="flex flex-col gap-0.5">
+                                <p className="text-[10px] text-[#78716C]">接收路由</p>
+                                <p className="text-sm font-medium text-[#FAFAF9]">{incomingCount}</p>
+                              </div>
+                              <div className="flex flex-col gap-0.5">
+                                <p className="text-[10px] text-[#78716C]">发送路由</p>
+                                <p className="text-sm font-medium text-[#FAFAF9]">{outgoingCount}</p>
+                              </div>
+                            </div>
+                          </div>
+                        )}
+
+                        <div className="flex flex-col gap-1">
+                          <p className="text-xs font-medium text-[#A8A29E]">最近信号路由</p>
+                          {relatedRoutes.slice(0, 5).map((r) => (
+                            <div
+                              key={r.id}
+                              className="flex items-center gap-2 rounded-[6px] bg-[#292524] px-3 py-2"
+                            >
+                              <span
+                                className={`h-1.5 w-1.5 rounded-full ${r.enabled ? 'bg-[#22C55E]' : 'bg-[#57534E]'}`}
+                              />
+                              <span className="flex-1 truncate font-mono text-xs text-[#D6D3D1]">
+                                {r.topic}
+                              </span>
+                              <span className="shrink-0 text-[10px] text-[#78716C]">
+                                → {r.target_type}
+                              </span>
+                            </div>
+                          ))}
+                          {relatedRoutes.length === 0 && (
+                            <p className="text-xs text-[#57534E]">无关联路由</p>
+                          )}
+                        </div>
+                      </>
+                    );
+                  })()}
                 </div>
               )}
               {rightPanel.state === 'AGENT_CHAT' && (
-                <div className="p-4">
-                  <p className="text-xs text-[#78716C]">Agent 对话 — T8 阶段实现</p>
+                <div className="flex flex-col items-center gap-3 p-6 text-center">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-[10px] bg-[#0D9488]/20">
+                    <MessageSquare size={20} className="text-[#0D9488]" />
+                  </div>
+                  <p className="text-sm font-medium text-[#FAFAF9]">Agent 对话</p>
+                  <p className="text-xs text-[#78716C]">
+                    此功能计划在 v0.3.6 实现，需要 RT 会话管理接口支持。
+                  </p>
                 </div>
               )}
             </div>

--- a/tests/unit/ui/agent-hub/agents-page.desktop-adapt.issue354.test.ts
+++ b/tests/unit/ui/agent-hub/agents-page.desktop-adapt.issue354.test.ts
@@ -1,0 +1,31 @@
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('agents page desktop adapt issue-354（桌面端适配与占位清理）', () => {
+  const sourcePath = path.resolve('src/ui/app/pages/AgentsPage.tsx');
+  const source = readFileSync(sourcePath, 'utf-8');
+
+  it('uses desktop-specific bottom padding override（桌面端覆盖底部内边距）', () => {
+    expect(source).toContain(
+      'pb-[calc(env(safe-area-inset-bottom,0px)+108px)] pt-2 lg:pb-6'
+    );
+  });
+
+  it('shows right panel only on lg breakpoint（右侧栏在 lg 断点显示）', () => {
+    expect(source).toContain('lg:flex lg:flex-col');
+    expect(source).not.toContain('md:flex md:flex-col');
+  });
+
+  it('replaces signal-detail placeholder with route counters（信号详情使用路由统计替代占位）', () => {
+    expect(source).toContain('接收路由');
+    expect(source).toContain('发送路由');
+    expect(source).not.toContain('完整 Signal History 面板将在后续版本实现');
+  });
+
+  it('replaces agent-chat placeholder with roadmap hint（Agent 对话占位改为规划提示）', () => {
+    expect(source).toContain('此功能计划在 v0.3.6 实现，需要 RT 会话管理接口支持。');
+    expect(source).toContain('<MessageSquare size={20} className="text-[#0D9488]" />');
+    expect(source).not.toContain('Agent 对话 — T8 阶段实现');
+  });
+});


### PR DESCRIPTION
## 变更摘要
- 修复内容区底部 `safe-area padding`（安全区底部内边距）：桌面端改为 `lg:pb-6`，去除多余 `108px` 空白。
- 修复右侧栏显示断点（breakpoint / 断点）：`md:flex` 调整为 `lg:flex`（`>=1024px`）。
- 替换 `SIGNAL_DETAIL` 占位内容：新增节点类型/状态展示与接收/发送路由统计，保留关联路由列表。
- 替换 `AGENT_CHAT` 占位内容：新增 `v0.3.6` 规划提示卡片与 `MessageSquare` 图标。
- 补充 issue354 回归测试：覆盖上述 1-4 条修复点。

## 验证
- `npx vitest run tests/unit/ui/agent-hub/agents-page.desktop-adapt.issue354.test.ts`
- `npx tsc --noEmit`（当前仓库无 `bun run typecheck` script / 脚本）
- `bun run build`

## 验收检查点
- [x] 桌面端（`>=1024px`）右侧栏正常显示（`380px` 固定宽度）
- [x] 桌面端内容区底部无额外 `108px` 空白
- [x] `SIGNAL_DETAIL` 面板显示节点类型 + 路由统计，无占位文字
- [x] `AGENT_CHAT` 面板显示“功能规划中”提示
- [x] 移动端（`<1024px`）功能不退化

## 说明
- 问题 5（移动端节点点击后详情 Sheet）已在代码中标注 TODO：`issue-354-mobile-sheet`。
- 本 PR 先交付 1-4 的高优先级修复。