### PR TITLE
fix(issue-374): sync linked task status after ending time block

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,6 +17,12 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 
+[features]
+# Ensure plain `cargo build --release` embeds frontend assets
+# instead of falling back to devUrl (localhost).
+default = ["custom-protocol"]
+custom-protocol = ["tauri/custom-protocol"]
+
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"

--- a/src/components/Chat/chat-sync-change-filter.ts
+++ b/src/components/Chat/chat-sync-change-filter.ts
@@ -21,8 +21,9 @@ export function shouldSkipSyncRefresh(change: unknown): boolean {
     return true;
   }
 
-  const docs = Array.isArray(payload.change?.docs)
-    ? payload.change.docs
+  const changeDocs = payload.change?.docs;
+  const docs = Array.isArray(changeDocs)
+    ? changeDocs
     : (Array.isArray(payload.docs) ? payload.docs : []);
 
   if (docs.length > 0) {

--- a/src/lib/adapters/mock/task-mock-adapter.ts
+++ b/src/lib/adapters/mock/task-mock-adapter.ts
@@ -48,7 +48,10 @@ export class TaskMockAdapter implements ITaskPort {
   async updateTask(id: string, input: UpdateTaskInput): Promise<TaskNode | null> {
     const idx = this.tasks.findIndex(t => t.id === id)
     if (idx === -1) return null
-    const updated: TaskNode = { ...this.tasks[idx], ...input, updatedAt: Date.now() }
+    const current = this.tasks[idx]
+    const now = Date.now()
+    const nextUpdatedAt = now > current.updatedAt ? now : current.updatedAt + 1
+    const updated: TaskNode = { ...current, ...input, updatedAt: nextUpdatedAt }
     this.tasks[idx] = updated
     return deepClone(updated)
   }

--- a/src/lib/db/storage.test.ts
+++ b/src/lib/db/storage.test.ts
@@ -13,12 +13,18 @@ const mockReadFileSync = vi.fn();
 const mockWriteFileSync = vi.fn();
 const mockMkdirSync = vi.fn();
 
-vi.mock('fs', () => ({
-  existsSync: (...args: unknown[]) => mockExistsSync(...args),
-  readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
-  writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
-  mkdirSync: (...args: unknown[]) => mockMkdirSync(...args),
-}));
+vi.mock('fs', () => {
+  const api = {
+    existsSync: (...args: unknown[]) => mockExistsSync(...args),
+    readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
+    writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+    mkdirSync: (...args: unknown[]) => mockMkdirSync(...args),
+  };
+  return {
+    ...api,
+    default: api,
+  };
+});
 
 describe('JSONLStorage', () => {
   beforeEach(() => {

--- a/src/ui/app/components/FocusTimerWidget.tsx
+++ b/src/ui/app/components/FocusTimerWidget.tsx
@@ -123,6 +123,7 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle>(function Focu
 
   // Task status selector in feedback dialog
   const activeBlockDataRef = useRef<ActiveBlockData | null>(null);
+  const taskStatusChoiceBlockRef = useRef<string | null>(null);
   const [linkedTask, setLinkedTask] = useState<TaskNode | null>(null);
   const [taskStatusChoice, setTaskStatusChoice] = useState<TaskStatusChoice>('continue');
 
@@ -213,6 +214,7 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle>(function Focu
   const applyActiveBlock = useCallback((block: ActiveBlockData | null) => {
     activeBlockDataRef.current = block;
     if (!block) {
+      taskStatusChoiceBlockRef.current = null;
       setUiState('idle');
       setRunningSubState('running');
       setTaskName('');
@@ -239,7 +241,10 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle>(function Focu
     } else {
       setLinkedTask(null);
     }
-    setTaskStatusChoice('continue');
+    if (taskStatusChoiceBlockRef.current !== block.startId) {
+      taskStatusChoiceBlockRef.current = block.startId;
+      setTaskStatusChoice('continue');
+    }
 
     setTaskName(block.name);
     setTaskNameDraft(block.name);
@@ -553,6 +558,7 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle>(function Focu
     setTaskName('');
     setTaskNameDraft('');
     setLinkedTask(null);
+    taskStatusChoiceBlockRef.current = null;
     setTaskStatusChoice('continue');
     countdownEndedRef.current = false;
     countdownOverrunRef.current = false;

--- a/src/ui/app/components/FocusTimerWidget.tsx
+++ b/src/ui/app/components/FocusTimerWidget.tsx
@@ -497,6 +497,8 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle>(function Focu
   const handleSubmitEnd = useCallback(async (feedbackText?: string) => {
     if (feedbackSubmitting) return;
     const trimmedFeedback = feedbackText?.trim() ?? '';
+    const blockDataSnapshot = activeBlockDataRef.current;
+    const taskStatusChoiceSnapshot = taskStatusChoice;
     if (trimmedFeedback.length === 0) {
       if (skipFeedbackConfirmState === 'idle') {
         startSkipFeedbackConfirmCooldown();
@@ -531,12 +533,11 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle>(function Focu
     console.log('[TB-UI] click submit-end -> endBlock done', { elapsedMs: Math.round(perfNow() - t0) });
 
     // Record block association and apply task status transition
-    const blockData = activeBlockDataRef.current;
-    if (blockData?.taskId) {
+    if (blockDataSnapshot?.taskId) {
       try {
-        await getTaskTimerService().onBlockEndForTask(blockData.taskId, blockData.startId);
-        if (taskStatusChoice !== 'continue') {
-          await getTaskService().transitionTask(blockData.taskId, taskStatusChoice as TaskStatus);
+        await getTaskTimerService().onBlockEndForTask(blockDataSnapshot.taskId, blockDataSnapshot.startId);
+        if (taskStatusChoiceSnapshot !== 'continue') {
+          await getTaskService().transitionTask(blockDataSnapshot.taskId, taskStatusChoiceSnapshot as TaskStatus);
         }
       } catch (error) {
         console.error('[TB-UI] task status update failed', error);

--- a/tests/e2e/timeblock-task-status.issue374.test.ts
+++ b/tests/e2e/timeblock-task-status.issue374.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Issue #374: linked task status transition after ending time block', () => {
+  test.beforeEach(async ({ page }) => {
+    const userId = `e2e-issue374-${Date.now()}`;
+    await page.addInitScript((nextUserId) => {
+      for (const key of Object.keys(localStorage)) {
+        if (key.startsWith('exomind:') || key.startsWith('exomind_')) {
+          localStorage.removeItem(key);
+        }
+      }
+      localStorage.setItem('exomind:sync-store', JSON.stringify({
+        state: {
+          currentUser: nextUserId,
+          isLoggedIn: true,
+        },
+        version: 0,
+      }));
+    }, userId);
+  });
+
+  test('selecting suspended in feedback should update linked task to 已挂起', async ({ page }) => {
+    const taskTitle = `Issue374-${Date.now()}`;
+
+    await page.goto('/tasks');
+    await page.waitForLoadState('networkidle');
+
+    const quickInput = page.getByPlaceholder('快速添加任务...');
+    await expect(quickInput).toBeVisible();
+    await quickInput.fill(taskTitle);
+    await quickInput.press('Enter');
+
+    const taskTitleInList = page.getByText(taskTitle, { exact: true }).first();
+    await expect(taskTitleInList).toBeVisible();
+    await taskTitleInList.click();
+
+    await expect(page).toHaveURL(/\/tasks\/.+/);
+    await expect(page.getByTestId('new-task-detail-page')).toBeVisible();
+
+    await page.getByRole('button', { name: '开始计时' }).click();
+    await expect(page).toHaveURL(/\/eventlog/);
+    await expect(page.getByTestId('new-focus-state-running')).toBeVisible();
+
+    await page.getByTestId('new-focus-end-button').click();
+    await expect(page.getByTestId('feedback-task-status-section')).toBeVisible();
+    await page.getByTestId('feedback-task-status-suspended').click();
+    await page.getByTestId('new-focus-feedback-textarea').fill('e2e suspend');
+    await page.getByTestId('new-focus-feedback-confirm').click();
+
+    await expect(page.getByTestId('new-focus-feedback-textarea')).toHaveCount(0);
+    await expect(page.getByTestId('new-focus-state-idle')).toBeVisible();
+
+    await page.getByRole('link', { name: '任务' }).first().click();
+    await expect(page).toHaveURL(/\/tasks/);
+
+    const taskTitleAfterEnd = page.getByText(taskTitle, { exact: true }).first();
+    await expect(taskTitleAfterEnd).toBeVisible();
+    await taskTitleAfterEnd.click();
+
+    await expect(page.getByTestId('new-task-detail-page')).toBeVisible();
+    await expect(page.getByText('已挂起', { exact: true })).toBeVisible();
+  });
+});

--- a/tests/unit/components/FocusTimerWidget.state-machine.issue175.test.tsx
+++ b/tests/unit/components/FocusTimerWidget.state-machine.issue175.test.tsx
@@ -13,6 +13,10 @@ const updateElapsedMock = vi.fn();
 const onBlockChangeMock = vi.fn(() => () => {});
 const startSyncMock = vi.fn().mockResolvedValue(undefined);
 const stopSyncMock = vi.fn().mockResolvedValue(undefined);
+const getTaskMock = vi.fn();
+const transitionTaskMock = vi.fn();
+const onBlockEndForTaskMock = vi.fn();
+let onBlockChangeHandler: ((block: unknown) => void) | null = null;
 let originalRequestAnimationFrame: typeof globalThis.requestAnimationFrame | undefined;
 let originalCancelAnimationFrame: typeof globalThis.cancelAnimationFrame | undefined;
 
@@ -28,6 +32,13 @@ vi.mock('@/lib/services', () => ({
     onBlockChange: onBlockChangeMock,
     startSync: startSyncMock,
     stopSync: stopSyncMock,
+  }),
+  getTaskService: () => ({
+    getTask: getTaskMock,
+    transitionTask: transitionTaskMock,
+  }),
+  getTaskTimerService: () => ({
+    onBlockEndForTask: onBlockEndForTaskMock,
   }),
 }));
 
@@ -53,8 +64,22 @@ describe('FocusTimerWidget state machine（新专注计时组件状态机）', (
     endBlockMock.mockResolvedValue(null);
     markEndingMock.mockResolvedValue(undefined);
     updateElapsedMock.mockResolvedValue(undefined);
+    getTaskMock.mockReset();
+    transitionTaskMock.mockReset();
+    onBlockEndForTaskMock.mockReset();
+    getTaskMock.mockResolvedValue(null);
+    transitionTaskMock.mockResolvedValue(null);
+    onBlockEndForTaskMock.mockResolvedValue(undefined);
+    onBlockChangeHandler = null;
     onBlockChangeMock.mockReset();
-    onBlockChangeMock.mockReturnValue(() => {});
+    onBlockChangeMock.mockImplementation((handler: (block: unknown) => void) => {
+      onBlockChangeHandler = handler;
+      return () => {
+        if (onBlockChangeHandler === handler) {
+          onBlockChangeHandler = null;
+        }
+      };
+    });
     startSyncMock.mockReset();
     stopSyncMock.mockReset();
     startSyncMock.mockResolvedValue(undefined);
@@ -375,6 +400,58 @@ describe('FocusTimerWidget state machine（新专注计时组件状态机）', (
       expect(endBlockMock).toHaveBeenCalledWith('记录反馈');
     });
     await waitFor(() => expect(screen.queryByTestId('new-focus-feedback-textarea')).toBeNull());
+  });
+
+  it('keeps task status transition when endBlock clears active block immediately（issue-374 结束瞬间清空活跃块仍更新任务状态）', async () => {
+    const now = Date.now();
+    loadActiveBlockMock.mockResolvedValueOnce({
+      startId: 'block-task-1',
+      name: '关联任务时间块',
+      startTime: now - 10_000,
+      elapsed: 10_000,
+      mode: 'countup',
+      paused: false,
+      phase: 'running',
+      taskId: 'task-1',
+    });
+    getTaskMock.mockResolvedValue({
+      id: 'task-1',
+      title: '关联任务',
+      status: 'in_progress',
+      priority: 'medium',
+      dependsOn: [],
+      tags: [],
+      createdAt: now - 20_000,
+      updatedAt: now - 5_000,
+    });
+    endBlockMock.mockImplementation(async () => {
+      onBlockChangeHandler?.(null);
+      return null;
+    });
+
+    render(<FocusTimerWidget />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('new-focus-state-running')).toBeInTheDocument();
+      expect(getTaskMock).toHaveBeenCalledWith('task-1');
+    });
+
+    fireEvent.click(screen.getByTestId('new-focus-end-button'));
+    await screen.findByTestId('new-focus-feedback-textarea');
+    await waitFor(() => {
+      expect(screen.getByTestId('feedback-task-status-section')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('feedback-task-status-completed'));
+    fireEvent.change(screen.getByTestId('new-focus-feedback-textarea'), {
+      target: { value: '结束并完成任务' },
+    });
+    fireEvent.click(screen.getByTestId('new-focus-feedback-confirm'));
+
+    await waitFor(() => {
+      expect(onBlockEndForTaskMock).toHaveBeenCalledWith('task-1', 'block-task-1');
+      expect(transitionTaskMock).toHaveBeenCalledWith('task-1', 'completed');
+    });
   });
 
   it('allows closing feedback dialog on Escape and reopening via end button（反馈弹窗可关闭且可再次拉起）', async () => {

--- a/tests/unit/components/FocusTimerWidget.state-machine.issue175.test.tsx
+++ b/tests/unit/components/FocusTimerWidget.state-machine.issue175.test.tsx
@@ -454,6 +454,75 @@ describe('FocusTimerWidget state machine（新专注计时组件状态机）', (
     });
   });
 
+  it('preserves selected task status when markEnding callback arrives late（issue-374 异步回调不应覆盖已选状态）', async () => {
+    const now = Date.now();
+    const runningBlock = {
+      startId: 'block-task-async',
+      name: '关联任务异步回调',
+      startTime: now - 10_000,
+      elapsed: 10_000,
+      mode: 'countup' as const,
+      paused: false,
+      phase: 'running' as const,
+      taskId: 'task-async',
+    };
+
+    loadActiveBlockMock.mockResolvedValueOnce(runningBlock);
+    getTaskMock.mockResolvedValue({
+      id: 'task-async',
+      title: '关联任务',
+      status: 'in_progress',
+      priority: 'medium',
+      dependsOn: [],
+      tags: [],
+      createdAt: now - 20_000,
+      updatedAt: now - 5_000,
+    });
+
+    let resolveMarkEnding: (() => void) | null = null;
+    markEndingMock.mockImplementation(() => new Promise<void>((resolve) => {
+      resolveMarkEnding = () => {
+        onBlockChangeHandler?.({
+          ...runningBlock,
+          phase: 'feedback_in_progress',
+          actionEndedAt: now,
+          feedbackStartedAt: now,
+        });
+        resolve();
+      };
+    }));
+
+    render(<FocusTimerWidget />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('new-focus-state-running')).toBeInTheDocument();
+      expect(getTaskMock).toHaveBeenCalledWith('task-async');
+    });
+
+    fireEvent.click(screen.getByTestId('new-focus-end-button'));
+    await screen.findByTestId('new-focus-feedback-textarea');
+    await waitFor(() => {
+      expect(screen.getByTestId('feedback-task-status-section')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('feedback-task-status-completed'));
+
+    await act(async () => {
+      resolveMarkEnding?.();
+      await Promise.resolve();
+    });
+
+    fireEvent.change(screen.getByTestId('new-focus-feedback-textarea'), {
+      target: { value: '异步回调后仍完成任务' },
+    });
+    fireEvent.click(screen.getByTestId('new-focus-feedback-confirm'));
+
+    await waitFor(() => {
+      expect(onBlockEndForTaskMock).toHaveBeenCalledWith('task-async', 'block-task-async');
+      expect(transitionTaskMock).toHaveBeenCalledWith('task-async', 'completed');
+    });
+  });
+
   it('allows closing feedback dialog on Escape and reopening via end button（反馈弹窗可关闭且可再次拉起）', async () => {
     render(<FocusTimerWidget />);
 

--- a/tests/unit/ui/agent-hub/agents-page.desktop-adapt.issue354.test.ts
+++ b/tests/unit/ui/agent-hub/agents-page.desktop-adapt.issue354.test.ts
@@ -22,9 +22,10 @@ describe('agents page desktop adapt issue-354（桌面端适配与占位清理�
     expect(source).not.toContain('完整 Signal History 面板将在后续版本实现');
   });
 
-  it('replaces agent-chat placeholder with roadmap hint（Agent 对话占位改为规划提示）', () => {
-    expect(source).toContain('此功能计划在 v0.3.6 实现，需要 RT 会话管理接口支持。');
-    expect(source).toContain('<MessageSquare size={20} className="text-[#0D9488]" />');
+  it('replaces chat placeholder with real conversation panel（Agent 对话占位替换为真实会话区）', () => {
+    expect(source).toContain('data-testid="agent-rightpanel-chat-panel"');
+    expect(source).toContain('暂无会话内容，发送第一条消息开始对话。');
+    expect(source).toContain('placeholder="输入消息..."');
     expect(source).not.toContain('Agent 对话 — T8 阶段实现');
   });
 });


### PR DESCRIPTION
## Summary
- fix race in `FocusTimerWidget` end flow by snapshotting `taskId/startId/statusChoice` before `endBlock`
- add regression test for `endBlock` + `onBlockChange(null)`竞态，确保仍会执行 `onBlockEndForTask` 与 `transitionTask`
- include minimal baseline test/tooling stabilizations required to pass full validation on latest `dev`

## Validation
- `npx tsc --noEmit`
- `npx vitest run tests/unit/components/FocusTimerWidget.state-machine.issue175.test.tsx`
- `npx vitest run`
- `bun run build`
- `cargo build --manifest-path src-tauri/Cargo.toml --release -p exomind`

## Issue
- closes #374