### PR TITLE
feat(task): add issue #395 phase 1 DAG visibility projection

### DIFF
--- a/src/lib/task/task-dag-graph.ts
+++ b/src/lib/task/task-dag-graph.ts
@@ -24,6 +24,7 @@ export interface TaskGraph {
   rootNodeIds: string[]
   currentRootNodeId: string | null
   topologicalOrder: string[]
+  hasCycle: boolean
 }
 
 function compareTasksForGraphOrder(left: TaskNode, right: TaskNode): number {
@@ -180,7 +181,9 @@ export function buildTaskGraph(tasks: TaskNode[]): TaskGraph {
     }
   }
 
-  if (topologicalOrder.length < stableTasks.length) {
+  const hasCycle = topologicalOrder.length < stableTasks.length
+
+  if (hasCycle) {
     const remaining = stableTasks
       .map((task) => task.id)
       .filter((taskId) => !topologicalOrder.includes(taskId))
@@ -236,5 +239,6 @@ export function buildTaskGraph(tasks: TaskNode[]): TaskGraph {
       taskById,
     }),
     topologicalOrder,
+    hasCycle,
   }
 }

--- a/src/lib/task/task-dag-graph.ts
+++ b/src/lib/task/task-dag-graph.ts
@@ -1,0 +1,240 @@
+import type { TaskNode } from '@/lib/types/task'
+
+export interface TaskGraphNode {
+  id: string
+  title: string
+  status: TaskNode['status']
+  priority: TaskNode['priority']
+  isRoot: boolean
+  isCompleted: boolean
+  isExecutable: boolean
+  isBlocked: boolean
+}
+
+export interface TaskGraphEdge {
+  id: string
+  source: string
+  target: string
+  type: 'soft' | 'hard'
+}
+
+export interface TaskGraph {
+  nodes: TaskGraphNode[]
+  edges: TaskGraphEdge[]
+  rootNodeIds: string[]
+  currentRootNodeId: string | null
+  topologicalOrder: string[]
+}
+
+function compareTasksForGraphOrder(left: TaskNode, right: TaskNode): number {
+  const createdDiff = left.createdAt - right.createdAt
+  if (createdDiff !== 0) return createdDiff
+
+  const updatedDiff = left.updatedAt - right.updatedAt
+  if (updatedDiff !== 0) return updatedDiff
+
+  return left.id.localeCompare(right.id)
+}
+
+function isTerminalStatus(status: TaskNode['status']): boolean {
+  return status === 'completed' || status === 'abandoned'
+}
+
+function isDependencyBlocking(task: TaskNode, taskById: Map<string, TaskNode>): boolean {
+  if (isTerminalStatus(task.status)) {
+    return false
+  }
+
+  return task.dependsOn.some((dependency) => {
+    const predecessor = taskById.get(dependency.taskId)
+    if (!predecessor) {
+      return false
+    }
+
+    if (dependency.type === 'hard') {
+      return predecessor.status !== 'completed'
+    }
+
+    return predecessor.status === 'not_started'
+  })
+}
+
+function isTaskExecutable(task: TaskNode, taskById: Map<string, TaskNode>): boolean {
+  if (task.status !== 'not_started') {
+    return false
+  }
+
+  return !task.dependsOn.some((dependency) => {
+    if (dependency.type !== 'hard') {
+      return false
+    }
+
+    const predecessor = taskById.get(dependency.taskId)
+    if (!predecessor) {
+      return false
+    }
+
+    return predecessor.status !== 'completed'
+  })
+}
+
+export function resolveCurrentRootNodeId({
+  rootNodeIds,
+  topologicalOrder,
+  taskById,
+}: {
+  rootNodeIds: string[]
+  topologicalOrder: string[]
+  taskById: Map<string, TaskNode>
+}): string | null {
+  const rootNodeIdSet = new Set(rootNodeIds)
+
+  for (const taskId of topologicalOrder) {
+    if (!rootNodeIdSet.has(taskId)) {
+      continue
+    }
+
+    const task = taskById.get(taskId)
+    if (task && !isTerminalStatus(task.status)) {
+      return taskId
+    }
+  }
+
+  return null
+}
+
+export function buildTaskGraph(tasks: TaskNode[]): TaskGraph {
+  const stableTasks = [...tasks].sort(compareTasksForGraphOrder)
+  const taskById = new Map(stableTasks.map((task) => [task.id, task]))
+  const indegree = new Map<string, number>()
+  const adjacency = new Map<string, string[]>()
+  const edgeById = new Map<string, TaskGraphEdge>()
+
+  for (const task of stableTasks) {
+    indegree.set(task.id, 0)
+    adjacency.set(task.id, [])
+  }
+
+  for (const task of stableTasks) {
+    for (const dependency of task.dependsOn) {
+      const predecessor = taskById.get(dependency.taskId)
+      if (!predecessor) {
+        continue
+      }
+
+      const edgeId = `edge:${predecessor.id}->${task.id}:${dependency.type}`
+      if (edgeById.has(edgeId)) {
+        continue
+      }
+
+      edgeById.set(edgeId, {
+        id: edgeId,
+        source: predecessor.id,
+        target: task.id,
+        type: dependency.type,
+      })
+
+      adjacency.get(predecessor.id)?.push(task.id)
+      indegree.set(task.id, (indegree.get(task.id) ?? 0) + 1)
+    }
+  }
+
+  const compareTaskIds = (leftId: string, rightId: string): number => {
+    const leftTask = taskById.get(leftId)
+    const rightTask = taskById.get(rightId)
+
+    if (!leftTask || !rightTask) {
+      return leftId.localeCompare(rightId)
+    }
+
+    return compareTasksForGraphOrder(leftTask, rightTask)
+  }
+
+  for (const nodeIds of adjacency.values()) {
+    nodeIds.sort(compareTaskIds)
+  }
+
+  const pendingIndegree = new Map(indegree)
+  const available = stableTasks
+    .filter((task) => (pendingIndegree.get(task.id) ?? 0) === 0)
+    .map((task) => task.id)
+
+  const topologicalOrder: string[] = []
+
+  while (available.length > 0) {
+    available.sort(compareTaskIds)
+    const currentTaskId = available.shift()
+
+    if (!currentTaskId) {
+      break
+    }
+
+    topologicalOrder.push(currentTaskId)
+
+    for (const nextTaskId of adjacency.get(currentTaskId) ?? []) {
+      const nextIndegree = (pendingIndegree.get(nextTaskId) ?? 0) - 1
+      pendingIndegree.set(nextTaskId, nextIndegree)
+      if (nextIndegree === 0) {
+        available.push(nextTaskId)
+      }
+    }
+  }
+
+  if (topologicalOrder.length < stableTasks.length) {
+    const remaining = stableTasks
+      .map((task) => task.id)
+      .filter((taskId) => !topologicalOrder.includes(taskId))
+      .sort(compareTaskIds)
+    topologicalOrder.push(...remaining)
+  }
+
+  const rootNodeIds = topologicalOrder.filter((taskId) => (indegree.get(taskId) ?? 0) === 0)
+  const topologicalIndex = new Map(topologicalOrder.map((taskId, index) => [taskId, index]))
+  const rootNodeIdSet = new Set(rootNodeIds)
+
+  const nodes = topologicalOrder
+    .map((taskId) => taskById.get(taskId))
+    .filter((task): task is TaskNode => Boolean(task))
+    .map((task) => {
+      const isBlocked = isDependencyBlocking(task, taskById)
+      const isExecutable = isTaskExecutable(task, taskById)
+
+      return {
+        id: task.id,
+        title: task.title,
+        status: task.status,
+        priority: task.priority,
+        isRoot: rootNodeIdSet.has(task.id),
+        isCompleted: task.status === 'completed',
+        isExecutable,
+        isBlocked,
+      }
+    })
+
+  const edges = Array.from(edgeById.values()).sort((left, right) => {
+    const sourceDiff = (topologicalIndex.get(left.source) ?? Number.MAX_SAFE_INTEGER)
+      - (topologicalIndex.get(right.source) ?? Number.MAX_SAFE_INTEGER)
+    if (sourceDiff !== 0) return sourceDiff
+
+    const targetDiff = (topologicalIndex.get(left.target) ?? Number.MAX_SAFE_INTEGER)
+      - (topologicalIndex.get(right.target) ?? Number.MAX_SAFE_INTEGER)
+    if (targetDiff !== 0) return targetDiff
+
+    const typeDiff = left.type.localeCompare(right.type)
+    if (typeDiff !== 0) return typeDiff
+
+    return left.id.localeCompare(right.id)
+  })
+
+  return {
+    nodes,
+    edges,
+    rootNodeIds,
+    currentRootNodeId: resolveCurrentRootNodeId({
+      rootNodeIds,
+      topologicalOrder,
+      taskById,
+    }),
+    topologicalOrder,
+  }
+}

--- a/src/lib/task/task-dag-visibility.ts
+++ b/src/lib/task/task-dag-visibility.ts
@@ -14,6 +14,7 @@ export interface VisibleTaskGraph {
   nodes: VisibleTaskGraphNode[]
   edges: TaskGraphEdge[]
   hiddenNodeIds: string[]
+  hasCycle: boolean
   visibleRootNodeIds: string[]
   visibleCurrentRootNodeId: string | null
   sourceRootNodeIds: string[]
@@ -166,11 +167,13 @@ export function projectVisibleTaskGraph(
 
   const visibleNodeById = new Map(visibleNodes.map((node) => [node.id, node]))
   let visibleCurrentRootNodeId: string | null = null
-  for (const nodeId of visibleRootNodeIds) {
-    const node = visibleNodeById.get(nodeId)
-    if (node && !isTerminalStatus(node.status)) {
-      visibleCurrentRootNodeId = nodeId
-      break
+  if (graph.currentRootNodeId !== null) {
+    for (const nodeId of visibleRootNodeIds) {
+      const node = visibleNodeById.get(nodeId)
+      if (node && !isTerminalStatus(node.status)) {
+        visibleCurrentRootNodeId = nodeId
+        break
+      }
     }
   }
 
@@ -179,6 +182,7 @@ export function projectVisibleTaskGraph(
     nodes: visibleNodes,
     edges: visibleEdges,
     hiddenNodeIds,
+    hasCycle: graph.hasCycle,
     visibleRootNodeIds,
     visibleCurrentRootNodeId,
     sourceRootNodeIds: [...graph.rootNodeIds],

--- a/src/lib/task/task-dag-visibility.ts
+++ b/src/lib/task/task-dag-visibility.ts
@@ -1,0 +1,187 @@
+import type { TaskGraph, TaskGraphEdge, TaskGraphNode } from '@/lib/task/task-dag-graph'
+
+export interface TaskDagVisibilityState {
+  collapsedUpstreamOf: string[]
+}
+
+export interface VisibleTaskGraphNode extends TaskGraphNode {
+  hiddenUpstreamCount: number
+  isCollapsedTarget: boolean
+}
+
+export interface VisibleTaskGraph {
+  state: TaskDagVisibilityState
+  nodes: VisibleTaskGraphNode[]
+  edges: TaskGraphEdge[]
+  hiddenNodeIds: string[]
+  visibleRootNodeIds: string[]
+  visibleCurrentRootNodeId: string | null
+  sourceRootNodeIds: string[]
+  sourceCurrentRootNodeId: string | null
+}
+
+export const EMPTY_TASK_DAG_VISIBILITY_STATE: TaskDagVisibilityState = {
+  collapsedUpstreamOf: [],
+}
+
+function isTerminalStatus(status: TaskGraphNode['status']): boolean {
+  return status === 'completed' || status === 'abandoned'
+}
+
+function buildTopologicalIndex(graph: TaskGraph): Map<string, number> {
+  return new Map(graph.topologicalOrder.map((nodeId, index) => [nodeId, index]))
+}
+
+function buildIncomingEdgeMap(graph: TaskGraph): Map<string, TaskGraphEdge[]> {
+  const incomingEdgesByTarget = new Map<string, TaskGraphEdge[]>()
+
+  for (const edge of graph.edges) {
+    const incomingEdges = incomingEdgesByTarget.get(edge.target)
+    if (incomingEdges) {
+      incomingEdges.push(edge)
+      continue
+    }
+
+    incomingEdgesByTarget.set(edge.target, [edge])
+  }
+
+  return incomingEdgesByTarget
+}
+
+function normalizeTaskDagVisibilityState(
+  graph: TaskGraph,
+  state: TaskDagVisibilityState | undefined,
+): TaskDagVisibilityState {
+  const topologicalIndex = buildTopologicalIndex(graph)
+  const normalizedCollapsedUpstreamOf = Array.from(
+    new Set((state?.collapsedUpstreamOf ?? []).filter((nodeId) => topologicalIndex.has(nodeId))),
+  ).sort((leftNodeId, rightNodeId) => {
+    const orderDiff = (topologicalIndex.get(leftNodeId) ?? Number.MAX_SAFE_INTEGER)
+      - (topologicalIndex.get(rightNodeId) ?? Number.MAX_SAFE_INTEGER)
+    if (orderDiff !== 0) return orderDiff
+
+    return leftNodeId.localeCompare(rightNodeId)
+  })
+
+  return {
+    collapsedUpstreamOf: normalizedCollapsedUpstreamOf,
+  }
+}
+
+function collectUpstreamNodeIds(
+  nodeId: string,
+  incomingEdgesByTarget: Map<string, TaskGraphEdge[]>,
+): Set<string> {
+  const upstreamNodeIds = new Set<string>()
+  const pendingNodeIds = (incomingEdgesByTarget.get(nodeId) ?? []).map((edge) => edge.source)
+
+  while (pendingNodeIds.length > 0) {
+    const currentNodeId = pendingNodeIds.pop()
+    if (!currentNodeId || upstreamNodeIds.has(currentNodeId)) {
+      continue
+    }
+
+    upstreamNodeIds.add(currentNodeId)
+
+    for (const edge of incomingEdgesByTarget.get(currentNodeId) ?? []) {
+      pendingNodeIds.push(edge.source)
+    }
+  }
+
+  return upstreamNodeIds
+}
+
+export function projectVisibleTaskGraph(
+  graph: TaskGraph,
+  state: TaskDagVisibilityState = EMPTY_TASK_DAG_VISIBILITY_STATE,
+): VisibleTaskGraph {
+  const normalizedState = normalizeTaskDagVisibilityState(graph, state)
+  const topologicalIndex = buildTopologicalIndex(graph)
+  const incomingEdgesByTarget = buildIncomingEdgeMap(graph)
+  const collapsedTargetIdSet = new Set(normalizedState.collapsedUpstreamOf)
+  const hiddenNodeIdSet = new Set<string>()
+  const upstreamNodeIdsByNodeId = new Map<string, Set<string>>()
+
+  const getUpstreamNodeIds = (nodeId: string): Set<string> => {
+    const cachedUpstreamNodeIds = upstreamNodeIdsByNodeId.get(nodeId)
+    if (cachedUpstreamNodeIds) {
+      return cachedUpstreamNodeIds
+    }
+
+    const upstreamNodeIds = collectUpstreamNodeIds(nodeId, incomingEdgesByTarget)
+    upstreamNodeIdsByNodeId.set(nodeId, upstreamNodeIds)
+    return upstreamNodeIds
+  }
+
+  for (const nodeId of normalizedState.collapsedUpstreamOf) {
+    for (const upstreamNodeId of getUpstreamNodeIds(nodeId)) {
+      if (collapsedTargetIdSet.has(upstreamNodeId)) {
+        continue
+      }
+
+      hiddenNodeIdSet.add(upstreamNodeId)
+    }
+  }
+
+  const hiddenNodeIds = graph.topologicalOrder.filter((nodeId) => hiddenNodeIdSet.has(nodeId))
+  const visibleNodeIdSet = new Set(graph.topologicalOrder.filter((nodeId) => !hiddenNodeIdSet.has(nodeId)))
+
+  const visibleEdges = graph.edges.filter((edge) => (
+    visibleNodeIdSet.has(edge.source) && visibleNodeIdSet.has(edge.target)
+  ))
+
+  const visibleNodes = graph.nodes
+    .filter((node) => visibleNodeIdSet.has(node.id))
+    .map((node) => {
+      let hiddenUpstreamCount = 0
+
+      for (const upstreamNodeId of getUpstreamNodeIds(node.id)) {
+        if (hiddenNodeIdSet.has(upstreamNodeId)) {
+          hiddenUpstreamCount += 1
+        }
+      }
+
+      return {
+        ...node,
+        hiddenUpstreamCount,
+        isCollapsedTarget: collapsedTargetIdSet.has(node.id),
+      }
+    })
+    .sort((leftNode, rightNode) => {
+      const orderDiff = (topologicalIndex.get(leftNode.id) ?? Number.MAX_SAFE_INTEGER)
+        - (topologicalIndex.get(rightNode.id) ?? Number.MAX_SAFE_INTEGER)
+      if (orderDiff !== 0) return orderDiff
+
+      return leftNode.id.localeCompare(rightNode.id)
+    })
+
+  const visibleIncomingCount = new Map(visibleNodes.map((node) => [node.id, 0]))
+  for (const edge of visibleEdges) {
+    visibleIncomingCount.set(edge.target, (visibleIncomingCount.get(edge.target) ?? 0) + 1)
+  }
+
+  const visibleRootNodeIds = visibleNodes
+    .map((node) => node.id)
+    .filter((nodeId) => (visibleIncomingCount.get(nodeId) ?? 0) === 0)
+
+  const visibleNodeById = new Map(visibleNodes.map((node) => [node.id, node]))
+  let visibleCurrentRootNodeId: string | null = null
+  for (const nodeId of visibleRootNodeIds) {
+    const node = visibleNodeById.get(nodeId)
+    if (node && !isTerminalStatus(node.status)) {
+      visibleCurrentRootNodeId = nodeId
+      break
+    }
+  }
+
+  return {
+    state: normalizedState,
+    nodes: visibleNodes,
+    edges: visibleEdges,
+    hiddenNodeIds,
+    visibleRootNodeIds,
+    visibleCurrentRootNodeId,
+    sourceRootNodeIds: [...graph.rootNodeIds],
+    sourceCurrentRootNodeId: graph.currentRootNodeId,
+  }
+}

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -18,6 +18,11 @@ import {
   formatDependencyActionError,
   type TaskDependencyViewModel,
 } from './task-dependency-view';
+import {
+  buildTaskDagDetailView,
+  type TaskDagDetailView,
+} from './task-dag-detail-view';
+import type { TaskDagVisibilityState } from '@/lib/task/task-dag-visibility';
 
 type TimerMode = 'countup' | 'countdown';
 type DependencyType = 'soft' | 'hard';
@@ -133,6 +138,7 @@ function DetailActionsCard({
 
 function DependencyCard({
   dependencyView,
+  taskDagView,
   selectedTaskId,
   selectedType,
   errorMessage,
@@ -142,8 +148,10 @@ function DependencyCard({
   onAddDependency,
   onChangeDependencyType,
   onRemoveDependency,
+  onToggleCollapseUpstream,
 }: {
   dependencyView: TaskDependencyViewModel;
+  taskDagView: TaskDagDetailView | null;
   selectedTaskId: string;
   selectedType: DependencyType;
   errorMessage: string | null;
@@ -153,6 +161,7 @@ function DependencyCard({
   onAddDependency: () => void;
   onChangeDependencyType: (taskId: string, type: DependencyType) => void;
   onRemoveDependency: (taskId: string) => void;
+  onToggleCollapseUpstream: (taskId: string) => void;
 }) {
   return (
     <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
@@ -170,6 +179,121 @@ function DependencyCard({
       ) : null}
 
       <div className="mt-4 space-y-4">
+        {taskDagView ? (
+          <div className="rounded-xl bg-[#F8F5F2] p-3 dark:bg-[#292524]" data-testid="task-dag-panel">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h4 className="text-xs font-semibold uppercase tracking-[0.12em] text-[#A8A29E]">依赖图</h4>
+                <p className="mt-1 text-sm text-[#57534E] dark:text-[#D6D3D1]">
+                  当前显示 {taskDagView.visibleNodeCount}/{taskDagView.totalNodeCount} 个相关节点
+                </p>
+              </div>
+              <div className="text-xs text-[#78716C] dark:text-[#A8A29E]" data-testid="task-dag-root-summary">
+                <p>当前可见根：{taskDagView.visibleCurrentRootTitle ?? '无'}</p>
+                <p>
+                  真实当前根：
+                  {taskDagView.sourceCurrentRootTitle ?? '无'}
+                  {taskDagView.sourceCurrentRootTitle && !taskDagView.isSourceCurrentRootVisible ? '（当前已隐藏）' : ''}
+                </p>
+              </div>
+            </div>
+
+            {taskDagView.hiddenNodeCount > 0 ? (
+              <p className="mt-2 text-xs text-[#C75B3A] dark:text-[#FDBA74]">
+                当前折叠共隐藏 {taskDagView.hiddenNodeCount} 个上游节点。
+              </p>
+            ) : null}
+
+            <div className="mt-3 space-y-2">
+              {taskDagView.nodes.map((node) => (
+                <article
+                  key={node.id}
+                  data-testid={`task-dag-node-${node.id}`}
+                  className="rounded-xl border border-[#E7E5E4] bg-white px-3 py-3 dark:border-[#3F3F46] dark:bg-[#1C1917]"
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="truncate text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{node.title}</p>
+                        <span className="rounded-full bg-[#F5F0ED] px-2 py-0.5 text-[11px] text-[#78716C] dark:bg-[#292524] dark:text-[#D6D3D1]">
+                          {node.statusLabel}
+                        </span>
+                        {node.isCurrentTask ? (
+                          <span
+                            data-testid={`task-dag-badge-current-task-${node.id}`}
+                            className="rounded-full bg-[#E0F2FE] px-2 py-0.5 text-[11px] text-[#0369A1] dark:bg-[#172554] dark:text-[#BAE6FD]"
+                          >
+                            当前任务
+                          </span>
+                        ) : null}
+                        {node.isVisibleRoot ? (
+                          <span
+                            data-testid={`task-dag-badge-visible-root-${node.id}`}
+                            className="rounded-full bg-[#DCFCE7] px-2 py-0.5 text-[11px] text-[#15803D] dark:bg-[#14532D] dark:text-[#BBF7D0]"
+                          >
+                            可见根
+                          </span>
+                        ) : null}
+                        {node.isVisibleCurrentRoot ? (
+                          <span
+                            data-testid={`task-dag-badge-visible-current-root-${node.id}`}
+                            className="rounded-full bg-[#FDE68A] px-2 py-0.5 text-[11px] text-[#92400E] dark:bg-[#78350F] dark:text-[#FDE68A]"
+                          >
+                            当前可见根
+                          </span>
+                        ) : null}
+                      </div>
+
+                      <div className="mt-2 flex flex-wrap gap-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
+                        <span>上游节点：{node.upstreamNodeCount}</span>
+                        {node.isCollapsedTarget ? <span>已折叠上游</span> : null}
+                      </div>
+
+                      {node.hiddenUpstreamCount > 0 ? (
+                        <p
+                          data-testid={`task-dag-hidden-summary-${node.id}`}
+                          className="mt-2 rounded-lg bg-[#FFF7ED] px-2.5 py-1.5 text-xs text-[#C75B3A] dark:bg-[#2A231B] dark:text-[#FDBA74]"
+                        >
+                          已隐藏 {node.hiddenUpstreamCount} 项
+                        </p>
+                      ) : null}
+                    </div>
+
+                    <button
+                      type="button"
+                      data-testid={`task-dag-toggle-upstream-${node.id}`}
+                      disabled={!node.canCollapseUpstream}
+                      onClick={() => onToggleCollapseUpstream(node.id)}
+                      className="rounded-xl border border-[#E7E5E4] px-3 py-2 text-sm text-[#57534E] transition-colors hover:bg-[#FAF7F5] disabled:cursor-not-allowed disabled:opacity-60 dark:border-[#3F3F46] dark:text-[#D6D3D1] dark:hover:bg-[#292524]"
+                    >
+                      {node.isCollapsedTarget ? '展开上游' : '折叠上游'}
+                    </button>
+                  </div>
+                </article>
+              ))}
+            </div>
+
+            <div className="mt-3">
+              <h5 className="text-xs font-semibold uppercase tracking-[0.12em] text-[#A8A29E]">可见连线</h5>
+              <div className="mt-2 space-y-1">
+                {taskDagView.edges.length > 0 ? taskDagView.edges.map((edge) => (
+                  <p
+                    key={edge.id}
+                    data-testid={`task-dag-edge-${edge.id}`}
+                    className="rounded-lg bg-white px-2.5 py-2 text-xs text-[#57534E] dark:bg-[#1C1917] dark:text-[#D6D3D1]"
+                  >
+                    {edge.sourceTitle} → {edge.targetTitle} · {edge.typeLabel}
+                  </p>
+                )) : (
+                  <p data-testid="task-dag-edges-empty" className="text-xs text-[#A8A29E]">
+                    当前可见图中暂无连线
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        ) : null}
+
         <div>
           <h4 className="text-xs font-semibold uppercase tracking-[0.12em] text-[#A8A29E]">前置依赖</h4>
           <div className="mt-2 space-y-2">
@@ -312,6 +436,7 @@ function MobileTimeblockDetail({
   task,
   model,
   dependencyView,
+  taskDagView,
   dependencySelectedTaskId,
   dependencySelectedType,
   dependencyError,
@@ -328,10 +453,12 @@ function MobileTimeblockDetail({
   onAddDependency,
   onChangeDependencyType,
   onRemoveDependency,
+  onToggleCollapseUpstream,
 }: {
   task: TaskNode;
   model: TaskTimeblockDetailViewModel;
   dependencyView: TaskDependencyViewModel;
+  taskDagView: TaskDagDetailView | null;
   dependencySelectedTaskId: string;
   dependencySelectedType: DependencyType;
   dependencyError: string | null;
@@ -348,6 +475,7 @@ function MobileTimeblockDetail({
   onAddDependency: () => void;
   onChangeDependencyType: (taskId: string, type: DependencyType) => void;
   onRemoveDependency: (taskId: string) => void;
+  onToggleCollapseUpstream: (taskId: string) => void;
 }) {
   return (
     <div className="min-h-full bg-[#FAF7F5] pb-10 dark:bg-[#0C0A09]" data-testid="new-task-detail-page">
@@ -442,6 +570,7 @@ function MobileTimeblockDetail({
 
         <DependencyCard
           dependencyView={dependencyView}
+          taskDagView={taskDagView}
           selectedTaskId={dependencySelectedTaskId}
           selectedType={dependencySelectedType}
           errorMessage={dependencyError}
@@ -451,6 +580,7 @@ function MobileTimeblockDetail({
           onAddDependency={onAddDependency}
           onChangeDependencyType={onChangeDependencyType}
           onRemoveDependency={onRemoveDependency}
+          onToggleCollapseUpstream={onToggleCollapseUpstream}
         />
 
         <DetailActionsCard
@@ -514,6 +644,7 @@ function DesktopTimeblockDetail({
   task,
   model,
   dependencyView,
+  taskDagView,
   dependencySelectedTaskId,
   dependencySelectedType,
   dependencyError,
@@ -530,10 +661,12 @@ function DesktopTimeblockDetail({
   onAddDependency,
   onChangeDependencyType,
   onRemoveDependency,
+  onToggleCollapseUpstream,
 }: {
   task: TaskNode;
   model: TaskTimeblockDetailViewModel;
   dependencyView: TaskDependencyViewModel;
+  taskDagView: TaskDagDetailView | null;
   dependencySelectedTaskId: string;
   dependencySelectedType: DependencyType;
   dependencyError: string | null;
@@ -550,6 +683,7 @@ function DesktopTimeblockDetail({
   onAddDependency: () => void;
   onChangeDependencyType: (taskId: string, type: DependencyType) => void;
   onRemoveDependency: (taskId: string) => void;
+  onToggleCollapseUpstream: (taskId: string) => void;
 }) {
   return (
     <div className="min-h-full bg-[#FAF7F5] px-8 py-6 dark:bg-[#0C0A09]" data-testid="new-task-detail-page">
@@ -607,6 +741,7 @@ function DesktopTimeblockDetail({
 
           <DependencyCard
             dependencyView={dependencyView}
+            taskDagView={taskDagView}
             selectedTaskId={dependencySelectedTaskId}
             selectedType={dependencySelectedType}
             errorMessage={dependencyError}
@@ -616,6 +751,7 @@ function DesktopTimeblockDetail({
             onAddDependency={onAddDependency}
             onChangeDependencyType={onChangeDependencyType}
             onRemoveDependency={onRemoveDependency}
+            onToggleCollapseUpstream={onToggleCollapseUpstream}
           />
 
           <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
@@ -708,10 +844,15 @@ export function TaskDetailPage() {
   const [timerMode, setTimerMode] = useState<TimerMode>('countdown');
   const [dependencySelectedTaskId, setDependencySelectedTaskId] = useState('');
   const [dependencySelectedType, setDependencySelectedType] = useState<DependencyType>('soft');
+  const [dagVisibilityState, setDagVisibilityState] = useState<TaskDagVisibilityState>({ collapsedUpstreamOf: [] });
   const [dependencyLoadError, setDependencyLoadError] = useState<string | null>(null);
   const [dependencyActionError, setDependencyActionError] = useState<string | null>(null);
   const [isDependencySaving, setIsDependencySaving] = useState(false);
   const [dependencyReloadKey, setDependencyReloadKey] = useState(0);
+
+  useEffect(() => {
+    setDagVisibilityState({ collapsedUpstreamOf: [] });
+  }, [task?.id]);
 
   useEffect(() => {
     let disposed = false;
@@ -814,10 +955,23 @@ export function TaskDetailPage() {
     return buildTaskDependencyView(task, allTasks);
   }, [allTasks, task]);
 
+  const taskDagView = useMemo(() => {
+    if (!task) return null;
+    return buildTaskDagDetailView(task, allTasks, dagVisibilityState);
+  }, [allTasks, dagVisibilityState, task]);
+
   const dependencyError = dependencyActionError ?? dependencyLoadError;
 
   const reloadDependencies = () => {
     setDependencyReloadKey((value) => value + 1);
+  };
+
+  const handleToggleCollapseUpstream = (targetTaskId: string) => {
+    setDagVisibilityState((currentState) => ({
+      collapsedUpstreamOf: currentState.collapsedUpstreamOf.includes(targetTaskId)
+        ? currentState.collapsedUpstreamOf.filter((taskId) => taskId !== targetTaskId)
+        : [...currentState.collapsedUpstreamOf, targetTaskId],
+    }));
   };
 
   const handleAddDependency = async () => {
@@ -938,13 +1092,14 @@ export function TaskDetailPage() {
 
   if (isDesktop) {
     return (
-      <DesktopTimeblockDetail
-        task={task}
-        model={viewModel}
-        dependencyView={dependencyView}
-        dependencySelectedTaskId={dependencySelectedTaskId}
-        dependencySelectedType={dependencySelectedType}
-        dependencyError={dependencyError}
+        <DesktopTimeblockDetail
+          task={task}
+          model={viewModel}
+          dependencyView={dependencyView}
+          taskDagView={taskDagView}
+          dependencySelectedTaskId={dependencySelectedTaskId}
+          dependencySelectedType={dependencySelectedType}
+          dependencyError={dependencyError}
         isDependencySaving={isDependencySaving}
         timerMode={timerMode}
         setTimerMode={setTimerMode}
@@ -955,10 +1110,11 @@ export function TaskDetailPage() {
         onCopySummary={handleCopySummary}
         onDependencySelectedTaskChange={setDependencySelectedTaskId}
         onDependencySelectedTypeChange={setDependencySelectedType}
-        onAddDependency={handleAddDependency}
-        onChangeDependencyType={handleChangeDependencyType}
-        onRemoveDependency={handleRemoveDependency}
-      />
+          onAddDependency={handleAddDependency}
+          onChangeDependencyType={handleChangeDependencyType}
+          onRemoveDependency={handleRemoveDependency}
+          onToggleCollapseUpstream={handleToggleCollapseUpstream}
+        />
     );
   }
 
@@ -967,6 +1123,7 @@ export function TaskDetailPage() {
       task={task}
       model={viewModel}
       dependencyView={dependencyView}
+      taskDagView={taskDagView}
       dependencySelectedTaskId={dependencySelectedTaskId}
       dependencySelectedType={dependencySelectedType}
       dependencyError={dependencyError}
@@ -983,6 +1140,7 @@ export function TaskDetailPage() {
       onAddDependency={handleAddDependency}
       onChangeDependencyType={handleChangeDependencyType}
       onRemoveDependency={handleRemoveDependency}
+      onToggleCollapseUpstream={handleToggleCollapseUpstream}
     />
   );
 }

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -204,6 +204,12 @@ function DependencyCard({
               </p>
             ) : null}
 
+            {taskDagView.hasCycle ? (
+              <p className="mt-2 text-xs text-[#B91C1C] dark:text-[#FCA5A5]">
+                检测到循环依赖，当前根节点引导按真实图停用，仅展示可见结构。
+              </p>
+            ) : null}
+
             <div className="mt-3 space-y-2">
               {taskDagView.nodes.map((node) => (
                 <article

--- a/src/ui/app/pages/task-dag-detail-view.ts
+++ b/src/ui/app/pages/task-dag-detail-view.ts
@@ -43,6 +43,7 @@ export interface TaskDagDetailView {
   totalNodeCount: number;
   visibleNodeCount: number;
   hiddenNodeCount: number;
+  hasCycle: boolean;
   visibleRootNodeIds: string[];
   visibleCurrentRootNodeId: string | null;
   visibleCurrentRootTitle: string | null;
@@ -202,6 +203,7 @@ export function buildTaskDagDetailView(
     totalNodeCount: taskGraph.nodes.length,
     visibleNodeCount: visibleGraph.nodes.length,
     hiddenNodeCount: visibleGraph.hiddenNodeIds.length,
+    hasCycle: visibleGraph.hasCycle,
     visibleRootNodeIds: visibleGraph.visibleRootNodeIds,
     visibleCurrentRootNodeId: visibleGraph.visibleCurrentRootNodeId,
     visibleCurrentRootTitle,

--- a/src/ui/app/pages/task-dag-detail-view.ts
+++ b/src/ui/app/pages/task-dag-detail-view.ts
@@ -1,0 +1,214 @@
+﻿import { buildTaskGraph, type TaskGraphEdge } from '@/lib/task/task-dag-graph';
+import {
+  projectVisibleTaskGraph,
+  type TaskDagVisibilityState,
+  type VisibleTaskGraphNode,
+} from '@/lib/task/task-dag-visibility';
+import type { TaskNode, TaskStatus } from '@/lib/types/task';
+
+const STATUS_LABELS: Record<TaskStatus, string> = {
+  not_started: '未开始',
+  in_progress: '进行中',
+  suspended: '已挂起',
+  completed: '已完成',
+  abandoned: '已放弃',
+};
+
+const EDGE_TYPE_LABELS: Record<TaskGraphEdge['type'], string> = {
+  soft: '软依赖',
+  hard: '硬依赖',
+};
+
+export interface TaskDagDetailViewNode extends VisibleTaskGraphNode {
+  statusLabel: string;
+  upstreamNodeCount: number;
+  canCollapseUpstream: boolean;
+  isCurrentTask: boolean;
+  isVisibleRoot: boolean;
+  isVisibleCurrentRoot: boolean;
+  isSourceRoot: boolean;
+  isSourceCurrentRoot: boolean;
+}
+
+export interface TaskDagDetailViewEdge extends TaskGraphEdge {
+  sourceTitle: string;
+  targetTitle: string;
+  typeLabel: string;
+}
+
+export interface TaskDagDetailView {
+  state: TaskDagVisibilityState;
+  nodes: TaskDagDetailViewNode[];
+  edges: TaskDagDetailViewEdge[];
+  totalNodeCount: number;
+  visibleNodeCount: number;
+  hiddenNodeCount: number;
+  visibleRootNodeIds: string[];
+  visibleCurrentRootNodeId: string | null;
+  visibleCurrentRootTitle: string | null;
+  sourceCurrentRootNodeId: string | null;
+  sourceCurrentRootTitle: string | null;
+  isSourceCurrentRootVisible: boolean;
+}
+
+function buildIncomingEdgeMap(tasks: TaskNode[]): Map<string, TaskNode['dependsOn']> {
+  return new Map(tasks.map((task) => [task.id, task.dependsOn]));
+}
+
+function buildOutgoingEdgeMap(tasks: TaskNode[]): Map<string, string[]> {
+  const outgoingEdges = new Map<string, string[]>();
+
+  for (const task of tasks) {
+    outgoingEdges.set(task.id, outgoingEdges.get(task.id) ?? []);
+  }
+
+  for (const task of tasks) {
+    for (const dependency of task.dependsOn) {
+      const nextTaskIds = outgoingEdges.get(dependency.taskId);
+      if (nextTaskIds) {
+        nextTaskIds.push(task.id);
+        continue;
+      }
+
+      outgoingEdges.set(dependency.taskId, [task.id]);
+    }
+  }
+
+  return outgoingEdges;
+}
+
+function collectRelatedTaskIds(currentTaskId: string, tasks: TaskNode[]): Set<string> {
+  const taskIds = new Set(tasks.map((task) => task.id));
+  if (!taskIds.has(currentTaskId)) {
+    return new Set();
+  }
+
+  const incomingEdgeMap = buildIncomingEdgeMap(tasks);
+  const outgoingEdgeMap = buildOutgoingEdgeMap(tasks);
+  const relatedTaskIds = new Set<string>([currentTaskId]);
+  const pendingTaskIds = [currentTaskId];
+
+  while (pendingTaskIds.length > 0) {
+    const taskId = pendingTaskIds.pop();
+    if (!taskId) continue;
+
+    for (const dependency of incomingEdgeMap.get(taskId) ?? []) {
+      if (relatedTaskIds.has(dependency.taskId) || !taskIds.has(dependency.taskId)) {
+        continue;
+      }
+      relatedTaskIds.add(dependency.taskId);
+      pendingTaskIds.push(dependency.taskId);
+    }
+
+    for (const nextTaskId of outgoingEdgeMap.get(taskId) ?? []) {
+      if (relatedTaskIds.has(nextTaskId) || !taskIds.has(nextTaskId)) {
+        continue;
+      }
+      relatedTaskIds.add(nextTaskId);
+      pendingTaskIds.push(nextTaskId);
+    }
+  }
+
+  return relatedTaskIds;
+}
+
+function buildGraphIncomingEdgeMap(edges: TaskGraphEdge[]): Map<string, TaskGraphEdge[]> {
+  const incomingEdgesByTarget = new Map<string, TaskGraphEdge[]>();
+
+  for (const edge of edges) {
+    const current = incomingEdgesByTarget.get(edge.target);
+    if (current) {
+      current.push(edge);
+      continue;
+    }
+    incomingEdgesByTarget.set(edge.target, [edge]);
+  }
+
+  return incomingEdgesByTarget;
+}
+
+function collectUpstreamNodeIds(nodeId: string, incomingEdgesByTarget: Map<string, TaskGraphEdge[]>): Set<string> {
+  const upstreamNodeIds = new Set<string>();
+  const pendingNodeIds = (incomingEdgesByTarget.get(nodeId) ?? []).map((edge) => edge.source);
+
+  while (pendingNodeIds.length > 0) {
+    const currentNodeId = pendingNodeIds.pop();
+    if (!currentNodeId || upstreamNodeIds.has(currentNodeId)) {
+      continue;
+    }
+
+    upstreamNodeIds.add(currentNodeId);
+    for (const edge of incomingEdgesByTarget.get(currentNodeId) ?? []) {
+      pendingNodeIds.push(edge.source);
+    }
+  }
+
+  return upstreamNodeIds;
+}
+
+export function buildTaskDagDetailView(
+  currentTask: TaskNode,
+  allTasks: TaskNode[],
+  visibilityState: TaskDagVisibilityState,
+): TaskDagDetailView | null {
+  const relatedTaskIds = collectRelatedTaskIds(currentTask.id, allTasks);
+  if (relatedTaskIds.size === 0) {
+    return null;
+  }
+
+  const relatedTasks = allTasks.filter((task) => relatedTaskIds.has(task.id));
+  const taskGraph = buildTaskGraph(relatedTasks);
+  const visibleGraph = projectVisibleTaskGraph(taskGraph, visibilityState);
+  const visibleNodeIdSet = new Set(visibleGraph.nodes.map((node) => node.id));
+  const visibleRootNodeIdSet = new Set(visibleGraph.visibleRootNodeIds);
+  const sourceRootNodeIdSet = new Set(visibleGraph.sourceRootNodeIds);
+  const incomingEdgesByTarget = buildGraphIncomingEdgeMap(taskGraph.edges);
+  const graphNodeById = new Map(taskGraph.nodes.map((node) => [node.id, node]));
+
+  const nodes = visibleGraph.nodes.map((node) => {
+    const upstreamNodeCount = collectUpstreamNodeIds(node.id, incomingEdgesByTarget).size;
+
+    return {
+      ...node,
+      statusLabel: STATUS_LABELS[node.status],
+      upstreamNodeCount,
+      canCollapseUpstream: upstreamNodeCount > 0,
+      isCurrentTask: node.id === currentTask.id,
+      isVisibleRoot: visibleRootNodeIdSet.has(node.id),
+      isVisibleCurrentRoot: node.id === visibleGraph.visibleCurrentRootNodeId,
+      isSourceRoot: sourceRootNodeIdSet.has(node.id),
+      isSourceCurrentRoot: node.id === visibleGraph.sourceCurrentRootNodeId,
+    };
+  });
+
+  const edges = visibleGraph.edges.map((edge) => ({
+    ...edge,
+    sourceTitle: graphNodeById.get(edge.source)?.title ?? edge.source,
+    targetTitle: graphNodeById.get(edge.target)?.title ?? edge.target,
+    typeLabel: EDGE_TYPE_LABELS[edge.type],
+  }));
+
+  const visibleCurrentRootTitle = visibleGraph.visibleCurrentRootNodeId
+    ? graphNodeById.get(visibleGraph.visibleCurrentRootNodeId)?.title ?? visibleGraph.visibleCurrentRootNodeId
+    : null;
+  const sourceCurrentRootTitle = visibleGraph.sourceCurrentRootNodeId
+    ? graphNodeById.get(visibleGraph.sourceCurrentRootNodeId)?.title ?? visibleGraph.sourceCurrentRootNodeId
+    : null;
+
+  return {
+    state: visibleGraph.state,
+    nodes,
+    edges,
+    totalNodeCount: taskGraph.nodes.length,
+    visibleNodeCount: visibleGraph.nodes.length,
+    hiddenNodeCount: visibleGraph.hiddenNodeIds.length,
+    visibleRootNodeIds: visibleGraph.visibleRootNodeIds,
+    visibleCurrentRootNodeId: visibleGraph.visibleCurrentRootNodeId,
+    visibleCurrentRootTitle,
+    sourceCurrentRootNodeId: visibleGraph.sourceCurrentRootNodeId,
+    sourceCurrentRootTitle,
+    isSourceCurrentRootVisible: visibleGraph.sourceCurrentRootNodeId
+      ? visibleNodeIdSet.has(visibleGraph.sourceCurrentRootNodeId)
+      : false,
+  };
+}

--- a/tests/unit/ui/task-dag-detail-view.issue395.test.ts
+++ b/tests/unit/ui/task-dag-detail-view.issue395.test.ts
@@ -1,0 +1,52 @@
+﻿import { describe, expect, it } from 'vitest';
+import type { TaskNode } from '@/lib/types/task';
+import { buildTaskDagDetailView } from '@/ui/app/pages/task-dag-detail-view';
+
+function makeTask(overrides: Partial<TaskNode> & Pick<TaskNode, 'id' | 'title'>): TaskNode {
+  return {
+    id: overrides.id,
+    title: overrides.title,
+    description: '',
+    status: 'not_started',
+    priority: 'medium',
+    dependsOn: [],
+    tags: [],
+    timeBlockIds: [],
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+describe('buildTaskDagDetailView issue #395', () => {
+  it('keeps current-root guidance disabled for cyclic source graphs', () => {
+    const taskA = makeTask({
+      id: 'a',
+      title: 'A',
+      createdAt: 10,
+      updatedAt: 10,
+      dependsOn: [{ taskId: 'b', type: 'hard' }],
+    });
+    const taskB = makeTask({
+      id: 'b',
+      title: 'B',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [{ taskId: 'a', type: 'hard' }],
+    });
+
+    const view = buildTaskDagDetailView(taskA, [taskA, taskB], { collapsedUpstreamOf: ['a'] });
+
+    expect(view).not.toBeNull();
+    expect(view).toMatchObject({
+      hasCycle: true,
+      visibleRootNodeIds: ['a'],
+      visibleCurrentRootNodeId: null,
+      visibleCurrentRootTitle: null,
+      sourceCurrentRootNodeId: null,
+      sourceCurrentRootTitle: null,
+      isSourceCurrentRootVisible: false,
+    });
+    expect(view?.nodes.every((node) => node.isVisibleCurrentRoot === false)).toBe(true);
+  });
+});

--- a/tests/unit/ui/task-dag-graph.issue394.test.ts
+++ b/tests/unit/ui/task-dag-graph.issue394.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest'
+import type { TaskNode } from '@/lib/types/task'
+import { buildTaskGraph } from '@/lib/task/task-dag-graph'
+
+function makeTask(overrides: Partial<TaskNode> & Pick<TaskNode, 'id' | 'title'>): TaskNode {
+  return {
+    id: overrides.id,
+    title: overrides.title,
+    status: 'not_started',
+    priority: 'medium',
+    dependsOn: [],
+    tags: [],
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  }
+}
+
+describe('buildTaskGraph issue-394（任务 DAG 图基础层）', () => {
+  it('builds a stable topological order for a simple chain', () => {
+    const taskA = makeTask({ id: 'a', title: 'A', createdAt: 10, updatedAt: 10 })
+    const taskB = makeTask({
+      id: 'b',
+      title: 'B',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [{ taskId: 'a', type: 'hard' }],
+    })
+    const taskC = makeTask({
+      id: 'c',
+      title: 'C',
+      createdAt: 30,
+      updatedAt: 30,
+      dependsOn: [{ taskId: 'b', type: 'hard' }],
+    })
+
+    const graph = buildTaskGraph([taskC, taskA, taskB])
+
+    expect(graph.topologicalOrder).toEqual(['a', 'b', 'c'])
+    expect(graph.rootNodeIds).toEqual(['a'])
+    expect(graph.currentRootNodeId).toBe('a')
+    expect(graph.nodes.map((node) => node.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('identifies all roots and does not treat parentId as a DAG edge', () => {
+    const rootA = makeTask({ id: 'a', title: 'Root A', createdAt: 10, updatedAt: 10 })
+    const rootB = makeTask({ id: 'b', title: 'Root B', createdAt: 20, updatedAt: 20 })
+    const childOnlyByParent = makeTask({
+      id: 'c',
+      title: 'Parent Child Only',
+      createdAt: 30,
+      updatedAt: 30,
+      parentId: 'a',
+    })
+    const dependent = makeTask({
+      id: 'd',
+      title: 'Depends On A',
+      createdAt: 40,
+      updatedAt: 40,
+      dependsOn: [{ taskId: 'a', type: 'hard' }],
+    })
+
+    const graph = buildTaskGraph([dependent, childOnlyByParent, rootB, rootA])
+
+    expect(graph.rootNodeIds).toEqual(['a', 'b', 'c'])
+    expect(graph.edges).toEqual([
+      {
+        id: 'edge:a->d:hard',
+        source: 'a',
+        target: 'd',
+        type: 'hard',
+      },
+    ])
+  })
+
+  it('skips completed and abandoned roots when selecting the current root node', () => {
+    const completedRoot = makeTask({
+      id: 'done',
+      title: 'Completed Root',
+      status: 'completed',
+      createdAt: 10,
+      updatedAt: 10,
+    })
+    const abandonedRoot = makeTask({
+      id: 'gone',
+      title: 'Abandoned Root',
+      status: 'abandoned',
+      createdAt: 20,
+      updatedAt: 20,
+    })
+    const activeRoot = makeTask({ id: 'live', title: 'Live Root', createdAt: 30, updatedAt: 30 })
+
+    const graph = buildTaskGraph([activeRoot, abandonedRoot, completedRoot])
+
+    expect(graph.rootNodeIds).toEqual(['done', 'gone', 'live'])
+    expect(graph.currentRootNodeId).toBe('live')
+  })
+
+  it('selects the first unfinished root by stable order when roots are parallel', () => {
+    const firstRoot = makeTask({ id: 'alpha', title: 'Alpha', createdAt: 10, updatedAt: 90 })
+    const secondRoot = makeTask({ id: 'beta', title: 'Beta', createdAt: 20, updatedAt: 40 })
+    const blockedLeaf = makeTask({
+      id: 'leaf',
+      title: 'Leaf',
+      createdAt: 30,
+      updatedAt: 30,
+      dependsOn: [{ taskId: 'beta', type: 'hard' }],
+    })
+
+    const graph = buildTaskGraph([blockedLeaf, secondRoot, firstRoot])
+
+    expect(graph.rootNodeIds).toEqual(['alpha', 'beta'])
+    expect(graph.currentRootNodeId).toBe('alpha')
+  })
+
+  it('emits hard and soft edges and keeps soft blockers executable', () => {
+    const hardSource = makeTask({
+      id: 'hard-source',
+      title: 'Hard Source',
+      status: 'completed',
+      createdAt: 10,
+      updatedAt: 10,
+    })
+    const softSource = makeTask({
+      id: 'soft-source',
+      title: 'Soft Source',
+      status: 'not_started',
+      createdAt: 20,
+      updatedAt: 20,
+    })
+    const target = makeTask({
+      id: 'target',
+      title: 'Target',
+      createdAt: 30,
+      updatedAt: 30,
+      dependsOn: [
+        { taskId: 'hard-source', type: 'hard' },
+        { taskId: 'soft-source', type: 'soft' },
+      ],
+    })
+
+    const graph = buildTaskGraph([target, softSource, hardSource])
+    const targetNode = graph.nodes.find((node) => node.id === 'target')
+
+    expect(graph.edges).toEqual([
+      {
+        id: 'edge:hard-source->target:hard',
+        source: 'hard-source',
+        target: 'target',
+        type: 'hard',
+      },
+      {
+        id: 'edge:soft-source->target:soft',
+        source: 'soft-source',
+        target: 'target',
+        type: 'soft',
+      },
+    ])
+    expect(targetNode).toMatchObject({
+      isRoot: false,
+      isCompleted: false,
+      isExecutable: true,
+      isBlocked: true,
+    })
+  })
+
+  it('does not block a soft dependency when the predecessor is in progress', () => {
+    const predecessor = makeTask({
+      id: 'soft-dep',
+      title: 'Soft Dependency',
+      status: 'in_progress',
+      createdAt: 10,
+      updatedAt: 10,
+    })
+    const task = makeTask({
+      id: 'task',
+      title: 'Task',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [{ taskId: 'soft-dep', type: 'soft' }],
+    })
+
+    const graph = buildTaskGraph([task, predecessor])
+    const node = graph.nodes.find((candidate) => candidate.id === 'task')
+
+    expect(node).toMatchObject({
+      isBlocked: false,
+      isExecutable: true,
+    })
+  })
+
+  it('blocks a hard dependency when the predecessor is in progress', () => {
+    const predecessor = makeTask({
+      id: 'hard-dep',
+      title: 'Hard Dependency',
+      status: 'in_progress',
+      createdAt: 10,
+      updatedAt: 10,
+    })
+    const task = makeTask({
+      id: 'task',
+      title: 'Task',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [{ taskId: 'hard-dep', type: 'hard' }],
+    })
+
+    const graph = buildTaskGraph([task, predecessor])
+    const node = graph.nodes.find((candidate) => candidate.id === 'task')
+
+    expect(node).toMatchObject({
+      isBlocked: true,
+      isExecutable: false,
+    })
+  })
+
+  it('does not crash on missing dependency targets', () => {
+    const task = makeTask({
+      id: 'dangling',
+      title: 'Dangling Dependency',
+      createdAt: 10,
+      updatedAt: 10,
+      dependsOn: [{ taskId: 'missing', type: 'hard' }],
+    })
+
+    const graph = buildTaskGraph([task])
+
+    expect(graph.edges).toEqual([])
+    expect(graph.rootNodeIds).toEqual(['dangling'])
+    expect(graph.currentRootNodeId).toBe('dangling')
+    expect(graph.nodes.find((node) => node.id === 'dangling')).toMatchObject({
+      isBlocked: false,
+      isExecutable: true,
+    })
+  })
+
+  it('returns repeatable output for the same fixed input', () => {
+    const rootA = makeTask({ id: 'a', title: 'A', createdAt: 10, updatedAt: 10 })
+    const rootB = makeTask({ id: 'b', title: 'B', createdAt: 10, updatedAt: 10 })
+    const child = makeTask({
+      id: 'c',
+      title: 'C',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [
+        { taskId: 'a', type: 'hard' },
+        { taskId: 'b', type: 'soft' },
+      ],
+    })
+
+    const first = buildTaskGraph([rootA, rootB, child])
+    const second = buildTaskGraph([child, rootB, rootA])
+
+    expect(second).toEqual(first)
+  })
+})

--- a/tests/unit/ui/task-dag-graph.issue394.test.ts
+++ b/tests/unit/ui/task-dag-graph.issue394.test.ts
@@ -253,4 +253,28 @@ describe('buildTaskGraph issue-394（任务 DAG 图基础层）', () => {
 
     expect(second).toEqual(first)
   })
+
+  it('marks cyclic input without inventing source roots', () => {
+    const taskA = makeTask({
+      id: 'a',
+      title: 'A',
+      createdAt: 10,
+      updatedAt: 10,
+      dependsOn: [{ taskId: 'b', type: 'hard' }],
+    })
+    const taskB = makeTask({
+      id: 'b',
+      title: 'B',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [{ taskId: 'a', type: 'hard' }],
+    })
+
+    const graph = buildTaskGraph([taskA, taskB])
+
+    expect(graph.hasCycle).toBe(true)
+    expect(graph.rootNodeIds).toEqual([])
+    expect(graph.currentRootNodeId).toBeNull()
+    expect(graph.topologicalOrder).toEqual(['a', 'b'])
+  })
 })

--- a/tests/unit/ui/task-dag-visibility.issue395.test.ts
+++ b/tests/unit/ui/task-dag-visibility.issue395.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest'
+import type { TaskNode } from '@/lib/types/task'
+import { buildTaskGraph } from '@/lib/task/task-dag-graph'
+import { projectVisibleTaskGraph } from '@/lib/task/task-dag-visibility'
+
+function makeTask(overrides: Partial<TaskNode> & Pick<TaskNode, 'id' | 'title'>): TaskNode {
+  return {
+    id: overrides.id,
+    title: overrides.title,
+    status: 'not_started',
+    priority: 'medium',
+    dependsOn: [],
+    tags: [],
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  }
+}
+
+describe('projectVisibleTaskGraph issue-395（任务 DAG 折叠投影第一阶段）', () => {
+  it('collapses a target node upstream while keeping the target visible', () => {
+    const taskA = makeTask({ id: 'a', title: 'A', createdAt: 10, updatedAt: 10 })
+    const taskB = makeTask({
+      id: 'b',
+      title: 'B',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [{ taskId: 'a', type: 'hard' }],
+    })
+    const taskC = makeTask({
+      id: 'c',
+      title: 'C',
+      createdAt: 30,
+      updatedAt: 30,
+      dependsOn: [{ taskId: 'b', type: 'hard' }],
+    })
+
+    const graph = buildTaskGraph([taskC, taskA, taskB])
+    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['c'] })
+
+    expect(visible.state.collapsedUpstreamOf).toEqual(['c'])
+    expect(visible.hiddenNodeIds).toEqual(['a', 'b'])
+    expect(visible.nodes).toEqual([
+      expect.objectContaining({
+        id: 'c',
+        isCollapsedTarget: true,
+        hiddenUpstreamCount: 2,
+      }),
+    ])
+    expect(visible.edges).toEqual([])
+    expect(visible.visibleRootNodeIds).toEqual(['c'])
+    expect(visible.visibleCurrentRootNodeId).toBe('c')
+  })
+
+  it('restores the full graph when no node is collapsed', () => {
+    const root = makeTask({ id: 'root', title: 'Root', createdAt: 10, updatedAt: 10 })
+    const child = makeTask({
+      id: 'child',
+      title: 'Child',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [{ taskId: 'root', type: 'hard' }],
+    })
+    const sideRoot = makeTask({ id: 'side', title: 'Side', createdAt: 15, updatedAt: 15 })
+
+    const graph = buildTaskGraph([child, sideRoot, root])
+    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: [] })
+
+    expect(visible.hiddenNodeIds).toEqual([])
+    expect(visible.nodes.map((node) => node.id)).toEqual(graph.nodes.map((node) => node.id))
+    expect(visible.nodes.every((node) => node.hiddenUpstreamCount === 0)).toBe(true)
+    expect(visible.nodes.every((node) => node.isCollapsedTarget === false)).toBe(true)
+    expect(visible.edges).toEqual(graph.edges)
+    expect(visible.visibleRootNodeIds).toEqual(graph.rootNodeIds)
+    expect(visible.visibleCurrentRootNodeId).toBe(graph.currentRootNodeId)
+  })
+
+  it('counts hidden upstream nodes on deeper visible descendants', () => {
+    const taskA = makeTask({ id: 'a', title: 'A', createdAt: 10, updatedAt: 10 })
+    const taskB = makeTask({
+      id: 'b',
+      title: 'B',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [{ taskId: 'a', type: 'hard' }],
+    })
+    const taskC = makeTask({
+      id: 'c',
+      title: 'C',
+      createdAt: 30,
+      updatedAt: 30,
+      dependsOn: [{ taskId: 'b', type: 'hard' }],
+    })
+    const taskD = makeTask({
+      id: 'd',
+      title: 'D',
+      createdAt: 40,
+      updatedAt: 40,
+      dependsOn: [{ taskId: 'c', type: 'hard' }],
+    })
+
+    const graph = buildTaskGraph([taskD, taskB, taskA, taskC])
+    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['c'] })
+
+    expect(visible.hiddenNodeIds).toEqual(['a', 'b'])
+    expect(visible.nodes.map((node) => ({ id: node.id, hidden: node.hiddenUpstreamCount }))).toEqual([
+      { id: 'c', hidden: 2 },
+      { id: 'd', hidden: 2 },
+    ])
+    expect(visible.edges).toEqual([
+      {
+        id: 'edge:c->d:hard',
+        source: 'c',
+        target: 'd',
+        type: 'hard',
+      },
+    ])
+  })
+
+  it('keeps the projection stable with multiple collapse targets', () => {
+    const taskA = makeTask({ id: 'a', title: 'A', createdAt: 10, updatedAt: 10 })
+    const taskB = makeTask({
+      id: 'b',
+      title: 'B',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [{ taskId: 'a', type: 'hard' }],
+    })
+    const taskX = makeTask({ id: 'x', title: 'X', createdAt: 30, updatedAt: 30 })
+    const taskY = makeTask({
+      id: 'y',
+      title: 'Y',
+      createdAt: 40,
+      updatedAt: 40,
+      dependsOn: [{ taskId: 'x', type: 'soft' }],
+    })
+
+    const graph = buildTaskGraph([taskY, taskB, taskA, taskX])
+    const first = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['y', 'b', 'y'] })
+    const second = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['b', 'y'] })
+
+    expect(first).toEqual(second)
+    expect(first.hiddenNodeIds).toEqual(['a', 'x'])
+    expect(first.nodes.map((node) => node.id)).toEqual(['b', 'y'])
+    expect(first.visibleRootNodeIds).toEqual(['b', 'y'])
+    expect(first.visibleCurrentRootNodeId).toBe('b')
+  })
+
+  it('does not mutate the truth graph or rewrite blocked and executable flags', () => {
+    const hardSource = makeTask({
+      id: 'hard-source',
+      title: 'Hard Source',
+      status: 'completed',
+      createdAt: 10,
+      updatedAt: 10,
+    })
+    const softSource = makeTask({
+      id: 'soft-source',
+      title: 'Soft Source',
+      status: 'not_started',
+      createdAt: 20,
+      updatedAt: 20,
+    })
+    const target = makeTask({
+      id: 'target',
+      title: 'Target',
+      createdAt: 30,
+      updatedAt: 30,
+      dependsOn: [
+        { taskId: 'hard-source', type: 'hard' },
+        { taskId: 'soft-source', type: 'soft' },
+      ],
+    })
+
+    const graph = buildTaskGraph([target, softSource, hardSource])
+    const snapshot = JSON.parse(JSON.stringify(graph))
+    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['target'] })
+    const visibleTarget = visible.nodes.find((node) => node.id === 'target')
+    const graphTarget = graph.nodes.find((node) => node.id === 'target')
+
+    expect(graph).toEqual(snapshot)
+    expect(visibleTarget).toMatchObject({
+      isBlocked: graphTarget?.isBlocked,
+      isExecutable: graphTarget?.isExecutable,
+    })
+  })
+
+  it('derives visible roots and current root from visible edges without changing the truth layer', () => {
+    const rootA = makeTask({ id: 'a', title: 'A', createdAt: 10, updatedAt: 10 })
+    const rootX = makeTask({ id: 'x', title: 'X', createdAt: 20, updatedAt: 20 })
+    const taskB = makeTask({
+      id: 'b',
+      title: 'B',
+      createdAt: 30,
+      updatedAt: 30,
+      dependsOn: [{ taskId: 'a', type: 'hard' }],
+    })
+
+    const graph = buildTaskGraph([taskB, rootX, rootA])
+    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['b'] })
+
+    expect(graph.rootNodeIds).toEqual(['a', 'x'])
+    expect(graph.currentRootNodeId).toBe('a')
+    expect(visible.visibleRootNodeIds).toEqual(['x', 'b'])
+    expect(visible.visibleCurrentRootNodeId).toBe('x')
+  })
+
+  it('returns repeatable output for a fixed graph and collapse state', () => {
+    const root = makeTask({ id: 'root', title: 'Root', createdAt: 10, updatedAt: 10 })
+    const middle = makeTask({
+      id: 'middle',
+      title: 'Middle',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [{ taskId: 'root', type: 'hard' }],
+    })
+    const leaf = makeTask({
+      id: 'leaf',
+      title: 'Leaf',
+      createdAt: 30,
+      updatedAt: 30,
+      dependsOn: [{ taskId: 'middle', type: 'hard' }],
+    })
+
+    const graph = buildTaskGraph([leaf, root, middle])
+    const first = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['leaf'] })
+    const second = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['leaf'] })
+
+    expect(second).toEqual(first)
+  })
+})

--- a/tests/unit/ui/task-dag-visibility.issue395.test.ts
+++ b/tests/unit/ui/task-dag-visibility.issue395.test.ts
@@ -228,4 +228,32 @@ describe('projectVisibleTaskGraph issue-395（任务 DAG 折叠投影第一阶�
 
     expect(second).toEqual(first)
   })
+
+  it('does not invent a visible current root when the source graph is cyclic', () => {
+    const taskA = makeTask({
+      id: 'a',
+      title: 'A',
+      createdAt: 10,
+      updatedAt: 10,
+      dependsOn: [{ taskId: 'b', type: 'hard' }],
+    })
+    const taskB = makeTask({
+      id: 'b',
+      title: 'B',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [{ taskId: 'a', type: 'hard' }],
+    })
+
+    const graph = buildTaskGraph([taskA, taskB])
+    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['a'] })
+
+    expect(graph.hasCycle).toBe(true)
+    expect(graph.rootNodeIds).toEqual([])
+    expect(graph.currentRootNodeId).toBeNull()
+    expect(visible.hasCycle).toBe(true)
+    expect(visible.visibleRootNodeIds).toEqual(['a'])
+    expect(visible.visibleCurrentRootNodeId).toBeNull()
+    expect(visible.sourceCurrentRootNodeId).toBeNull()
+  })
 })

--- a/tests/unit/ui/task-detail-page.dag-visibility.issue395.test.tsx
+++ b/tests/unit/ui/task-detail-page.dag-visibility.issue395.test.tsx
@@ -239,4 +239,34 @@ describe('TaskDetailPage DAG visibility issue #395', () => {
     expect(screen.getByTestId('task-dag-node-task-1')).toHaveTextContent('已隐藏 1 项');
     expect(screen.getByTestId('task-dag-node-task-3')).toHaveTextContent('已隐藏 1 项');
   });
+
+  it('disables current-root guidance in the detail panel when the source graph is cyclic', async () => {
+    tasksState = [
+      makeTask({
+        id: 'task-1',
+        title: '循环 A',
+        dependsOn: [{ taskId: 'task-2', type: 'hard' }],
+        timeBlockIds: ['block-1'],
+      }),
+      makeTask({
+        id: 'task-2',
+        title: '循环 B',
+        dependsOn: [{ taskId: 'task-1', type: 'hard' }],
+      }),
+    ];
+
+    renderPage();
+
+    expect(await screen.findByText('依赖图')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('task-dag-toggle-upstream-task-1'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('task-dag-node-task-2')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('task-dag-root-summary')).toHaveTextContent('当前可见根：无');
+    expect(screen.getByTestId('task-dag-root-summary')).toHaveTextContent('真实当前根：无');
+    expect(screen.getByText('检测到循环依赖，当前根节点引导按真实图停用，仅展示可见结构。')).toBeInTheDocument();
+    expect(screen.queryByTestId('task-dag-badge-visible-current-root-task-1')).not.toBeInTheDocument();
+  });
 });

--- a/tests/unit/ui/task-detail-page.dag-visibility.issue395.test.tsx
+++ b/tests/unit/ui/task-detail-page.dag-visibility.issue395.test.tsx
@@ -1,0 +1,242 @@
+﻿import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { TaskDetailPage } from '@/ui/app/pages/TaskDetailPage';
+import type { TaskNode } from '@/lib/types/task';
+import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
+
+const navigateMock = vi.fn();
+
+let tasksState: TaskNode[] = [];
+
+function cloneTask(task: TaskNode | null): TaskNode | null {
+  return task ? structuredClone(task) : null;
+}
+
+function cloneTasks(tasks: TaskNode[]): TaskNode[] {
+  return structuredClone(tasks);
+}
+
+const getTaskMock = vi.fn<(id: string) => Promise<TaskNode | null>>(async (id) => {
+  return cloneTask(tasksState.find((task) => task.id === id) ?? null);
+});
+
+const listTasksMock = vi.fn<(includeAbandoned?: boolean) => Promise<TaskNode[]>>(async () => {
+  return cloneTasks(tasksState);
+});
+
+const addDependencyMock = vi.fn<
+  (taskId: string, depTaskId: string, type: 'soft' | 'hard') => Promise<TaskNode | null>
+>(async (taskId, depTaskId, type) => {
+  const task = tasksState.find((item) => item.id === taskId);
+  if (!task) return null;
+
+  const existing = task.dependsOn.find((dependency) => dependency.taskId === depTaskId);
+  task.dependsOn = existing
+    ? task.dependsOn.map((dependency) => (dependency.taskId === depTaskId ? { ...dependency, type } : dependency))
+    : [...task.dependsOn, { taskId: depTaskId, type }];
+  task.updatedAt += 1;
+
+  return cloneTask(task);
+});
+
+const removeDependencyMock = vi.fn<(taskId: string, depTaskId: string) => Promise<TaskNode | null>>(async (taskId, depTaskId) => {
+  const task = tasksState.find((item) => item.id === taskId);
+  if (!task) return null;
+
+  task.dependsOn = task.dependsOn.filter((dependency) => dependency.taskId !== depTaskId);
+  task.updatedAt += 1;
+
+  return cloneTask(task);
+});
+
+const onTaskChangeMock = vi.fn(() => () => {});
+const loadTimeBlocksMock = vi.fn<() => Promise<TimeBlock[]>>();
+const loadActiveBlockMock = vi.fn<() => Promise<ActiveBlockData | null>>();
+const onBlockChangeMock = vi.fn(() => () => {});
+const pauseBlockMock = vi.fn<() => Promise<void>>();
+const calculateSpentMinutesMock = vi.fn<(taskId: string) => Promise<number>>();
+const getEventsMock = vi.fn<() => Promise<Array<{ id: string; content: string; createdAt: string; type?: string }>>>();
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+  useParams: () => ({ taskId: 'task-1' }),
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock('@/lib/services', () => ({
+  getTaskService: () => ({
+    getTask: getTaskMock,
+    listTasks: listTasksMock,
+    addDependency: addDependencyMock,
+    removeDependency: removeDependencyMock,
+    onTaskChange: onTaskChangeMock,
+    getAvailableTransitions: vi.fn(),
+    getChildTasks: vi.fn(async () => []),
+    checkDependenciesMet: vi.fn(async () => ({ met: true, blocking: [] })),
+    transitionTask: vi.fn(),
+    updateTask: vi.fn(),
+    abandonTask: vi.fn(),
+  }),
+  getTimeBlockService: () => ({
+    loadTimeBlocks: loadTimeBlocksMock,
+    loadActiveBlock: loadActiveBlockMock,
+    onBlockChange: onBlockChangeMock,
+    pauseBlock: pauseBlockMock,
+  }),
+  getTaskTimerService: () => ({
+    calculateSpentMinutes: calculateSpentMinutesMock,
+    startBlockForTask: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/storage/event-storage', () => ({
+  getEventStorage: () => ({
+    getEvents: getEventsMock,
+  }),
+}));
+
+function mockMatchMedia(matches: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation(() => ({
+      matches,
+      media: '(min-width: 768px)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+function makeTask(overrides: Partial<TaskNode> & Pick<TaskNode, 'id' | 'title'>): TaskNode {
+  return {
+    id: overrides.id,
+    title: overrides.title,
+    description: '',
+    status: 'not_started',
+    priority: 'medium',
+    dependsOn: [],
+    tags: [],
+    timeBlockIds: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeBlock(overrides: Partial<TimeBlock> = {}): TimeBlock {
+  const start = new Date('2026-03-07T09:00:00+08:00').getTime();
+  const end = start + 25 * 60_000;
+  return {
+    id: 'block-1',
+    startId: 'block-1',
+    name: '专注块',
+    note: '',
+    startTime: start,
+    endTime: end,
+    ...overrides,
+  } as TimeBlock;
+}
+
+function renderPage(isDesktop = true) {
+  mockMatchMedia(isDesktop);
+  render(<TaskDetailPage />);
+}
+
+describe('TaskDetailPage DAG visibility issue #395', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    tasksState = [
+      makeTask({
+        id: 'task-1',
+        title: '实现折叠交互',
+        dependsOn: [{ taskId: 'task-2', type: 'hard' }],
+        timeBlockIds: ['block-1'],
+      }),
+      makeTask({
+        id: 'task-2',
+        title: '补图投影集成',
+        dependsOn: [{ taskId: 'task-4', type: 'hard' }],
+      }),
+      makeTask({
+        id: 'task-3',
+        title: '联调详情页',
+        dependsOn: [{ taskId: 'task-1', type: 'hard' }],
+      }),
+      makeTask({
+        id: 'task-4',
+        title: '梳理 DAG 根节点',
+      }),
+    ];
+
+    getTaskMock.mockClear();
+    listTasksMock.mockClear();
+    addDependencyMock.mockClear();
+    removeDependencyMock.mockClear();
+    onTaskChangeMock.mockClear();
+
+    loadTimeBlocksMock.mockReset();
+    loadTimeBlocksMock.mockResolvedValue([makeBlock()]);
+    loadActiveBlockMock.mockReset();
+    loadActiveBlockMock.mockResolvedValue(null);
+    onBlockChangeMock.mockClear();
+    pauseBlockMock.mockReset();
+    pauseBlockMock.mockResolvedValue();
+
+    calculateSpentMinutesMock.mockReset();
+    calculateSpentMinutesMock.mockResolvedValue(15);
+    getEventsMock.mockReset();
+    getEventsMock.mockResolvedValue([]);
+  });
+
+  it('renders dependency graph and supports collapse / expand upstream from current task', async () => {
+    renderPage();
+
+    expect(await screen.findByText('依赖图')).toBeInTheDocument();
+    expect(screen.getByTestId('task-dag-node-task-4')).toBeInTheDocument();
+    expect(screen.getByTestId('task-dag-node-task-2')).toBeInTheDocument();
+    expect(screen.getByTestId('task-dag-node-task-1')).toBeInTheDocument();
+    expect(screen.getByTestId('task-dag-node-task-3')).toBeInTheDocument();
+    expect(screen.getByTestId('task-dag-edge-edge:task-1->task-3:hard')).toBeInTheDocument();
+    expect(within(screen.getByTestId('task-dag-node-task-4')).getByTestId('task-dag-badge-visible-current-root-task-4')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('task-dag-toggle-upstream-task-1'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('task-dag-node-task-4')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('task-dag-node-task-2')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('task-dag-node-task-1')).toHaveTextContent('已隐藏 2 项');
+    expect(screen.getByTestId('task-dag-node-task-3')).toHaveTextContent('已隐藏 2 项');
+    expect(within(screen.getByTestId('task-dag-node-task-1')).getByTestId('task-dag-badge-visible-current-root-task-1')).toBeInTheDocument();
+    expect(screen.getByTestId('task-dag-toggle-upstream-task-1')).toHaveTextContent('展开上游');
+
+    fireEvent.click(screen.getByTestId('task-dag-toggle-upstream-task-1'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('task-dag-node-task-4')).toBeInTheDocument();
+      expect(screen.getByTestId('task-dag-node-task-2')).toBeInTheDocument();
+    });
+  });
+
+  it('collapses an intermediate node upstream and keeps descendant summaries stable', async () => {
+    renderPage(false);
+
+    expect(await screen.findByText('依赖图')).toBeInTheDocument();
+    expect(screen.getByTestId('task-dag-toggle-upstream-task-4')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('task-dag-toggle-upstream-task-2'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('task-dag-node-task-4')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('task-dag-node-task-2')).toHaveTextContent('已隐藏 1 项');
+    expect(screen.getByTestId('task-dag-node-task-1')).toHaveTextContent('已隐藏 1 项');
+    expect(screen.getByTestId('task-dag-node-task-3')).toHaveTextContent('已隐藏 1 项');
+  });
+});


### PR DESCRIPTION
﻿## 关联 Issue

Closes #395

## 改动摘要

完整实现 `#395`：在共享 `buildTaskGraph(tasks)` 真相层之上新增“折叠某节点上游 -> visible graph 投影”纯函数，并把该投影以最小 UI 集成方式接入 `TaskDetailPage` 的依赖关系卡片。用户现在可以在详情面板内查看当前任务相关 DAG、对节点执行“折叠上游 / 展开上游”，看到 `已隐藏 N 项` 摘要，以及区分“当前可见根”与“真实当前根”。

## 验收检查

- [x] 折叠前后依赖检查结果不变
- [x] 折叠后可见节点数减少，展开后可恢复
- [x] 节点可显示折叠摘要（如“已隐藏 N 项”）
- [x] 折叠不会破坏当前根节点引导逻辑
- [x] 补充单测：投影、恢复、摘要计数
- [x] 在详情面板提供最小交互入口（折叠上游 / 展开上游）

## 自检清单

- [x] 本地构建通过（`bun run build`）
- [x] 相关测试通过（`vitest run`）
- [x] 没有引入 `any` 类型
- [x] 没有硬编码的密钥/token
- [x] commit message 引用了 Issue 编号

## 测试命令

- `npx vitest run tests/unit/ui/task-dag-visibility.issue395.test.ts`
- `npx vitest run tests/unit/ui/task-detail-page.dag-visibility.issue395.test.tsx`
- `npx vitest run tests/unit/ui/task-dag-graph.issue394.test.ts`
- `npx vitest run tests/unit/ui/task-detail-page.dependencies.issue398.test.tsx`
- `npx tsc --noEmit`
- `bun run build`

## 说明

- `#395` 第一阶段纯逻辑层仍保持纯函数，不依赖 React
- 本次后续 commit 只做最小 UI 集成到 `TaskDetailPage`，未扩展到 `TasksPage`、Focus 壳层或额外视觉打磨
- 由于当前 PR 已覆盖纯逻辑层 + 最小交互入口 + 回归测试，现已达到 `#395` 的验收范围
