### PR TITLE
feat(task): add context-aware back link in timeblock detail

### DIFF
--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -29,6 +29,22 @@ import { TimerConfigPanel } from '@/ui/app/components/TimerConfigPanel';
 import { useTimerConfig } from '@/ui/app/hooks/useTimerConfig';
 
 type DependencyType = 'soft' | 'hard';
+type TimeblockSourceTab = 'now' | 'today' | 'week' | 'month';
+
+const TIMEBLOCK_SOURCE_LABEL: Record<TimeblockSourceTab, string> = {
+  now: '当下',
+  today: '今日',
+  week: '一周',
+  month: '本月',
+};
+
+interface TimeblockSourceBackLink {
+  to: string;
+  search?: Record<string, string>;
+  label: string;
+  breadcrumb: string;
+  sourceLabel: string;
+}
 
 function badgeClassName(badge: TimeblockBadge): string {
   if (badge.tone === 'success') return 'bg-[#DCFCE7] text-[#15803D]';
@@ -77,6 +93,31 @@ function resolvePreferredBlockId(): string | undefined {
   return fromHash || undefined;
 }
 
+function resolveTimeblockSourceBackLink(): TimeblockSourceBackLink {
+  if (typeof window === 'undefined') {
+    return {
+      to: '/tasks',
+      label: '← 返回任务',
+      breadcrumb: '任务 > 时间块详情',
+      sourceLabel: '任务',
+    };
+  }
+
+  const searchParams = new URLSearchParams(window.location.search);
+  const from = searchParams.get('from')?.trim() as TimeblockSourceTab | undefined;
+  const isKnownSource = Boolean(from && from in TIMEBLOCK_SOURCE_LABEL);
+  const sourceTab = isKnownSource ? from : undefined;
+  const sourceLabel = sourceTab ? TIMEBLOCK_SOURCE_LABEL[sourceTab] : '任务';
+
+  return {
+    to: '/tasks',
+    search: sourceTab ? { tab: sourceTab } : undefined,
+    label: `← 返回${sourceLabel}`,
+    breadcrumb: sourceTab ? `任务 > ${sourceLabel} > 时间块详情` : '任务 > 时间块详情',
+    sourceLabel,
+  };
+}
+
 function buildVirtualTaskFromBlock(block: TimeBlock): TaskNode {
   const estimatedMinutes = Math.max(1, Math.round((block.endTime - block.startTime) / 60_000));
   return {
@@ -109,15 +150,17 @@ function DetailActionsCard({
       <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">操作</h3>
       <div className="mt-3 space-y-2">
         {model.actions.map((action) => {
-          if (action.id === 'open-task' || action.id === 'open-eventlog') {
+          if (action.id === 'back-source' || action.id === 'open-task' || action.id === 'open-eventlog') {
             return (
               <Link
                 key={action.id}
                 to={action.to!}
+                search={action.search}
                 className="flex w-full items-center justify-between rounded-xl border border-[#E7E5E4] px-3 py-2 text-sm text-[#44403C] transition-colors hover:bg-[#FAF7F5] dark:border-[#292524] dark:text-[#E7E5E4] dark:hover:bg-[#292524]"
+                data-testid={action.id === 'back-source' ? 'timeblock-action-back-link' : undefined}
               >
                 <span>{action.label}</span>
-                <span className="text-xs text-[#A8A29E]">打开</span>
+                <span className="text-xs text-[#A8A29E]">{action.id === 'back-source' ? '返回' : '打开'}</span>
               </Link>
             );
           }
@@ -454,6 +497,7 @@ function DependencyCard({
 function MobileTimeblockDetail({
   task,
   model,
+  backLink,
   dependencyView,
   taskDagView,
   dependencySelectedTaskId,
@@ -476,6 +520,7 @@ function MobileTimeblockDetail({
 }: {
   task: TaskNode;
   model: TaskTimeblockDetailViewModel;
+  backLink: TimeblockSourceBackLink;
   dependencyView: TaskDependencyViewModel;
   taskDagView: TaskDagDetailView | null;
   dependencySelectedTaskId: string;
@@ -498,18 +543,29 @@ function MobileTimeblockDetail({
 }) {
   return (
     <div className="min-h-full bg-[#FAF7F5] pb-10 dark:bg-[#0C0A09]" data-testid="new-task-detail-page">
-      <header className="sticky top-0 z-10 flex items-center justify-between border-b border-[#F0ECE8] bg-[#FAF7F5]/95 px-4 py-3 backdrop-blur dark:border-[#292524] dark:bg-[#0C0A09]/95">
+      <header className="sticky top-0 z-10 flex items-start justify-between gap-3 border-b border-[#F0ECE8] bg-[#FAF7F5]/95 px-4 py-3 backdrop-blur dark:border-[#292524] dark:bg-[#0C0A09]/95">
         <Link
-          to="/tasks"
+          to={backLink.to}
+          search={backLink.search}
           className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
-          aria-label="返回任务列表（Back to tasks）"
+          aria-label={`返回${backLink.sourceLabel}`}
         >
           <ArrowLeft size={16} />
         </Link>
-        <h1 className="text-base font-semibold text-[#1C1917] dark:text-[#FAFAF9]">时间块详情</h1>
+        <div className="min-w-0 flex-1 pt-0.5">
+          <h1 className="text-base font-semibold text-[#1C1917] dark:text-[#FAFAF9]">时间块详情</h1>
+          <Link
+            to={backLink.to}
+            search={backLink.search}
+            className="mt-1 inline-flex text-xs font-medium text-[#78716C] underline-offset-2 hover:underline dark:text-[#A8A29E]"
+            data-testid="timeblock-back-link-mobile"
+          >
+            {backLink.label}
+          </Link>
+        </div>
         <button
           type="button"
-          className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
+          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
           aria-label="更多操作（More actions）"
         >
           <Ellipsis size={16} />
@@ -645,6 +701,7 @@ function MobileTimeblockDetail({
 function DesktopTimeblockDetail({
   task,
   model,
+  backLink,
   dependencyView,
   taskDagView,
   dependencySelectedTaskId,
@@ -667,6 +724,7 @@ function DesktopTimeblockDetail({
 }: {
   task: TaskNode;
   model: TaskTimeblockDetailViewModel;
+  backLink: TimeblockSourceBackLink;
   dependencyView: TaskDependencyViewModel;
   taskDagView: TaskDagDetailView | null;
   dependencySelectedTaskId: string;
@@ -690,9 +748,19 @@ function DesktopTimeblockDetail({
   return (
     <div className="min-h-full bg-[#FAF7F5] px-8 py-6 dark:bg-[#0C0A09]" data-testid="new-task-detail-page">
       <header className="rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]">
-        <p className="text-xs text-[#A8A29E]">任务 &gt; 今日 &gt; 时间块详情</p>
+        <p className="text-xs text-[#A8A29E]">{backLink.breadcrumb}</p>
         <div className="mt-2 flex items-center justify-between gap-3">
-          <h1 className="text-2xl font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{model.summary.blockName}</h1>
+          <div className="min-w-0">
+            <h1 className="text-2xl font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{model.summary.blockName}</h1>
+            <Link
+              to={backLink.to}
+              search={backLink.search}
+              className="mt-2 inline-flex text-sm font-medium text-[#78716C] underline-offset-2 hover:underline dark:text-[#A8A29E]"
+              data-testid="timeblock-back-link-desktop"
+            >
+              {backLink.label}
+            </Link>
+          </div>
           <div className="flex flex-wrap items-center gap-2">
             {model.summary.badges.map((badge) => (
               <span key={badge.label} className={`rounded-full px-3 py-1 text-xs font-semibold ${badgeClassName(badge)}`}>
@@ -817,6 +885,7 @@ export function TaskDetailPage() {
   const navigate = useNavigate();
   const isDesktop = useIsDesktop();
   const preferredBlockId = blockIdParam || resolvePreferredBlockId();
+  const backLink = resolveTimeblockSourceBackLink();
 
   const [task, setTask] = useState<TaskNode | null>(null);
   const [timeBlocks, setTimeBlocks] = useState<TimeBlock[]>([]);
@@ -954,8 +1023,13 @@ export function TaskDetailPage() {
       eventLogs,
       reviewMarkdown,
       useMockData: getUseMockDataEnabled(),
+      backAction: {
+        label: backLink.label,
+        to: backLink.to,
+        search: backLink.search,
+      },
     });
-  }, [activeBlock, eventLogs, preferredBlockId, reviewMarkdown, task, timeBlocks]);
+  }, [activeBlock, backLink.label, backLink.search, backLink.to, eventLogs, preferredBlockId, reviewMarkdown, task, timeBlocks]);
 
   const taskGraph = useMemo(() => buildTaskGraph(allTasks), [allTasks]);
   const taskById = useMemo(() => new Map(allTasks.map((candidate) => [candidate.id, candidate])), [allTasks]);
@@ -1107,9 +1181,9 @@ export function TaskDetailPage() {
   if (!task || !viewModel || !dependencyView) {
     return (
       <div className="min-h-full bg-[#FAF7F5] px-6 py-6 dark:bg-[#0C0A09]">
-        <Link to="/tasks" className="inline-flex items-center gap-1 text-sm text-[#78716C] dark:text-[#A8A29E]">
+        <Link to={backLink.to} search={backLink.search} className="inline-flex items-center gap-1 text-sm text-[#78716C] dark:text-[#A8A29E]">
           <ArrowLeft size={16} />
-          返回任务
+          {backLink.label.replace('← ', '')}
         </Link>
         <p className="mt-3 text-sm text-[#A8A29E]">任务不存在</p>
       </div>
@@ -1121,6 +1195,7 @@ export function TaskDetailPage() {
       <DesktopTimeblockDetail
         task={task}
         model={viewModel}
+        backLink={backLink}
         dependencyView={dependencyView}
         taskDagView={taskDagView}
         dependencySelectedTaskId={dependencySelectedTaskId}
@@ -1148,6 +1223,7 @@ export function TaskDetailPage() {
     <MobileTimeblockDetail
       task={task}
       model={viewModel}
+      backLink={backLink}
       dependencyView={dependencyView}
       taskDagView={taskDagView}
       dependencySelectedTaskId={dependencySelectedTaskId}

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -38,6 +38,10 @@ const TIMEBLOCK_SOURCE_LABEL: Record<TimeblockSourceTab, string> = {
   month: '本月',
 };
 
+function isTimeblockSourceTab(value: string): value is TimeblockSourceTab {
+  return Object.prototype.hasOwnProperty.call(TIMEBLOCK_SOURCE_LABEL, value);
+}
+
 interface TimeblockSourceBackLink {
   to: string;
   search?: Record<string, string>;
@@ -104,9 +108,8 @@ function resolveTimeblockSourceBackLink(): TimeblockSourceBackLink {
   }
 
   const searchParams = new URLSearchParams(window.location.search);
-  const from = searchParams.get('from')?.trim() as TimeblockSourceTab | undefined;
-  const isKnownSource = Boolean(from && from in TIMEBLOCK_SOURCE_LABEL);
-  const sourceTab = isKnownSource ? from : undefined;
+  const from = searchParams.get('from')?.trim();
+  const sourceTab = from && isTimeblockSourceTab(from) ? from : undefined;
   const sourceLabel = sourceTab ? TIMEBLOCK_SOURCE_LABEL[sourceTab] : '任务';
 
   return {

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -318,6 +318,7 @@ export function TasksPage() {
                               key={item.id}
                               to="/tasks/block/$blockId"
                               params={{ blockId: item.blockId }}
+                              search={{ from: activeTab }}
                               data-testid={`tasks-today-block-link-${item.blockId}`}
                               className="block"
                             >

--- a/src/ui/app/pages/task-timeblock-detail-view.ts
+++ b/src/ui/app/pages/task-timeblock-detail-view.ts
@@ -57,9 +57,10 @@ export interface TimeblockAiSummary {
 }
 
 export interface TimeblockActionItem {
-  id: 'open-task' | 'open-eventlog' | 'restart' | 'copy-summary';
+  id: 'back-source' | 'open-task' | 'open-eventlog' | 'restart' | 'copy-summary';
   label: string;
   to?: string;
+  search?: Record<string, string>;
 }
 
 export interface TimeblockEventLog {
@@ -87,6 +88,11 @@ export interface BuildTaskTimeblockDetailViewModelInput {
   reviewMarkdown?: string;
   useMockData?: boolean;
   now?: Date;
+  backAction?: {
+    label: string;
+    to: string;
+    search?: Record<string, string>;
+  };
 }
 
 const STATUS_BADGE_LABEL: Record<TaskNode['status'], string> = {
@@ -399,6 +405,15 @@ export function buildTaskTimeblockDetailViewModel(input: BuildTaskTimeblockDetai
     { key: 'expected', label: '预期', value: input.task.estimatedMinutes ? formatMinutes(input.task.estimatedMinutes) : '未估时' },
     { key: 'event_count', label: '事件数', value: `${timeline.items.length}` },
   ];
+  const actions: TimeblockActionItem[] = [
+    ...(input.backAction
+      ? [{ id: 'back-source', label: input.backAction.label, to: input.backAction.to, search: input.backAction.search } as const]
+      : []),
+    { id: 'open-task', label: '查看关联任务', to: `/tasks/${input.task.id}` },
+    { id: 'open-eventlog', label: '打开 EventLog', to: '/eventlog' },
+    { id: 'restart', label: '再来一个时间块' },
+    { id: 'copy-summary', label: '复制总结' },
+  ];
 
   return {
     summary: {
@@ -416,11 +431,6 @@ export function buildTaskTimeblockDetailViewModel(input: BuildTaskTimeblockDetai
     planActual: buildPlanActual(input.task, block, scheduleBadge),
     timeline,
     aiSummary,
-    actions: [
-      { id: 'open-task', label: '查看关联任务', to: `/tasks/${input.task.id}` },
-      { id: 'open-eventlog', label: '打开 EventLog', to: '/eventlog' },
-      { id: 'restart', label: '再来一个时间块' },
-      { id: 'copy-summary', label: '复制总结' },
-    ],
+    actions,
   };
 }

--- a/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
+++ b/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
@@ -198,6 +198,7 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
   });
 
   it('renders desktop two-column timeblock detail（桌面端双列时间块详情）', async () => {
+    window.history.replaceState({}, '', '/tasks/block/block-1?from=today');
     mockMatchMedia(true);
     render(<TaskDetailPage />);
 

--- a/tests/unit/ui/timeblock-detail-back-link.issue406.test.tsx
+++ b/tests/unit/ui/timeblock-detail-back-link.issue406.test.tsx
@@ -1,0 +1,223 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { TaskDetailPage } from '@/ui/app/pages/TaskDetailPage';
+import { buildTaskTimeblockDetailViewModel } from '@/ui/app/pages/task-timeblock-detail-view';
+import type { TaskNode } from '@/lib/types/task';
+import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
+
+const navigateMock = vi.fn();
+
+const listTasksMock = vi.fn<(includeAbandoned?: boolean) => Promise<TaskNode[]>>();
+const loadTimeBlocksMock = vi.fn<() => Promise<TimeBlock[]>>();
+const loadActiveBlockMock = vi.fn<() => Promise<ActiveBlockData | null>>();
+const onBlockChangeMock = vi.fn(() => () => {});
+const onTaskChangeMock = vi.fn(() => () => {});
+const getEventsMock = vi.fn<
+  () => Promise<Array<{ id: string; content: string; createdAt: string; type?: string }>>
+>();
+
+function resolveHref(
+  to: string | undefined,
+  params?: Record<string, string>,
+  search?: Record<string, unknown>,
+): string {
+  let href = to ?? '';
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      href = href.replace(`$${key}`, encodeURIComponent(value));
+    }
+  }
+  if (search) {
+    const query = new URLSearchParams();
+    for (const [key, value] of Object.entries(search)) {
+      if (value == null) continue;
+      query.set(key, String(value));
+    }
+    const queryText = query.toString();
+    if (queryText) {
+      href = `${href}?${queryText}`;
+    }
+  }
+  return href;
+}
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    to,
+    params,
+    search,
+    ...props
+  }: {
+    children: ReactNode;
+    to?: string;
+    params?: Record<string, string>;
+    search?: Record<string, unknown>;
+  }) => (
+    <a href={resolveHref(to, params, search)} {...props}>
+      {children}
+    </a>
+  ),
+  useParams: () => ({ blockId: 'block-1' }),
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock('@/lib/services', () => ({
+  getTaskService: () => ({
+    getTask: vi.fn(async () => null),
+    listTasks: listTasksMock,
+    addDependency: vi.fn(),
+    removeDependency: vi.fn(),
+    getAvailableTransitions: vi.fn(async () => ['in_progress']),
+    getChildTasks: vi.fn(async () => []),
+    checkDependenciesMet: vi.fn(async () => ({ met: true, blocking: [] })),
+    onTaskChange: onTaskChangeMock,
+    transitionTask: vi.fn(),
+    updateTask: vi.fn(),
+    abandonTask: vi.fn(),
+  }),
+  getTimeBlockService: () => ({
+    loadTimeBlocks: loadTimeBlocksMock,
+    loadActiveBlock: loadActiveBlockMock,
+    onBlockChange: onBlockChangeMock,
+    pauseBlock: vi.fn(async () => {}),
+  }),
+  getTaskTimerService: () => ({
+    calculateSpentMinutes: vi.fn(async () => 90),
+    startBlockForTask: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/storage/event-storage', () => ({
+  getEventStorage: () => ({
+    getEvents: getEventsMock,
+  }),
+}));
+
+function mockMatchMedia(matches: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation(() => ({
+      matches,
+      media: '(min-width: 768px)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+function makeTask(overrides: Partial<TaskNode> = {}): TaskNode {
+  return {
+    id: 'task-1',
+    title: '深度工作：返回来源上下文',
+    description: '验证时间块详情返回链接',
+    status: 'completed',
+    priority: 'high',
+    dependsOn: [],
+    tags: ['frontend'],
+    estimatedMinutes: 90,
+    timeBlockIds: ['block-1'],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeBlock(overrides: Partial<TimeBlock> = {}): TimeBlock {
+  const start = new Date('2026-03-06T09:00:00+08:00').getTime();
+  const end = new Date('2026-03-06T10:30:00+08:00').getTime();
+  return {
+    id: 'block-1',
+    startId: 'block-1',
+    endId: 'block-1-end',
+    name: '深度工作：返回来源上下文',
+    note: '补上返回入口',
+    tags: new Set(['block_feedback']),
+    startTime: start,
+    endTime: end,
+    ...overrides,
+  };
+}
+
+function renderDetail(search = '', isDesktop = false): void {
+  window.history.replaceState({}, '', `/tasks/block/block-1${search}`);
+  mockMatchMedia(isDesktop);
+  render(<TaskDetailPage />);
+}
+
+describe('timeblock detail back link issue #406', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    listTasksMock.mockResolvedValue([makeTask()]);
+    loadTimeBlocksMock.mockResolvedValue([makeBlock()]);
+    loadActiveBlockMock.mockResolvedValue(null);
+    getEventsMock.mockResolvedValue([]);
+  });
+
+  it.each([
+    ['today', '今日'],
+    ['now', '当下'],
+    ['week', '一周'],
+    ['month', '本月'],
+  ])('renders mobile back link for from=%s', async (from, label) => {
+    renderDetail(`?from=${from}`, false);
+
+    await waitFor(() => {
+      expect(loadTimeBlocksMock).toHaveBeenCalled();
+    });
+
+    const backLink = await screen.findByTestId('timeblock-back-link-mobile');
+    expect(backLink).toHaveTextContent(`← 返回${label}`);
+    expect(backLink).toHaveAttribute('href', `/tasks?tab=${from}`);
+  });
+
+  it('falls back to generic tasks link when source is missing', async () => {
+    renderDetail('', false);
+
+    await waitFor(() => {
+      expect(loadTimeBlocksMock).toHaveBeenCalled();
+    });
+
+    const backLink = await screen.findByTestId('timeblock-back-link-mobile');
+    expect(backLink).toHaveTextContent('← 返回任务');
+    expect(backLink).toHaveAttribute('href', '/tasks');
+  });
+
+  it('renders desktop back link and contextual breadcrumb', async () => {
+    renderDetail('?from=today', true);
+
+    await waitFor(() => {
+      expect(loadTimeBlocksMock).toHaveBeenCalled();
+    });
+
+    expect(await screen.findByText('任务 > 今日 > 时间块详情')).toBeInTheDocument();
+    const backLink = screen.getByTestId('timeblock-back-link-desktop');
+    expect(backLink).toHaveTextContent('← 返回今日');
+    expect(backLink).toHaveAttribute('href', '/tasks?tab=today');
+  });
+
+  it('adds a back action into the view model actions list', () => {
+    const model = buildTaskTimeblockDetailViewModel({
+      task: makeTask(),
+      blocks: [makeBlock()],
+      useMockData: true,
+      backAction: {
+        label: '← 返回今日',
+        to: '/tasks',
+        search: { tab: 'today' },
+      },
+    });
+
+    expect(model.actions[0]).toEqual({
+      id: 'back-source',
+      label: '← 返回今日',
+      to: '/tasks',
+      search: { tab: 'today' },
+    });
+  });
+});

--- a/tests/unit/ui/timeblock-detail-back-link.issue406.test.tsx
+++ b/tests/unit/ui/timeblock-detail-back-link.issue406.test.tsx
@@ -188,6 +188,18 @@ describe('timeblock detail back link issue #406', () => {
     expect(backLink).toHaveAttribute('href', '/tasks');
   });
 
+  it.each(['toString', 'constructor'])('falls back to generic tasks link for prototype key source=%s', async (from) => {
+    renderDetail(`?from=${from}`, false);
+
+    await waitFor(() => {
+      expect(loadTimeBlocksMock).toHaveBeenCalled();
+    });
+
+    const backLink = await screen.findByTestId('timeblock-back-link-mobile');
+    expect(backLink).toHaveTextContent('← 返回任务');
+    expect(backLink).toHaveAttribute('href', '/tasks');
+  });
+
   it('renders desktop back link and contextual breadcrumb', async () => {
     renderDetail('?from=today', true);
 


### PR DESCRIPTION
## Summary
- add source-aware back links from timeblock detail back to the originating Tasks tab
- show the contextual back link in both mobile and desktop timeblock detail headers
- add unit coverage for source tab mapping, fallback behavior, and back action wiring

## Testing
- npx vitest run tests/unit/ui/timeblock-detail-back-link.issue406.test.tsx tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
- npx tsc --noEmit
- bun run build

Fixes #406