### PR TITLE
feat(task): implement issue #398 P0 dependency editor

### DIFF
--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -13,8 +13,14 @@ import {
   type TaskTimeblockDetailViewModel,
   type TimeblockBadge,
 } from './task-timeblock-detail-view';
+import {
+  buildTaskDependencyView,
+  formatDependencyActionError,
+  type TaskDependencyViewModel,
+} from './task-dependency-view';
 
 type TimerMode = 'countup' | 'countdown';
+type DependencyType = 'soft' | 'hard';
 
 function badgeClassName(badge: TimeblockBadge): string {
   if (badge.tone === 'success') return 'bg-[#DCFCE7] text-[#15803D]';
@@ -125,9 +131,191 @@ function DetailActionsCard({
   );
 }
 
+function DependencyCard({
+  dependencyView,
+  selectedTaskId,
+  selectedType,
+  errorMessage,
+  isSaving,
+  onSelectedTaskChange,
+  onSelectedTypeChange,
+  onAddDependency,
+  onChangeDependencyType,
+  onRemoveDependency,
+}: {
+  dependencyView: TaskDependencyViewModel;
+  selectedTaskId: string;
+  selectedType: DependencyType;
+  errorMessage: string | null;
+  isSaving: boolean;
+  onSelectedTaskChange: (value: string) => void;
+  onSelectedTypeChange: (value: DependencyType) => void;
+  onAddDependency: () => void;
+  onChangeDependencyType: (taskId: string, type: DependencyType) => void;
+  onRemoveDependency: (taskId: string) => void;
+}) {
+  return (
+    <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">依赖关系</h3>
+          <p className="mt-1 text-xs text-[#A8A29E]">先完成前置任务，再推进当前任务。</p>
+        </div>
+      </div>
+
+      {errorMessage ? (
+        <p role="alert" className="mt-3 rounded-xl bg-[#FEE2E2] px-3 py-2 text-xs text-[#B91C1C] dark:bg-[#3F1D1D] dark:text-[#FECACA]">
+          {errorMessage}
+        </p>
+      ) : null}
+
+      <div className="mt-4 space-y-4">
+        <div>
+          <h4 className="text-xs font-semibold uppercase tracking-[0.12em] text-[#A8A29E]">前置依赖</h4>
+          <div className="mt-2 space-y-2">
+            {dependencyView.currentDependencies.length > 0 ? dependencyView.currentDependencies.map((dependency) => (
+              <article
+                key={dependency.taskId}
+                data-testid={`dependency-item-${dependency.taskId}`}
+                className="rounded-xl border border-[#E7E5E4] px-3 py-3 dark:border-[#292524]"
+              >
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{dependency.title}</p>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      <span className="rounded-full bg-[#F5F0ED] px-2.5 py-1 text-xs text-[#78716C] dark:bg-[#292524] dark:text-[#D6D3D1]">
+                        {dependency.statusLabel}
+                      </span>
+                      {dependency.missing ? (
+                        <span className="rounded-full bg-[#FFF7ED] px-2.5 py-1 text-xs text-[#C75B3A] dark:bg-[#2A231B] dark:text-[#FDBA74]">
+                          请刷新后确认
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  <div className="flex flex-col gap-2 sm:w-[176px]">
+                    <select
+                      data-testid={`dependency-type-${dependency.taskId}`}
+                      value={dependency.type}
+                      disabled={isSaving}
+                      onChange={(event) => onChangeDependencyType(dependency.taskId, event.target.value as DependencyType)}
+                      className="w-full rounded-xl border border-[#E7E5E4] bg-[#FAF7F5] px-3 py-2 text-sm text-[#44403C] focus:outline-none focus:ring-2 focus:ring-[#C75B3A]/40 dark:border-[#292524] dark:bg-[#292524] dark:text-[#E7E5E4]"
+                    >
+                      <option value="soft">soft</option>
+                      <option value="hard">hard</option>
+                    </select>
+                    <button
+                      type="button"
+                      data-testid={`dependency-remove-${dependency.taskId}`}
+                      disabled={isSaving}
+                      onClick={() => onRemoveDependency(dependency.taskId)}
+                      className="rounded-xl border border-[#E7E5E4] px-3 py-2 text-sm text-[#57534E] transition-colors hover:bg-[#FAF7F5] disabled:cursor-not-allowed disabled:opacity-60 dark:border-[#292524] dark:text-[#D6D3D1] dark:hover:bg-[#292524]"
+                    >
+                      删除依赖
+                    </button>
+                  </div>
+                </div>
+              </article>
+            )) : (
+              <p
+                data-testid="dependency-current-empty"
+                className="rounded-xl bg-[#F8F5F2] px-3 py-3 text-sm text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
+              >
+                暂无前置依赖
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-xl bg-[#F8F5F2] p-3 dark:bg-[#292524]">
+          <h4 className="text-xs font-semibold uppercase tracking-[0.12em] text-[#A8A29E]">新增依赖</h4>
+          <div className="mt-3 grid gap-2 sm:grid-cols-[minmax(0,1fr)_140px_auto]">
+            <label className="space-y-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
+              <span>依赖任务</span>
+              <select
+                data-testid="dependency-add-task-select"
+                value={selectedTaskId}
+                disabled={isSaving}
+                onChange={(event) => onSelectedTaskChange(event.target.value)}
+                className="w-full rounded-xl border border-[#E7E5E4] bg-white px-3 py-2 text-sm text-[#44403C] focus:outline-none focus:ring-2 focus:ring-[#C75B3A]/40 dark:border-[#3F3F46] dark:bg-[#1C1917] dark:text-[#E7E5E4]"
+              >
+                <option value="">请选择任务</option>
+                {dependencyView.candidates.map((candidate) => (
+                  <option key={candidate.id} value={candidate.id}>
+                    {candidate.title} · {candidate.statusLabel}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="space-y-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
+              <span>类型</span>
+              <select
+                data-testid="dependency-add-type-select"
+                value={selectedType}
+                disabled={isSaving}
+                onChange={(event) => onSelectedTypeChange(event.target.value as DependencyType)}
+                className="w-full rounded-xl border border-[#E7E5E4] bg-white px-3 py-2 text-sm text-[#44403C] focus:outline-none focus:ring-2 focus:ring-[#C75B3A]/40 dark:border-[#3F3F46] dark:bg-[#1C1917] dark:text-[#E7E5E4]"
+              >
+                <option value="soft">soft</option>
+                <option value="hard">hard</option>
+              </select>
+            </label>
+
+            <div className="flex items-end">
+              <button
+                type="button"
+                data-testid="dependency-add-button"
+                disabled={isSaving || !selectedTaskId}
+                onClick={onAddDependency}
+                className="w-full rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
+              >
+                添加依赖
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <h4 className="text-xs font-semibold uppercase tracking-[0.12em] text-[#A8A29E]">谁依赖我</h4>
+          <div className="mt-2 space-y-2">
+            {dependencyView.reverseDependencies.length > 0 ? dependencyView.reverseDependencies.map((dependency) => (
+              <article
+                key={dependency.taskId}
+                data-testid={`reverse-dependency-item-${dependency.taskId}`}
+                className="rounded-xl border border-[#E7E5E4] px-3 py-3 dark:border-[#292524]"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{dependency.title}</p>
+                    <p className="mt-1 text-xs text-[#A8A29E]">状态：{dependency.statusLabel}</p>
+                  </div>
+                  <span className="rounded-full bg-[#F5F0ED] px-2.5 py-1 text-xs text-[#78716C] dark:bg-[#292524] dark:text-[#D6D3D1]">
+                    {dependency.typeLabel}
+                  </span>
+                </div>
+              </article>
+            )) : (
+              <p className="rounded-xl bg-[#F8F5F2] px-3 py-3 text-sm text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]">
+                暂无任务依赖当前任务
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function MobileTimeblockDetail({
   task,
   model,
+  dependencyView,
+  dependencySelectedTaskId,
+  dependencySelectedType,
+  dependencyError,
+  isDependencySaving,
   timerMode,
   setTimerMode,
   hasOtherActiveBlock,
@@ -135,9 +323,19 @@ function MobileTimeblockDetail({
   onStartTimer,
   onPauseAndGoEventlog,
   onCopySummary,
+  onDependencySelectedTaskChange,
+  onDependencySelectedTypeChange,
+  onAddDependency,
+  onChangeDependencyType,
+  onRemoveDependency,
 }: {
   task: TaskNode;
   model: TaskTimeblockDetailViewModel;
+  dependencyView: TaskDependencyViewModel;
+  dependencySelectedTaskId: string;
+  dependencySelectedType: DependencyType;
+  dependencyError: string | null;
+  isDependencySaving: boolean;
   timerMode: TimerMode;
   setTimerMode: (mode: TimerMode) => void;
   hasOtherActiveBlock: boolean;
@@ -145,6 +343,11 @@ function MobileTimeblockDetail({
   onStartTimer: () => void;
   onPauseAndGoEventlog: () => void;
   onCopySummary: () => void;
+  onDependencySelectedTaskChange: (value: string) => void;
+  onDependencySelectedTypeChange: (value: DependencyType) => void;
+  onAddDependency: () => void;
+  onChangeDependencyType: (taskId: string, type: DependencyType) => void;
+  onRemoveDependency: (taskId: string) => void;
 }) {
   return (
     <div className="min-h-full bg-[#FAF7F5] pb-10 dark:bg-[#0C0A09]" data-testid="new-task-detail-page">
@@ -237,6 +440,19 @@ function MobileTimeblockDetail({
           </div>
         </section>
 
+        <DependencyCard
+          dependencyView={dependencyView}
+          selectedTaskId={dependencySelectedTaskId}
+          selectedType={dependencySelectedType}
+          errorMessage={dependencyError}
+          isSaving={isDependencySaving}
+          onSelectedTaskChange={onDependencySelectedTaskChange}
+          onSelectedTypeChange={onDependencySelectedTypeChange}
+          onAddDependency={onAddDependency}
+          onChangeDependencyType={onChangeDependencyType}
+          onRemoveDependency={onRemoveDependency}
+        />
+
         <DetailActionsCard
           model={model}
           onRestart={onStartTimer}
@@ -297,6 +513,11 @@ function MobileTimeblockDetail({
 function DesktopTimeblockDetail({
   task,
   model,
+  dependencyView,
+  dependencySelectedTaskId,
+  dependencySelectedType,
+  dependencyError,
+  isDependencySaving,
   timerMode,
   setTimerMode,
   hasOtherActiveBlock,
@@ -304,9 +525,19 @@ function DesktopTimeblockDetail({
   onStartTimer,
   onPauseAndGoEventlog,
   onCopySummary,
+  onDependencySelectedTaskChange,
+  onDependencySelectedTypeChange,
+  onAddDependency,
+  onChangeDependencyType,
+  onRemoveDependency,
 }: {
   task: TaskNode;
   model: TaskTimeblockDetailViewModel;
+  dependencyView: TaskDependencyViewModel;
+  dependencySelectedTaskId: string;
+  dependencySelectedType: DependencyType;
+  dependencyError: string | null;
+  isDependencySaving: boolean;
   timerMode: TimerMode;
   setTimerMode: (mode: TimerMode) => void;
   hasOtherActiveBlock: boolean;
@@ -314,6 +545,11 @@ function DesktopTimeblockDetail({
   onStartTimer: () => void;
   onPauseAndGoEventlog: () => void;
   onCopySummary: () => void;
+  onDependencySelectedTaskChange: (value: string) => void;
+  onDependencySelectedTypeChange: (value: DependencyType) => void;
+  onAddDependency: () => void;
+  onChangeDependencyType: (taskId: string, type: DependencyType) => void;
+  onRemoveDependency: (taskId: string) => void;
 }) {
   return (
     <div className="min-h-full bg-[#FAF7F5] px-8 py-6 dark:bg-[#0C0A09]" data-testid="new-task-detail-page">
@@ -368,6 +604,19 @@ function DesktopTimeblockDetail({
             <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">洞察</h3>
             <p className="mt-2 text-sm text-[#44403C] dark:text-[#E7E5E4]">{task.title}</p>
           </section>
+
+          <DependencyCard
+            dependencyView={dependencyView}
+            selectedTaskId={dependencySelectedTaskId}
+            selectedType={dependencySelectedType}
+            errorMessage={dependencyError}
+            isSaving={isDependencySaving}
+            onSelectedTaskChange={onDependencySelectedTaskChange}
+            onSelectedTypeChange={onDependencySelectedTypeChange}
+            onAddDependency={onAddDependency}
+            onChangeDependencyType={onChangeDependencyType}
+            onRemoveDependency={onRemoveDependency}
+          />
 
           <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
             <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">计划 vs 实际</h3>
@@ -455,7 +704,14 @@ export function TaskDetailPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [reviewMarkdown, setReviewMarkdown] = useState('');
   const [eventLogs, setEventLogs] = useState<TimeblockEventLog[]>([]);
+  const [allTasks, setAllTasks] = useState<TaskNode[]>([]);
   const [timerMode, setTimerMode] = useState<TimerMode>('countdown');
+  const [dependencySelectedTaskId, setDependencySelectedTaskId] = useState('');
+  const [dependencySelectedType, setDependencySelectedType] = useState<DependencyType>('soft');
+  const [dependencyLoadError, setDependencyLoadError] = useState<string | null>(null);
+  const [dependencyActionError, setDependencyActionError] = useState<string | null>(null);
+  const [isDependencySaving, setIsDependencySaving] = useState(false);
+  const [dependencyReloadKey, setDependencyReloadKey] = useState(0);
 
   useEffect(() => {
     let disposed = false;
@@ -463,31 +719,43 @@ export function TaskDetailPage() {
     const timeBlockService = getTimeBlockService();
     const load = async () => {
       if (!taskId && !preferredBlockId) {
+        setAllTasks([]);
+        setDependencyLoadError(null);
         setIsLoading(false);
         return;
       }
 
-      const [loadedTask, blocks, currentBlock] = await Promise.all([
+      const listedTasksPromise = taskService.listTasks(true)
+        .then((tasks) => {
+          if (!disposed) setDependencyLoadError(null);
+          return tasks;
+        })
+        .catch((error) => {
+          if (!disposed) setDependencyLoadError(formatDependencyActionError(error, 'load'));
+          return [] as TaskNode[];
+        });
+
+      const [loadedTask, blocks, currentBlock, listedTasks] = await Promise.all([
         taskId ? taskService.getTask(taskId) : Promise.resolve(null),
         timeBlockService.loadTimeBlocks(),
         timeBlockService.loadActiveBlock(),
+        listedTasksPromise,
       ]);
       let nextTask = loadedTask;
       if (!nextTask && preferredBlockId) {
         const matchedBlock = blocks.find((block) => block.id === preferredBlockId || block.startId === preferredBlockId);
         if (matchedBlock) {
-          const allTasks = await taskService.listTasks(true);
-          const linked = allTasks.find((candidate) => (candidate.timeBlockIds ?? []).includes(matchedBlock.startId));
+          const linked = listedTasks.find((candidate) => (candidate.timeBlockIds ?? []).includes(matchedBlock.startId));
           nextTask = linked ?? buildVirtualTaskFromBlock(matchedBlock);
         }
       }
       if (!nextTask) {
-        const fallbackTasks = await taskService.listTasks();
-        nextTask = fallbackTasks[0] ?? null;
+        nextTask = listedTasks[0] ?? null;
       }
 
       if (disposed) return;
       setTask(nextTask);
+      setAllTasks(listedTasks);
       setTimeBlocks(blocks);
       setActiveBlock(nextTask && currentBlock?.taskId === nextTask.id ? currentBlock : null);
       setHasOtherActiveBlock(Boolean(currentBlock && nextTask && currentBlock.taskId !== nextTask.id));
@@ -526,7 +794,7 @@ export function TaskDetailPage() {
       unsubscribeTasks();
       unsubscribeBlocks();
     };
-  }, [preferredBlockId, taskId]);
+  }, [dependencyReloadKey, preferredBlockId, taskId]);
 
   const viewModel = useMemo(() => {
     if (!task) return null;
@@ -540,6 +808,85 @@ export function TaskDetailPage() {
       useMockData: getUseMockDataEnabled(),
     });
   }, [activeBlock, eventLogs, preferredBlockId, reviewMarkdown, task, timeBlocks]);
+
+  const dependencyView = useMemo(() => {
+    if (!task) return null;
+    return buildTaskDependencyView(task, allTasks);
+  }, [allTasks, task]);
+
+  const dependencyError = dependencyActionError ?? dependencyLoadError;
+
+  const reloadDependencies = () => {
+    setDependencyReloadKey((value) => value + 1);
+  };
+
+  const handleAddDependency = async () => {
+    if (!task || !dependencyView) return;
+
+    setDependencyActionError(null);
+    if (!dependencySelectedTaskId) {
+      setDependencyActionError('请选择依赖任务');
+      return;
+    }
+    if (!dependencyView.candidates.some((candidate) => candidate.id === dependencySelectedTaskId)) {
+      setDependencyActionError('依赖任务不存在，请刷新后重试');
+      return;
+    }
+
+    setIsDependencySaving(true);
+    try {
+      const updated = await getTaskService().addDependency(task.id, dependencySelectedTaskId, dependencySelectedType);
+      if (!updated) {
+        setDependencyActionError('当前任务不存在，依赖未保存');
+        return;
+      }
+      setDependencySelectedTaskId('');
+      setDependencySelectedType('soft');
+      reloadDependencies();
+    } catch (error) {
+      setDependencyActionError(formatDependencyActionError(error, 'add'));
+    } finally {
+      setIsDependencySaving(false);
+    }
+  };
+
+  const handleChangeDependencyType = async (depTaskId: string, type: DependencyType) => {
+    if (!task) return;
+
+    setDependencyActionError(null);
+    setIsDependencySaving(true);
+    try {
+      const updated = await getTaskService().addDependency(task.id, depTaskId, type);
+      if (!updated) {
+        setDependencyActionError('当前任务不存在，依赖未更新');
+        return;
+      }
+      reloadDependencies();
+    } catch (error) {
+      setDependencyActionError(formatDependencyActionError(error, 'update'));
+    } finally {
+      setIsDependencySaving(false);
+    }
+  };
+
+  const handleRemoveDependency = async (depTaskId: string) => {
+    if (!task) return;
+
+    setDependencyActionError(null);
+    setIsDependencySaving(true);
+    try {
+      const updated = await getTaskService().removeDependency(task.id, depTaskId);
+      if (!updated) {
+        setDependencyActionError('当前任务不存在，依赖未删除');
+        return;
+      }
+      reloadDependencies();
+    } catch (error) {
+      setDependencyActionError(formatDependencyActionError(error, 'remove'));
+    } finally {
+      setIsDependencySaving(false);
+    }
+  };
 
   const handleStartTimer = () => {
     if (!taskId) return;
@@ -577,7 +924,7 @@ export function TaskDetailPage() {
     );
   }
 
-  if (!task || !viewModel) {
+  if (!task || !viewModel || !dependencyView) {
     return (
       <div className="min-h-full bg-[#FAF7F5] px-6 py-6 dark:bg-[#0C0A09]">
         <Link to="/tasks" className="inline-flex items-center gap-1 text-sm text-[#78716C] dark:text-[#A8A29E]">
@@ -594,6 +941,11 @@ export function TaskDetailPage() {
       <DesktopTimeblockDetail
         task={task}
         model={viewModel}
+        dependencyView={dependencyView}
+        dependencySelectedTaskId={dependencySelectedTaskId}
+        dependencySelectedType={dependencySelectedType}
+        dependencyError={dependencyError}
+        isDependencySaving={isDependencySaving}
         timerMode={timerMode}
         setTimerMode={setTimerMode}
         hasOtherActiveBlock={hasOtherActiveBlock}
@@ -601,6 +953,11 @@ export function TaskDetailPage() {
         onStartTimer={handleStartTimer}
         onPauseAndGoEventlog={handlePauseAndGoEventlog}
         onCopySummary={handleCopySummary}
+        onDependencySelectedTaskChange={setDependencySelectedTaskId}
+        onDependencySelectedTypeChange={setDependencySelectedType}
+        onAddDependency={handleAddDependency}
+        onChangeDependencyType={handleChangeDependencyType}
+        onRemoveDependency={handleRemoveDependency}
       />
     );
   }
@@ -609,6 +966,11 @@ export function TaskDetailPage() {
     <MobileTimeblockDetail
       task={task}
       model={viewModel}
+      dependencyView={dependencyView}
+      dependencySelectedTaskId={dependencySelectedTaskId}
+      dependencySelectedType={dependencySelectedType}
+      dependencyError={dependencyError}
+      isDependencySaving={isDependencySaving}
       timerMode={timerMode}
       setTimerMode={setTimerMode}
       hasOtherActiveBlock={hasOtherActiveBlock}
@@ -616,6 +978,11 @@ export function TaskDetailPage() {
       onStartTimer={handleStartTimer}
       onPauseAndGoEventlog={handlePauseAndGoEventlog}
       onCopySummary={handleCopySummary}
+      onDependencySelectedTaskChange={setDependencySelectedTaskId}
+      onDependencySelectedTypeChange={setDependencySelectedType}
+      onAddDependency={handleAddDependency}
+      onChangeDependencyType={handleChangeDependencyType}
+      onRemoveDependency={handleRemoveDependency}
     />
   );
 }

--- a/src/ui/app/pages/task-dependency-view.ts
+++ b/src/ui/app/pages/task-dependency-view.ts
@@ -1,0 +1,96 @@
+import type { TaskNode, TaskStatus } from '@/lib/types/task';
+
+type DependencyType = 'soft' | 'hard';
+type DependencyAction = 'load' | 'add' | 'update' | 'remove';
+
+export interface TaskDependencyItem {
+  taskId: string;
+  title: string;
+  statusLabel: string;
+  type: DependencyType;
+  typeLabel: string;
+  missing: boolean;
+}
+
+export interface TaskDependencyCandidate {
+  id: string;
+  title: string;
+  statusLabel: string;
+}
+
+export interface TaskDependencyViewModel {
+  currentDependencies: TaskDependencyItem[];
+  reverseDependencies: TaskDependencyItem[];
+  candidates: TaskDependencyCandidate[];
+}
+
+const STATUS_LABELS: Record<TaskStatus, string> = {
+  not_started: '未开始',
+  in_progress: '进行中',
+  suspended: '已挂起',
+  completed: '已完成',
+  abandoned: '已放弃',
+};
+
+const TYPE_LABELS: Record<DependencyType, string> = {
+  soft: '软依赖',
+  hard: '硬依赖',
+};
+
+function buildDependencyItem(taskMap: Map<string, TaskNode>, taskId: string, type: DependencyType): TaskDependencyItem {
+  const task = taskMap.get(taskId);
+  if (!task) {
+    return {
+      taskId,
+      title: `任务不存在（${taskId}）`,
+      statusLabel: '目标不存在',
+      type,
+      typeLabel: TYPE_LABELS[type],
+      missing: true,
+    };
+  }
+
+  return {
+    taskId,
+    title: task.title,
+    statusLabel: STATUS_LABELS[task.status],
+    type,
+    typeLabel: TYPE_LABELS[type],
+    missing: false,
+  };
+}
+
+export function buildTaskDependencyView(task: TaskNode, allTasks: TaskNode[]): TaskDependencyViewModel {
+  const taskMap = new Map(allTasks.map((item) => [item.id, item]));
+
+  return {
+    currentDependencies: task.dependsOn.map((dependency) => buildDependencyItem(taskMap, dependency.taskId, dependency.type)),
+    reverseDependencies: allTasks
+      .flatMap((candidate) => candidate.dependsOn
+        .filter((dependency) => dependency.taskId === task.id)
+        .map((dependency) => buildDependencyItem(taskMap, candidate.id, dependency.type))),
+    candidates: allTasks.map((candidate) => ({
+      id: candidate.id,
+      title: candidate.title,
+      statusLabel: STATUS_LABELS[candidate.status],
+    })),
+  };
+}
+
+export function formatDependencyActionError(error: unknown, action: DependencyAction): string {
+  const message = error instanceof Error ? error.message.trim() : String(error ?? '').trim();
+  if (message.toLowerCase().includes('not found')) {
+    return '依赖任务不存在，请刷新后重试';
+  }
+
+  if (action === 'load') {
+    return `依赖列表加载失败：${message || '请稍后重试'}`;
+  }
+  if (action === 'update') {
+    return `更新依赖失败：${message || '请稍后重试'}`;
+  }
+  if (action === 'remove') {
+    return `删除依赖失败：${message || '请稍后重试'}`;
+  }
+  return `新增依赖失败：${message || '请稍后重试'}`;
+}

--- a/tests/e2e/playwright.issue398.config.ts
+++ b/tests/e2e/playwright.issue398.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from '@playwright/test';
+import {
+  getBaseUse,
+  getChromiumProject,
+  withPlaywrightEnv,
+} from './playwright.termux';
+
+const WEB_PORT = 1542;
+const HMR_PORT = 1543;
+const POUCHDB_PORT = 7095;
+const ASR_PORT = 2060;
+const BASE_URL = `http://localhost:${WEB_PORT}`;
+
+export default defineConfig({
+  testDir: '.',
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: 'list',
+  use: getBaseUse(BASE_URL),
+  projects: [getChromiumProject()],
+  webServer: {
+    command: 'node Scripts/test/runtime-dispatch.cjs vite-dev',
+    cwd: '../..',
+    url: BASE_URL,
+    reuseExistingServer: false,
+    timeout: 180000,
+    env: withPlaywrightEnv({
+      ...process.env,
+      EXOMIND_WEB_PORT: String(WEB_PORT),
+      EXOMIND_HMR_PORT: String(HMR_PORT),
+      EXOMIND_POUCHDB_PORT: String(POUCHDB_PORT),
+      EXOMIND_ASR_PORT: String(ASR_PORT),
+      VITE_SYNC_SERVER_URL: `http://localhost:${POUCHDB_PORT}`,
+      VITE_ASR_SERVER_URL: `http://localhost:${ASR_PORT}`,
+    }),
+  },
+});

--- a/tests/e2e/task-detail-dependencies.issue398.test.ts
+++ b/tests/e2e/task-detail-dependencies.issue398.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Issue #398 Task detail dependencies（任务详情依赖关系）', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      for (const key of Object.keys(localStorage)) {
+        if (key.startsWith('exomind:') || key.startsWith('exomind_')) {
+          localStorage.removeItem(key);
+        }
+      }
+
+      localStorage.setItem('exomind:uiMode', 'new');
+      localStorage.setItem('exomind:useMockData', 'true');
+    });
+  });
+
+  test('can view, switch, remove and add dependencies in task detail', async ({ page }) => {
+    await page.goto('/tasks/node-002');
+
+    await expect(page.getByTestId('new-task-detail-page')).toBeVisible();
+    await expect(page.getByRole('heading', { name: '实现 CRUD 服务层' })).toBeVisible();
+    await expect(page.getByText('依赖关系')).toBeVisible();
+
+    const currentDependency = page.getByTestId('dependency-item-node-001');
+    await expect(currentDependency).toBeVisible();
+    await expect(currentDependency.getByText('完成 TaskNode 数据模型')).toBeVisible();
+    await expect(currentDependency.getByText('已完成')).toBeVisible();
+
+    const reverseDependency = page.getByTestId('reverse-dependency-item-node-003');
+    await expect(reverseDependency).toBeVisible();
+    await expect(reverseDependency.getByText('编写单元测试')).toBeVisible();
+    await expect(reverseDependency.getByText('软依赖')).toBeVisible();
+
+    const typeSelect = page.getByTestId('dependency-type-node-001');
+    await typeSelect.selectOption('soft');
+    await expect(typeSelect).toHaveValue('soft');
+
+    await page.getByTestId('dependency-remove-node-001').click();
+    await expect(page.getByTestId('dependency-current-empty')).toBeVisible();
+
+    await page.getByTestId('dependency-add-task-select').selectOption('node-001');
+    await page.getByTestId('dependency-add-type-select').selectOption('hard');
+    await page.getByTestId('dependency-add-button').click();
+
+    await expect(page.getByTestId('dependency-item-node-001')).toBeVisible();
+    await expect(page.getByTestId('dependency-type-node-001')).toHaveValue('hard');
+  });
+});

--- a/tests/unit/ui/task-detail-page.dependencies.issue398.test.tsx
+++ b/tests/unit/ui/task-detail-page.dependencies.issue398.test.tsx
@@ -1,0 +1,286 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { TaskDetailPage } from '@/ui/app/pages/TaskDetailPage';
+import type { TaskNode } from '@/lib/types/task';
+import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
+
+const navigateMock = vi.fn();
+
+let tasksState: TaskNode[] = [];
+let addDependencyFailure: Error | null = null;
+let removeDependencyFailure: Error | null = null;
+
+function cloneTask(task: TaskNode | null): TaskNode | null {
+  return task ? structuredClone(task) : null;
+}
+
+function cloneTasks(tasks: TaskNode[]): TaskNode[] {
+  return structuredClone(tasks);
+}
+
+const getTaskMock = vi.fn<(id: string) => Promise<TaskNode | null>>(async (id) => {
+  return cloneTask(tasksState.find((task) => task.id === id) ?? null);
+});
+
+const listTasksMock = vi.fn<(includeAbandoned?: boolean) => Promise<TaskNode[]>>(async () => {
+  return cloneTasks(tasksState);
+});
+
+const addDependencyMock = vi.fn<
+  (taskId: string, depTaskId: string, type: 'soft' | 'hard') => Promise<TaskNode | null>
+>(async (taskId, depTaskId, type) => {
+  if (addDependencyFailure) throw addDependencyFailure;
+
+  const task = tasksState.find((item) => item.id === taskId);
+  if (!task) return null;
+
+  const target = tasksState.find((item) => item.id === depTaskId);
+  if (!target) throw new Error(`Dependency target ${depTaskId} not found`);
+
+  const existing = task.dependsOn.find((dependency) => dependency.taskId === depTaskId);
+  task.dependsOn = existing
+    ? task.dependsOn.map((dependency) => (dependency.taskId === depTaskId ? { ...dependency, type } : dependency))
+    : [...task.dependsOn, { taskId: depTaskId, type }];
+  task.updatedAt += 1;
+
+  return cloneTask(task);
+});
+
+const removeDependencyMock = vi.fn<(taskId: string, depTaskId: string) => Promise<TaskNode | null>>(async (taskId, depTaskId) => {
+  if (removeDependencyFailure) throw removeDependencyFailure;
+
+  const task = tasksState.find((item) => item.id === taskId);
+  if (!task) return null;
+
+  task.dependsOn = task.dependsOn.filter((dependency) => dependency.taskId !== depTaskId);
+  task.updatedAt += 1;
+
+  return cloneTask(task);
+});
+
+const onTaskChangeMock = vi.fn(() => () => {});
+
+const loadTimeBlocksMock = vi.fn<() => Promise<TimeBlock[]>>();
+const loadActiveBlockMock = vi.fn<() => Promise<ActiveBlockData | null>>();
+const onBlockChangeMock = vi.fn(() => () => {});
+const pauseBlockMock = vi.fn<() => Promise<void>>();
+
+const calculateSpentMinutesMock = vi.fn<(taskId: string) => Promise<number>>();
+const getEventsMock = vi.fn<() => Promise<Array<{ id: string; content: string; createdAt: string; type?: string }>>>();
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+  useParams: () => ({ taskId: 'task-1' }),
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock('@/lib/services', () => ({
+  getTaskService: () => ({
+    getTask: getTaskMock,
+    listTasks: listTasksMock,
+    addDependency: addDependencyMock,
+    removeDependency: removeDependencyMock,
+    onTaskChange: onTaskChangeMock,
+    getAvailableTransitions: vi.fn(),
+    getChildTasks: vi.fn(async () => []),
+    checkDependenciesMet: vi.fn(async () => ({ met: true, blocking: [] })),
+    transitionTask: vi.fn(),
+    updateTask: vi.fn(),
+    abandonTask: vi.fn(),
+  }),
+  getTimeBlockService: () => ({
+    loadTimeBlocks: loadTimeBlocksMock,
+    loadActiveBlock: loadActiveBlockMock,
+    onBlockChange: onBlockChangeMock,
+    pauseBlock: pauseBlockMock,
+  }),
+  getTaskTimerService: () => ({
+    calculateSpentMinutes: calculateSpentMinutesMock,
+    startBlockForTask: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/storage/event-storage', () => ({
+  getEventStorage: () => ({
+    getEvents: getEventsMock,
+  }),
+}));
+
+function mockMatchMedia(matches: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation(() => ({
+      matches,
+      media: '(min-width: 768px)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+function makeTask(overrides: Partial<TaskNode> = {}): TaskNode {
+  return {
+    id: 'task-1',
+    title: '任务详情：依赖关系 MVP',
+    description: '在详情页增加依赖关系卡片',
+    status: 'not_started',
+    priority: 'high',
+    dependsOn: [],
+    tags: ['issue-398'],
+    estimatedMinutes: 60,
+    timeBlockIds: ['block-1'],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeBlock(overrides: Partial<TimeBlock> = {}): TimeBlock {
+  const start = new Date('2026-03-07T09:00:00+08:00').getTime();
+  const end = new Date('2026-03-07T10:00:00+08:00').getTime();
+  return {
+    id: 'block-1',
+    startId: 'block-1',
+    endId: 'block-1-end',
+    name: '任务详情：依赖关系 MVP',
+    note: 'issue 398 P0',
+    tags: new Set(['block_feedback']),
+    startTime: start,
+    endTime: end,
+    ...overrides,
+  };
+}
+
+function renderPage(isDesktop = true) {
+  mockMatchMedia(isDesktop);
+  render(<TaskDetailPage />);
+}
+
+describe('TaskDetailPage dependencies issue #398 P0', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    addDependencyFailure = null;
+    removeDependencyFailure = null;
+
+    tasksState = [
+      makeTask({
+        id: 'task-1',
+        title: '实现依赖关系卡片',
+        dependsOn: [{ taskId: 'task-2', type: 'soft' }],
+      }),
+      makeTask({
+        id: 'task-2',
+        title: '补 task.service 单测',
+        status: 'in_progress',
+        timeBlockIds: [],
+      }),
+      makeTask({
+        id: 'task-3',
+        title: '联调任务详情页',
+        status: 'completed',
+        dependsOn: [{ taskId: 'task-1', type: 'hard' }],
+        timeBlockIds: [],
+      }),
+    ];
+
+    getTaskMock.mockClear();
+    listTasksMock.mockClear();
+    addDependencyMock.mockClear();
+    removeDependencyMock.mockClear();
+    onTaskChangeMock.mockClear();
+
+    loadTimeBlocksMock.mockReset();
+    loadTimeBlocksMock.mockResolvedValue([makeBlock()]);
+    loadActiveBlockMock.mockReset();
+    loadActiveBlockMock.mockResolvedValue(null);
+    onBlockChangeMock.mockClear();
+    pauseBlockMock.mockReset();
+    pauseBlockMock.mockResolvedValue();
+
+    calculateSpentMinutesMock.mockReset();
+    calculateSpentMinutesMock.mockResolvedValue(15);
+    getEventsMock.mockReset();
+    getEventsMock.mockResolvedValue([]);
+  });
+
+  it('renders current dependencies and reverse dependencies（渲染当前依赖与反向依赖）', async () => {
+    renderPage(false);
+
+    expect(await screen.findByText('依赖关系')).toBeInTheDocument();
+
+    const currentItem = await screen.findByTestId('dependency-item-task-2');
+    expect(within(currentItem).getByText('补 task.service 单测')).toBeInTheDocument();
+    expect(within(currentItem).getByText('进行中')).toBeInTheDocument();
+    expect(within(currentItem).getByDisplayValue('soft')).toBeInTheDocument();
+
+    const reverseItem = screen.getByTestId('reverse-dependency-item-task-3');
+    expect(within(reverseItem).getByText('联调任务详情页')).toBeInTheDocument();
+    expect(within(reverseItem).getByText('状态：已完成')).toBeInTheDocument();
+    expect(within(reverseItem).getByText('硬依赖')).toBeInTheDocument();
+  });
+
+  it('adds a hard dependency（新增 hard 依赖）', async () => {
+    tasksState[0].dependsOn = [];
+    renderPage();
+
+    await screen.findByTestId('dependency-add-task-select');
+    expect(screen.getByTestId('dependency-current-empty')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('dependency-add-task-select'), { target: { value: 'task-2' } });
+    fireEvent.change(screen.getByTestId('dependency-add-type-select'), { target: { value: 'hard' } });
+    fireEvent.click(screen.getByTestId('dependency-add-button'));
+
+    await waitFor(() => {
+      expect(addDependencyMock).toHaveBeenCalledWith('task-1', 'task-2', 'hard');
+    });
+
+    const currentItem = await screen.findByTestId('dependency-item-task-2');
+    expect(within(currentItem).getByDisplayValue('hard')).toBeInTheDocument();
+    expect(screen.queryByTestId('dependency-current-empty')).not.toBeInTheDocument();
+  });
+
+  it('switches dependency type from soft to hard（切换依赖类型）', async () => {
+    renderPage();
+
+    const typeSelect = await screen.findByTestId('dependency-type-task-2');
+    fireEvent.change(typeSelect, { target: { value: 'hard' } });
+
+    await waitFor(() => {
+      expect(addDependencyMock).toHaveBeenCalledWith('task-1', 'task-2', 'hard');
+    });
+
+    const currentItem = await screen.findByTestId('dependency-item-task-2');
+    expect(within(currentItem).getByDisplayValue('hard')).toBeInTheDocument();
+  });
+
+  it('removes dependency（删除依赖）', async () => {
+    renderPage();
+
+    fireEvent.click(await screen.findByTestId('dependency-remove-task-2'));
+
+    await waitFor(() => {
+      expect(removeDependencyMock).toHaveBeenCalledWith('task-1', 'task-2');
+    });
+
+    expect(await screen.findByTestId('dependency-current-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('dependency-item-task-2')).not.toBeInTheDocument();
+  });
+
+  it('shows readable error when dependency service throws not found（服务报错时展示基础错误提示）', async () => {
+    tasksState[0].dependsOn = [];
+    addDependencyFailure = new Error('Dependency target task-99 not found');
+    renderPage();
+
+    await screen.findByTestId('dependency-add-task-select');
+    fireEvent.change(screen.getByTestId('dependency-add-task-select'), { target: { value: 'task-2' } });
+    fireEvent.click(screen.getByTestId('dependency-add-button'));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('依赖任务不存在，请刷新后重试');
+  });
+});

--- a/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
+++ b/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
@@ -8,6 +8,9 @@ import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
 const navigateMock = vi.fn();
 
 const getTaskMock = vi.fn<(id: string) => Promise<TaskNode | null>>();
+const listTasksMock = vi.fn<(includeAbandoned?: boolean) => Promise<TaskNode[]>>();
+const addDependencyMock = vi.fn<(taskId: string, depTaskId: string, type: 'soft' | 'hard') => Promise<TaskNode | null>>();
+const removeDependencyMock = vi.fn<(taskId: string, depTaskId: string) => Promise<TaskNode | null>>();
 const getAvailableTransitionsMock = vi.fn<(id: string) => Promise<Array<TaskNode['status']>>>();
 const getChildTasksMock = vi.fn<(parentId: string) => Promise<TaskNode[]>>();
 const checkDependenciesMetMock = vi.fn<(taskId: string) => Promise<{ met: boolean; blocking: Array<{ taskId: string; type: 'soft' | 'hard'; status: TaskNode['status'] }> }>>();
@@ -33,6 +36,9 @@ vi.mock('@tanstack/react-router', () => ({
 vi.mock('@/lib/services', () => ({
   getTaskService: () => ({
     getTask: getTaskMock,
+    listTasks: listTasksMock,
+    addDependency: addDependencyMock,
+    removeDependency: removeDependencyMock,
     getAvailableTransitions: getAvailableTransitionsMock,
     getChildTasks: getChildTasksMock,
     checkDependenciesMet: checkDependenciesMetMock,
@@ -112,6 +118,9 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
   beforeEach(() => {
     navigateMock.mockReset();
     getTaskMock.mockResolvedValue(makeTask());
+    listTasksMock.mockResolvedValue([makeTask()]);
+    addDependencyMock.mockResolvedValue(makeTask());
+    removeDependencyMock.mockResolvedValue(makeTask());
     getAvailableTransitionsMock.mockResolvedValue(['in_progress']);
     getChildTasksMock.mockResolvedValue([]);
     checkDependenciesMetMock.mockResolvedValue({ met: true, blocking: [] });


### PR DESCRIPTION
﻿## Summary
- add issue #398 P0 dependency management directly inside `TaskDetailPage`
- show current dependencies and reverse dependencies with a lightweight shared view helper
- cover the flow with focused unit tests and a dedicated Playwright E2E config/test

## Scope
- P0 only for #398
- no P1 items such as UI cycle prevention, self-dependency prevention, candidate disabling, or graph UI

## Testing
- `npx tsc --noEmit`
- `npx vitest run tests/unit/ui/task-detail-page.timeblock-detail.test.tsx tests/unit/ui/task-detail-page.dependencies.issue398.test.tsx tests/unit/services/task-hierarchy.issue336.test.ts`
- `bun run build`
- `node Scripts/test/playwright-runner.cjs test tests/e2e/task-ui.issue213.test.ts --config tests/e2e/playwright.issue213.config.ts`
- `node Scripts/test/playwright-runner.cjs test tests/e2e/task-detail-dependencies.issue398.test.ts --config tests/e2e/playwright.issue398.config.ts`

Closes #398
