### PR TITLE
feat(task): add timer config panel for issue #400

### DIFF
--- a/src/ui/app/components/TimerConfigPanel.tsx
+++ b/src/ui/app/components/TimerConfigPanel.tsx
@@ -1,0 +1,174 @@
+import { ChevronDown } from 'lucide-react';
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { Input } from '@/components/ui/input';
+import type { TimerMode } from '@/lib/services';
+
+const PRESET_COUNTDOWN_MINUTES = [15, 25, 45, 60] as const;
+
+function isPresetCountdownMinutes(minutes: number): boolean {
+  return PRESET_COUNTDOWN_MINUTES.includes(minutes as (typeof PRESET_COUNTDOWN_MINUTES)[number]);
+}
+
+function expectedOptionClass(active: boolean): string {
+  return `relative z-10 h-8 w-full whitespace-nowrap rounded-[8px] px-[8px] text-center text-[12px] transition-colors duration-200 ${
+    active
+      ? 'font-semibold text-[#1C1917] dark:text-[#FAFAF9]'
+      : 'text-[#78716C] hover:text-[#57534E] dark:hover:text-[#D6D3D1]'
+  }`;
+}
+
+function resolveCountdownOptionIndex(minutes: number): number {
+  const presetIndex = PRESET_COUNTDOWN_MINUTES.indexOf(minutes as (typeof PRESET_COUNTDOWN_MINUTES)[number]);
+  return presetIndex >= 0 ? presetIndex : PRESET_COUNTDOWN_MINUTES.length;
+}
+
+interface TimerConfigPanelProps {
+  timerMode: TimerMode;
+  countdownMinutes: number;
+  setTimerMode: (mode: TimerMode) => void;
+  setCountdownMinutes: (minutes: number) => void;
+  customDurationDraft: string;
+  setCustomDurationDraft: (draft: string) => void;
+  commitCustomDuration: () => void;
+}
+
+export function TimerConfigPanel({
+  timerMode,
+  countdownMinutes,
+  setTimerMode,
+  setCountdownMinutes,
+  customDurationDraft,
+  setCustomDurationDraft,
+  commitCustomDuration,
+}: TimerConfigPanelProps) {
+  const customDurationInputRef = useRef<HTMLInputElement | null>(null);
+  const [isCustomDurationEditing, setIsCustomDurationEditing] = useState(false);
+
+  const isCustomDurationSelected = timerMode === 'countdown' && !isPresetCountdownMinutes(countdownMinutes);
+  const customDurationTriggerText = isCustomDurationSelected ? `${countdownMinutes}m` : '自定义';
+  const activeCountdownOptionIndex = resolveCountdownOptionIndex(countdownMinutes);
+
+  useEffect(() => {
+    if (timerMode !== 'countdown') {
+      setIsCustomDurationEditing(false);
+    }
+  }, [timerMode]);
+
+  useEffect(() => {
+    if (!isCustomDurationEditing) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      customDurationInputRef.current?.focus();
+      customDurationInputRef.current?.select();
+    });
+  }, [isCustomDurationEditing]);
+
+  const closeCustomDurationEditor = () => {
+    setIsCustomDurationEditing(false);
+  };
+
+  const handleCustomDurationCommit = () => {
+    commitCustomDuration();
+    closeCustomDurationEditor();
+  };
+
+  const handleCustomDurationKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleCustomDurationCommit();
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      setCustomDurationDraft(String(countdownMinutes));
+      closeCustomDurationEditor();
+    }
+  };
+
+  return (
+    <>
+      <div className="mt-3 flex gap-2">
+        <button
+          type="button"
+          data-testid="task-mode-countdown"
+          aria-pressed={timerMode === 'countdown'}
+          onClick={() => setTimerMode('countdown')}
+          className={`rounded-xl px-3 py-1.5 text-xs ${timerMode === 'countdown' ? 'bg-[#C75B3A] text-white' : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'}`}
+        >
+          倒计时
+        </button>
+        <button
+          type="button"
+          data-testid="task-mode-countup"
+          aria-pressed={timerMode === 'countup'}
+          onClick={() => setTimerMode('countup')}
+          className={`rounded-xl px-3 py-1.5 text-xs ${timerMode === 'countup' ? 'bg-[#C75B3A] text-white' : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'}`}
+        >
+          正计时
+        </button>
+      </div>
+
+      {timerMode === 'countdown' ? (
+        <div className="mt-3 flex min-w-0 flex-col gap-1.5">
+          <span className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">预期时长</span>
+          <div className="relative min-w-0 overflow-hidden rounded-[10px] border border-[#FFFFFF60] bg-white/35 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]">
+            <div
+              data-testid="task-countdown-active-indicator"
+              className="pointer-events-none absolute inset-y-0 left-0 w-1/5 rounded-[8px] border border-[#FFFFFFCC] bg-white/55 shadow-[0_1px_2px_rgba(0,0,0,0.05)] transition-transform duration-200 ease-out dark:border-[#FFFFFF66] dark:bg-[#FFFFFF14]"
+              style={{ transform: `translateX(${activeCountdownOptionIndex * 100}%)` }}
+            />
+            <div className="relative z-10 grid min-w-0 grid-cols-5 gap-0">
+              {PRESET_COUNTDOWN_MINUTES.map((minutes) => (
+                <button
+                  key={minutes}
+                  type="button"
+                  data-testid={`task-countdown-preset-${minutes}`}
+                  onClick={() => {
+                    closeCustomDurationEditor();
+                    setCountdownMinutes(minutes);
+                  }}
+                  className={expectedOptionClass(countdownMinutes === minutes)}
+                >
+                  {minutes}m
+                </button>
+              ))}
+
+              {isCustomDurationEditing ? (
+                <Input
+                  ref={customDurationInputRef}
+                  data-testid="task-countdown-custom-input"
+                  value={customDurationDraft}
+                  onChange={(event) => {
+                    setCustomDurationDraft(event.target.value.replace(/[^\d]/g, ''));
+                  }}
+                  onBlur={handleCustomDurationCommit}
+                  onKeyDown={handleCustomDurationKeyDown}
+                  aria-label="自定义倒计时分钟（Custom countdown minutes）"
+                  placeholder="分钟"
+                  className="relative z-10 h-8 w-full border-transparent bg-transparent px-[6px] text-center text-[12px] font-semibold leading-none text-[#1C1917] shadow-none outline-none ring-0 focus-visible:ring-0 dark:text-[#FAFAF9]"
+                />
+              ) : (
+                <button
+                  type="button"
+                  data-testid="task-countdown-custom-trigger"
+                  onClick={() => setIsCustomDurationEditing(true)}
+                  className={`relative z-10 flex h-8 w-full items-center justify-center gap-1 whitespace-nowrap rounded-[8px] px-[8px] text-[12px] transition-colors duration-200 ${
+                    isCustomDurationSelected
+                      ? 'font-semibold text-[#1C1917] dark:text-[#FAFAF9]'
+                      : 'text-[#C75B3A] hover:text-[#B24D2F]'
+                  }`}
+                  aria-label="自定义倒计时（Custom countdown）"
+                >
+                  <ChevronDown size={12} className="transition-transform" />
+                  {customDurationTriggerText}
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/ui/app/hooks/useTimerConfig.ts
+++ b/src/ui/app/hooks/useTimerConfig.ts
@@ -23,13 +23,26 @@ export interface UseTimerConfigResult {
   timerConfig: { mode: 'countup' } | { mode: 'countdown'; minutes: number };
 }
 
-export function useTimerConfig(initialMinutes?: number): UseTimerConfigResult {
+export function useTimerConfig(initialMinutes?: number, resetKey?: string): UseTimerConfigResult {
   const normalizedInitialMinutes = normalizeCountdownMinutes(initialMinutes);
   const hasUserConfiguredRef = useRef(false);
+  const lastResetKeyRef = useRef(resetKey);
 
   const [timerMode, setTimerModeState] = useState<TimerMode>('countdown');
   const [countdownMinutes, setCountdownMinutesState] = useState(normalizedInitialMinutes);
   const [customDurationDraft, setCustomDurationDraftState] = useState(String(normalizedInitialMinutes));
+
+  useEffect(() => {
+    if (lastResetKeyRef.current === resetKey) {
+      return;
+    }
+
+    lastResetKeyRef.current = resetKey;
+    hasUserConfiguredRef.current = false;
+    setTimerModeState('countdown');
+    setCountdownMinutesState(normalizedInitialMinutes);
+    setCustomDurationDraftState(String(normalizedInitialMinutes));
+  }, [normalizedInitialMinutes, resetKey]);
 
   useEffect(() => {
     if (hasUserConfiguredRef.current) {

--- a/src/ui/app/hooks/useTimerConfig.ts
+++ b/src/ui/app/hooks/useTimerConfig.ts
@@ -1,0 +1,89 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { TimerMode } from '@/lib/services';
+
+const DEFAULT_COUNTDOWN_MINUTES = 25;
+const MAX_CUSTOM_COUNTDOWN_MINUTES = 720;
+
+function normalizeCountdownMinutes(minutes?: number): number {
+  if (!Number.isFinite(minutes)) {
+    return DEFAULT_COUNTDOWN_MINUTES;
+  }
+
+  return Math.max(1, Math.min(MAX_CUSTOM_COUNTDOWN_MINUTES, Math.round(minutes ?? DEFAULT_COUNTDOWN_MINUTES)));
+}
+
+export interface UseTimerConfigResult {
+  timerMode: 'countup' | 'countdown';
+  countdownMinutes: number;
+  setTimerMode: (mode: 'countup' | 'countdown') => void;
+  setCountdownMinutes: (minutes: number) => void;
+  customDurationDraft: string;
+  setCustomDurationDraft: (draft: string) => void;
+  commitCustomDuration: () => void;
+  timerConfig: { mode: 'countup' } | { mode: 'countdown'; minutes: number };
+}
+
+export function useTimerConfig(initialMinutes?: number): UseTimerConfigResult {
+  const normalizedInitialMinutes = normalizeCountdownMinutes(initialMinutes);
+  const hasUserConfiguredRef = useRef(false);
+
+  const [timerMode, setTimerModeState] = useState<TimerMode>('countdown');
+  const [countdownMinutes, setCountdownMinutesState] = useState(normalizedInitialMinutes);
+  const [customDurationDraft, setCustomDurationDraftState] = useState(String(normalizedInitialMinutes));
+
+  useEffect(() => {
+    if (hasUserConfiguredRef.current) {
+      return;
+    }
+
+    setCountdownMinutesState(normalizedInitialMinutes);
+    setCustomDurationDraftState(String(normalizedInitialMinutes));
+  }, [normalizedInitialMinutes]);
+
+  const setTimerMode = (mode: TimerMode) => {
+    hasUserConfiguredRef.current = true;
+    setTimerModeState(mode);
+  };
+
+  const setCountdownMinutes = (minutes: number) => {
+    const safeMinutes = normalizeCountdownMinutes(minutes);
+    hasUserConfiguredRef.current = true;
+    setTimerModeState('countdown');
+    setCountdownMinutesState(safeMinutes);
+    setCustomDurationDraftState(String(safeMinutes));
+  };
+
+  const setCustomDurationDraft = (draft: string) => {
+    hasUserConfiguredRef.current = true;
+    setCustomDurationDraftState(draft);
+  };
+
+  const commitCustomDuration = () => {
+    const parsedValue = Number.parseInt(customDurationDraft.trim(), 10);
+    if (Number.isFinite(parsedValue)) {
+      setCountdownMinutes(parsedValue);
+      return;
+    }
+
+    setCustomDurationDraftState(String(countdownMinutes));
+  };
+
+  const timerConfig = useMemo<UseTimerConfigResult['timerConfig']>(() => {
+    if (timerMode === 'countdown') {
+      return { mode: 'countdown', minutes: countdownMinutes };
+    }
+
+    return { mode: 'countup' };
+  }, [countdownMinutes, timerMode]);
+
+  return {
+    timerMode,
+    countdownMinutes,
+    setTimerMode,
+    setCountdownMinutes,
+    customDurationDraft,
+    setCustomDurationDraft,
+    commitCustomDuration,
+    timerConfig,
+  };
+}

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -832,7 +832,7 @@ export function TaskDetailPage() {
     setCustomDurationDraft,
     commitCustomDuration,
     timerConfig,
-  } = useTimerConfig(task?.estimatedMinutes);
+  } = useTimerConfig(task?.estimatedMinutes, task?.id);
 
   useEffect(() => {
     setDagVisibilityState({ collapsedUpstreamOf: [] });

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeft, Ellipsis, Pause, Play } from 'lucide-react';
 import { Link, useNavigate, useParams } from '@tanstack/react-router';
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useState, type ReactNode } from 'react';
 import { getTaskService, getTaskTimerService, getTimeBlockService } from '@/lib/services';
 import type { TaskNode } from '@/lib/types/task';
 import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
@@ -823,6 +823,10 @@ export function TaskDetailPage() {
   const [dependencyActionError, setDependencyActionError] = useState<string | null>(null);
   const [isDependencySaving, setIsDependencySaving] = useState(false);
   const [dependencyReloadKey, setDependencyReloadKey] = useState(0);
+  const timerResetKey = taskId ?? preferredBlockId ?? task?.id;
+  const timerInitialMinutes = taskId
+    ? task?.id === taskId ? task.estimatedMinutes : undefined
+    : task?.estimatedMinutes;
   const {
     timerMode,
     countdownMinutes,
@@ -832,7 +836,16 @@ export function TaskDetailPage() {
     setCustomDurationDraft,
     commitCustomDuration,
     timerConfig,
-  } = useTimerConfig(task?.estimatedMinutes, task?.id);
+  } = useTimerConfig(timerInitialMinutes, timerResetKey);
+
+  useLayoutEffect(() => {
+    setIsLoading(true);
+    setTask(null);
+    setActiveBlock(null);
+    setHasOtherActiveBlock(false);
+    setEventLogs([]);
+    setReviewMarkdown('');
+  }, [dependencyReloadKey, preferredBlockId, taskId]);
 
   useEffect(() => {
     setDagVisibilityState({ collapsedUpstreamOf: [] });

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -25,8 +25,9 @@ import {
   type TaskDagDetailView,
 } from './task-dag-detail-view';
 import type { TaskDagVisibilityState } from '@/lib/task/task-dag-visibility';
+import { TimerConfigPanel } from '@/ui/app/components/TimerConfigPanel';
+import { useTimerConfig } from '@/ui/app/hooks/useTimerConfig';
 
-type TimerMode = 'countup' | 'countdown';
 type DependencyType = 'soft' | 'hard';
 
 function badgeClassName(badge: TimeblockBadge): string {
@@ -449,8 +450,7 @@ function MobileTimeblockDetail({
   dependencySelectedType,
   dependencyError,
   isDependencySaving,
-  timerMode,
-  setTimerMode,
+  timerControls,
   hasOtherActiveBlock,
   hasActiveBlockOnTask,
   onStartTimer,
@@ -472,8 +472,7 @@ function MobileTimeblockDetail({
   dependencySelectedType: DependencyType;
   dependencyError: string | null;
   isDependencySaving: boolean;
-  timerMode: TimerMode;
-  setTimerMode: (mode: TimerMode) => void;
+  timerControls: ReactNode;
   hasOtherActiveBlock: boolean;
   hasActiveBlockOnTask: boolean;
   onStartTimer: () => void;
@@ -606,26 +605,7 @@ function MobileTimeblockDetail({
           className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]"
         >
           <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">计时控制</h3>
-          <div className="mt-3 flex gap-2">
-            <button
-              type="button"
-              data-testid="task-mode-countdown"
-              aria-pressed={timerMode === 'countdown'}
-              onClick={() => setTimerMode('countdown')}
-              className={`rounded-xl px-3 py-1.5 text-xs ${timerMode === 'countdown' ? 'bg-[#C75B3A] text-white' : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'}`}
-            >
-              倒计时
-            </button>
-            <button
-              type="button"
-              data-testid="task-mode-countup"
-              aria-pressed={timerMode === 'countup'}
-              onClick={() => setTimerMode('countup')}
-              className={`rounded-xl px-3 py-1.5 text-xs ${timerMode === 'countup' ? 'bg-[#C75B3A] text-white' : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'}`}
-            >
-              正计时
-            </button>
-          </div>
+          {timerControls}
           <div className="mt-3 flex gap-2">
             <button
               type="button"
@@ -661,8 +641,7 @@ function DesktopTimeblockDetail({
   dependencySelectedType,
   dependencyError,
   isDependencySaving,
-  timerMode,
-  setTimerMode,
+  timerControls,
   hasOtherActiveBlock,
   hasActiveBlockOnTask,
   onStartTimer,
@@ -684,8 +663,7 @@ function DesktopTimeblockDetail({
   dependencySelectedType: DependencyType;
   dependencyError: string | null;
   isDependencySaving: boolean;
-  timerMode: TimerMode;
-  setTimerMode: (mode: TimerMode) => void;
+  timerControls: ReactNode;
   hasOtherActiveBlock: boolean;
   hasActiveBlockOnTask: boolean;
   onStartTimer: () => void;
@@ -796,26 +774,7 @@ function DesktopTimeblockDetail({
             className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]"
           >
             <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">计时控制</h3>
-            <div className="mt-3 flex gap-2">
-              <button
-                type="button"
-                data-testid="task-mode-countdown"
-                aria-pressed={timerMode === 'countdown'}
-                onClick={() => setTimerMode('countdown')}
-                className={`rounded-xl px-3 py-1.5 text-xs ${timerMode === 'countdown' ? 'bg-[#C75B3A] text-white' : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'}`}
-              >
-                倒计时
-              </button>
-              <button
-                type="button"
-                data-testid="task-mode-countup"
-                aria-pressed={timerMode === 'countup'}
-                onClick={() => setTimerMode('countup')}
-                className={`rounded-xl px-3 py-1.5 text-xs ${timerMode === 'countup' ? 'bg-[#C75B3A] text-white' : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'}`}
-              >
-                正计时
-              </button>
-            </div>
+            {timerControls}
             <div className="mt-3 flex gap-2">
               <button
                 type="button"
@@ -857,7 +816,6 @@ export function TaskDetailPage() {
   const [reviewMarkdown, setReviewMarkdown] = useState('');
   const [eventLogs, setEventLogs] = useState<TimeblockEventLog[]>([]);
   const [allTasks, setAllTasks] = useState<TaskNode[]>([]);
-  const [timerMode, setTimerMode] = useState<TimerMode>('countdown');
   const [dependencySelectedTaskId, setDependencySelectedTaskId] = useState('');
   const [dependencySelectedType, setDependencySelectedType] = useState<DependencyType>('soft');
   const [dagVisibilityState, setDagVisibilityState] = useState<TaskDagVisibilityState>({ collapsedUpstreamOf: [] });
@@ -865,6 +823,16 @@ export function TaskDetailPage() {
   const [dependencyActionError, setDependencyActionError] = useState<string | null>(null);
   const [isDependencySaving, setIsDependencySaving] = useState(false);
   const [dependencyReloadKey, setDependencyReloadKey] = useState(0);
+  const {
+    timerMode,
+    countdownMinutes,
+    setTimerMode,
+    setCountdownMinutes,
+    customDurationDraft,
+    setCustomDurationDraft,
+    commitCustomDuration,
+    timerConfig,
+  } = useTimerConfig(task?.estimatedMinutes);
 
   useEffect(() => {
     setDagVisibilityState({ collapsedUpstreamOf: [] });
@@ -971,6 +939,17 @@ export function TaskDetailPage() {
   const rootGuidance = useMemo(() => (
     <TaskCurrentRootCard graph={taskGraph} taskById={taskById} currentTaskId={task?.id} />
   ), [task?.id, taskById, taskGraph]);
+  const timerControls = (
+    <TimerConfigPanel
+      timerMode={timerMode}
+      countdownMinutes={countdownMinutes}
+      setTimerMode={setTimerMode}
+      setCountdownMinutes={setCountdownMinutes}
+      customDurationDraft={customDurationDraft}
+      setCustomDurationDraft={setCustomDurationDraft}
+      commitCustomDuration={commitCustomDuration}
+    />
+  );
 
   const dependencyView = useMemo(() => {
     if (!task) return null;
@@ -1066,10 +1045,7 @@ export function TaskDetailPage() {
 
   const handleStartTimer = () => {
     if (!taskId) return;
-    const config = timerMode === 'countdown'
-      ? { mode: 'countdown' as const, minutes: 25 }
-      : { mode: 'countup' as const };
-    void getTaskTimerService().startBlockForTask(taskId, config).then(() => {
+    void getTaskTimerService().startBlockForTask(taskId, timerConfig).then(() => {
       void navigate({ to: '/eventlog' });
     });
   };
@@ -1114,17 +1090,16 @@ export function TaskDetailPage() {
 
   if (isDesktop) {
     return (
-        <DesktopTimeblockDetail
-          task={task}
-          model={viewModel}
-          dependencyView={dependencyView}
-          taskDagView={taskDagView}
-          dependencySelectedTaskId={dependencySelectedTaskId}
-          dependencySelectedType={dependencySelectedType}
-          dependencyError={dependencyError}
+      <DesktopTimeblockDetail
+        task={task}
+        model={viewModel}
+        dependencyView={dependencyView}
+        taskDagView={taskDagView}
+        dependencySelectedTaskId={dependencySelectedTaskId}
+        dependencySelectedType={dependencySelectedType}
+        dependencyError={dependencyError}
         isDependencySaving={isDependencySaving}
-        timerMode={timerMode}
-        setTimerMode={setTimerMode}
+        timerControls={timerControls}
         hasOtherActiveBlock={hasOtherActiveBlock}
         hasActiveBlockOnTask={Boolean(activeBlock)}
         onStartTimer={handleStartTimer}
@@ -1133,11 +1108,11 @@ export function TaskDetailPage() {
         rootGuidance={rootGuidance}
         onDependencySelectedTaskChange={setDependencySelectedTaskId}
         onDependencySelectedTypeChange={setDependencySelectedType}
-          onAddDependency={handleAddDependency}
-          onChangeDependencyType={handleChangeDependencyType}
-          onRemoveDependency={handleRemoveDependency}
-          onToggleCollapseUpstream={handleToggleCollapseUpstream}
-        />
+        onAddDependency={handleAddDependency}
+        onChangeDependencyType={handleChangeDependencyType}
+        onRemoveDependency={handleRemoveDependency}
+        onToggleCollapseUpstream={handleToggleCollapseUpstream}
+      />
     );
   }
 
@@ -1151,8 +1126,7 @@ export function TaskDetailPage() {
       dependencySelectedType={dependencySelectedType}
       dependencyError={dependencyError}
       isDependencySaving={isDependencySaving}
-      timerMode={timerMode}
-      setTimerMode={setTimerMode}
+      timerControls={timerControls}
       hasOtherActiveBlock={hasOtherActiveBlock}
       hasActiveBlockOnTask={Boolean(activeBlock)}
       onStartTimer={handleStartTimer}

--- a/tests/unit/hooks/use-timer-config.issue400.test.ts
+++ b/tests/unit/hooks/use-timer-config.issue400.test.ts
@@ -24,4 +24,24 @@ describe('useTimerConfig', () => {
 
     expect(result.current.timerConfig).toEqual({ mode: 'countup' });
   });
+
+  it('resets to next task initial minutes when reset key changes（任务切换时按新任务重新初始化）', () => {
+    const { result, rerender } = renderHook(
+      ({ initialMinutes, resetKey }: { initialMinutes?: number; resetKey?: string }) => useTimerConfig(initialMinutes, resetKey),
+      {
+        initialProps: { initialMinutes: 120, resetKey: 'task-1' },
+      },
+    );
+
+    act(() => {
+      result.current.setTimerMode('countup');
+    });
+
+    rerender({ initialMinutes: 30, resetKey: 'task-2' });
+
+    expect(result.current.timerMode).toBe('countdown');
+    expect(result.current.countdownMinutes).toBe(30);
+    expect(result.current.customDurationDraft).toBe('30');
+    expect(result.current.timerConfig).toEqual({ mode: 'countdown', minutes: 30 });
+  });
 });

--- a/tests/unit/hooks/use-timer-config.issue400.test.ts
+++ b/tests/unit/hooks/use-timer-config.issue400.test.ts
@@ -1,0 +1,27 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useTimerConfig } from '@/ui/app/hooks/useTimerConfig';
+
+describe('useTimerConfig', () => {
+  it('defaults to 25-minute countdown config（默认返回 25 分钟倒计时配置）', () => {
+    const { result } = renderHook(() => useTimerConfig());
+
+    expect(result.current.timerConfig).toEqual({ mode: 'countdown', minutes: 25 });
+  });
+
+  it('uses provided initial minutes（使用传入的初始分钟数）', () => {
+    const { result } = renderHook(() => useTimerConfig(45));
+
+    expect(result.current.countdownMinutes).toBe(45);
+  });
+
+  it('switches timerConfig to countup（切换到正计时后返回 countup 配置）', () => {
+    const { result } = renderHook(() => useTimerConfig());
+
+    act(() => {
+      result.current.setTimerMode('countup');
+    });
+
+    expect(result.current.timerConfig).toEqual({ mode: 'countup' });
+  });
+});

--- a/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
+++ b/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { TaskDetailPage } from '@/ui/app/pages/TaskDetailPage';
 import type { TaskNode } from '@/lib/types/task';
 import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
@@ -22,6 +22,7 @@ const onBlockChangeMock = vi.fn(() => () => {});
 const pauseBlockMock = vi.fn<() => Promise<void>>();
 
 const calculateSpentMinutesMock = vi.fn<(taskId: string) => Promise<number>>();
+const startBlockForTaskMock = vi.fn();
 
 const getEventsMock = vi.fn<
   () => Promise<Array<{ id: string; content: string; createdAt: string; type?: string }>>
@@ -55,7 +56,7 @@ vi.mock('@/lib/services', () => ({
   }),
   getTaskTimerService: () => ({
     calculateSpentMinutes: calculateSpentMinutesMock,
-    startBlockForTask: vi.fn(),
+    startBlockForTask: startBlockForTaskMock,
   }),
 }));
 
@@ -117,6 +118,8 @@ function makeBlock(overrides: Partial<TimeBlock> = {}): TimeBlock {
 describe('TaskDetailPage timeblock detail layout（时间块详情布局）', () => {
   beforeEach(() => {
     navigateMock.mockReset();
+    startBlockForTaskMock.mockReset();
+    startBlockForTaskMock.mockResolvedValue(null);
     getTaskMock.mockResolvedValue(makeTask({ status: 'in_progress', createdAt: 20, updatedAt: 20 }));
     listTasksMock.mockResolvedValue([
       makeTask({
@@ -197,5 +200,20 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
     expect(await screen.findByTestId('task-current-root-card')).toHaveTextContent('优先收口 DAG 根节点');
     expect(screen.getByTestId('task-current-root-link')).toBeInTheDocument();
     expect(screen.getByTestId('task-current-root-dag-link')).toBeInTheDocument();
+  });
+
+  it('starts countdown with task estimated minutes instead of hardcoded 25（开始计时时使用任务预估分钟数）', async () => {
+    mockMatchMedia(false);
+    render(<TaskDetailPage />);
+
+    await screen.findByText('时间块详情');
+
+    expect(screen.getByTestId('task-countdown-custom-trigger')).toHaveTextContent('120m');
+
+    fireEvent.click(screen.getByText('开始计时'));
+
+    await waitFor(() => {
+      expect(startBlockForTaskMock).toHaveBeenCalledWith('task-1', { mode: 'countdown', minutes: 120 });
+    });
   });
 });

--- a/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
+++ b/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
@@ -268,4 +268,44 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
       expect(startBlockForTaskMock).toHaveBeenCalledWith('task-2', { mode: 'countdown', minutes: 30 });
     });
   });
+
+  it('hides stale timer actions while next task is still loading（切换任务加载中不允许沿用旧配置启动）', async () => {
+    mockMatchMedia(false);
+    getTaskMock.mockImplementation(async (id: string) => {
+      if (id === 'task-2') {
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        return makeTask({
+          id: 'task-2',
+          title: '切换后的任务 B',
+          estimatedMinutes: 30,
+          status: 'not_started',
+          createdAt: 30,
+          updatedAt: 30,
+        });
+      }
+
+      return makeTask({ status: 'in_progress', createdAt: 20, updatedAt: 20 });
+    });
+
+    const { rerender } = render(<TaskDetailPage />);
+
+    await screen.findByText('时间块详情');
+    fireEvent.click(screen.getByTestId('task-mode-countup'));
+
+    currentTaskId = 'task-2';
+    rerender(<TaskDetailPage />);
+
+    expect(screen.getByText('加载中...')).toBeInTheDocument();
+    expect(screen.queryByText('开始计时')).toBeNull();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('task-countdown-custom-trigger')).toHaveTextContent('30m');
+    });
+
+    fireEvent.click(screen.getByText('开始计时'));
+
+    await waitFor(() => {
+      expect(startBlockForTaskMock).toHaveBeenCalledWith('task-2', { mode: 'countdown', minutes: 30 });
+    });
+  });
 });

--- a/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
+++ b/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
@@ -27,10 +27,11 @@ const startBlockForTaskMock = vi.fn();
 const getEventsMock = vi.fn<
   () => Promise<Array<{ id: string; content: string; createdAt: string; type?: string }>>
 >();
+let currentTaskId = 'task-1';
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
-  useParams: () => ({ taskId: 'task-1' }),
+  useParams: () => ({ taskId: currentTaskId }),
   useNavigate: () => navigateMock,
 }));
 
@@ -117,10 +118,24 @@ function makeBlock(overrides: Partial<TimeBlock> = {}): TimeBlock {
 
 describe('TaskDetailPage timeblock detail layout（时间块详情布局）', () => {
   beforeEach(() => {
+    currentTaskId = 'task-1';
     navigateMock.mockReset();
     startBlockForTaskMock.mockReset();
     startBlockForTaskMock.mockResolvedValue(null);
-    getTaskMock.mockResolvedValue(makeTask({ status: 'in_progress', createdAt: 20, updatedAt: 20 }));
+    getTaskMock.mockImplementation(async (id: string) => {
+      if (id === 'task-2') {
+        return makeTask({
+          id: 'task-2',
+          title: '切换后的任务 B',
+          estimatedMinutes: 30,
+          status: 'not_started',
+          createdAt: 30,
+          updatedAt: 30,
+        });
+      }
+
+      return makeTask({ status: 'in_progress', createdAt: 20, updatedAt: 20 });
+    });
     listTasksMock.mockResolvedValue([
       makeTask({
         id: 'task-root',
@@ -135,6 +150,14 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
         status: 'in_progress',
         createdAt: 20,
         updatedAt: 20,
+      }),
+      makeTask({
+        id: 'task-2',
+        title: '切换后的任务 B',
+        estimatedMinutes: 30,
+        status: 'not_started',
+        createdAt: 30,
+        updatedAt: 30,
       }),
     ]);
     addDependencyMock.mockResolvedValue(makeTask());
@@ -214,6 +237,35 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
 
     await waitFor(() => {
       expect(startBlockForTaskMock).toHaveBeenCalledWith('task-1', { mode: 'countdown', minutes: 120 });
+    });
+  });
+
+  it('resets timer config after switching to another task（切换任务后重置为新任务的初始计时配置）', async () => {
+    mockMatchMedia(false);
+    const { rerender } = render(<TaskDetailPage />);
+
+    await screen.findByText('时间块详情');
+
+    fireEvent.click(screen.getByTestId('task-mode-countup'));
+    expect(screen.getByTestId('task-mode-countup')).toHaveAttribute('aria-pressed', 'true');
+
+    currentTaskId = 'task-2';
+    rerender(<TaskDetailPage />);
+
+    await waitFor(() => {
+      expect(getTaskMock).toHaveBeenCalledWith('task-2');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('task-mode-countdown')).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    expect(screen.getByTestId('task-countdown-custom-trigger')).toHaveTextContent('30m');
+
+    fireEvent.click(screen.getByText('开始计时'));
+
+    await waitFor(() => {
+      expect(startBlockForTaskMock).toHaveBeenCalledWith('task-2', { mode: 'countdown', minutes: 30 });
     });
   });
 });

--- a/tests/unit/ui/timer-config-panel.issue400.test.tsx
+++ b/tests/unit/ui/timer-config-panel.issue400.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TimerConfigPanel } from '@/ui/app/components/TimerConfigPanel';
+
+describe('TimerConfigPanel', () => {
+  it('defaults to countdown mode with 25 preset selected（默认倒计时显示 25 分钟）', () => {
+    render(
+      <TimerConfigPanel
+        timerMode="countdown"
+        countdownMinutes={25}
+        setTimerMode={vi.fn()}
+        setCountdownMinutes={vi.fn()}
+        customDurationDraft="25"
+        setCustomDurationDraft={vi.fn()}
+        commitCustomDuration={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('task-mode-countdown')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('task-countdown-preset-15')).toBeInTheDocument();
+    expect(screen.getByTestId('task-countdown-preset-25')).toBeInTheDocument();
+    expect(screen.getByTestId('task-countdown-preset-45')).toBeInTheDocument();
+    expect(screen.getByTestId('task-countdown-preset-60')).toBeInTheDocument();
+    expect(screen.getByTestId('task-countdown-preset-25')).toHaveClass('font-semibold');
+  });
+
+  it('hides countdown presets in countup mode（切到正计时时隐藏倒计时预设）', () => {
+    render(
+      <TimerConfigPanel
+        timerMode="countup"
+        countdownMinutes={25}
+        setTimerMode={vi.fn()}
+        setCountdownMinutes={vi.fn()}
+        customDurationDraft="25"
+        setCustomDurationDraft={vi.fn()}
+        commitCustomDuration={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('task-mode-countup')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.queryByTestId('task-countdown-preset-25')).toBeNull();
+    expect(screen.queryByTestId('task-countdown-custom-trigger')).toBeNull();
+  });
+
+  it('calls preset callback when preset button clicked（点击预设按钮触发回调）', () => {
+    const setCountdownMinutes = vi.fn();
+
+    render(
+      <TimerConfigPanel
+        timerMode="countdown"
+        countdownMinutes={25}
+        setTimerMode={vi.fn()}
+        setCountdownMinutes={setCountdownMinutes}
+        customDurationDraft="25"
+        setCustomDurationDraft={vi.fn()}
+        commitCustomDuration={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('task-countdown-preset-45'));
+
+    expect(setCountdownMinutes).toHaveBeenCalledWith(45);
+  });
+
+  it('commits custom countdown input（自定义输入提交回调正确）', () => {
+    const setCustomDurationDraft = vi.fn();
+    const commitCustomDuration = vi.fn();
+
+    render(
+      <TimerConfigPanel
+        timerMode="countdown"
+        countdownMinutes={25}
+        setTimerMode={vi.fn()}
+        setCountdownMinutes={vi.fn()}
+        customDurationDraft="25"
+        setCustomDurationDraft={setCustomDurationDraft}
+        commitCustomDuration={commitCustomDuration}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('task-countdown-custom-trigger'));
+    const customInput = screen.getByTestId('task-countdown-custom-input');
+    fireEvent.change(customInput, { target: { value: '37' } });
+    fireEvent.keyDown(customInput, { key: 'Enter' });
+
+    expect(setCustomDurationDraft).toHaveBeenCalledWith('37');
+    expect(commitCustomDuration).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows estimated minutes as initial selected value（estimatedMinutes 作为初始选中值）', () => {
+    render(
+      <TimerConfigPanel
+        timerMode="countdown"
+        countdownMinutes={45}
+        setTimerMode={vi.fn()}
+        setCountdownMinutes={vi.fn()}
+        customDurationDraft="45"
+        setCustomDurationDraft={vi.fn()}
+        commitCustomDuration={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('task-countdown-preset-45')).toHaveClass('font-semibold');
+  });
+});


### PR DESCRIPTION
## Summary
- add `useTimerConfig` hook to centralize task detail timer mode, preset/custom duration state, and derived timer config
- add `TimerConfigPanel` reusing the existing time-block configuration interaction with 15/25/45/60 presets plus custom duration
- replace the hardcoded 25-minute countdown in `TaskDetailPage` with task-aware timer config seeded from `TaskNode.estimatedMinutes`
- reset timer config when the current task identity changes so one task's custom timer selection does not leak into another task
- hide stale task detail actions while the next task is still loading so a new route cannot start timing with the previous task's config
- add unit coverage for the hook, config panel, task detail countdown start behavior, cross-task timer reset behavior, and async task-switch loading behavior

## Validation
- `npx vitest run tests/unit/ui/task-detail-page.timeblock-detail.test.tsx tests/unit/hooks/use-timer-config.issue400.test.ts tests/unit/ui/timer-config-panel.issue400.test.tsx`
- `npx tsc --noEmit`
- `bun run build`

## Notes
- service smoke startup/curl verification was attempted locally, but background process launch was blocked by the current shell policy in this environment

refs #400
