### PR TITLE
feat(task): 支持任务预期时间可调整（estimatedMinutes）(#384)

### DIFF
--- a/src/ui/app/components/EstimatedTimeEditor.tsx
+++ b/src/ui/app/components/EstimatedTimeEditor.tsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { getTaskService } from '@/lib/services';
 
 const PRESET_ESTIMATED_MINUTES = [15, 25, 45, 60] as const;
+const ESTIMATED_OPTION_COUNT = PRESET_ESTIMATED_MINUTES.length + 2;
 
 function expectedOptionClass(active: boolean): string {
   return `relative z-10 h-8 w-full whitespace-nowrap rounded-[8px] px-[8px] text-center text-[12px] transition-colors duration-200 ${
@@ -24,10 +25,6 @@ function normalizePositiveMinutes(value: string): number | undefined {
   const parsed = Number.parseInt(digitsOnly, 10);
   if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
   return parsed;
-}
-
-function formatCurrentMinutes(minutes: number | undefined): string {
-  return minutes ? `${minutes} 分钟` : '未估时';
 }
 
 export interface EstimatedTimeEditorProps {
@@ -72,10 +69,10 @@ export function EstimatedTimeEditor({
   }, [isCustomEditing]);
 
   const activeIndex = minutes === undefined
-    ? null
+    ? 0
     : isPresetEstimatedMinutes(minutes)
-      ? PRESET_ESTIMATED_MINUTES.indexOf(minutes as (typeof PRESET_ESTIMATED_MINUTES)[number])
-      : PRESET_ESTIMATED_MINUTES.length;
+      ? PRESET_ESTIMATED_MINUTES.indexOf(minutes as (typeof PRESET_ESTIMATED_MINUTES)[number]) + 1
+      : PRESET_ESTIMATED_MINUTES.length + 1;
   const isCustomSelected = minutes !== undefined && !isPresetEstimatedMinutes(minutes);
 
   async function persistMinutes(nextMinutes: number | undefined): Promise<void> {
@@ -144,48 +141,38 @@ export function EstimatedTimeEditor({
 
   return (
     <div className="mt-3 flex min-w-0 flex-col gap-2" data-testid="estimated-time-editor">
-      <div className="flex flex-wrap items-start justify-between gap-2">
-        <div className="min-w-0">
-          <p className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">任务估时</p>
-          <p
-            data-testid="estimated-time-current"
-            className="mt-1 text-xs font-semibold text-[#1C1917] dark:text-[#FAFAF9]"
-          >
-            当前：{formatCurrentMinutes(minutes)}
-          </p>
-        </div>
-
-        <button
-          type="button"
-          data-testid="estimated-time-clear"
-          aria-pressed={minutes === undefined}
-          disabled={isSaving}
-          onClick={() => {
-            void persistMinutes(undefined);
-          }}
-          className={`rounded-full border px-3 py-1 text-[11px] transition-colors ${
-            minutes === undefined
-              ? 'border-[#C75B3A] bg-[#FFF7ED] text-[#C75B3A] dark:border-[#E8734E] dark:bg-[#2A1510] dark:text-[#F4A589]'
-              : 'border-[#E7E5E4] text-[#78716C] hover:text-[#57534E] dark:border-[#292524] dark:text-[#A8A29E] dark:hover:text-[#D6D3D1]'
-          } disabled:cursor-not-allowed disabled:opacity-60`}
-        >
-          {isSaving && minutes === undefined ? '保存中...' : '清空'}
-        </button>
-      </div>
+      <p className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">任务估时</p>
 
       <div
         className="relative min-w-0 overflow-hidden rounded-[10px] border border-[#E7E5E4] bg-[#F5F0ED]/50 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]"
         data-testid="estimated-time-selector"
       >
-        {activeIndex !== null ? (
-          <div
-            data-testid="estimated-time-active-indicator"
-            className="pointer-events-none absolute inset-y-0 left-0 w-1/5 rounded-[8px] border border-[#FFFFFFCC] bg-white/55 shadow-[0_1px_2px_rgba(0,0,0,0.05)] transition-transform duration-200 ease-out dark:border-[#FFFFFF66] dark:bg-[#FFFFFF14]"
-            style={{ transform: `translateX(${activeIndex * 100}%)` }}
-          />
-        ) : null}
+        <div
+          data-testid="estimated-time-active-indicator"
+          className="pointer-events-none absolute inset-y-0 left-0 rounded-[8px] border border-[#FFFFFFCC] bg-white/55 shadow-[0_1px_2px_rgba(0,0,0,0.05)] transition-transform duration-200 ease-out dark:border-[#FFFFFF66] dark:bg-[#FFFFFF14]"
+          style={{
+            width: `${100 / ESTIMATED_OPTION_COUNT}%`,
+            transform: `translateX(${activeIndex * 100}%)`,
+          }}
+        />
 
-        <div className="relative z-10 grid min-w-0 grid-cols-5 gap-0">
+        <div
+          className="relative z-10 grid min-w-0 gap-0"
+          style={{ gridTemplateColumns: `repeat(${ESTIMATED_OPTION_COUNT}, minmax(0, 1fr))` }}
+        >
+          <button
+            type="button"
+            data-testid="estimated-time-none"
+            aria-pressed={minutes === undefined}
+            disabled={isSaving}
+            onClick={() => {
+              void persistMinutes(undefined);
+            }}
+            className={expectedOptionClass(minutes === undefined)}
+          >
+            无
+          </button>
+
           {PRESET_ESTIMATED_MINUTES.map((preset) => (
             <button
               key={preset}

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -914,6 +914,7 @@ export function TaskDetailPage() {
   const backLink = resolveTimeblockSourceBackLink();
 
   const [task, setTask] = useState<TaskNode | null>(null);
+  const [isVirtualTask, setIsVirtualTask] = useState(false);
   const [timeBlocks, setTimeBlocks] = useState<TimeBlock[]>([]);
   const [activeBlock, setActiveBlock] = useState<ActiveBlockData | null>(null);
   const [hasOtherActiveBlock, setHasOtherActiveBlock] = useState(false);
@@ -946,6 +947,7 @@ export function TaskDetailPage() {
   useLayoutEffect(() => {
     setIsLoading(true);
     setTask(null);
+    setIsVirtualTask(false);
     setActiveBlock(null);
     setHasOtherActiveBlock(false);
     setEventLogs([]);
@@ -985,11 +987,17 @@ export function TaskDetailPage() {
         listedTasksPromise,
       ]);
       let nextTask = loadedTask;
+      let nextTaskIsVirtual = false;
       if (!nextTask && preferredBlockId) {
         const matchedBlock = blocks.find((block) => block.id === preferredBlockId || block.startId === preferredBlockId);
         if (matchedBlock) {
           const linked = listedTasks.find((candidate) => (candidate.timeBlockIds ?? []).includes(matchedBlock.startId));
-          nextTask = linked ?? buildVirtualTaskFromBlock(matchedBlock);
+          if (linked) {
+            nextTask = linked;
+          } else {
+            nextTask = buildVirtualTaskFromBlock(matchedBlock);
+            nextTaskIsVirtual = true;
+          }
         }
       }
       if (!nextTask) {
@@ -998,6 +1006,7 @@ export function TaskDetailPage() {
 
       if (disposed) return;
       setTask(nextTask);
+      setIsVirtualTask(nextTaskIsVirtual);
       setAllTasks(listedTasks);
       setTimeBlocks(blocks);
       setActiveBlock(nextTask && currentBlock?.taskId === nextTask.id ? currentBlock : null);
@@ -1062,10 +1071,7 @@ export function TaskDetailPage() {
   const rootGuidance = useMemo(() => (
     <TaskCurrentRootCard graph={taskGraph} taskById={taskById} currentTaskId={task?.id} />
   ), [task?.id, taskById, taskGraph]);
-  const canEditEstimatedTime = useMemo(
-    () => (task ? allTasks.some((candidate) => candidate.id === task.id) : false),
-    [allTasks, task],
-  );
+  const canEditEstimatedTime = useMemo(() => Boolean(task) && !isVirtualTask, [isVirtualTask, task]);
   const timerControls = (
     <TimerConfigPanel
       timerMode={timerMode}

--- a/tests/unit/ui/estimated-time-editor.issue384.test.tsx
+++ b/tests/unit/ui/estimated-time-editor.issue384.test.tsx
@@ -31,10 +31,11 @@ describe('EstimatedTimeEditor issue #384', () => {
     updateTaskMock.mockResolvedValue(makeTask());
   });
 
-  it('renders current estimatedMinutes and highlights current preset（显示当前估时并高亮预设）', () => {
+  it('renders selected preset without current text（高亮预设且不显示当前文案）', () => {
     render(<EstimatedTimeEditor taskId="task-1" currentMinutes={25} />);
 
-    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：25 分钟');
+    expect(screen.queryByTestId('estimated-time-current')).not.toBeInTheDocument();
+    expect(screen.getByTestId('estimated-time-none')).toHaveAttribute('aria-pressed', 'false');
     expect(screen.getByTestId('estimated-time-preset-25')).toHaveAttribute('aria-pressed', 'true');
   });
 
@@ -47,7 +48,7 @@ describe('EstimatedTimeEditor issue #384', () => {
       expect(updateTaskMock).toHaveBeenCalledWith('task-1', { estimatedMinutes: 45 });
     });
 
-    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：45 分钟');
+    expect(screen.getByTestId('estimated-time-none')).toHaveAttribute('aria-pressed', 'false');
     expect(screen.getByTestId('estimated-time-preset-45')).toHaveAttribute('aria-pressed', 'true');
   });
 
@@ -62,21 +63,20 @@ describe('EstimatedTimeEditor issue #384', () => {
       expect(updateTaskMock).toHaveBeenCalledWith('task-1', { estimatedMinutes: 90 });
     });
 
-    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：90 分钟');
+    expect(screen.getByTestId('estimated-time-custom-trigger')).toHaveTextContent('90m');
     expect(screen.getByTestId('estimated-time-custom-trigger')).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('clear resets the value to undefined（清空估时）', async () => {
+  it('none option resets the value to undefined（无选项重置估时）', async () => {
     render(<EstimatedTimeEditor taskId="task-1" currentMinutes={60} />);
 
-    fireEvent.click(screen.getByTestId('estimated-time-clear'));
+    fireEvent.click(screen.getByTestId('estimated-time-none'));
 
     await waitFor(() => {
       expect(updateTaskMock).toHaveBeenCalledWith('task-1', { estimatedMinutes: undefined });
     });
 
-    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：未估时');
-    expect(screen.getByTestId('estimated-time-clear')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('estimated-time-none')).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('calls onUpdate after successful save（保存成功后回调 onUpdate）', async () => {

--- a/tests/unit/ui/task-detail-page.estimated-time-race.issue384.test.tsx
+++ b/tests/unit/ui/task-detail-page.estimated-time-race.issue384.test.tsx
@@ -167,4 +167,17 @@ describe('TaskDetailPage estimated minutes race issue #384', () => {
 
     expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：30 分钟');
   });
+
+  it('shows estimated editor when task is loaded directly even if listTasks is empty（任务直达加载时仍显示估时入口）', async () => {
+    const directTask = makeTask({ id: 'task-1', title: '任务 A', estimatedMinutes: 25, updatedAt: 30 });
+
+    getTaskMock.mockResolvedValueOnce(structuredClone(directTask));
+    listTasksMock.mockResolvedValueOnce([]);
+
+    render(<TaskDetailPage />);
+
+    await screen.findByText('关联任务：任务 A');
+    expect(screen.getByTestId('estimated-time-editor')).toBeInTheDocument();
+    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：25 分钟');
+  });
 });

--- a/tests/unit/ui/task-detail-page.estimated-time-race.issue384.test.tsx
+++ b/tests/unit/ui/task-detail-page.estimated-time-race.issue384.test.tsx
@@ -146,7 +146,7 @@ describe('TaskDetailPage estimated minutes race issue #384', () => {
     const view = render(<TaskDetailPage />);
 
     await screen.findByText('关联任务：任务 A');
-    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：60 分钟');
+    expect(screen.getByTestId('estimated-time-preset-60')).toHaveAttribute('aria-pressed', 'true');
 
     fireEvent.click(screen.getByTestId('estimated-time-preset-45'));
 
@@ -158,14 +158,16 @@ describe('TaskDetailPage estimated minutes race issue #384', () => {
     view.rerender(<TaskDetailPage />);
 
     await screen.findByText('关联任务：任务 B');
-    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：30 分钟');
+    expect(screen.getByTestId('estimated-time-custom-trigger')).toHaveTextContent('30m');
+    expect(screen.getByTestId('estimated-time-custom-trigger')).toHaveAttribute('aria-pressed', 'true');
 
     await act(async () => {
       pendingSave.resolve(makeTask({ id: 'task-1', title: '任务 A', estimatedMinutes: 45, updatedAt: 999 }));
       await pendingSave.promise;
     });
 
-    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：30 分钟');
+    expect(screen.getByTestId('estimated-time-custom-trigger')).toHaveTextContent('30m');
+    expect(screen.getByTestId('estimated-time-custom-trigger')).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('shows estimated editor when task is loaded directly even if listTasks is empty（任务直达加载时仍显示估时入口）', async () => {
@@ -178,6 +180,6 @@ describe('TaskDetailPage estimated minutes race issue #384', () => {
 
     await screen.findByText('关联任务：任务 A');
     expect(screen.getByTestId('estimated-time-editor')).toBeInTheDocument();
-    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：25 分钟');
+    expect(screen.getByTestId('estimated-time-preset-25')).toHaveAttribute('aria-pressed', 'true');
   });
 });


### PR DESCRIPTION
## Summary
- fix TaskDetailPage estimated-time editor visibility gate to rely on whether the detail task is virtual, instead of requiring it to exist in listTasks results
- keep the editor available for directly loaded real tasks even when task listing is temporarily empty/unavailable
- preserve the hide behavior for virtual timeblock-only tasks
- in 时间块详情 estimated-time editor, replace the right-side 清空 action with a left-most 无 option in the selector row
- remove duplicated 当前：xx分钟 text under 任务估时; rely on existing upper 预期 metric to present current estimate
- update regression tests to assert selector state (无/preset/custom) instead of removed current-text node

## Validation
- 
px vitest run tests/unit/ui/estimated-time-editor.issue384.test.tsx tests/unit/ui/task-detail-page.estimated-time-race.issue384.test.tsx tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
- 
px tsc --noEmit
- un run build

## Notes
- refs #384