### PR TITLE
fix: 修复事件日志来源设备串位并补齐多端来源元数据

### DIFF
--- a/src/components/Chat/ChatPage.tsx
+++ b/src/components/Chat/ChatPage.tsx
@@ -52,6 +52,9 @@ interface ChatPageProps {
   hideHeader?: boolean;
 }
 
+const UNKNOWN_DEVICE_LABEL = '未知设备';
+const UNKNOWN_PLATFORM_LABEL = '未知平台';
+
 function resolvePlatformLabel(platform?: string): string {
   if (!platform) {
     return 'Web';
@@ -72,6 +75,40 @@ function resolveAvatarInitial(name: string): string {
   return trimmed.charAt(0).toUpperCase();
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function formatEventSourceLabel(event: Event): string {
+  if (!isRecord(event.metadata)) {
+    return UNKNOWN_DEVICE_LABEL;
+  }
+
+  const sourceRaw = event.metadata.source;
+  if (!isRecord(sourceRaw)) {
+    return UNKNOWN_DEVICE_LABEL;
+  }
+
+  const platform = readNonEmptyString(sourceRaw.platform);
+  const deviceName = readNonEmptyString(sourceRaw.deviceName);
+  const platformLabel = platform ? resolvePlatformLabel(platform) : UNKNOWN_PLATFORM_LABEL;
+
+  if (!platform && !deviceName) {
+    return UNKNOWN_DEVICE_LABEL;
+  }
+
+  const resolvedDeviceName = deviceName ?? (platform ? `${platformLabel} Device` : UNKNOWN_DEVICE_LABEL);
+  return `${resolvedDeviceName} · ${platformLabel}`;
+}
+
 export function ChatPage({ variant = 'default', hideHeader = false }: ChatPageProps = {}) {
   const envMap = import.meta.env as Record<string, string | undefined>;
   const [events, setEvents] = useState<Event[]>([]);
@@ -89,21 +126,12 @@ export function ChatPage({ variant = 'default', hideHeader = false }: ChatPagePr
   const refreshInFlightRef = useRef(false);
   const refreshQueuedRef = useRef(false);
   const eventLogService = useRef(getEventLogService());
-  const { currentUser, isLoggedIn, credentials } = useSyncStore();
+  const { currentUser, isLoggedIn } = useSyncStore();
   const voiceMessageInputRef = useRef<VoiceMessageInputHandle | null>(null);
   const timeBlockWidgetRef = useRef<TimeBlockWidgetHandle | null>(null);
   const focusTimerWidgetRef = useRef<FocusTimerWidgetHandle | null>(null);
   const userDisplayName = currentUser || 'Hailay';
-  const userMeta = useMemo(() => {
-    const deviceName = credentials?.deviceName?.trim() || '本机设备';
-    const platformLabel = resolvePlatformLabel(credentials?.platform);
-    return {
-      deviceName,
-      platformLabel,
-      avatarInitial: resolveAvatarInitial(userDisplayName),
-    };
-  }, [credentials?.deviceName, credentials?.platform, userDisplayName]);
-  const assistantDeviceLabel = `· ExoMind · ${userMeta.platformLabel}`;
+  const userAvatarInitial = useMemo(() => resolveAvatarInitial(userDisplayName), [userDisplayName]);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
     listEndRef.current?.scrollIntoView({ behavior, block: 'end' });
@@ -539,6 +567,7 @@ export function ChatPage({ variant = 'default', hideHeader = false }: ChatPagePr
             )}
             {events.map((event) => {
               const systemEvent = isSystemEvent(event);
+              const eventSourceLabel = formatEventSourceLabel(event);
               if (systemEvent) {
                 const isAgentFeedback = event.tags.has('agent_feedback');
                 return (
@@ -558,7 +587,7 @@ export function ChatPage({ variant = 'default', hideHeader = false }: ChatPagePr
                         data-testid="new-mobile-message-meta"
                       >
                         <span className="text-xs font-semibold text-strong">AI 助理</span>
-                        <span className="text-muted">{assistantDeviceLabel}</span>
+                        <span className="text-muted">{eventSourceLabel}</span>
                         <span className="text-muted">{formatMessageTime(event.timestamp)}</span>
                       </div>
                       <div
@@ -588,8 +617,7 @@ export function ChatPage({ variant = 'default', hideHeader = false }: ChatPagePr
                       className="mb-1 flex items-center justify-end gap-1 text-[11px] leading-[1.4]"
                       data-testid="new-mobile-message-meta"
                     >
-                      <span className="text-muted">{userMeta.deviceName}</span>
-                      <span className="text-muted">· App ·</span>
+                      <span className="text-muted">{eventSourceLabel}</span>
                       <span className="text-muted">{formatMessageTime(event.timestamp)}</span>
                       <span className="text-xs font-semibold text-strong">{userDisplayName}</span>
                     </div>
@@ -600,7 +628,7 @@ export function ChatPage({ variant = 'default', hideHeader = false }: ChatPagePr
                   </div>
                   <Avatar className="h-8 w-8 shrink-0">
                     <AvatarFallback className="rounded-full bg-orange-100 text-[11px] font-semibold text-orange-800 dark:bg-orange-950 dark:text-orange-100">
-                      {userMeta.avatarInitial}
+                      {userAvatarInitial}
                     </AvatarFallback>
                   </Avatar>
                 </div>

--- a/src/components/Chat/chat-event-pagination.ts
+++ b/src/components/Chat/chat-event-pagination.ts
@@ -1,5 +1,11 @@
 import type { Event as StorageEvent } from '@/lib/storage/event-storage';
-import type { Event as UiEvent } from '@/lib/types/event';
+import type { Event as UiEvent, EventMetadata, Tag } from '@/lib/types/event';
+
+const TAGS_METADATA_KEY = 'tags';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
 
 function parseTimestamp(createdAt: string): number {
   const parsed = Date.parse(createdAt);
@@ -15,12 +21,40 @@ function sortByTimeAsc(events: UiEvent[]): UiEvent[] {
   });
 }
 
+function normalizeTags(rawTags: unknown, fallbackType?: string): Tag[] {
+  if (Array.isArray(rawTags)) {
+    const tags = rawTags.filter((tag): tag is Tag => typeof tag === 'string' && tag.length > 0);
+    if (tags.length > 0) {
+      return tags;
+    }
+  }
+
+  if (typeof fallbackType === 'string' && fallbackType.length > 0) {
+    return [fallbackType];
+  }
+
+  return [];
+}
+
+function toEventMetadata(rawMetadata: unknown): EventMetadata | undefined {
+  if (!isRecord(rawMetadata)) {
+    return undefined;
+  }
+
+  const metadata = { ...rawMetadata };
+  delete metadata[TAGS_METADATA_KEY];
+
+  return Object.keys(metadata).length > 0 ? (metadata as EventMetadata) : undefined;
+}
+
 export function toUiEvent(event: StorageEvent): UiEvent {
+  const tags = normalizeTags(isRecord(event.metadata) ? event.metadata[TAGS_METADATA_KEY] : undefined, event.type);
   return {
     id: event.id,
     timestamp: parseTimestamp(event.createdAt),
     content: event.content,
-    tags: new Set<string>(event.type ? [event.type] : []),
+    tags: new Set<string>(tags),
+    metadata: toEventMetadata(event.metadata),
   };
 }
 

--- a/src/lib/adapters/web-eventlog-storage.ts
+++ b/src/lib/adapters/web-eventlog-storage.ts
@@ -1,8 +1,13 @@
-import type { EventData, Tag } from '../types/event';
+import type { EventData, EventMetadata, Tag } from '../types/event';
 import type { IEventLogPort } from '../environment/interfaces/eventlog.port';
 import { getEventStorage, type Event as StorageEvent } from '../storage/event-storage';
 
 const NOTE_TAG: Tag = 'note';
+const TAGS_METADATA_KEY = 'tags';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
 
 /**
  * WebEventLogStorageAdapter
@@ -38,25 +43,53 @@ export class WebEventLogStorageAdapter implements IEventLogPort {
   }
 
   private toStorageEvent(event: EventData): StorageEvent {
+    const metadata = this.mergeMetadataWithTags(event.metadata, event.tags);
     return {
       id: event.id,
       content: event.content,
       createdAt: new Date(event.timestamp).toISOString(),
       type: event.tags[0] || NOTE_TAG,
-      metadata: {
-        tags: event.tags,
-      },
+      metadata,
     };
   }
 
   private fromStorageEvent(event: StorageEvent): EventData {
     const parsedTimestamp = Date.parse(event.createdAt);
+    const metadataRecord = this.toMetadataRecord(event.metadata);
+    const tags = this.normalizeTags(metadataRecord?.[TAGS_METADATA_KEY], event.type);
+    const metadata = this.stripTagsFromMetadata(metadataRecord);
+
     return {
       id: event.id,
       timestamp: Number.isNaN(parsedTimestamp) ? Date.now() : parsedTimestamp,
       content: event.content,
-      tags: this.normalizeTags(event.metadata?.tags, event.type),
+      tags,
+      metadata,
     };
+  }
+
+  private mergeMetadataWithTags(metadata: EventMetadata | undefined, tags: Tag[]): Record<string, unknown> {
+    const baseMetadata = isRecord(metadata) ? { ...metadata } : {};
+    return {
+      ...baseMetadata,
+      [TAGS_METADATA_KEY]: [...tags],
+    };
+  }
+
+  private toMetadataRecord(rawMetadata: unknown): Record<string, unknown> | null {
+    if (!isRecord(rawMetadata)) {
+      return null;
+    }
+    return { ...rawMetadata };
+  }
+
+  private stripTagsFromMetadata(metadata: Record<string, unknown> | null): EventMetadata | undefined {
+    if (!metadata) {
+      return undefined;
+    }
+    const nextMetadata = { ...metadata };
+    delete nextMetadata[TAGS_METADATA_KEY];
+    return Object.keys(nextMetadata).length > 0 ? (nextMetadata as EventMetadata) : undefined;
   }
 
   private normalizeTags(rawTags: unknown, fallbackType?: string): Tag[] {

--- a/src/lib/eventlog/source-metadata.ts
+++ b/src/lib/eventlog/source-metadata.ts
@@ -1,0 +1,137 @@
+import type { EventSourceMetadata } from '../types/event';
+import { createUuidV4 } from '../utils/uuid';
+
+const SYNC_STORE_KEY = 'exomind:sync-store';
+const DEVICE_ID_KEY = 'exomind:deviceId';
+const DEVICE_NAME_KEY = 'exomind:deviceName';
+
+const UNKNOWN_DEVICE_NAME = '未知设备';
+const UNKNOWN_PLATFORM = 'Unknown';
+
+interface SyncStoreSnapshot {
+  state?: {
+    credentials?: {
+      deviceName?: unknown;
+      platform?: unknown;
+    };
+  };
+  credentials?: {
+    deviceName?: unknown;
+    platform?: unknown;
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function readLocalStorageString(key: string): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const value = localStorage.getItem(key);
+    return readString(value);
+  } catch {
+    return null;
+  }
+}
+
+function readSyncStoreSnapshot(): SyncStoreSnapshot | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const raw = localStorage.getItem(SYNC_STORE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    return isRecord(parsed) ? (parsed as SyncStoreSnapshot) : null;
+  } catch {
+    return null;
+  }
+}
+
+function readCredentialField(field: 'deviceName' | 'platform'): string | null {
+  const snapshot = readSyncStoreSnapshot();
+  if (!snapshot) {
+    return null;
+  }
+
+  const stateCredentials = snapshot.state?.credentials;
+  const rootCredentials = snapshot.credentials;
+
+  return (
+    readString(stateCredentials?.[field])
+    ?? readString(rootCredentials?.[field])
+    ?? null
+  );
+}
+
+function detectPlatformFromNavigator(): string {
+  if (typeof navigator === 'undefined') {
+    return UNKNOWN_PLATFORM;
+  }
+
+  const ua = navigator.userAgent ?? '';
+  const nativePlatform = readString(navigator.platform) ?? UNKNOWN_PLATFORM;
+
+  if (/Android/.test(ua)) return 'Android';
+  if (/iPhone|iPad|iPod/.test(ua)) return 'iOS';
+  if (/Mac/.test(ua)) return 'macOS';
+  if (/Win/.test(ua)) return 'Windows';
+  if (/Linux/.test(ua)) return 'Linux';
+  return nativePlatform;
+}
+
+function resolvePlatform(): string {
+  return readCredentialField('platform') ?? detectPlatformFromNavigator();
+}
+
+function resolveDeviceName(platform: string): string {
+  return (
+    readCredentialField('deviceName')
+    ?? readLocalStorageString(DEVICE_NAME_KEY)
+    ?? (platform !== UNKNOWN_PLATFORM ? `${platform} Device` : UNKNOWN_DEVICE_NAME)
+  );
+}
+
+function resolveDeviceId(): string {
+  if (typeof window === 'undefined') {
+    return 'unknown-device';
+  }
+
+  const stored = readLocalStorageString(DEVICE_ID_KEY);
+  if (stored) {
+    return stored;
+  }
+
+  const created = createUuidV4();
+  try {
+    localStorage.setItem(DEVICE_ID_KEY, created);
+  } catch {
+    return 'unknown-device';
+  }
+  return created;
+}
+
+export function getEventSourceMetadata(): EventSourceMetadata {
+  const platform = resolvePlatform();
+  return {
+    deviceId: resolveDeviceId(),
+    deviceName: resolveDeviceName(platform),
+    platform,
+    app: 'ExoMind',
+  };
+}

--- a/src/lib/eventlog/transfer.ts
+++ b/src/lib/eventlog/transfer.ts
@@ -10,6 +10,10 @@ export interface EventLogTransferPayloadV1 {
 
 const TRANSFER_VERSION = 1;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function isEventData(value: unknown): value is EventData {
   if (!value || typeof value !== 'object') {
     return false;
@@ -22,7 +26,8 @@ function isEventData(value: unknown): value is EventData {
     Number.isFinite(item.timestamp) &&
     typeof item.content === 'string' &&
     Array.isArray(item.tags) &&
-    item.tags.every((tag) => typeof tag === 'string')
+    item.tags.every((tag) => typeof tag === 'string') &&
+    (item.metadata === undefined || isRecord(item.metadata))
   );
 }
 

--- a/src/lib/services/eventlog.service.ts
+++ b/src/lib/services/eventlog.service.ts
@@ -14,6 +14,7 @@ import type { IEventLogPort } from '../environment/interfaces/eventlog.port';
 import type { Event, NoteContent, Tag, EventData } from '../types/event';
 import { WebEventLogStorageAdapter } from '../adapters/web-eventlog-storage';
 import { createUuidV4 } from '../utils/uuid';
+import { getEventSourceMetadata } from '../eventlog/source-metadata';
 import {
   createTransferPayload,
   parseTransferPayload,
@@ -70,6 +71,9 @@ export class EventLogServiceImpl implements EventLogService {
       timestamp: Date.now(),
       content,
       tags: tags ? Array.from(tags) : [NOTE_TAG],
+      metadata: {
+        source: getEventSourceMetadata(),
+      },
     };
 
     await this.port.appendEvent(eventData);
@@ -128,6 +132,7 @@ export class EventLogServiceImpl implements EventLogService {
       timestamp: data.timestamp,
       content: data.content,
       tags: new Set(data.tags),
+      metadata: data.metadata,
     };
   }
 

--- a/src/lib/services/timeblock.service.ts
+++ b/src/lib/services/timeblock.service.ts
@@ -27,6 +27,7 @@ import type {
 import { getFeedbackPreferences, type FeedbackPreferences } from '../../config/feedback-preferences';
 import { getSelectedRuntimeTarget, toRuntimeBaseUrl } from '@/config/runtime-target';
 import { createUuidV4 } from '../utils/uuid';
+import { getEventSourceMetadata } from '../eventlog/source-metadata';
 
 // 存储键
 const TIME_BLOCKS_KEY = 'time_blocks';
@@ -386,6 +387,7 @@ export class TimeBlockServiceImpl implements TimeBlockService {
       createdAt: new Date(submittedAt).toISOString(),
       type: 'block_feedback',
       metadata: {
+        source: getEventSourceMetadata(),
         startTime: activeData.startTime,
         actionEndedAt,
         feedbackStartedAt,
@@ -531,6 +533,9 @@ export class TimeBlockServiceImpl implements TimeBlockService {
       content,
       createdAt,
       type: tag,
+      metadata: {
+        source: getEventSourceMetadata(),
+      },
     });
   }
 

--- a/src/lib/types/event.ts
+++ b/src/lib/types/event.ts
@@ -10,6 +10,18 @@ export type Timestamp = number;
 export type NoteContent = string;
 export type Tag = string;
 
+export interface EventSourceMetadata {
+  deviceId: string;
+  deviceName: string;
+  platform: string;
+  app: 'ExoMind';
+}
+
+export interface EventMetadata {
+  source?: EventSourceMetadata;
+  [key: string]: unknown;
+}
+
 // 标签常量
 export const SYSTEM_TAGS = {
   BLOCK_START: 'block_start' as Tag,
@@ -27,6 +39,7 @@ export interface EventData {
   timestamp: Timestamp;
   content: string;
   tags: string[];
+  metadata?: EventMetadata;
 }
 
 // 事件类型（UI 使用）
@@ -35,6 +48,7 @@ export interface Event {
   timestamp: Timestamp;
   content: string;
   tags: Set<Tag>;
+  metadata?: EventMetadata;
 }
 
 // 时间块数据类型（存储用）

--- a/src/ui/hooks/useSignalStream.ts
+++ b/src/ui/hooks/useSignalStream.ts
@@ -14,6 +14,8 @@ import {
   type ReviewCompletedPayload,
 } from '@/lib/services/signal-handlers';
 import { getEventStorage } from '@/lib/storage/event-storage';
+import { getEventSourceMetadata } from '@/lib/eventlog/source-metadata';
+import { createUuidV4 } from '@/lib/utils/uuid';
 import {
   getSelectedRuntimeTarget,
   subscribeRuntimeTargetChanges,
@@ -91,10 +93,13 @@ export function useSignalStream(): void {
         const content = formatReviewAsMarkdown(payload);
         const storage = getEventStorage();
         await storage.addEvent({
-          id: crypto.randomUUID(),
+          id: createUuidV4(),
           content,
           createdAt: new Date().toISOString(),
           type: 'agent_feedback',
+          metadata: {
+            source: getEventSourceMetadata(),
+          },
         });
         console.log('[SignalStream] review.completed → EventStorage (agent_feedback)');
       },

--- a/tests/e2e/eventlog.test.ts
+++ b/tests/e2e/eventlog.test.ts
@@ -14,7 +14,7 @@ test.describe('EventLog Page', () => {
       }
     });
     await page.goto('/eventlog');
-    await page.waitForLoadState('networkidle');
+    await expect(eventInput(page)).toBeVisible();
   });
 
   test('loads eventlog shell and input area', async ({ page }) => {

--- a/tests/unit/agent-hub/agent-types-contract.issue204.test.ts
+++ b/tests/unit/agent-hub/agent-types-contract.issue204.test.ts
@@ -93,7 +93,7 @@ class FakeAgentPort implements IAgentPort {
 
 describe('agent hub type contracts issue-204（Agent Hub 类型契约）', () => {
   it('exposes runtime constants for view mode and port contract（暴露运行时常量契约）', () => {
-    expect(AGENT_HUB_VIEW_MODES).toEqual(['topology', 'list', 'device']);
+    expect(AGENT_HUB_VIEW_MODES).toEqual(['topology', 'nodes', 'routes', 'device']);
     expect(AGENT_PORT_KEYWORDS).toContain('streamConversation');
   });
 

--- a/tests/unit/components/timeblock-new-mobile-layout.issue175.test.ts
+++ b/tests/unit/components/timeblock-new-mobile-layout.issue175.test.ts
@@ -8,7 +8,7 @@ describe('TimeBlockWidget issue-175 new-mobile structure', () => {
 
   it('uses a dedicated action row in running state for mobile layout', () => {
     expect(source).toContain('data-testid="timeblock-action-row"');
-    expect(source).toContain('rounded-[24px] border-0 bg-[#EDECE9]');
+    expect(source).toContain('rounded-[24px] border-0 bg-warning');
     expect(source).toContain('rounded-[24px] border-0 bg-[#FDECEB]');
   });
 });

--- a/tests/unit/eventlog/eventlog-port-contract.test.ts
+++ b/tests/unit/eventlog/eventlog-port-contract.test.ts
@@ -32,6 +32,13 @@ describe('EventLogService port contract', () => {
 
     expect(port.listEvents).toHaveBeenCalled();
     expect(port.appendEvent).toHaveBeenCalledTimes(1);
+    const [event] = port.appendEvent.mock.calls[0] as [EventData];
+    expect(event.metadata?.source).toEqual(expect.objectContaining({
+      app: 'ExoMind',
+      deviceId: expect.any(String),
+      deviceName: expect.any(String),
+      platform: expect.any(String),
+    }));
   });
 
   it('keeps addEvent working when crypto.randomUUID is unavailable', async () => {
@@ -55,6 +62,9 @@ describe('EventLogService port contract', () => {
     expect(port.appendEvent).toHaveBeenCalledTimes(1);
     const [event] = port.appendEvent.mock.calls[0] as [EventData];
     expect(event.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    expect(event.metadata?.source).toEqual(expect.objectContaining({
+      app: 'ExoMind',
+    }));
     expect(getRandomValues).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/services/timeblock.service.test.ts
+++ b/tests/unit/services/timeblock.service.test.ts
@@ -19,6 +19,7 @@ vi.mock('@/config/feedback-preferences', () => ({
 }));
 
 import { TimeBlockServiceImpl } from '@/lib/services/timeblock.service';
+import { DEFAULT_EMBEDDED_RUNTIME_PORT } from '@/config/runtime-target';
 
 type MemoryEnv = {
   storage: {
@@ -81,6 +82,20 @@ describe('TimeBlockServiceImpl', () => {
     expect(stored?.elapsed).toBeLessThanOrEqual(25 * 60 * 1000);
     expect(stored?.elapsed).toBeGreaterThanOrEqual(25 * 60 * 1000 - 2000);
     expect(addEventMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'block_start' }));
+
+    const blockStartCall = addEventMock.mock.calls
+      .map(([event]) => event)
+      .find((event) => event.type === 'block_start');
+    expect(blockStartCall).toEqual(expect.objectContaining({
+      metadata: expect.objectContaining({
+        source: expect.objectContaining({
+          app: 'ExoMind',
+          deviceId: expect.any(String),
+          deviceName: expect.any(String),
+          platform: expect.any(String),
+        }),
+      }),
+    }));
   });
 
   it('writes block_feedback event when ending with feedback', async () => {
@@ -425,7 +440,7 @@ describe('TimeBlockServiceImpl', () => {
     expect(restarted.startId).not.toBe(first.startId);
   });
 
-  it('publishes timeblock.completed to embedded RT on port 4077（发布到内嵌 RT 4077）', async () => {
+  it('publishes timeblock.completed to embedded RT default port（发布到内嵌 RT 默认端口）', async () => {
     const env = createMemoryEnv();
     const addEvent = vi.fn();
     const getEvents = vi.fn().mockResolvedValue([]);
@@ -453,7 +468,7 @@ describe('TimeBlockServiceImpl', () => {
 
     expect(fetchSpy).toHaveBeenCalled();
     expect(fetchSpy).toHaveBeenCalledWith(
-      'http://localhost:4077/signals/publish',
+      `http://${window.location.hostname || 'localhost'}:${DEFAULT_EMBEDDED_RUNTIME_PORT}/signals/publish`,
       expect.objectContaining({ method: 'POST' }),
     );
   });

--- a/tests/unit/tauri/runtime-embedded.m1.test.ts
+++ b/tests/unit/tauri/runtime-embedded.m1.test.ts
@@ -6,7 +6,9 @@ describe('runtime embedded startup m1（Runtime 内嵌启动约束）', () => {
     const tauriLib = readFileSync('src-tauri/src/lib.rs', 'utf-8');
     expect(tauriLib).toContain('.setup(');
     expect(tauriLib).toMatch(/runtime.*start/i);
-    expect(tauriLib).toContain('ensure_runtime_started(runtime_state, None, Some(4077))');
+    expect(tauriLib).toContain('fn resolve_embedded_runtime_port() -> u16');
+    expect(tauriLib).toContain('unwrap_or(9124)');
+    expect(tauriLib).toContain('ensure_runtime_started(runtime_state, None, Some(runtime_port))');
   });
 
   it('runtime commands no longer spawn bun server script（不再通过 bun 脚本拉起 runtime）', () => {

--- a/tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx
+++ b/tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { AgentsPage } from '@/ui/app/pages/AgentsPage';
 import { AGENT_HUB_MOCK_FIXTURE } from '@/lib/adapters/mock/fixtures/agent-hub';
 import type { RuntimeHostRecord } from '@/lib/types/agent-hub';
+import { DEFAULT_EMBEDDED_RUNTIME_PORT } from '@/config/runtime-target';
 
 const agentHubMocks = vi.hoisted(() => ({
   getTopology: vi.fn(),
@@ -138,24 +139,24 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
     runtimeControlMocks.getStatus.mockResolvedValue({
       running: false,
       host: '127.0.0.1',
-      port: 4077,
+      port: DEFAULT_EMBEDDED_RUNTIME_PORT,
     });
     runtimeControlMocks.startRuntime.mockResolvedValue({
       running: true,
       host: '127.0.0.1',
-      port: 4077,
+      port: DEFAULT_EMBEDDED_RUNTIME_PORT,
       pid: 9527,
     });
     runtimeControlMocks.stopRuntime.mockResolvedValue({
       running: false,
       host: '127.0.0.1',
-      port: 4077,
+      port: DEFAULT_EMBEDDED_RUNTIME_PORT,
     });
   });
 
   it('opens manager sheet from device view and adds runtime host（设备页可打开主机管理并新增 RuntimeHost）', async () => {
     render(<AgentsPage />);
-    fireEvent.click(await screen.findByTestId('agent-view-toggle-device'));
+    fireEvent.click(await screen.findByRole('button', { name: '设备' }));
 
     await waitFor(() => {
       expect(screen.getByTestId('runtime-host-panel')).toBeInTheDocument();
@@ -179,7 +180,7 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
 
   it('probes runtime host and updates status badge（探测后更新状态徽标）', async () => {
     render(<AgentsPage />);
-    fireEvent.click(await screen.findByTestId('agent-view-toggle-device'));
+    fireEvent.click(await screen.findByRole('button', { name: '设备' }));
 
     await waitFor(() => {
       expect(screen.getByTestId('runtime-host-status-runtime-host-1')).toHaveTextContent('offline');
@@ -195,7 +196,7 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
 
   it('starts and stops local runtime from device panel（设备页可启停本地 Runtime）', async () => {
     render(<AgentsPage />);
-    fireEvent.click(await screen.findByTestId('agent-view-toggle-device'));
+    fireEvent.click(await screen.findByRole('button', { name: '设备' }));
 
     await waitFor(() => {
       expect(screen.getByTestId('runtime-local-status')).toHaveTextContent('stopped');
@@ -205,7 +206,7 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
     await waitFor(() => {
       expect(runtimeControlMocks.startRuntime).toHaveBeenCalledWith({
         host: '127.0.0.1',
-        port: 4077,
+        port: DEFAULT_EMBEDDED_RUNTIME_PORT,
       });
       expect(screen.getByTestId('runtime-local-status')).toHaveTextContent('running');
     });
@@ -219,7 +220,7 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
 
   it('switches runtime target to external and saves host address（可切换外部 Runtime 并保存地址）', async () => {
     render(<AgentsPage />);
-    fireEvent.click(await screen.findByTestId('agent-view-toggle-device'));
+    fireEvent.click(await screen.findByRole('button', { name: '设备' }));
 
     await waitFor(() => {
       expect(screen.getByTestId('runtime-target-mode-embedded')).toHaveAttribute('aria-pressed', 'true');

--- a/tests/unit/ui/agent-hub/agents-page.desktop-adapt.issue354.test.ts
+++ b/tests/unit/ui/agent-hub/agents-page.desktop-adapt.issue354.test.ts
@@ -7,9 +7,8 @@ describe('agents page desktop adapt issue-354（桌面端适配与占位清理�
   const source = readFileSync(sourcePath, 'utf-8');
 
   it('uses desktop-specific bottom padding override（桌面端覆盖底部内边距）', () => {
-    expect(source).toContain(
-      'pb-[calc(env(safe-area-inset-bottom,0px)+108px)] pt-2 lg:pb-6'
-    );
+    expect(source).toContain('pb-[calc(env(safe-area-inset-bottom,0px)+108px)]');
+    expect(source).toContain('md:pb-6');
   });
 
   it('shows right panel only on lg breakpoint（右侧栏在 lg 断点显示）', () => {

--- a/tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agents-page.issue204.test.tsx
@@ -205,12 +205,12 @@ describe('agents page issue-204（主页面三视图与添加节点）', () => {
       expect(screen.getByText('user.input.text → classifier')).toBeInTheDocument();
       expect(screen.getByText('session.end → reviewer')).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByTestId('agent-view-toggle-list'));
-    expect(screen.getByTestId('agent-list-view')).toBeInTheDocument();
-    expect(screen.getByTestId('agent-list-filter-all')).toBeInTheDocument();
-    expect(screen.getByTestId('agent-signal-route-section')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '节点' }));
+    expect(screen.getByText('全部')).toBeInTheDocument();
     expect(screen.getByText('Echo Agent')).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId('agent-view-toggle-device'));
+
+    fireEvent.click(screen.getByRole('button', { name: '设备' }));
     expect(screen.getByTestId('agent-device-view')).toBeInTheDocument();
     expect(screen.getByTestId('agent-device-overview-card')).toBeInTheDocument();
   });
@@ -223,6 +223,10 @@ describe('agents page issue-204（主页面三视图与添加节点）', () => {
     });
 
     fireEvent.click(screen.getByTestId('agent-add-node-button'));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '添加信号输入' })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: '添加信号输入' }));
     expect(screen.getByTestId('agent-add-node-sheet')).toBeInTheDocument();
     expect(screen.getByText('添加设备')).toBeInTheDocument();
 
@@ -245,10 +249,10 @@ describe('agents page issue-204（主页面三视图与添加节点）', () => {
     render(<AgentsPage />);
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Agent 网络' })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Agent Hub' })).toBeInTheDocument();
     });
 
-    const heading = screen.getByRole('heading', { name: 'Agent 网络' });
+    const heading = screen.getByRole('heading', { name: 'Agent Hub' });
     expect(heading.className).toContain('text-lg');
     expect(heading.className).toContain('font-semibold');
     expect(heading.className).not.toContain('text-[30px]');

--- a/tests/unit/ui/agent-hub/agents-page.runtime.issue201.test.tsx
+++ b/tests/unit/ui/agent-hub/agents-page.runtime.issue201.test.tsx
@@ -188,13 +188,18 @@ describe('agents page runtime issue-201（AgentsPage 真实数据聚合）', () 
 
   it('shows aggregated runtime agents with source host badge（聚合显示并标注来源主机）', async () => {
     render(<AgentsPage />);
-    fireEvent.click(await screen.findByTestId('agent-view-toggle-list'));
+    fireEvent.click(await screen.findByRole('button', { name: '节点' }));
 
     await waitFor(() => {
       expect(screen.getByText('Echo Agent')).toBeInTheDocument();
       expect(screen.getAllByText(/来源 127\.0\.0\.1:1919/).length).toBeGreaterThanOrEqual(1);
-      expect(screen.getByTestId('agent-signal-route-section')).toBeInTheDocument();
-      expect(screen.getAllByTestId(/agent-signal-route-row-/).length).toBeGreaterThanOrEqual(5);
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: '路由' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('信号路由')).toBeInTheDocument();
+      expect(screen.getAllByText(/user\.input\.text|session\.end|timeblock\.completed/).length).toBeGreaterThanOrEqual(3);
     });
   });
 
@@ -202,6 +207,7 @@ describe('agents page runtime issue-201（AgentsPage 真实数据聚合）', () 
     render(<AgentsPage />);
 
     fireEvent.click(await screen.findByTestId('agent-add-node-button'));
+    fireEvent.click(await screen.findByRole('button', { name: '添加信号输入' }));
     expect(screen.getByTestId('agent-add-node-sheet')).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('agent-add-node-option-device'));
@@ -213,6 +219,7 @@ describe('agents page runtime issue-201（AgentsPage 真实数据聚合）', () 
     runtimeManagerMocks.removeHost.mockResolvedValue(undefined);
     render(<AgentsPage />);
     fireEvent.click(await screen.findByTestId('agent-add-node-button'));
+    fireEvent.click(await screen.findByRole('button', { name: '添加信号输入' }));
     fireEvent.click(screen.getByTestId('agent-add-node-option-device'));
 
     fireEvent.click(await screen.findByTestId('runtime-host-probe-host-b'));

--- a/tests/unit/ui/now-message-meta.issue175.test.ts
+++ b/tests/unit/ui/now-message-meta.issue175.test.ts
@@ -14,7 +14,8 @@ describe('new now message meta issue-175 structure', () => {
 
   it('contains device and time text format for message meta', () => {
     expect(source).toContain('AI 助理');
-    expect(source).toContain('· App ·');
+    expect(source).toContain('formatEventSourceLabel(event)');
+    expect(source).toContain('未知设备');
     expect(source).toContain('formatMessageTime(event.timestamp)');
   });
 });


### PR DESCRIPTION
﻿## 背景
- 事件日志中的来源设备显示使用了当前设备信息，而不是事件实际发送设备，导致手机/电脑发送的同文案在列表中来源显示错误。

## 变更内容
- 为事件类型新增 `metadata.source` 结构（`deviceId/deviceName/platform/app`）。
- 新增统一来源元数据解析器：`src/lib/eventlog/source-metadata.ts`。
- 在事件写入链路补齐来源：
  - `EventLogService` 写入用户事件时附带 `metadata.source`
  - `TimeBlockService` 写入 `block_*` / `block_feedback` 时附带 `metadata.source`
  - `useSignalStream` 写入 `agent_feedback` 时附带 `metadata.source`
- 调整 Web 存储适配器，确保 metadata 在读写过程中完整保留。
- 调整 transfer 校验与分页映射，允许并保留 metadata。
- Chat 页面改为按事件自身 `metadata.source` 渲染来源标签；缺失来源时显示“未知设备”。

## 测试与工具链修复
- 修复并对齐若干陈旧测试断言（agent hub / timeblock / tauri 启动断言等），与当前实现一致。
- 修复 E2E `eventlog.test.ts` 在长连接场景下 `networkidle` 超时问题（改为基于可见元素就绪）。
- 处理 Playwright 并发产物目录冲突（串行执行并使用独立输出目录）。

## 验证结果
- `npx tsc --noEmit` ✅
- `npx vitest run`（全量）✅
- `bun run build` ✅
- `npx playwright test tests/e2e/eventlog.test.ts` ✅
- `npx playwright test tests/e2e/eventlog-multi-device-sync.issue27.test.ts -c tests/e2e/playwright.issue27.config.ts --output test-results/issue27-run` ✅

## 备注
- 本地已有的 `src-tauri/Cargo.toml` 改动未纳入本次提交。
