### PR TITLE
feat: add in-app reminders MVP (#375)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { UpdateToast } from "@/ui/components/UpdateToast";
 import { TimeBlockSyncCoordinator } from "@/ui/app/components/TimeBlockSyncCoordinator";
 import { TaskSyncCoordinator } from "@/ui/app/components/TaskSyncCoordinator";
+import { ReminderSyncCoordinator } from "@/ui/app/components/ReminderSyncCoordinator";
 import {
   initUpdateChecker,
   destroyUpdateChecker,
@@ -35,6 +36,7 @@ function App() {
       <ThemeController />
       <TimeBlockSyncCoordinator />
       <TaskSyncCoordinator />
+      <ReminderSyncCoordinator />
       <RouterProvider router={appRouter} />
       <Toaster />
       <UpdateToast />

--- a/src/lib/adapters/reminder-pouch-adapter.ts
+++ b/src/lib/adapters/reminder-pouch-adapter.ts
@@ -1,0 +1,78 @@
+import type { IReminderPort } from '@/lib/environment/interfaces/reminder.port';
+import { getCurrentUserId } from '@/lib/storage/event-storage';
+import { getReminderStorage } from '@/lib/storage/reminder-storage';
+import {
+  transitionReminder,
+  type CreateReminderInput,
+  type Reminder,
+  type ReminderStatus,
+  type UpdateReminderInput,
+} from '@/lib/types/reminder';
+import { createUuidV4 } from '@/lib/utils/uuid';
+
+export class ReminderPouchAdapter implements IReminderPort {
+  constructor(private readonly userId?: string) {}
+
+  private get storage() {
+    return getReminderStorage(this.userId || getCurrentUserId());
+  }
+
+  async listReminders(): Promise<Reminder[]> {
+    return this.storage.getReminders();
+  }
+
+  async getReminderById(id: string): Promise<Reminder | null> {
+    const reminder = await this.storage.getReminder(id);
+    return reminder ?? null;
+  }
+
+  async createReminder(input: CreateReminderInput): Promise<Reminder> {
+    const now = Date.now();
+    const reminder: Reminder = {
+      id: createUuidV4(),
+      title: input.title.trim(),
+      content: input.content,
+      dueAt: input.dueAt,
+      status: 'pending',
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await this.storage.addReminder(reminder);
+    return reminder;
+  }
+
+  async updateReminder(id: string, input: UpdateReminderInput): Promise<Reminder | null> {
+    const updates: UpdateReminderInput = {
+      ...input,
+      ...(typeof input.title === 'string' ? { title: input.title.trim() } : {}),
+    };
+    const updated = await this.storage.updateReminder(id, updates);
+    return updated ?? null;
+  }
+
+  async transitionReminder(id: string, to: ReminderStatus, at = Date.now()): Promise<Reminder | null> {
+    const current = await this.storage.getReminder(id);
+    if (!current) return null;
+
+    const next = transitionReminder(current, to, at);
+    const updated = await this.storage.updateReminder(id, {
+      status: next.status,
+      completedAt: next.completedAt,
+      updatedAt: next.updatedAt,
+    });
+    return updated ?? next;
+  }
+
+  async startSync(remoteUrl: string): Promise<void> {
+    await this.storage.syncToRemote(remoteUrl);
+  }
+
+  async stopSync(): Promise<void> {
+    await this.storage.stopSync();
+  }
+
+  onRemoteChange(callback: (change: unknown) => void): () => void {
+    return this.storage.onRemoteChange(callback);
+  }
+}

--- a/src/lib/environment/interfaces/reminder.port.ts
+++ b/src/lib/environment/interfaces/reminder.port.ts
@@ -1,0 +1,17 @@
+import type {
+  CreateReminderInput,
+  Reminder,
+  ReminderStatus,
+  UpdateReminderInput,
+} from '@/lib/types/reminder';
+
+export interface IReminderPort {
+  listReminders(): Promise<Reminder[]>;
+  getReminderById(id: string): Promise<Reminder | null>;
+  createReminder(input: CreateReminderInput): Promise<Reminder>;
+  updateReminder(id: string, input: UpdateReminderInput): Promise<Reminder | null>;
+  transitionReminder(id: string, to: ReminderStatus, at?: number): Promise<Reminder | null>;
+  startSync(remoteUrl: string): Promise<void>;
+  stopSync(): Promise<void>;
+  onRemoteChange(callback: (change: unknown) => void): () => void;
+}

--- a/src/lib/services/command-palette.commands.ts
+++ b/src/lib/services/command-palette.commands.ts
@@ -1,10 +1,11 @@
 import { setTasksDefaultTab } from '@/config/tasks-default-tab';
 import type { CommandDefinition } from '@/lib/types/command-palette';
 
-export type CoreNavigationPath = '/eventlog' | '/tasks' | '/settings' | '/me' | '/agents';
+export type CoreNavigationPath = '/eventlog' | '/tasks' | '/reminders' | '/settings' | '/me' | '/agents';
 
 interface CreateCoreNavigationCommandsOptions {
   navigate: (path: CoreNavigationPath) => Promise<void> | void;
+  openReminderComposer?: () => void;
 }
 
 export function createCoreNavigationCommands(
@@ -73,6 +74,33 @@ export function createCoreNavigationCommands(
       keywords: ['账户', 'profile'],
       async execute() {
         await options.navigate('/me');
+        return { ok: true };
+      },
+    },
+    {
+      id: 'navigate:reminders',
+      title: '打开提醒',
+      description: '跳转到提醒页面',
+      category: 'navigation',
+      permissionTier: 'safe',
+      aliases: ['提醒', 'reminder', 'reminders'],
+      keywords: ['定时提醒', '通知', '日程'],
+      async execute() {
+        await options.navigate('/reminders');
+        return { ok: true };
+      },
+    },
+    {
+      id: 'action:create-reminder',
+      title: '新建提醒',
+      description: '在提醒页打开新建提醒表单',
+      category: 'action',
+      permissionTier: 'safe',
+      aliases: ['创建提醒', '添加提醒', 'new reminder'],
+      keywords: ['提醒', '创建', 'deadline'],
+      async execute() {
+        options.openReminderComposer?.();
+        await options.navigate('/reminders');
         return { ok: true };
       },
     },

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -14,6 +14,14 @@ export type { TaskService } from './task.service';
 export { TaskTimerServiceImpl, getTaskTimerService } from './task-timer.service';
 export type { TaskTimerService } from './task-timer.service';
 
+export { ReminderServiceImpl, getReminderService } from './reminder.service';
+export type { ReminderService } from './reminder.service';
+export {
+  ReminderSchedulerServiceImpl,
+  getReminderSchedulerService,
+} from './reminder-scheduler.service';
+export type { ReminderSchedulerService } from './reminder-scheduler.service';
+
 export { MeServiceImpl, getMeService } from './me.service';
 export type { MeService } from './me.service';
 export { AgentHubServiceImpl, getAgentHubService } from './agent-hub.service';

--- a/src/lib/services/reminder-scheduler.service.ts
+++ b/src/lib/services/reminder-scheduler.service.ts
@@ -1,0 +1,115 @@
+import type { Reminder } from '@/lib/types/reminder';
+import { getReminderService, type ReminderService } from './reminder.service';
+
+export const DEFAULT_REMINDER_SCHEDULER_INTERVAL_MS = 30_000;
+
+export interface ReminderSchedulerService {
+  start(intervalMs?: number): void;
+  stop(): void;
+  runNow(): Promise<void>;
+  onTriggered(listener: (reminder: Reminder) => void): () => void;
+}
+
+export class ReminderSchedulerServiceImpl implements ReminderSchedulerService {
+  private readonly reminderService: ReminderService;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private pollIntervalMs = DEFAULT_REMINDER_SCHEDULER_INTERVAL_MS;
+  private listeners = new Set<(reminder: Reminder) => void>();
+  private inFlight = false;
+  private notifiedTriggeredIds = new Set<string>();
+
+  constructor(reminderService?: ReminderService) {
+    this.reminderService = reminderService ?? getReminderService();
+  }
+
+  start(intervalMs = DEFAULT_REMINDER_SCHEDULER_INTERVAL_MS): void {
+    const normalizedInterval = Number.isFinite(intervalMs) && intervalMs >= 5_000
+      ? Math.trunc(intervalMs)
+      : DEFAULT_REMINDER_SCHEDULER_INTERVAL_MS;
+
+    if (this.timer) {
+      if (this.pollIntervalMs === normalizedInterval) {
+        return;
+      }
+      this.stop();
+    }
+
+    this.pollIntervalMs = normalizedInterval;
+    void this.runNow();
+    this.timer = setInterval(() => {
+      void this.runNow();
+    }, this.pollIntervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async runNow(): Promise<void> {
+    if (this.inFlight) return;
+    this.inFlight = true;
+
+    try {
+      const now = Date.now();
+      const duePending = await this.reminderService.getDuePendingReminders(now);
+
+      for (const pendingReminder of duePending) {
+        const triggered = await this.reminderService.markTriggered(pendingReminder.id, now);
+        if (triggered && triggered.status === 'triggered') {
+          this.notifiedTriggeredIds.add(triggered.id);
+          this.emitTriggered(triggered);
+        }
+      }
+
+      const allReminders = await this.reminderService.listReminders();
+      const triggeredReminders = allReminders.filter((reminder) => reminder.status === 'triggered');
+      const activeTriggeredIds = new Set(triggeredReminders.map((reminder) => reminder.id));
+
+      for (const triggeredReminder of triggeredReminders) {
+        if (this.notifiedTriggeredIds.has(triggeredReminder.id)) {
+          continue;
+        }
+
+        this.notifiedTriggeredIds.add(triggeredReminder.id);
+        this.emitTriggered(triggeredReminder);
+      }
+
+      for (const knownId of Array.from(this.notifiedTriggeredIds)) {
+        if (!activeTriggeredIds.has(knownId)) {
+          this.notifiedTriggeredIds.delete(knownId);
+        }
+      }
+    } finally {
+      this.inFlight = false;
+    }
+  }
+
+  onTriggered(listener: (reminder: Reminder) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private emitTriggered(reminder: Reminder): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(reminder);
+      } catch {
+        // ignore listener exceptions
+      }
+    }
+  }
+}
+
+let reminderSchedulerServiceInstance: ReminderSchedulerService | null = null;
+
+export function getReminderSchedulerService(): ReminderSchedulerService {
+  if (!reminderSchedulerServiceInstance) {
+    reminderSchedulerServiceInstance = new ReminderSchedulerServiceImpl();
+  }
+  return reminderSchedulerServiceInstance;
+}

--- a/src/lib/services/reminder.service.ts
+++ b/src/lib/services/reminder.service.ts
@@ -1,0 +1,184 @@
+import { ReminderPouchAdapter } from '@/lib/adapters/reminder-pouch-adapter';
+import type { IReminderPort } from '@/lib/environment/interfaces/reminder.port';
+import type {
+  CreateReminderInput,
+  Reminder,
+  ReminderStatus,
+  UpdateReminderInput,
+} from '@/lib/types/reminder';
+
+export interface ReminderService {
+  listReminders(): Promise<Reminder[]>;
+  listRemindersByStatus(status: ReminderStatus): Promise<Reminder[]>;
+  getReminder(id: string): Promise<Reminder | null>;
+  createReminder(input: CreateReminderInput): Promise<Reminder>;
+  updateReminder(id: string, input: UpdateReminderInput): Promise<Reminder | null>;
+  markTriggered(id: string, triggeredAt?: number): Promise<Reminder | null>;
+  completeReminder(id: string, completedAt?: number): Promise<Reminder | null>;
+  getDuePendingReminders(at?: number): Promise<Reminder[]>;
+  startSync(remoteUrl: string): Promise<void>;
+  stopSync(): Promise<void>;
+  onReminderChange(callback: () => void): () => void;
+}
+
+function normalizeDueAt(value: number): number {
+  if (!Number.isFinite(value)) {
+    throw new Error('提醒时间无效');
+  }
+  return Math.trunc(value);
+}
+
+function assertNonEmptyTitle(title: string): string {
+  const normalized = title.trim();
+  if (!normalized) {
+    throw new Error('提醒标题不能为空');
+  }
+  return normalized;
+}
+
+export class ReminderServiceImpl implements ReminderService {
+  private readonly port: IReminderPort;
+  private syncUnsubscribe: (() => void) | null = null;
+  private changeListeners = new Set<() => void>();
+
+  constructor(port?: IReminderPort) {
+    this.port = port ?? new ReminderPouchAdapter();
+  }
+
+  listReminders(): Promise<Reminder[]> {
+    return this.port.listReminders();
+  }
+
+  async listRemindersByStatus(status: ReminderStatus): Promise<Reminder[]> {
+    const reminders = await this.port.listReminders();
+    return reminders.filter((reminder) => reminder.status === status);
+  }
+
+  getReminder(id: string): Promise<Reminder | null> {
+    return this.port.getReminderById(id);
+  }
+
+  async createReminder(input: CreateReminderInput): Promise<Reminder> {
+    const created = await this.port.createReminder({
+      ...input,
+      title: assertNonEmptyTitle(input.title),
+      dueAt: normalizeDueAt(input.dueAt),
+    });
+    this.notifyChangeListeners();
+
+    if (created.dueAt <= Date.now()) {
+      const triggered = await this.port.transitionReminder(created.id, 'triggered', Date.now());
+      this.notifyChangeListeners();
+      return triggered ?? created;
+    }
+
+    return created;
+  }
+
+  async updateReminder(id: string, input: UpdateReminderInput): Promise<Reminder | null> {
+    const current = await this.port.getReminderById(id);
+    if (!current) return null;
+
+    if (current.status !== 'pending') {
+      throw new Error('仅未到期提醒可编辑');
+    }
+
+    const patch: UpdateReminderInput = {};
+    if (typeof input.title === 'string') {
+      patch.title = assertNonEmptyTitle(input.title);
+    }
+    if (typeof input.content === 'string') {
+      patch.content = input.content;
+    }
+    if (typeof input.dueAt === 'number') {
+      patch.dueAt = normalizeDueAt(input.dueAt);
+    }
+
+    const updated = await this.port.updateReminder(id, patch);
+    if (!updated) return null;
+
+    this.notifyChangeListeners();
+
+    if (updated.dueAt <= Date.now()) {
+      const triggered = await this.port.transitionReminder(updated.id, 'triggered', Date.now());
+      this.notifyChangeListeners();
+      return triggered ?? updated;
+    }
+
+    return updated;
+  }
+
+  async markTriggered(id: string, triggeredAt = Date.now()): Promise<Reminder | null> {
+    const current = await this.port.getReminderById(id);
+    if (!current) return null;
+    if (current.status === 'triggered' || current.status === 'completed') return current;
+
+    const triggered = await this.port.transitionReminder(id, 'triggered', triggeredAt);
+    if (triggered) {
+      this.notifyChangeListeners();
+    }
+    return triggered;
+  }
+
+  async completeReminder(id: string, completedAt = Date.now()): Promise<Reminder | null> {
+    const current = await this.port.getReminderById(id);
+    if (!current) return null;
+    if (current.status === 'completed') return current;
+
+    const completed = await this.port.transitionReminder(id, 'completed', completedAt);
+    if (completed) {
+      this.notifyChangeListeners();
+    }
+    return completed;
+  }
+
+  async getDuePendingReminders(at = Date.now()): Promise<Reminder[]> {
+    const reminders = await this.port.listReminders();
+    return reminders
+      .filter((reminder) => reminder.status === 'pending' && reminder.dueAt <= at)
+      .sort((left, right) => left.dueAt - right.dueAt);
+  }
+
+  async startSync(remoteUrl: string): Promise<void> {
+    if (!this.syncUnsubscribe) {
+      this.syncUnsubscribe = this.port.onRemoteChange(() => {
+        this.notifyChangeListeners();
+      });
+    }
+    await this.port.startSync(remoteUrl);
+  }
+
+  async stopSync(): Promise<void> {
+    if (this.syncUnsubscribe) {
+      this.syncUnsubscribe();
+      this.syncUnsubscribe = null;
+    }
+    await this.port.stopSync();
+  }
+
+  onReminderChange(callback: () => void): () => void {
+    this.changeListeners.add(callback);
+    return () => {
+      this.changeListeners.delete(callback);
+    };
+  }
+
+  private notifyChangeListeners(): void {
+    for (const listener of this.changeListeners) {
+      try {
+        listener();
+      } catch {
+        // ignore listener exceptions
+      }
+    }
+  }
+}
+
+let reminderServiceInstance: ReminderService | null = null;
+
+export function getReminderService(): ReminderService {
+  if (!reminderServiceInstance) {
+    reminderServiceInstance = new ReminderServiceImpl();
+  }
+  return reminderServiceInstance;
+}

--- a/src/lib/storage/reminder-storage.ts
+++ b/src/lib/storage/reminder-storage.ts
@@ -1,0 +1,294 @@
+import PouchDB from 'pouchdb';
+import { buildSyncErrorLog } from './sync-error';
+import type { Reminder, ReminderStatus } from '@/lib/types/reminder';
+
+const POUCHDB_PREFIX_ENV = 'EXOMIND_REMINDER_STORAGE_PREFIX';
+const DEFAULT_TEST_POUCHDB_PREFIX = '.tmp/pouchdb-reminder-storage/';
+
+interface ReminderDoc extends Reminder {
+  _id: string;
+  _rev?: string;
+}
+
+const BY_DUE_AT_MAP = `function(doc) {
+  if (doc._id && doc._id.startsWith('reminder:')) {
+    emit(doc.dueAt, null);
+  }
+}`;
+
+const BY_STATUS_MAP = `function(doc) {
+  if (doc._id && doc._id.startsWith('reminder:')) {
+    emit(doc.status, null);
+  }
+}`;
+
+function normalizePouchDbPrefix(prefix: string): string {
+  const trimmed = prefix.trim();
+  if (trimmed.length === 0) return DEFAULT_TEST_POUCHDB_PREFIX;
+  const normalized = trimmed.replace(/\\/g, '/');
+  return normalized.endsWith('/') ? normalized : `${normalized}/`;
+}
+
+function readNodeEnv(name: string): string | undefined {
+  if (typeof process === 'undefined' || !process.env) return undefined;
+  return process.env[name];
+}
+
+function resolvePouchDbPrefix(explicitPrefix?: string): string | undefined {
+  if (typeof explicitPrefix === 'string' && explicitPrefix.trim().length > 0) {
+    return normalizePouchDbPrefix(explicitPrefix);
+  }
+
+  const envPrefix = readNodeEnv(POUCHDB_PREFIX_ENV);
+  if (typeof envPrefix === 'string' && envPrefix.trim().length > 0) {
+    return normalizePouchDbPrefix(envPrefix);
+  }
+
+  if (readNodeEnv('VITEST') || readNodeEnv('VITEST_WORKER_ID') || readNodeEnv('NODE_ENV') === 'test') {
+    return DEFAULT_TEST_POUCHDB_PREFIX;
+  }
+
+  return undefined;
+}
+
+export interface ReminderStorageOptions {
+  pouchDbPrefix?: string;
+}
+
+const storageInstances: Map<string, ReminderStorage> = new Map();
+
+function buildCacheKey(userId: string, prefix?: string): string {
+  return `${prefix ?? ''}::${userId}`;
+}
+
+export function getReminderStorage(userId: string, options?: ReminderStorageOptions): ReminderStorage {
+  const prefix = resolvePouchDbPrefix(options?.pouchDbPrefix);
+  const cacheKey = buildCacheKey(userId, prefix);
+  if (!storageInstances.has(cacheKey)) {
+    storageInstances.set(cacheKey, new ReminderStorage(userId, { pouchDbPrefix: prefix }));
+  }
+  return storageInstances.get(cacheKey)!;
+}
+
+export function clearAllReminderStorageInstances(): void {
+  storageInstances.clear();
+}
+
+export class ReminderStorage {
+  private db: PouchDB.Database<Reminder>;
+  private initialized = false;
+  private syncReplication: PouchDB.Replication.Sync<Reminder> | null = null;
+  private changeListeners: Array<(change: unknown) => void> = [];
+  private lastSyncErrorSignature: string | null = null;
+
+  constructor(userId: string, options: ReminderStorageOptions = {}) {
+    const dbName = `reminders_${userId}`;
+    const prefix = resolvePouchDbPrefix(options.pouchDbPrefix);
+    this.db = prefix
+      ? new PouchDB<Reminder>(dbName, { prefix })
+      : new PouchDB<Reminder>(dbName);
+    this.initializeDesignDoc();
+  }
+
+  private async initializeDesignDoc(): Promise<void> {
+    if (this.initialized) return;
+
+    const designDoc = {
+      _id: '_design/reminders',
+      views: {
+        by_due_at: { map: BY_DUE_AT_MAP },
+        by_status: { map: BY_STATUS_MAP },
+      },
+    };
+
+    try {
+      await (this.db as unknown as { put(doc: unknown): Promise<unknown> }).put(designDoc);
+      this.initialized = true;
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'status' in error && (error as { status: number }).status === 409) {
+        try {
+          const existing = await this.db.get<{
+            _rev: string;
+            views?: {
+              by_due_at?: { map?: string };
+              by_status?: { map?: string };
+            };
+          }>('_design/reminders');
+
+          const hasLatest =
+            existing.views?.by_due_at?.map === BY_DUE_AT_MAP &&
+            existing.views?.by_status?.map === BY_STATUS_MAP;
+
+          if (!hasLatest) {
+            await (this.db as unknown as { put(doc: unknown): Promise<unknown> }).put({
+              ...designDoc,
+              _rev: existing._rev,
+            });
+          }
+          this.initialized = true;
+        } catch (updateError) {
+          console.warn('更新 ReminderStorage 设计文档失败:', updateError);
+        }
+      } else {
+        console.warn('创建 ReminderStorage 设计文档失败:', error);
+      }
+    }
+  }
+
+  async addReminder(reminder: Reminder): Promise<void> {
+    await this.initializeDesignDoc();
+    const doc: ReminderDoc = { ...reminder, _id: `reminder:${reminder.id}` };
+    await this.db.put(doc as unknown as Parameters<typeof this.db.put>[0]);
+    this.notifyChangeListeners({ type: 'local', doc });
+  }
+
+  async getReminder(id: string): Promise<Reminder | undefined> {
+    await this.initializeDesignDoc();
+    try {
+      const doc = await this.db.get<Reminder>(`reminder:${id}`);
+      return this.toReminder(doc as unknown as ReminderDoc);
+    } catch {
+      return undefined;
+    }
+  }
+
+  async getReminders(): Promise<Reminder[]> {
+    await this.initializeDesignDoc();
+    const result = await this.db.query<ReminderDoc>('reminders/by_due_at', {
+      include_docs: true,
+      descending: false,
+    });
+    return result.rows.filter((row) => row.doc).map((row) => this.toReminder(row.doc!));
+  }
+
+  async getRemindersByStatus(status: ReminderStatus): Promise<Reminder[]> {
+    await this.initializeDesignDoc();
+    const result = await this.db.query<ReminderDoc>('reminders/by_status', {
+      include_docs: true,
+      key: status,
+    });
+    return result.rows.filter((row) => row.doc).map((row) => this.toReminder(row.doc!));
+  }
+
+  async updateReminder(id: string, updates: Partial<Reminder>): Promise<Reminder | undefined> {
+    await this.initializeDesignDoc();
+    try {
+      const doc = await this.db.get<Reminder>(`reminder:${id}`);
+      const updated = { ...doc, ...updates, updatedAt: Date.now() };
+      await this.db.put(updated as unknown as Parameters<typeof this.db.put>[0]);
+      this.notifyChangeListeners({ type: 'local', doc: updated });
+      return this.toReminder(updated as unknown as ReminderDoc);
+    } catch {
+      return undefined;
+    }
+  }
+
+  async count(): Promise<number> {
+    await this.initializeDesignDoc();
+    const result = await this.db.query<Reminder>('reminders/by_due_at');
+    return result.rows.length;
+  }
+
+  async clearAll(): Promise<void> {
+    await this.initializeDesignDoc();
+    const result = await this.db.allDocs({ include_docs: true });
+    const docsToDelete = result.rows
+      .filter((row) => row.id && row.id.startsWith('reminder:'))
+      .map((row) => ({ _id: row.id, _rev: row.value?.rev, _deleted: true }));
+    if (docsToDelete.length > 0) {
+      await this.db.bulkDocs(docsToDelete as unknown as Parameters<typeof this.db.bulkDocs>[0]);
+    }
+  }
+
+  async syncToRemote(remoteUrl: string): Promise<PouchDB.Replication.Sync<Reminder>> {
+    if (this.syncReplication) {
+      this.syncReplication.cancel();
+    }
+
+    this.syncReplication = this.db.sync(remoteUrl, { live: true, retry: true });
+    this.syncReplication.on('active', () => {
+      this.lastSyncErrorSignature = null;
+    });
+    this.syncReplication.on('change', (change: unknown) => {
+      const direction = this.extractSyncDirection(change);
+      if (direction && direction !== 'pull') return;
+      this.notifyChangeListeners(change);
+    });
+    this.syncReplication.on('error', (error: unknown) => {
+      this.logSyncError(remoteUrl, error);
+    });
+    return this.syncReplication;
+  }
+
+  async stopSync(): Promise<void> {
+    if (this.syncReplication) {
+      this.syncReplication.cancel();
+      this.syncReplication = null;
+    }
+  }
+
+  onRemoteChange(callback: (change: unknown) => void): () => void {
+    this.changeListeners.push(callback);
+    return () => {
+      const idx = this.changeListeners.indexOf(callback);
+      if (idx > -1) this.changeListeners.splice(idx, 1);
+    };
+  }
+
+  getSyncStatus(): { active: boolean; paused: boolean; error: unknown } {
+    return {
+      active: this.syncReplication !== null,
+      paused: false,
+      error: null,
+    };
+  }
+
+  async close(): Promise<void> {
+    await this.stopSync();
+    await this.db.close();
+    for (const [key, instance] of storageInstances.entries()) {
+      if (instance === this) {
+        storageInstances.delete(key);
+        break;
+      }
+    }
+  }
+
+  private toReminder(doc: ReminderDoc): Reminder {
+    const obj = { ...doc } as Record<string, unknown>;
+    delete obj._id;
+    delete obj._rev;
+    delete obj._conflicts;
+    return obj as unknown as Reminder;
+  }
+
+  private notifyChangeListeners(change: unknown): void {
+    for (const listener of this.changeListeners) {
+      try {
+        listener(change);
+      } catch {
+        console.error('ReminderStorage 变更监听器执行错误');
+      }
+    }
+  }
+
+  private extractSyncDirection(change: unknown): string | null {
+    if (!change || typeof change !== 'object' || !('direction' in change)) return null;
+    const direction = (change as { direction?: unknown }).direction;
+    return typeof direction === 'string' && direction.trim().length > 0 ? direction : null;
+  }
+
+  private logSyncError(remoteUrl: string, error: unknown): void {
+    const [message, payload] = buildSyncErrorLog('ReminderStorage', remoteUrl, error);
+    const signature = JSON.stringify({
+      message,
+      remoteUrl,
+      code: payload.code,
+      status: payload.status,
+      errorMessage: payload.message,
+    });
+    if (signature === this.lastSyncErrorSignature) return;
+    this.lastSyncErrorSignature = signature;
+    console.error(message, payload);
+  }
+}

--- a/src/lib/types/reminder.ts
+++ b/src/lib/types/reminder.ts
@@ -1,0 +1,51 @@
+export type ReminderStatus = 'pending' | 'triggered' | 'completed';
+
+export interface Reminder {
+  id: string;
+  title: string;
+  content: string;
+  dueAt: number;
+  status: ReminderStatus;
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+}
+
+export interface CreateReminderInput {
+  title: string;
+  content: string;
+  dueAt: number;
+}
+
+export interface UpdateReminderInput {
+  title?: string;
+  content?: string;
+  dueAt?: number;
+}
+
+const VALID_TRANSITIONS: Record<ReminderStatus, ReminderStatus[]> = {
+  pending: ['triggered', 'completed'],
+  triggered: ['completed'],
+  completed: [],
+};
+
+export function canTransitionReminder(from: ReminderStatus, to: ReminderStatus): boolean {
+  return VALID_TRANSITIONS[from].includes(to);
+}
+
+export function transitionReminder(
+  reminder: Reminder,
+  to: ReminderStatus,
+  at: number = Date.now(),
+): Reminder {
+  if (!canTransitionReminder(reminder.status, to)) {
+    throw new Error(`Invalid reminder transition: ${reminder.status} -> ${to}`);
+  }
+
+  return {
+    ...reminder,
+    status: to,
+    updatedAt: at,
+    ...(to === 'completed' ? { completedAt: at } : {}),
+  };
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -10,6 +10,8 @@ import { getCommandRegistryService } from '@/lib/services/command-registry.servi
 import { getCommandPaletteService } from '@/lib/services/command-palette.service';
 import { createCoreNavigationCommands, type CoreNavigationPath } from '@/lib/services/command-palette.commands';
 import { CommandPalette } from '@/ui/app/components/CommandPalette';
+import { ReminderNotifier } from '@/ui/app/components/ReminderNotifier';
+import { requestReminderCompose } from '@/ui/stores/reminder-ui-store';
 import type { CommandContext } from '@/lib/types/command-palette';
 
 const FocusPage = lazy(async () => {
@@ -30,6 +32,11 @@ const LegalSupportPage = lazy(async () => {
 const TasksPage = lazy(async () => {
   const module = await import('@/ui/app/pages/TasksPage');
   return { default: module.TasksPage };
+});
+
+const RemindersPage = lazy(async () => {
+  const module = await import('@/ui/app/pages/RemindersPage');
+  return { default: module.RemindersPage };
 });
 
 const TaskDetailPage = lazy(async () => {
@@ -312,6 +319,7 @@ function NewLayout() {
 
     registryService.setCommands('core-navigation', createCoreNavigationCommands({
       navigate: navigateTo,
+      openReminderComposer: requestReminderCompose,
     }));
 
     return () => {
@@ -366,6 +374,7 @@ function NewLayout() {
     || location.pathname === '/dashboard'
     || location.pathname === '/tasks'
     || location.pathname.startsWith('/tasks/')
+    || location.pathname === '/reminders'
     || location.pathname === '/me'
     || location.pathname === '/update'
     || location.pathname === '/settings'
@@ -378,18 +387,22 @@ function NewLayout() {
       <>
         <DesktopLayout activePath={location.pathname} />
         {commandPaletteActive ? <CommandPalette context={commandContext} /> : null}
+        <ReminderNotifier />
       </>
     );
   }
 
   return (
-    <MobileShell
-      locationPath={location.pathname}
-      navItems={navItems}
-      desktopFrame={isDesktop}
-      commandPaletteActive={commandPaletteActive}
-      commandContext={commandContext}
-    />
+    <>
+      <MobileShell
+        locationPath={location.pathname}
+        navItems={navItems}
+        desktopFrame={isDesktop}
+        commandPaletteActive={commandPaletteActive}
+        commandContext={commandContext}
+      />
+      <ReminderNotifier />
+    </>
   );
 }
 
@@ -477,6 +490,18 @@ const newTasksRoute = createRoute({
     return (
       <LazyPage>
         <TasksPage />
+      </LazyPage>
+    );
+  },
+});
+
+const newRemindersRoute = createRoute({
+  getParentRoute: () => newRootRoute,
+  path: '/reminders',
+  component: function NewReminders() {
+    return (
+      <LazyPage>
+        <RemindersPage />
       </LazyPage>
     );
   },
@@ -646,6 +671,7 @@ const newRouteTree = newRootRoute.addChildren([
   newDashboardRoute,
   newEventlogRoute,
   newTasksRoute,
+  newRemindersRoute,
   newTaskDetailRoute,
   newMeRoute,
   newSettingsRoute,

--- a/src/ui/app/components/ReminderNotifier.tsx
+++ b/src/ui/app/components/ReminderNotifier.tsx
@@ -1,0 +1,189 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { ToastAction } from '@/components/ui/toast';
+import { toast } from '@/components/ui/toast-hook';
+import { getTimerEndSoundPresetById } from '@/lib/media/timer-end-sounds';
+import {
+  getReminderSchedulerService,
+  DEFAULT_REMINDER_SCHEDULER_INTERVAL_MS,
+} from '@/lib/services/reminder-scheduler.service';
+import { getReminderService } from '@/lib/services/reminder.service';
+import type { Reminder } from '@/lib/types/reminder';
+import { getTimerPreferences } from '@/config/timer-preferences';
+import { requestReminderFocus } from '@/ui/stores/reminder-ui-store';
+
+function formatDueAt(timestamp: number): string {
+  return new Date(timestamp).toLocaleString('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatRelativeDueText(dueAt: number, now = Date.now()): string {
+  const diffMinutes = Math.round((dueAt - now) / 60000);
+  if (Math.abs(diffMinutes) <= 1) return '刚刚到期';
+  if (diffMinutes > 0) {
+    if (diffMinutes < 60) return `${diffMinutes} 分钟后到期`;
+    const diffHours = Math.round(diffMinutes / 60);
+    if (diffHours < 24) return `${diffHours} 小时后到期`;
+    const diffDays = Math.round(diffHours / 24);
+    return `${diffDays} 天后到期`;
+  }
+
+  const overdue = Math.abs(diffMinutes);
+  if (overdue < 60) return `已过期 ${overdue} 分钟`;
+  const overdueHours = Math.round(overdue / 60);
+  if (overdueHours < 24) return `已过期 ${overdueHours} 小时`;
+  const overdueDays = Math.round(overdueHours / 24);
+  return `已过期 ${overdueDays} 天`;
+}
+
+function extractNotificationBody(reminder: Reminder): string {
+  const compact = reminder.content.replace(/[#>*`_\-\[\]\(\)]/g, ' ').replace(/\s+/g, ' ').trim();
+  if (compact.length > 0) {
+    return compact.slice(0, 120);
+  }
+  return `${formatDueAt(reminder.dueAt)} · ${formatRelativeDueText(reminder.dueAt)}`;
+}
+
+export function ReminderNotifier(): null {
+  const navigate = useNavigate();
+  const reminderServiceRef = useRef(getReminderService());
+  const schedulerRef = useRef(getReminderSchedulerService());
+  const toastHandleRef = useRef<ReturnType<typeof toast> | null>(null);
+
+  const playReminderSound = useCallback(async () => {
+    const preferences = getTimerPreferences();
+    if (!preferences.countdownEndSoundEnabled) return;
+
+    const preset = getTimerEndSoundPresetById(preferences.countdownEndSoundPresetId);
+    try {
+      const audio = new Audio(preset.url);
+      audio.loop = false;
+      audio.preload = 'auto';
+      audio.currentTime = 0;
+      await audio.play();
+    } catch {
+      // Ignore autoplay failures.
+    }
+  }, []);
+
+  const openReminderPage = useCallback((id: string) => {
+    requestReminderFocus(id);
+    void navigate({ to: '/reminders' });
+  }, [navigate]);
+
+  const sendSystemNotification = useCallback(async (reminder: Reminder) => {
+    if (typeof window === 'undefined' || typeof Notification === 'undefined') {
+      return;
+    }
+
+    let permission = Notification.permission;
+    if (permission === 'default') {
+      try {
+        permission = await Notification.requestPermission();
+      } catch {
+        return;
+      }
+    }
+
+    if (permission !== 'granted') {
+      return;
+    }
+
+    try {
+      const notification = new Notification(reminder.title, {
+        body: extractNotificationBody(reminder),
+        tag: `reminder:${reminder.id}`,
+        requireInteraction: true,
+      });
+      notification.onclick = () => {
+        if (typeof window.focus === 'function') {
+          window.focus();
+        }
+        openReminderPage(reminder.id);
+        notification.close();
+      };
+    } catch {
+      // Ignore unsupported Notification constructor errors.
+    }
+  }, [openReminderPage]);
+
+  const syncTriggeredToast = useCallback(async () => {
+    const reminders = await reminderServiceRef.current.listReminders();
+    const triggered = reminders
+      .filter((reminder) => reminder.status === 'triggered')
+      .sort((left, right) => right.dueAt - left.dueAt);
+
+    if (triggered.length === 0) {
+      toastHandleRef.current?.dismiss();
+      toastHandleRef.current = null;
+      return;
+    }
+
+    const leadReminder = triggered[0];
+    const title = triggered.length > 1
+      ? `有 ${triggered.length} 条提醒待处理`
+      : `提醒到期：${leadReminder.title}`;
+    const description = `${formatDueAt(leadReminder.dueAt)} · ${formatRelativeDueText(leadReminder.dueAt)}`;
+    const action = (
+      <ToastAction
+        altText="标记提醒已处理"
+        onClick={() => {
+          void reminderServiceRef.current.completeReminder(leadReminder.id);
+        }}
+      >
+        已处理
+      </ToastAction>
+    );
+
+    if (toastHandleRef.current) {
+      toastHandleRef.current.update({
+        id: toastHandleRef.current.id,
+        title,
+        description,
+        action,
+        onClick: () => openReminderPage(leadReminder.id),
+        duration: 24 * 60 * 60 * 1000,
+      });
+      return;
+    }
+
+    toastHandleRef.current = toast({
+      title,
+      description,
+      action,
+      onClick: () => openReminderPage(leadReminder.id),
+      duration: 24 * 60 * 60 * 1000,
+    });
+  }, [openReminderPage]);
+
+  useEffect(() => {
+    const scheduler = schedulerRef.current;
+
+    const unsubscribeTriggered = scheduler.onTriggered((reminder) => {
+      void playReminderSound();
+      void sendSystemNotification(reminder);
+      void syncTriggeredToast();
+    });
+
+    const unsubscribeChange = reminderServiceRef.current.onReminderChange(() => {
+      void syncTriggeredToast();
+    });
+
+    scheduler.start(DEFAULT_REMINDER_SCHEDULER_INTERVAL_MS);
+    void syncTriggeredToast();
+
+    return () => {
+      unsubscribeTriggered();
+      unsubscribeChange();
+      scheduler.stop();
+      toastHandleRef.current?.dismiss();
+      toastHandleRef.current = null;
+    };
+  }, [playReminderSound, sendSystemNotification, syncTriggeredToast]);
+
+  return null;
+}

--- a/src/ui/app/components/ReminderSyncCoordinator.tsx
+++ b/src/ui/app/components/ReminderSyncCoordinator.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState } from 'react';
+import { resolveSyncServerUrl, SYNC_SERVER_URL_CHANGED_EVENT } from '@/config/port-env';
+import { getReminderService } from '@/lib/services/reminder.service';
+import { buildSyncErrorLog } from '@/lib/storage/sync-error';
+import { buildRemoteDbUrl } from '@/lib/sync/remote-db-url';
+import { useSyncStore } from '@/ui/stores/sync-store';
+
+const REMINDER_REMOTE_DB_SUFFIX = 'reminders';
+
+function buildReminderRemoteDbUrl(baseUrl: string, currentUser: string): string {
+  return buildRemoteDbUrl(baseUrl, `${currentUser}__${REMINDER_REMOTE_DB_SUFFIX}`);
+}
+
+export function ReminderSyncCoordinator(): null {
+  const reminderServiceRef = useRef(getReminderService());
+  const isLoggedIn = useSyncStore((state) => state.isLoggedIn);
+  const currentUser = useSyncStore((state) => state.currentUser);
+  const [syncServerUrl, setSyncServerUrl] = useState(() =>
+    resolveSyncServerUrl(import.meta.env as Record<string, string | undefined>)
+  );
+
+  useEffect(() => {
+    const refreshSyncServerUrl = () => {
+      setSyncServerUrl(resolveSyncServerUrl(import.meta.env as Record<string, string | undefined>));
+    };
+
+    refreshSyncServerUrl();
+    window.addEventListener(SYNC_SERVER_URL_CHANGED_EVENT, refreshSyncServerUrl);
+    return () => {
+      window.removeEventListener(SYNC_SERVER_URL_CHANGED_EVENT, refreshSyncServerUrl);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isLoggedIn || !currentUser) {
+      void reminderServiceRef.current.stopSync();
+      return;
+    }
+
+    let cancelled = false;
+    const remoteUrl = buildReminderRemoteDbUrl(syncServerUrl, currentUser);
+
+    void reminderServiceRef.current.startSync(remoteUrl).catch((error) => {
+      if (cancelled) return;
+      const [message, payload] = buildSyncErrorLog('ReminderSyncCoordinator', remoteUrl, error);
+      console.error(message, payload);
+    });
+
+    return () => {
+      cancelled = true;
+      void reminderServiceRef.current.stopSync();
+    };
+  }, [currentUser, isLoggedIn, syncServerUrl]);
+
+  return null;
+}

--- a/src/ui/app/pages/RemindersPage.tsx
+++ b/src/ui/app/pages/RemindersPage.tsx
@@ -1,0 +1,450 @@
+import { Check, Pencil, Plus } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { EventMarkdown } from '@/components/Chat/EventMarkdown';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { getReminderService } from '@/lib/services/reminder.service';
+import type { Reminder } from '@/lib/types/reminder';
+import { useReminderUiStore } from '@/ui/stores/reminder-ui-store';
+
+type ReminderTab = 'pending' | 'triggered' | 'completed';
+
+const TAB_LABEL: Record<ReminderTab, string> = {
+  pending: '未到期',
+  triggered: '已触发',
+  completed: '已完成',
+};
+
+const TAB_EMPTY_TEXT: Record<ReminderTab, string> = {
+  pending: '暂无未到期提醒，创建一个新的提醒吧。',
+  triggered: '暂无待处理的已触发提醒。',
+  completed: '暂无已完成提醒。',
+};
+
+function toDatetimeLocalValue(timestamp: number): string {
+  const date = new Date(timestamp);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+function parseDatetimeLocalValue(value: string): number | null {
+  if (!value.trim()) return null;
+  const parsed = new Date(value);
+  const timestamp = parsed.getTime();
+  if (!Number.isFinite(timestamp)) return null;
+  return timestamp;
+}
+
+function resolveInitialDueAt(): string {
+  const now = new Date();
+  now.setSeconds(0, 0);
+  now.setMinutes(now.getMinutes() + 5);
+  return toDatetimeLocalValue(now.getTime());
+}
+
+function formatDueAt(timestamp: number): string {
+  return new Date(timestamp).toLocaleString('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatRelativeDue(dueAt: number, nowMs: number): string {
+  const diffMinutes = Math.round((dueAt - nowMs) / 60_000);
+  if (Math.abs(diffMinutes) <= 1) return '即将触发';
+
+  if (diffMinutes > 0) {
+    if (diffMinutes < 60) return `${diffMinutes} 分钟后`;
+    const diffHours = Math.round(diffMinutes / 60);
+    if (diffHours < 24) return `${diffHours} 小时后`;
+    const diffDays = Math.round(diffHours / 24);
+    return `${diffDays} 天后`;
+  }
+
+  const overdueMinutes = Math.abs(diffMinutes);
+  if (overdueMinutes < 60) return `已过期 ${overdueMinutes} 分钟`;
+  const overdueHours = Math.round(overdueMinutes / 60);
+  if (overdueHours < 24) return `已过期 ${overdueHours} 小时`;
+  const overdueDays = Math.round(overdueHours / 24);
+  return `已过期 ${overdueDays} 天`;
+}
+
+function sortRemindersByTab(tab: ReminderTab, reminders: Reminder[]): Reminder[] {
+  const cloned = [...reminders];
+
+  if (tab === 'pending') {
+    return cloned.sort((left, right) => left.dueAt - right.dueAt);
+  }
+
+  if (tab === 'triggered') {
+    return cloned.sort((left, right) => right.dueAt - left.dueAt);
+  }
+
+  return cloned.sort((left, right) => (right.completedAt ?? right.updatedAt) - (left.completedAt ?? left.updatedAt));
+}
+
+export function RemindersPage() {
+  const reminderServiceRef = useRef(getReminderService());
+  const [activeTab, setActiveTab] = useState<ReminderTab>('pending');
+  const [reminders, setReminders] = useState<Reminder[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  const [highlightedReminderId, setHighlightedReminderId] = useState<string | null>(null);
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingReminderId, setEditingReminderId] = useState<string | null>(null);
+  const [formTitle, setFormTitle] = useState('');
+  const [formContent, setFormContent] = useState('');
+  const [formDueAt, setFormDueAt] = useState(() => resolveInitialDueAt());
+  const [formError, setFormError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const composeRequestToken = useReminderUiStore((state) => state.composeRequestToken);
+  const focusReminderId = useReminderUiStore((state) => state.focusReminderId);
+  const clearFocus = useReminderUiStore((state) => state.clearFocus);
+  const seenComposeRequestTokenRef = useRef(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setNowMs(Date.now());
+    }, 30_000);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  useEffect(() => {
+    let disposed = false;
+    const service = reminderServiceRef.current;
+
+    const loadReminders = async () => {
+      const list = await service.listReminders();
+      if (disposed) return;
+      setReminders(list);
+      setLoading(false);
+    };
+
+    void loadReminders();
+    const unsubscribe = service.onReminderChange(() => {
+      void loadReminders();
+    });
+
+    return () => {
+      disposed = true;
+      unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (composeRequestToken === 0 || composeRequestToken === seenComposeRequestTokenRef.current) {
+      return;
+    }
+
+    seenComposeRequestTokenRef.current = composeRequestToken;
+    setEditingReminderId(null);
+    setFormTitle('');
+    setFormContent('');
+    setFormDueAt(resolveInitialDueAt());
+    setFormError('');
+    setDialogOpen(true);
+  }, [composeRequestToken]);
+
+  useEffect(() => {
+    if (!focusReminderId) return;
+
+    setActiveTab('triggered');
+    setHighlightedReminderId(focusReminderId);
+    clearFocus();
+
+    const timeout = setTimeout(() => {
+      const target = document.getElementById(`reminder-card-${focusReminderId}`);
+      target?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }, 120);
+
+    const clearHighlightTimeout = setTimeout(() => {
+      setHighlightedReminderId((current) => (
+        current === focusReminderId ? null : current
+      ));
+    }, 2_000);
+
+    return () => {
+      clearTimeout(timeout);
+      clearTimeout(clearHighlightTimeout);
+    };
+  }, [clearFocus, focusReminderId]);
+
+  const tabCounts = useMemo(() => ({
+    pending: reminders.filter((reminder) => reminder.status === 'pending').length,
+    triggered: reminders.filter((reminder) => reminder.status === 'triggered').length,
+    completed: reminders.filter((reminder) => reminder.status === 'completed').length,
+  }), [reminders]);
+
+  const visibleReminders = useMemo(() => {
+    const tabItems = reminders.filter((reminder) => reminder.status === activeTab);
+    return sortRemindersByTab(activeTab, tabItems);
+  }, [activeTab, reminders]);
+
+  const openCreateDialog = () => {
+    setEditingReminderId(null);
+    setFormTitle('');
+    setFormContent('');
+    setFormDueAt(resolveInitialDueAt());
+    setFormError('');
+    setDialogOpen(true);
+  };
+
+  const openEditDialog = (reminder: Reminder) => {
+    if (reminder.status !== 'pending') return;
+
+    setEditingReminderId(reminder.id);
+    setFormTitle(reminder.title);
+    setFormContent(reminder.content);
+    setFormDueAt(toDatetimeLocalValue(reminder.dueAt));
+    setFormError('');
+    setDialogOpen(true);
+  };
+
+  const handleCompleteReminder = async (reminderId: string) => {
+    await reminderServiceRef.current.completeReminder(reminderId);
+  };
+
+  const handleSubmit = async () => {
+    const title = formTitle.trim();
+    if (!title) {
+      setFormError('提醒标题不能为空');
+      return;
+    }
+
+    const dueAt = parseDatetimeLocalValue(formDueAt);
+    if (!dueAt) {
+      setFormError('请选择有效的提醒时间');
+      return;
+    }
+
+    setSubmitting(true);
+    setFormError('');
+
+    try {
+      const normalizedDueAt = dueAt < Date.now() ? Date.now() : dueAt;
+      if (editingReminderId) {
+        await reminderServiceRef.current.updateReminder(editingReminderId, {
+          title,
+          content: formContent,
+          dueAt: normalizedDueAt,
+        });
+      } else {
+        await reminderServiceRef.current.createReminder({
+          title,
+          content: formContent,
+          dueAt: normalizedDueAt,
+        });
+      }
+
+      setDialogOpen(false);
+      setEditingReminderId(null);
+      setFormTitle('');
+      setFormContent('');
+      setFormDueAt(resolveInitialDueAt());
+    } catch (error) {
+      setFormError(error instanceof Error ? error.message : '保存提醒失败');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full min-h-full flex-col bg-[#FAF7F5] dark:bg-[#0C0A09]" data-testid="reminders-page">
+      <header className="flex items-center justify-between border-b border-[#F0ECE8] px-6 py-3 dark:border-[#292524] md:px-8 lg:px-10">
+        <div>
+          <h1 className="text-lg font-semibold text-[#1C1917] dark:text-[#FAFAF9]">提醒</h1>
+          <p className="text-xs text-[#A8A29E] dark:text-[#78716C]">替代微信提醒的应用内定时提醒</p>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          onClick={openCreateDialog}
+          className="h-9 gap-1 rounded-full bg-[#C75B3A] px-3 text-white hover:bg-[#B24D2F]"
+        >
+          <Plus size={16} />
+          新建
+        </Button>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-[calc(env(safe-area-inset-bottom,0px)+88px)] pt-3 md:px-8 md:pb-24 lg:px-10">
+        <div className="mb-4 flex gap-1 overflow-x-auto pb-1">
+          {(Object.keys(TAB_LABEL) as ReminderTab[]).map((tab) => {
+            const active = tab === activeTab;
+            return (
+              <button
+                key={tab}
+                type="button"
+                onClick={() => setActiveTab(tab)}
+                className={`shrink-0 rounded-2xl px-4 py-1.5 text-[13px] ${
+                  active
+                    ? 'bg-[#C75B3A] font-semibold text-white'
+                    : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'
+                }`}
+              >
+                {TAB_LABEL[tab]} ({tabCounts[tab]})
+              </button>
+            );
+          })}
+        </div>
+
+        {loading ? (
+          <p className="text-sm text-[#A8A29E]">提醒加载中...</p>
+        ) : visibleReminders.length === 0 ? (
+          <p className="rounded-2xl border border-dashed border-[#D6D3D1] bg-[#FAF7F5] px-4 py-5 text-center text-sm text-[#A8A29E] dark:border-[#3A3432] dark:bg-[#1C1917] dark:text-[#B8B1AC]">
+            {TAB_EMPTY_TEXT[activeTab]}
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {visibleReminders.map((reminder) => (
+              <article
+                id={`reminder-card-${reminder.id}`}
+                key={reminder.id}
+                className={`rounded-2xl border bg-white p-4 transition-colors dark:bg-[#1C1917] ${
+                  highlightedReminderId === reminder.id
+                    ? 'border-[#C75B3A] shadow-[0_0_0_2px_rgba(199,91,58,0.15)]'
+                    : 'border-[#E7E5E4] dark:border-[#292524]'
+                }`}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <h2 className="truncate text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">
+                      {reminder.title}
+                    </h2>
+                    <p className="mt-1 text-xs text-[#A8A29E]">
+                      {formatDueAt(reminder.dueAt)} · {formatRelativeDue(reminder.dueAt, nowMs)}
+                    </p>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    {reminder.status === 'pending' ? (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => openEditDialog(reminder)}
+                          className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] transition-colors hover:bg-[#EDE6E0] dark:bg-[#292524] dark:text-[#A8A29E]"
+                          aria-label="编辑提醒"
+                        >
+                          <Pencil size={14} />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            void handleCompleteReminder(reminder.id);
+                          }}
+                          className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[#E8F5E9] text-[#15803D] transition-colors hover:bg-[#DCF0DE]"
+                          aria-label="标记已处理"
+                        >
+                          <Check size={14} />
+                        </button>
+                      </>
+                    ) : reminder.status === 'triggered' ? (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          void handleCompleteReminder(reminder.id);
+                        }}
+                        className="inline-flex items-center gap-1 rounded-full bg-[#E8F5E9] px-3 py-1.5 text-xs font-medium text-[#15803D] transition-colors hover:bg-[#DCF0DE]"
+                      >
+                        <Check size={14} />
+                        已处理
+                      </button>
+                    ) : null}
+                  </div>
+                </div>
+
+                <div className="mt-3 rounded-xl border border-[#F0ECE8] bg-[#FAF7F5] px-3 py-2 dark:border-[#292524] dark:bg-[#0F0D0C]">
+                  <EventMarkdown content={reminder.content || '*（无正文）*'} />
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{editingReminderId ? '编辑提醒' : '新建提醒'}</DialogTitle>
+            <DialogDescription>
+              填写提醒标题、Markdown 正文和触发时间（精确到分钟）。
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <label className="text-xs text-[#78716C]">标题</label>
+              <Input
+                value={formTitle}
+                onChange={(event) => setFormTitle(event.target.value)}
+                placeholder="例如：提交周报"
+                autoFocus
+              />
+            </div>
+
+            <div className="space-y-1">
+              <label className="text-xs text-[#78716C]">内容（Markdown）</label>
+              <Textarea
+                value={formContent}
+                onChange={(event) => setFormContent(event.target.value)}
+                placeholder="写下提醒详情，例如待办清单、链接、备注..."
+                rows={6}
+                className="resize-none"
+              />
+            </div>
+
+            <div className="space-y-1">
+              <label className="text-xs text-[#78716C]">触发时间</label>
+              <Input
+                type="datetime-local"
+                value={formDueAt}
+                onChange={(event) => setFormDueAt(event.target.value)}
+                min={toDatetimeLocalValue(Date.now())}
+              />
+            </div>
+
+            {formError ? (
+              <p className="text-xs text-[#DC2626]">{formError}</p>
+            ) : null}
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDialogOpen(false)}
+              disabled={submitting}
+            >
+              取消
+            </Button>
+            <Button
+              onClick={() => {
+                void handleSubmit();
+              }}
+              disabled={submitting}
+              className="bg-[#C75B3A] text-white hover:bg-[#B24D2F]"
+            >
+              {submitting ? '保存中...' : '保存'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/ui/stores/reminder-ui-store.ts
+++ b/src/ui/stores/reminder-ui-store.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+
+interface ReminderUiState {
+  composeRequestToken: number;
+  focusReminderId: string | null;
+  requestCompose: () => void;
+  requestFocus: (id: string) => void;
+  clearFocus: () => void;
+}
+
+export const useReminderUiStore = create<ReminderUiState>((set) => ({
+  composeRequestToken: 0,
+  focusReminderId: null,
+  requestCompose: () => set((state) => ({
+    composeRequestToken: state.composeRequestToken + 1,
+  })),
+  requestFocus: (id: string) => set({
+    focusReminderId: id,
+  }),
+  clearFocus: () => set({
+    focusReminderId: null,
+  }),
+}));
+
+export function requestReminderCompose(): void {
+  useReminderUiStore.getState().requestCompose();
+}
+
+export function requestReminderFocus(id: string): void {
+  useReminderUiStore.getState().requestFocus(id);
+}

--- a/tests/unit/services/reminder-scheduler.service.issue375.test.ts
+++ b/tests/unit/services/reminder-scheduler.service.issue375.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ReminderSchedulerServiceImpl,
+} from '@/lib/services/reminder-scheduler.service';
+import type { ReminderService } from '@/lib/services/reminder.service';
+import type { Reminder } from '@/lib/types/reminder';
+
+function makeReminder(overrides: Partial<Reminder> = {}): Reminder {
+  const now = Date.now();
+  return {
+    id: overrides.id ?? `reminder-${Math.random().toString(16).slice(2)}`,
+    title: overrides.title ?? 'scheduler reminder',
+    content: overrides.content ?? '',
+    dueAt: overrides.dueAt ?? now,
+    status: overrides.status ?? 'pending',
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    completedAt: overrides.completedAt,
+  };
+}
+
+function createReminderServiceMock(state: { reminders: Reminder[] }): ReminderService {
+  const getDuePendingReminders = vi.fn(async (at: number) => state.reminders
+    .filter((reminder) => reminder.status === 'pending' && reminder.dueAt <= at));
+
+  const markTriggered = vi.fn(async (id: string, triggeredAt = Date.now()) => {
+    const reminder = state.reminders.find((item) => item.id === id);
+    if (!reminder) return null;
+    if (reminder.status !== 'pending') return { ...reminder };
+    reminder.status = 'triggered';
+    reminder.updatedAt = triggeredAt;
+    return { ...reminder };
+  });
+
+  const listReminders = vi.fn(async () => state.reminders.map((reminder) => ({ ...reminder })));
+
+  const noOp = vi.fn();
+  const unresolved = vi.fn(async () => null);
+  const unresolvedList = vi.fn(async () => []);
+
+  return {
+    listReminders,
+    listRemindersByStatus: unresolvedList,
+    getReminder: unresolved,
+    createReminder: unresolved as unknown as ReminderService['createReminder'],
+    updateReminder: unresolved as unknown as ReminderService['updateReminder'],
+    markTriggered,
+    completeReminder: unresolved,
+    getDuePendingReminders,
+    startSync: noOp as unknown as ReminderService['startSync'],
+    stopSync: noOp as unknown as ReminderService['stopSync'],
+    onReminderChange: () => () => {},
+  };
+}
+
+describe('ReminderSchedulerService issue-375', () => {
+  it('transitions due pending reminders and emits triggered events once', async () => {
+    const state = {
+      reminders: [
+        makeReminder({ id: 'pending-1', dueAt: Date.now() - 1_000, status: 'pending' }),
+      ],
+    };
+    const reminderService = createReminderServiceMock(state);
+    const scheduler = new ReminderSchedulerServiceImpl(reminderService);
+    const triggeredIds: string[] = [];
+
+    scheduler.onTriggered((reminder) => {
+      triggeredIds.push(reminder.id);
+    });
+
+    await scheduler.runNow();
+    await scheduler.runNow();
+
+    expect(triggeredIds).toEqual(['pending-1']);
+    expect(state.reminders[0].status).toBe('triggered');
+  });
+
+  it('re-emits a reminder after it is completed then triggered again', async () => {
+    const triggered = makeReminder({ id: 'r-1', status: 'triggered' });
+    const state = {
+      reminders: [triggered],
+    };
+    const reminderService = createReminderServiceMock(state);
+    const scheduler = new ReminderSchedulerServiceImpl(reminderService);
+    const triggeredIds: string[] = [];
+
+    scheduler.onTriggered((reminder) => {
+      triggeredIds.push(reminder.id);
+    });
+
+    await scheduler.runNow();
+    state.reminders = [];
+    await scheduler.runNow();
+    state.reminders = [makeReminder({ ...triggered, status: 'triggered' })];
+    await scheduler.runNow();
+
+    expect(triggeredIds).toEqual(['r-1', 'r-1']);
+  });
+});

--- a/tests/unit/services/reminder.service.issue375.test.ts
+++ b/tests/unit/services/reminder.service.issue375.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReminderServiceImpl } from '@/lib/services/reminder.service';
+import type { IReminderPort } from '@/lib/environment/interfaces/reminder.port';
+import type { Reminder, ReminderStatus } from '@/lib/types/reminder';
+
+function makeReminder(overrides: Partial<Reminder> = {}): Reminder {
+  const now = Date.now();
+  return {
+    id: overrides.id ?? `reminder-${Math.random().toString(16).slice(2)}`,
+    title: overrides.title ?? 'test reminder',
+    content: overrides.content ?? '',
+    dueAt: overrides.dueAt ?? now + 60_000,
+    status: overrides.status ?? 'pending',
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    completedAt: overrides.completedAt,
+  };
+}
+
+function createMockPort(initialReminders: Reminder[]): IReminderPort {
+  const store = new Map(initialReminders.map((reminder) => [reminder.id, { ...reminder }]));
+  const listeners = new Set<(change: unknown) => void>();
+
+  return {
+    listReminders: vi.fn(async () => Array.from(store.values()).map((reminder) => ({ ...reminder }))),
+    getReminderById: vi.fn(async (id: string) => {
+      const reminder = store.get(id);
+      return reminder ? { ...reminder } : null;
+    }),
+    createReminder: vi.fn(async (input) => {
+      const now = Date.now();
+      const created: Reminder = {
+        id: `created-${store.size + 1}`,
+        title: input.title,
+        content: input.content,
+        dueAt: input.dueAt,
+        status: 'pending',
+        createdAt: now,
+        updatedAt: now,
+      };
+      store.set(created.id, created);
+      return { ...created };
+    }),
+    updateReminder: vi.fn(async (id: string, updates) => {
+      const current = store.get(id);
+      if (!current) return null;
+      const next = { ...current, ...updates, updatedAt: Date.now() };
+      store.set(id, next);
+      return { ...next };
+    }),
+    transitionReminder: vi.fn(async (id: string, to: ReminderStatus, at = Date.now()) => {
+      const current = store.get(id);
+      if (!current) return null;
+      const next: Reminder = {
+        ...current,
+        status: to,
+        updatedAt: at,
+        ...(to === 'completed' ? { completedAt: at } : {}),
+      };
+      store.set(id, next);
+      return { ...next };
+    }),
+    startSync: vi.fn(async () => {}),
+    stopSync: vi.fn(async () => {}),
+    onRemoteChange: vi.fn((callback: (change: unknown) => void) => {
+      listeners.add(callback);
+      return () => listeners.delete(callback);
+    }),
+  };
+}
+
+describe('ReminderService issue-375', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('creates overdue reminder and immediately marks it triggered', async () => {
+    const port = createMockPort([]);
+    const service = new ReminderServiceImpl(port);
+
+    const result = await service.createReminder({
+      title: 'overdue',
+      content: 'content',
+      dueAt: Date.now() - 30_000,
+    });
+
+    expect(result.status).toBe('triggered');
+    expect(port.transitionReminder).toHaveBeenCalledWith(result.id, 'triggered', expect.any(Number));
+  });
+
+  it('rejects editing non-pending reminders', async () => {
+    const reminder = makeReminder({ id: 'r1', status: 'triggered' });
+    const port = createMockPort([reminder]);
+    const service = new ReminderServiceImpl(port);
+
+    await expect(service.updateReminder('r1', { title: 'new title' })).rejects.toThrow('仅未到期提醒可编辑');
+  });
+
+  it('returns due pending reminders sorted by nearest due first', async () => {
+    const reminders = [
+      makeReminder({ id: 'pending-late', dueAt: 3_000, status: 'pending' }),
+      makeReminder({ id: 'pending-early', dueAt: 1_000, status: 'pending' }),
+      makeReminder({ id: 'triggered', dueAt: 500, status: 'triggered' }),
+      makeReminder({ id: 'pending-future', dueAt: 10_000, status: 'pending' }),
+    ];
+    const port = createMockPort(reminders);
+    const service = new ReminderServiceImpl(port);
+
+    const due = await service.getDuePendingReminders(4_000);
+    expect(due.map((item) => item.id)).toEqual(['pending-early', 'pending-late']);
+  });
+});


### PR DESCRIPTION
## Summary
- implement issue #375 in-app reminders MVP with independent reminder storage + sync
- add reminder domain/service/scheduler, /reminders page, and persistent in-app/system reminder notifications
- add command palette entries (打开提醒, 新建提醒) and wire route without adding nav items
- add unit tests for reminder service and scheduler

## Verification
- npx tsc --noEmit
- npx vitest run
- bun run build
- cargo build --manifest-path src-tauri/Cargo.toml --release -p exomind --features custom-protocol

Closes #375