### PR TITLE
fix(ci): macOS/Linux 构建产物未上传

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -983,7 +983,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: macos-dmg-${{ steps.hash.outputs.HASH }}
-          path: src-tauri/target/release/bundle/dmg/
+          path: |
+            target/release/bundle/dmg/
+            src-tauri/target/release/bundle/dmg/
           if-no-files-found: ignore
 
   build-linux:
@@ -1079,14 +1081,18 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: linux-deb-${{ steps.hash.outputs.HASH }}
-          path: src-tauri/target/release/bundle/deb/
+          path: |
+            target/release/bundle/deb/
+            src-tauri/target/release/bundle/deb/
           if-no-files-found: ignore
 
       - name: Upload Linux AppImage Artifact (上传 AppImage)
         uses: actions/upload-artifact@v4
         with:
           name: linux-appimage-${{ steps.hash.outputs.HASH }}
-          path: src-tauri/target/release/bundle/appimage/
+          path: |
+            target/release/bundle/appimage/
+            src-tauri/target/release/bundle/appimage/
           if-no-files-found: ignore
 
   create-release:


### PR DESCRIPTION
## Summary

- macOS DMG, Linux DEB/AppImage artifacts were silently not uploaded due to wrong path prefix
- `npx tauri build` outputs to `target/release/bundle/` (workspace root), not `src-tauri/target/release/bundle/`
- This caused `latest.json` to miss macOS and Linux entries → download page showed no builds for these platforms

## Root Cause

The upload-artifact steps searched `src-tauri/target/release/bundle/{dmg,deb,appimage}/` but Tauri CLI writes bundles to `target/release/bundle/`. Combined with `if-no-files-found: ignore`, the failure was silent.

CI log evidence:
```
build-macos: Bundling ExoMind_0.3.5_aarch64.dmg (target/release/bundle/dmg/...)
build-macos: No files were found with the provided path: src-tauri/target/release/bundle/dmg/
```

## Fix

Add both `target/release/bundle/` and `src-tauri/target/release/bundle/` paths to all three upload steps (DMG, DEB, AppImage), mirroring the pattern already used for Windows EXE uploads.

## Test plan

- [ ] Merge to dev, tag `release/v0.3.5` re-push
- [ ] Verify macOS DMG and Linux AppImage/DEB appear in GitHub Actions artifacts
- [ ] Verify `latest.json` on R2 contains all platform entries
- [ ] Verify download page shows macOS and Linux builds

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)