### PR TITLE
feat(task): add estimatedMinutes editor for #384

### DIFF
--- a/src/ui/app/components/EstimatedTimeEditor.tsx
+++ b/src/ui/app/components/EstimatedTimeEditor.tsx
@@ -1,0 +1,239 @@
+import { ChevronDown } from 'lucide-react';
+import { type KeyboardEvent, useEffect, useRef, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { getTaskService } from '@/lib/services';
+
+const PRESET_ESTIMATED_MINUTES = [15, 25, 45, 60] as const;
+
+function expectedOptionClass(active: boolean): string {
+  return `relative z-10 h-8 w-full whitespace-nowrap rounded-[8px] px-[8px] text-center text-[12px] transition-colors duration-200 ${
+    active
+      ? 'font-semibold text-[#1C1917] dark:text-[#FAFAF9]'
+      : 'text-[#78716C] hover:text-[#57534E] dark:hover:text-[#D6D3D1]'
+  }`;
+}
+
+function isPresetEstimatedMinutes(minutes: number): boolean {
+  return PRESET_ESTIMATED_MINUTES.includes(minutes as (typeof PRESET_ESTIMATED_MINUTES)[number]);
+}
+
+function normalizePositiveMinutes(value: string): number | undefined {
+  const digitsOnly = value.replace(/[^\d]/g, '');
+  if (digitsOnly.length === 0) return undefined;
+
+  const parsed = Number.parseInt(digitsOnly, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return parsed;
+}
+
+function formatCurrentMinutes(minutes: number | undefined): string {
+  return minutes ? `${minutes} 分钟` : '未估时';
+}
+
+export interface EstimatedTimeEditorProps {
+  taskId: string;
+  currentMinutes?: number;
+  onUpdate?: (minutes: number | undefined) => void;
+}
+
+export function EstimatedTimeEditor({
+  taskId,
+  currentMinutes,
+  onUpdate,
+}: EstimatedTimeEditorProps) {
+  const [minutes, setMinutes] = useState<number | undefined>(currentMinutes);
+  const [customDraft, setCustomDraft] = useState(currentMinutes ? String(currentMinutes) : '');
+  const [isCustomEditing, setIsCustomEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const customInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    setMinutes(currentMinutes);
+    setCustomDraft(currentMinutes ? String(currentMinutes) : '');
+  }, [currentMinutes]);
+
+  useEffect(() => {
+    if (!isCustomEditing) return;
+
+    const timer = window.setTimeout(() => {
+      customInputRef.current?.focus();
+      customInputRef.current?.select();
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [isCustomEditing]);
+
+  const activeIndex = minutes === undefined
+    ? null
+    : isPresetEstimatedMinutes(minutes)
+      ? PRESET_ESTIMATED_MINUTES.indexOf(minutes as (typeof PRESET_ESTIMATED_MINUTES)[number])
+      : PRESET_ESTIMATED_MINUTES.length;
+  const isCustomSelected = minutes !== undefined && !isPresetEstimatedMinutes(minutes);
+
+  async function persistMinutes(nextMinutes: number | undefined): Promise<void> {
+    setIsSaving(true);
+    setErrorMessage(null);
+
+    try {
+      const updated = await getTaskService().updateTask(taskId, { estimatedMinutes: nextMinutes });
+      if (!updated) {
+        throw new Error('当前任务不存在，估时未保存');
+      }
+
+      setMinutes(nextMinutes);
+      setCustomDraft(nextMinutes ? String(nextMinutes) : '');
+      setIsCustomEditing(false);
+      onUpdate?.(nextMinutes);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '估时保存失败，请稍后重试');
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  function openCustomEditor(): void {
+    setErrorMessage(null);
+    setCustomDraft(minutes ? String(minutes) : '');
+    setIsCustomEditing(true);
+  }
+
+  function applyCustomMinutes(value: string): void {
+    const nextMinutes = normalizePositiveMinutes(value);
+
+    if (nextMinutes === undefined) {
+      if (value.trim().length === 0) {
+        setErrorMessage(null);
+        setCustomDraft(minutes ? String(minutes) : '');
+        setIsCustomEditing(false);
+        return;
+      }
+
+      setErrorMessage('请输入正整数分钟');
+      customInputRef.current?.focus();
+      return;
+    }
+
+    void persistMinutes(nextMinutes);
+  }
+
+  function handleCustomInputKeyDown(event: KeyboardEvent<HTMLInputElement>): void {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      applyCustomMinutes(customDraft);
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      setErrorMessage(null);
+      setCustomDraft(minutes ? String(minutes) : '');
+      setIsCustomEditing(false);
+    }
+  }
+
+  return (
+    <div className="mt-3 flex min-w-0 flex-col gap-2" data-testid="estimated-time-editor">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">任务估时</p>
+          <p
+            data-testid="estimated-time-current"
+            className="mt-1 text-xs font-semibold text-[#1C1917] dark:text-[#FAFAF9]"
+          >
+            当前：{formatCurrentMinutes(minutes)}
+          </p>
+        </div>
+
+        <button
+          type="button"
+          data-testid="estimated-time-clear"
+          aria-pressed={minutes === undefined}
+          disabled={isSaving}
+          onClick={() => {
+            void persistMinutes(undefined);
+          }}
+          className={`rounded-full border px-3 py-1 text-[11px] transition-colors ${
+            minutes === undefined
+              ? 'border-[#C75B3A] bg-[#FFF7ED] text-[#C75B3A] dark:border-[#E8734E] dark:bg-[#2A1510] dark:text-[#F4A589]'
+              : 'border-[#E7E5E4] text-[#78716C] hover:text-[#57534E] dark:border-[#292524] dark:text-[#A8A29E] dark:hover:text-[#D6D3D1]'
+          } disabled:cursor-not-allowed disabled:opacity-60`}
+        >
+          {isSaving && minutes === undefined ? '保存中...' : '清空'}
+        </button>
+      </div>
+
+      <div
+        className="relative min-w-0 overflow-hidden rounded-[10px] border border-[#E7E5E4] bg-[#F5F0ED]/50 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]"
+        data-testid="estimated-time-selector"
+      >
+        {activeIndex !== null ? (
+          <div
+            data-testid="estimated-time-active-indicator"
+            className="pointer-events-none absolute inset-y-0 left-0 w-1/5 rounded-[8px] border border-[#FFFFFFCC] bg-white/55 shadow-[0_1px_2px_rgba(0,0,0,0.05)] transition-transform duration-200 ease-out dark:border-[#FFFFFF66] dark:bg-[#FFFFFF14]"
+            style={{ transform: `translateX(${activeIndex * 100}%)` }}
+          />
+        ) : null}
+
+        <div className="relative z-10 grid min-w-0 grid-cols-5 gap-0">
+          {PRESET_ESTIMATED_MINUTES.map((preset) => (
+            <button
+              key={preset}
+              type="button"
+              data-testid={`estimated-time-preset-${preset}`}
+              aria-pressed={minutes === preset}
+              disabled={isSaving}
+              onClick={() => {
+                void persistMinutes(preset);
+              }}
+              className={expectedOptionClass(minutes === preset)}
+            >
+              {preset}m
+            </button>
+          ))}
+
+          {isCustomEditing ? (
+            <Input
+              ref={customInputRef}
+              data-testid="estimated-time-custom-input"
+              value={customDraft}
+              disabled={isSaving}
+              onChange={(event) => {
+                setCustomDraft(event.target.value.replace(/[^\d]/g, ''));
+              }}
+              onBlur={() => applyCustomMinutes(customDraft)}
+              onKeyDown={handleCustomInputKeyDown}
+              aria-label="自定义估时分钟（Custom estimated minutes）"
+              placeholder="分钟"
+              className="relative z-10 h-8 w-full border-transparent bg-transparent px-[6px] text-center text-[12px] font-semibold leading-none text-[#1C1917] shadow-none outline-none ring-0 focus-visible:ring-0 dark:text-[#FAFAF9]"
+            />
+          ) : (
+            <button
+              type="button"
+              data-testid="estimated-time-custom-trigger"
+              aria-pressed={isCustomSelected}
+              disabled={isSaving}
+              onClick={openCustomEditor}
+              className={`relative z-10 flex h-8 w-full items-center justify-center gap-1 whitespace-nowrap rounded-[8px] px-[8px] text-[12px] transition-colors duration-200 ${
+                isCustomSelected
+                  ? 'font-semibold text-[#1C1917] dark:text-[#FAFAF9]'
+                  : 'text-[#C75B3A] hover:text-[#B24D2F]'
+              }`}
+              aria-label="自定义估时（Custom estimated minutes）"
+            >
+              <ChevronDown size={12} className="transition-transform" />
+              {isCustomSelected ? `${minutes}m` : '自定义'}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {errorMessage ? (
+        <p role="alert" className="text-xs text-[#B91C1C] dark:text-[#FCA5A5]">
+          {errorMessage}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/ui/app/components/EstimatedTimeEditor.tsx
+++ b/src/ui/app/components/EstimatedTimeEditor.tsx
@@ -41,6 +41,7 @@ export function EstimatedTimeEditor({
   currentMinutes,
   onUpdate,
 }: EstimatedTimeEditorProps) {
+  const activeTaskIdRef = useRef(taskId);
   const [minutes, setMinutes] = useState<number | undefined>(currentMinutes);
   const [customDraft, setCustomDraft] = useState(currentMinutes ? String(currentMinutes) : '');
   const [isCustomEditing, setIsCustomEditing] = useState(false);
@@ -49,9 +50,13 @@ export function EstimatedTimeEditor({
   const customInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
+    activeTaskIdRef.current = taskId;
     setMinutes(currentMinutes);
     setCustomDraft(currentMinutes ? String(currentMinutes) : '');
-  }, [currentMinutes]);
+    setIsCustomEditing(false);
+    setErrorMessage(null);
+    setIsSaving(false);
+  }, [currentMinutes, taskId]);
 
   useEffect(() => {
     if (!isCustomEditing) return;
@@ -74,22 +79,26 @@ export function EstimatedTimeEditor({
   const isCustomSelected = minutes !== undefined && !isPresetEstimatedMinutes(minutes);
 
   async function persistMinutes(nextMinutes: number | undefined): Promise<void> {
+    const requestTaskId = taskId;
     setIsSaving(true);
     setErrorMessage(null);
 
     try {
-      const updated = await getTaskService().updateTask(taskId, { estimatedMinutes: nextMinutes });
+      const updated = await getTaskService().updateTask(requestTaskId, { estimatedMinutes: nextMinutes });
       if (!updated) {
         throw new Error('当前任务不存在，估时未保存');
       }
+      if (activeTaskIdRef.current !== requestTaskId) return;
 
       setMinutes(nextMinutes);
       setCustomDraft(nextMinutes ? String(nextMinutes) : '');
       setIsCustomEditing(false);
       onUpdate?.(nextMinutes);
     } catch (error) {
+      if (activeTaskIdRef.current !== requestTaskId) return;
       setErrorMessage(error instanceof Error ? error.message : '估时保存失败，请稍后重试');
     } finally {
+      if (activeTaskIdRef.current !== requestTaskId) return;
       setIsSaving(false);
     }
   }

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeft, Ellipsis, Pause, Play } from 'lucide-react';
 import { Link, useNavigate, useParams } from '@tanstack/react-router';
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { getTaskService, getTaskTimerService, getTimeBlockService } from '@/lib/services';
 import type { TaskNode } from '@/lib/types/task';
 import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
@@ -9,6 +9,7 @@ import { useIsDesktop } from '@/ui/app/hooks/useIsDesktop';
 import { getUseMockDataEnabled } from '@/config/mock-data';
 import { buildTaskGraph } from '@/lib/task/task-dag-graph';
 import { TaskCurrentRootCard } from '@/ui/app/components/TaskCurrentRootCard';
+import { EstimatedTimeEditor } from '@/ui/app/components/EstimatedTimeEditor';
 import {
   buildTaskTimeblockDetailViewModel,
   type TimeblockEventLog,
@@ -457,6 +458,8 @@ function MobileTimeblockDetail({
   onPauseAndGoEventlog,
   onCopySummary,
   rootGuidance,
+  canEditEstimatedTime,
+  onEstimatedMinutesUpdate,
   onDependencySelectedTaskChange,
   onDependencySelectedTypeChange,
   onAddDependency,
@@ -480,6 +483,8 @@ function MobileTimeblockDetail({
   onPauseAndGoEventlog: () => void;
   onCopySummary: () => void;
   rootGuidance?: ReactNode;
+  canEditEstimatedTime: boolean;
+  onEstimatedMinutesUpdate: (minutes: number | undefined) => void;
   onDependencySelectedTaskChange: (value: string) => void;
   onDependencySelectedTypeChange: (value: DependencyType) => void;
   onAddDependency: () => void;
@@ -518,6 +523,13 @@ function MobileTimeblockDetail({
           </div>
           <h2 className="mt-3 text-base font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{model.summary.blockName}</h2>
           <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">关联任务：{task.title}</p>
+          {canEditEstimatedTime ? (
+            <EstimatedTimeEditor
+              taskId={task.id}
+              currentMinutes={task.estimatedMinutes}
+              onUpdate={onEstimatedMinutesUpdate}
+            />
+          ) : null}
           <div className="mt-3 grid grid-cols-2 gap-2">
             {model.summary.metrics.map((metric) => (
               <div key={metric.key} className="rounded-xl bg-[#F8F5F2] px-3 py-2 dark:bg-[#292524]">
@@ -669,6 +681,8 @@ function DesktopTimeblockDetail({
   onPauseAndGoEventlog,
   onCopySummary,
   rootGuidance,
+  canEditEstimatedTime,
+  onEstimatedMinutesUpdate,
   onDependencySelectedTaskChange,
   onDependencySelectedTypeChange,
   onAddDependency,
@@ -692,6 +706,8 @@ function DesktopTimeblockDetail({
   onPauseAndGoEventlog: () => void;
   onCopySummary: () => void;
   rootGuidance?: ReactNode;
+  canEditEstimatedTime: boolean;
+  onEstimatedMinutesUpdate: (minutes: number | undefined) => void;
   onDependencySelectedTaskChange: (value: string) => void;
   onDependencySelectedTypeChange: (value: DependencyType) => void;
   onAddDependency: () => void;
@@ -724,6 +740,13 @@ function DesktopTimeblockDetail({
             </div>
           ))}
         </div>
+        {canEditEstimatedTime ? (
+          <EstimatedTimeEditor
+            taskId={task.id}
+            currentMinutes={task.estimatedMinutes}
+            onUpdate={onEstimatedMinutesUpdate}
+          />
+        ) : null}
       </section>
 
       <section className="mt-4 grid grid-cols-[minmax(0,1fr)_340px] gap-4">
@@ -971,6 +994,10 @@ export function TaskDetailPage() {
   const rootGuidance = useMemo(() => (
     <TaskCurrentRootCard graph={taskGraph} taskById={taskById} currentTaskId={task?.id} />
   ), [task?.id, taskById, taskGraph]);
+  const canEditEstimatedTime = useMemo(
+    () => (task ? allTasks.some((candidate) => candidate.id === task.id) : false),
+    [allTasks, task],
+  );
 
   const dependencyView = useMemo(() => {
     if (!task) return null;
@@ -1092,6 +1119,27 @@ export function TaskDetailPage() {
     }
   };
 
+  const handleEstimatedMinutesUpdate = useCallback((minutes: number | undefined) => {
+    const updatedAt = Date.now();
+    setTask((current) => {
+      if (!current) return current;
+      return {
+        ...current,
+        estimatedMinutes: minutes,
+        updatedAt,
+      };
+    });
+    setAllTasks((current) => current.map((candidate) => (
+      candidate.id === task?.id
+        ? {
+            ...candidate,
+            estimatedMinutes: minutes,
+            updatedAt,
+          }
+        : candidate
+    )));
+  }, [task?.id]);
+
   if (isLoading) {
     return (
       <div className="min-h-full bg-[#FAF7F5] px-6 py-6 dark:bg-[#0C0A09]">
@@ -1131,9 +1179,11 @@ export function TaskDetailPage() {
         onPauseAndGoEventlog={handlePauseAndGoEventlog}
         onCopySummary={handleCopySummary}
         rootGuidance={rootGuidance}
+        canEditEstimatedTime={canEditEstimatedTime}
+        onEstimatedMinutesUpdate={handleEstimatedMinutesUpdate}
         onDependencySelectedTaskChange={setDependencySelectedTaskId}
         onDependencySelectedTypeChange={setDependencySelectedType}
-          onAddDependency={handleAddDependency}
+        onAddDependency={handleAddDependency}
           onChangeDependencyType={handleChangeDependencyType}
           onRemoveDependency={handleRemoveDependency}
           onToggleCollapseUpstream={handleToggleCollapseUpstream}
@@ -1159,6 +1209,8 @@ export function TaskDetailPage() {
       onPauseAndGoEventlog={handlePauseAndGoEventlog}
       onCopySummary={handleCopySummary}
       rootGuidance={rootGuidance}
+      canEditEstimatedTime={canEditEstimatedTime}
+      onEstimatedMinutesUpdate={handleEstimatedMinutesUpdate}
       onDependencySelectedTaskChange={setDependencySelectedTaskId}
       onDependencySelectedTypeChange={setDependencySelectedType}
       onAddDependency={handleAddDependency}

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -1120,9 +1120,12 @@ export function TaskDetailPage() {
   };
 
   const handleEstimatedMinutesUpdate = useCallback((minutes: number | undefined) => {
+    const sourceTaskId = task?.id;
+    if (!sourceTaskId) return;
+
     const updatedAt = Date.now();
     setTask((current) => {
-      if (!current) return current;
+      if (!current || current.id !== sourceTaskId) return current;
       return {
         ...current,
         estimatedMinutes: minutes,
@@ -1130,7 +1133,7 @@ export function TaskDetailPage() {
       };
     });
     setAllTasks((current) => current.map((candidate) => (
-      candidate.id === task?.id
+      candidate.id === sourceTaskId
         ? {
             ...candidate,
             estimatedMinutes: minutes,

--- a/tests/unit/ui/estimated-time-editor.issue384.test.tsx
+++ b/tests/unit/ui/estimated-time-editor.issue384.test.tsx
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { TaskNode } from '@/lib/types/task';
+import { EstimatedTimeEditor } from '@/ui/app/components/EstimatedTimeEditor';
+
+const updateTaskMock = vi.fn<(taskId: string, input: { estimatedMinutes?: number }) => Promise<TaskNode | null>>();
+
+vi.mock('@/lib/services', () => ({
+  getTaskService: () => ({
+    updateTask: updateTaskMock,
+  }),
+}));
+
+function makeTask(overrides: Partial<TaskNode> = {}): TaskNode {
+  return {
+    id: 'task-1',
+    title: '补 EstimatedTimeEditor',
+    status: 'not_started',
+    priority: 'medium',
+    dependsOn: [],
+    tags: ['issue-384'],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('EstimatedTimeEditor issue #384', () => {
+  beforeEach(() => {
+    updateTaskMock.mockReset();
+    updateTaskMock.mockResolvedValue(makeTask());
+  });
+
+  it('renders current estimatedMinutes and highlights current preset（显示当前估时并高亮预设）', () => {
+    render(<EstimatedTimeEditor taskId="task-1" currentMinutes={25} />);
+
+    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：25 分钟');
+    expect(screen.getByTestId('estimated-time-preset-25')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('clicking a preset updates the estimatedMinutes（点击预设更新估时）', async () => {
+    render(<EstimatedTimeEditor taskId="task-1" currentMinutes={25} />);
+
+    fireEvent.click(screen.getByTestId('estimated-time-preset-45'));
+
+    await waitFor(() => {
+      expect(updateTaskMock).toHaveBeenCalledWith('task-1', { estimatedMinutes: 45 });
+    });
+
+    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：45 分钟');
+    expect(screen.getByTestId('estimated-time-preset-45')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('custom input updates the estimatedMinutes（自定义输入更新估时）', async () => {
+    render(<EstimatedTimeEditor taskId="task-1" />);
+
+    fireEvent.click(screen.getByTestId('estimated-time-custom-trigger'));
+    fireEvent.change(screen.getByTestId('estimated-time-custom-input'), { target: { value: '90' } });
+    fireEvent.keyDown(screen.getByTestId('estimated-time-custom-input'), { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(updateTaskMock).toHaveBeenCalledWith('task-1', { estimatedMinutes: 90 });
+    });
+
+    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：90 分钟');
+    expect(screen.getByTestId('estimated-time-custom-trigger')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('clear resets the value to undefined（清空估时）', async () => {
+    render(<EstimatedTimeEditor taskId="task-1" currentMinutes={60} />);
+
+    fireEvent.click(screen.getByTestId('estimated-time-clear'));
+
+    await waitFor(() => {
+      expect(updateTaskMock).toHaveBeenCalledWith('task-1', { estimatedMinutes: undefined });
+    });
+
+    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：未估时');
+    expect(screen.getByTestId('estimated-time-clear')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('calls onUpdate after successful save（保存成功后回调 onUpdate）', async () => {
+    const onUpdate = vi.fn();
+    render(<EstimatedTimeEditor taskId="task-1" onUpdate={onUpdate} />);
+
+    fireEvent.click(screen.getByTestId('estimated-time-preset-15'));
+
+    await waitFor(() => {
+      expect(updateTaskMock).toHaveBeenCalledWith('task-1', { estimatedMinutes: 15 });
+    });
+
+    expect(onUpdate).toHaveBeenCalledWith(15);
+  });
+});

--- a/tests/unit/ui/task-detail-page.estimated-time-race.issue384.test.tsx
+++ b/tests/unit/ui/task-detail-page.estimated-time-race.issue384.test.tsx
@@ -1,0 +1,170 @@
+import type { ReactNode } from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskDetailPage } from '@/ui/app/pages/TaskDetailPage';
+import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
+import type { TaskNode } from '@/lib/types/task';
+
+let routeTaskId = 'task-1';
+
+const navigateMock = vi.fn();
+const getTaskMock = vi.fn<(id: string) => Promise<TaskNode | null>>();
+const listTasksMock = vi.fn<(includeAbandoned?: boolean) => Promise<TaskNode[]>>();
+const updateTaskMock = vi.fn<(id: string, input: { estimatedMinutes?: number }) => Promise<TaskNode | null>>();
+const onTaskChangeMock = vi.fn(() => () => {});
+
+const loadTimeBlocksMock = vi.fn<() => Promise<TimeBlock[]>>();
+const loadActiveBlockMock = vi.fn<() => Promise<ActiveBlockData | null>>();
+const onBlockChangeMock = vi.fn(() => () => {});
+
+const getEventsMock = vi.fn<
+  () => Promise<Array<{ id: string; content: string; createdAt: string; type?: string }>>
+>();
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+  useParams: () => ({ taskId: routeTaskId }),
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock('@/lib/services', () => ({
+  getTaskService: () => ({
+    getTask: getTaskMock,
+    listTasks: listTasksMock,
+    addDependency: vi.fn(),
+    removeDependency: vi.fn(),
+    getAvailableTransitions: vi.fn(),
+    getChildTasks: vi.fn(async () => []),
+    checkDependenciesMet: vi.fn(async () => ({ met: true, blocking: [] })),
+    onTaskChange: onTaskChangeMock,
+    transitionTask: vi.fn(),
+    updateTask: updateTaskMock,
+    abandonTask: vi.fn(),
+  }),
+  getTimeBlockService: () => ({
+    loadTimeBlocks: loadTimeBlocksMock,
+    loadActiveBlock: loadActiveBlockMock,
+    onBlockChange: onBlockChangeMock,
+    pauseBlock: vi.fn(async () => undefined),
+  }),
+  getTaskTimerService: () => ({
+    calculateSpentMinutes: vi.fn(async () => 0),
+    startBlockForTask: vi.fn(async () => undefined),
+  }),
+}));
+
+vi.mock('@/lib/storage/event-storage', () => ({
+  getEventStorage: () => ({
+    getEvents: getEventsMock,
+  }),
+}));
+
+function makeTask(overrides: Partial<TaskNode> = {}): TaskNode {
+  return {
+    id: 'task-1',
+    title: '任务 A',
+    description: 'A desc',
+    status: 'in_progress',
+    priority: 'high',
+    dependsOn: [],
+    tags: [],
+    estimatedMinutes: 60,
+    createdAt: 10,
+    updatedAt: 10,
+    ...overrides,
+  };
+}
+
+function mockMatchMedia(matches: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation(() => ({
+      matches,
+      media: '(min-width: 768px)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('TaskDetailPage estimated minutes race issue #384', () => {
+  beforeEach(() => {
+    routeTaskId = 'task-1';
+    navigateMock.mockReset();
+    onTaskChangeMock.mockClear();
+
+    const taskA = makeTask({ id: 'task-1', title: '任务 A', estimatedMinutes: 60, updatedAt: 10 });
+    const taskB = makeTask({ id: 'task-2', title: '任务 B', estimatedMinutes: 30, updatedAt: 20 });
+
+    getTaskMock.mockReset();
+    getTaskMock.mockImplementation(async (id) => {
+      if (id === 'task-1') return structuredClone(taskA);
+      if (id === 'task-2') return structuredClone(taskB);
+      return null;
+    });
+
+    listTasksMock.mockReset();
+    listTasksMock.mockResolvedValue([structuredClone(taskA), structuredClone(taskB)]);
+
+    updateTaskMock.mockReset();
+
+    loadTimeBlocksMock.mockReset();
+    loadTimeBlocksMock.mockResolvedValue([]);
+    loadActiveBlockMock.mockReset();
+    loadActiveBlockMock.mockResolvedValue(null);
+    onBlockChangeMock.mockClear();
+
+    getEventsMock.mockReset();
+    getEventsMock.mockResolvedValue([]);
+
+    mockMatchMedia(false);
+  });
+
+  it('does not let stale save response overwrite current task display（旧响应不污染当前任务估时显示）', async () => {
+    const pendingSave = createDeferred<TaskNode | null>();
+    updateTaskMock.mockImplementation(async (id, input) => {
+      if (id === 'task-1' && input.estimatedMinutes === 45) {
+        return pendingSave.promise;
+      }
+      return makeTask({ id, estimatedMinutes: input.estimatedMinutes, updatedAt: Date.now() });
+    });
+
+    const view = render(<TaskDetailPage />);
+
+    await screen.findByText('关联任务：任务 A');
+    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：60 分钟');
+
+    fireEvent.click(screen.getByTestId('estimated-time-preset-45'));
+
+    await waitFor(() => {
+      expect(updateTaskMock).toHaveBeenCalledWith('task-1', { estimatedMinutes: 45 });
+    });
+
+    routeTaskId = 'task-2';
+    view.rerender(<TaskDetailPage />);
+
+    await screen.findByText('关联任务：任务 B');
+    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：30 分钟');
+
+    await act(async () => {
+      pendingSave.resolve(makeTask({ id: 'task-1', title: '任务 A', estimatedMinutes: 45, updatedAt: 999 }));
+      await pendingSave.promise;
+    });
+
+    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：30 分钟');
+  });
+});


### PR DESCRIPTION
## Summary
- add `EstimatedTimeEditor` for editing task `estimatedMinutes`
- support preset buttons `15 / 25 / 45 / 60`, custom positive integer input, and clear-to-undefined
- mount the editor in TaskDetailPage metadata/summary area only, without touching timer controls or dependency editor scopes
- fix stale async response race: delayed save from task A no longer overrides task B display after route switch
- add page-level regression test for issue #384 race condition

## Validation
- `npx vitest run tests/unit/ui/task-detail-page.estimated-time-race.issue384.test.tsx`
- `npx vitest run tests/unit/ui/estimated-time-editor.issue384.test.tsx tests/unit/ui/task-detail-page.timeblock-detail.test.tsx tests/unit/ui/task-detail-page.dependencies.issue398.test.tsx tests/unit/ui/task-detail-page.dag-visibility.issue395.test.tsx`
- `npx tsc --noEmit`
- `bun run build`

## Notes
- closes #384
- Track B only; no changes to timer control area, dependency editor area, DAG/visibility scope, or `task.service.ts`