### PR TITLE
feat(task): filter dependency candidates for #398 P1

### DIFF
--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -165,6 +165,8 @@ function DependencyCard({
   onRemoveDependency: (taskId: string) => void;
   onToggleCollapseUpstream: (taskId: string) => void;
 }) {
+  const selectedCandidate = dependencyView.candidates.find((candidate) => candidate.id === selectedTaskId) ?? null;
+
   return (
     <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
       <div className="flex items-center justify-between gap-3">
@@ -374,11 +376,19 @@ function DependencyCard({
               >
                 <option value="">请选择任务</option>
                 {dependencyView.candidates.map((candidate) => (
-                  <option key={candidate.id} value={candidate.id}>
-                    {candidate.title} · {candidate.statusLabel}
+                  <option key={candidate.id} value={candidate.id} disabled={candidate.disabled}>
+                    {candidate.title} · {candidate.statusLabel}{candidate.disabledReason ? ` · ${candidate.disabledReason}` : ''}
                   </option>
                 ))}
               </select>
+              {selectedCandidate?.disabledReason ? (
+                <p
+                  data-testid="dependency-add-task-disabled-reason"
+                  className="text-[11px] text-[#C75B3A] dark:text-[#FDBA74]"
+                >
+                  当前候选不可选：{selectedCandidate.disabledReason}
+                </p>
+              ) : null}
             </label>
 
             <label className="space-y-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
@@ -399,7 +409,7 @@ function DependencyCard({
               <button
                 type="button"
                 data-testid="dependency-add-button"
-                disabled={isSaving || !selectedTaskId}
+                disabled={isSaving || !selectedTaskId || selectedCandidate?.disabled === true}
                 onClick={onAddDependency}
                 className="w-full rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
               >
@@ -1004,8 +1014,13 @@ export function TaskDetailPage() {
       setDependencyActionError('请选择依赖任务');
       return;
     }
-    if (!dependencyView.candidates.some((candidate) => candidate.id === dependencySelectedTaskId)) {
+    const selectedCandidate = dependencyView.candidates.find((candidate) => candidate.id === dependencySelectedTaskId);
+    if (!selectedCandidate) {
       setDependencyActionError('依赖任务不存在，请刷新后重试');
+      return;
+    }
+    if (selectedCandidate.disabled) {
+      setDependencyActionError(`该依赖不可选：${selectedCandidate.disabledReason ?? '请更换其他任务'}`);
       return;
     }
 

--- a/src/ui/app/pages/task-dependency-view.ts
+++ b/src/ui/app/pages/task-dependency-view.ts
@@ -16,6 +16,8 @@ export interface TaskDependencyCandidate {
   id: string;
   title: string;
   statusLabel: string;
+  disabled: boolean;
+  disabledReason?: string;
 }
 
 export interface TaskDependencyViewModel {
@@ -60,8 +62,44 @@ function buildDependencyItem(taskMap: Map<string, TaskNode>, taskId: string, typ
   };
 }
 
+function wouldCreateDependencyCycle(taskId: string, depTaskId: string, taskMap: Map<string, TaskNode>): boolean {
+  const visited = new Set<string>();
+  const queue = [depTaskId];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) {
+      continue;
+    }
+
+    if (current === taskId) {
+      return true;
+    }
+
+    if (visited.has(current)) {
+      continue;
+    }
+
+    visited.add(current);
+
+    const task = taskMap.get(current);
+    if (!task) {
+      continue;
+    }
+
+    for (const dependency of task.dependsOn) {
+      if (!visited.has(dependency.taskId)) {
+        queue.push(dependency.taskId);
+      }
+    }
+  }
+
+  return false;
+}
+
 export function buildTaskDependencyView(task: TaskNode, allTasks: TaskNode[]): TaskDependencyViewModel {
   const taskMap = new Map(allTasks.map((item) => [item.id, item]));
+  const existingDependencyIds = new Set(task.dependsOn.map((dependency) => dependency.taskId));
 
   return {
     currentDependencies: task.dependsOn.map((dependency) => buildDependencyItem(taskMap, dependency.taskId, dependency.type)),
@@ -69,11 +107,23 @@ export function buildTaskDependencyView(task: TaskNode, allTasks: TaskNode[]): T
       .flatMap((candidate) => candidate.dependsOn
         .filter((dependency) => dependency.taskId === task.id)
         .map((dependency) => buildDependencyItem(taskMap, candidate.id, dependency.type))),
-    candidates: allTasks.map((candidate) => ({
-      id: candidate.id,
-      title: candidate.title,
-      statusLabel: STATUS_LABELS[candidate.status],
-    })),
+    candidates: allTasks
+      .filter((candidate) => candidate.id !== task.id && !existingDependencyIds.has(candidate.id))
+      .map((candidate) => {
+        const disabledReason = candidate.status === 'abandoned'
+          ? '任务已放弃'
+          : wouldCreateDependencyCycle(task.id, candidate.id, taskMap)
+            ? '会形成循环依赖'
+            : undefined;
+
+        return {
+          id: candidate.id,
+          title: candidate.title,
+          statusLabel: STATUS_LABELS[candidate.status],
+          disabled: Boolean(disabledReason),
+          disabledReason,
+        };
+      }),
   };
 }
 

--- a/tests/unit/ui/task-dependency-view.issue398-p1.test.ts
+++ b/tests/unit/ui/task-dependency-view.issue398-p1.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type { TaskNode } from '@/lib/types/task';
+import { buildTaskDependencyView } from '@/ui/app/pages/task-dependency-view';
+
+function makeTask(overrides: Partial<TaskNode> & Pick<TaskNode, 'id' | 'title'>): TaskNode {
+  return {
+    id: overrides.id,
+    title: overrides.title,
+    description: '',
+    status: 'not_started',
+    priority: 'medium',
+    dependsOn: [],
+    tags: [],
+    timeBlockIds: [],
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+describe('buildTaskDependencyView issue #398 P1', () => {
+  it('excludes current task from candidates（排除当前任务自身）', () => {
+    const currentTask = makeTask({ id: 'task-1', title: '当前任务' });
+    const otherTask = makeTask({ id: 'task-2', title: '其他任务' });
+
+    const view = buildTaskDependencyView(currentTask, [currentTask, otherTask]);
+
+    expect(view.candidates.map((candidate) => candidate.id)).toEqual(['task-2']);
+  });
+
+  it('excludes existing dependencies from candidates（排除已存在依赖）', () => {
+    const dependencyTask = makeTask({ id: 'task-2', title: '已有依赖' });
+    const currentTask = makeTask({
+      id: 'task-1',
+      title: '当前任务',
+      dependsOn: [{ taskId: 'task-2', type: 'soft' }],
+    });
+    const otherTask = makeTask({ id: 'task-3', title: '新候选' });
+
+    const view = buildTaskDependencyView(currentTask, [currentTask, dependencyTask, otherTask]);
+
+    expect(view.candidates.map((candidate) => candidate.id)).toEqual(['task-3']);
+  });
+
+  it('marks abandoned tasks as disabled（已放弃任务标记禁用）', () => {
+    const currentTask = makeTask({ id: 'task-1', title: '当前任务' });
+    const abandonedTask = makeTask({
+      id: 'task-2',
+      title: '已放弃任务',
+      status: 'abandoned',
+    });
+
+    const view = buildTaskDependencyView(currentTask, [currentTask, abandonedTask]);
+    const candidate = view.candidates.find((item) => item.id === 'task-2');
+
+    expect(candidate).toMatchObject({
+      id: 'task-2',
+      disabled: true,
+      disabledReason: '任务已放弃',
+    });
+  });
+
+  it('marks cycle-producing candidates as disabled（会成环的候选标记禁用）', () => {
+    const taskA = makeTask({
+      id: 'task-a',
+      title: '任务 A',
+      dependsOn: [{ taskId: 'task-b', type: 'hard' }],
+    });
+    const taskB = makeTask({
+      id: 'task-b',
+      title: '任务 B',
+      dependsOn: [{ taskId: 'task-c', type: 'hard' }],
+    });
+    const taskC = makeTask({ id: 'task-c', title: '任务 C' });
+    const taskD = makeTask({ id: 'task-d', title: '任务 D' });
+
+    const view = buildTaskDependencyView(taskC, [taskA, taskB, taskC, taskD]);
+    const cycleCandidate = view.candidates.find((item) => item.id === 'task-a');
+
+    expect(cycleCandidate).toMatchObject({
+      id: 'task-a',
+      disabled: true,
+      disabledReason: '会形成循环依赖',
+    });
+  });
+
+  it('keeps valid candidates selectable（正常候选保持可选）', () => {
+    const taskA = makeTask({ id: 'task-a', title: '任务 A' });
+    const taskB = makeTask({ id: 'task-b', title: '任务 B' });
+
+    const view = buildTaskDependencyView(taskA, [taskA, taskB]);
+    const candidate = view.candidates.find((item) => item.id === 'task-b');
+
+    expect(candidate).toMatchObject({
+      id: 'task-b',
+      disabled: false,
+    });
+    expect(candidate?.disabledReason).toBeUndefined();
+  });
+});

--- a/tests/unit/ui/task-detail-page.dependencies.issue398.test.tsx
+++ b/tests/unit/ui/task-detail-page.dependencies.issue398.test.tsx
@@ -244,6 +244,30 @@ describe('TaskDetailPage dependencies issue #398 P0', () => {
     expect(screen.queryByTestId('dependency-current-empty')).not.toBeInTheDocument();
   });
 
+  it('renders disabled candidates and prevents blocked selections（渲染禁用候选并阻止选择）', async () => {
+    tasksState[0].dependsOn = [];
+    tasksState.push(makeTask({
+      id: 'task-4',
+      title: '归档旧方案',
+      status: 'abandoned',
+      timeBlockIds: [],
+    }));
+    renderPage();
+
+    const taskSelect = await screen.findByTestId('dependency-add-task-select');
+
+    expect(within(taskSelect).queryByRole('option', { name: '实现依赖关系卡片 · 未开始' })).not.toBeInTheDocument();
+    expect(within(taskSelect).getByRole('option', { name: '补 task.service 单测 · 进行中' })).not.toBeDisabled();
+    expect(within(taskSelect).getByRole('option', { name: '联调任务详情页 · 已完成 · 会形成循环依赖' })).toBeDisabled();
+    expect(within(taskSelect).getByRole('option', { name: '归档旧方案 · 已放弃 · 任务已放弃' })).toBeDisabled();
+
+    fireEvent.change(taskSelect, { target: { value: 'task-3' } });
+
+    expect(screen.getByTestId('dependency-add-button')).toBeDisabled();
+    expect(screen.getByTestId('dependency-add-task-disabled-reason')).toHaveTextContent('会形成循环依赖');
+    expect(addDependencyMock).not.toHaveBeenCalled();
+  });
+
   it('switches dependency type from soft to hard（切换依赖类型）', async () => {
     renderPage();
 


### PR DESCRIPTION
﻿## Summary
- filter dependency candidates in the task detail dependency editor
- disable abandoned and cycle-producing candidates with readable reasons
- add unit coverage for candidate filtering and disabled-option rendering

## Validation
- `npx vitest run tests/unit/ui/task-dependency-view.issue398-p1.test.ts tests/unit/ui/task-detail-page.dependencies.issue398.test.tsx`
- `npx tsc --noEmit`
- `bun run build`

## Issue
refs #398
