### PR TITLE
fix(task): resolve current root from unblocked tasks for #411

### DIFF
--- a/src/lib/task/task-dag-graph.ts
+++ b/src/lib/task/task-dag-graph.ts
@@ -22,6 +22,7 @@ export interface TaskGraph {
   nodes: TaskGraphNode[]
   edges: TaskGraphEdge[]
   rootNodeIds: string[]
+  currentRootCandidateNodeIds: string[]
   currentRootNodeId: string | null
   topologicalOrder: string[]
   hasCycle: boolean
@@ -79,29 +80,35 @@ function isTaskExecutable(task: TaskNode, taskById: Map<string, TaskNode>): bool
   })
 }
 
-export function resolveCurrentRootNodeId({
-  rootNodeIds,
+export function resolveCurrentRootCandidateNodeIds({
   topologicalOrder,
   taskById,
 }: {
-  rootNodeIds: string[]
   topologicalOrder: string[]
   taskById: Map<string, TaskNode>
-}): string | null {
-  const rootNodeIdSet = new Set(rootNodeIds)
+}): string[] {
+  const candidates: string[] = []
 
   for (const taskId of topologicalOrder) {
-    if (!rootNodeIdSet.has(taskId)) {
+    const task = taskById.get(taskId)
+    if (!task || isTerminalStatus(task.status)) {
       continue
     }
 
-    const task = taskById.get(taskId)
-    if (task && !isTerminalStatus(task.status)) {
-      return taskId
+    if (!isDependencyBlocking(task, taskById)) {
+      candidates.push(taskId)
     }
   }
 
-  return null
+  return candidates
+}
+
+export function resolveCurrentRootNodeId({
+  currentRootCandidateNodeIds,
+}: {
+  currentRootCandidateNodeIds: string[]
+}): string | null {
+  return currentRootCandidateNodeIds[0] ?? null
 }
 
 export function buildTaskGraph(tasks: TaskNode[]): TaskGraph {
@@ -192,6 +199,10 @@ export function buildTaskGraph(tasks: TaskNode[]): TaskGraph {
   }
 
   const rootNodeIds = topologicalOrder.filter((taskId) => (indegree.get(taskId) ?? 0) === 0)
+  const currentRootCandidateNodeIds = resolveCurrentRootCandidateNodeIds({
+    topologicalOrder,
+    taskById,
+  })
   const topologicalIndex = new Map(topologicalOrder.map((taskId, index) => [taskId, index]))
   const rootNodeIdSet = new Set(rootNodeIds)
 
@@ -233,10 +244,9 @@ export function buildTaskGraph(tasks: TaskNode[]): TaskGraph {
     nodes,
     edges,
     rootNodeIds,
+    currentRootCandidateNodeIds,
     currentRootNodeId: resolveCurrentRootNodeId({
-      rootNodeIds,
-      topologicalOrder,
-      taskById,
+      currentRootCandidateNodeIds,
     }),
     topologicalOrder,
     hasCycle,

--- a/src/ui/app/components/TaskCurrentRootCard.tsx
+++ b/src/ui/app/components/TaskCurrentRootCard.tsx
@@ -36,7 +36,7 @@ export function TaskCurrentRootCard({
     ? graph.nodes.find((node) => node.id === graph.currentRootNodeId) ?? null
     : null;
   const isViewingCurrentRoot = Boolean(currentRootTask && currentTaskId === currentRootTask.id);
-  const rootOrder = currentRootTask ? graph.rootNodeIds.indexOf(currentRootTask.id) + 1 : 0;
+  const currentRootOrder = currentRootTask ? graph.currentRootCandidateNodeIds.indexOf(currentRootTask.id) + 1 : 0;
 
   return (
     <section
@@ -66,14 +66,14 @@ export function TaskCurrentRootCard({
               </div>
               <p className="mt-3 truncate text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{currentRootTask.title}</p>
               <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
-                {`共 ${graph.rootNodeIds.length} 个根节点 · 当前按稳定顺序排第 ${rootOrder} 个`}
+                {`共 ${graph.currentRootCandidateNodeIds.length} 个未阻塞节点 · 当前按稳定顺序排第 ${currentRootOrder} 个`}
               </p>
             </>
           ) : (
             <>
-              <p className="mt-3 text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">暂无未完成根节点</p>
+              <p className="mt-3 text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">暂无未阻塞节点</p>
               <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
-                所有根节点都已完成或放弃，后续可从 DAG 视图继续检查整体依赖结构。
+                当前所有未终态节点都被依赖关系阻塞，可前往 DAG 视图检查阻塞来源。
               </p>
             </>
           )}

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -184,10 +184,10 @@ export function TaskDagPage() {
             <div className="min-w-0 flex-1">
               <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#A8A29E]">当前根节点</p>
               <p className="mt-2 truncate text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">
-                {currentRootTask?.title ?? '暂无未完成根节点'}
+                {currentRootTask?.title ?? '暂无未阻塞节点'}
               </p>
               <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
-                {`节点 ${graph.nodes.length} 个 · 边 ${graph.edges.length} 条 · 根节点 ${graph.rootNodeIds.length} 个`}
+                {`节点 ${graph.nodes.length} 个 · 边 ${graph.edges.length} 条 · 未阻塞节点 ${graph.currentRootCandidateNodeIds.length} 个`}
               </p>
             </div>
           </div>

--- a/tests/unit/ui/task-current-root-card.issue411.test.tsx
+++ b/tests/unit/ui/task-current-root-card.issue411.test.tsx
@@ -1,0 +1,110 @@
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { buildTaskGraph } from '@/lib/task/task-dag-graph';
+import type { TaskNode } from '@/lib/types/task';
+import { TaskCurrentRootCard } from '@/ui/app/components/TaskCurrentRootCard';
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+function makeTask(overrides: Partial<TaskNode> & { id: string; title: string }): TaskNode {
+  return {
+    id: overrides.id,
+    title: overrides.title,
+    description: undefined,
+    status: 'not_started',
+    priority: 'medium',
+    dependsOn: [],
+    tags: [],
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+function renderCurrentRootCard(tasks: TaskNode[]) {
+  const graph = buildTaskGraph(tasks);
+  const taskById = new Map(tasks.map((task) => [task.id, task]));
+  render(<TaskCurrentRootCard graph={graph} taskById={taskById} />);
+  return { graph };
+}
+
+describe('TaskCurrentRootCard issue-411（当前根节点按未阻塞判定）', () => {
+  it('shows downstream unblocked node instead of empty state when structural roots are terminal', () => {
+    const completedRoot = makeTask({
+      id: 'done-root',
+      title: '已完成根节点',
+      status: 'completed',
+      createdAt: 10,
+      updatedAt: 10,
+    });
+    const downstream = makeTask({
+      id: 'downstream-open',
+      title: '下游可执行节点',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [{ taskId: 'done-root', type: 'hard' }],
+    });
+
+    const { graph } = renderCurrentRootCard([downstream, completedRoot]);
+
+    expect(graph.rootNodeIds).toEqual(['done-root']);
+    expect(graph.currentRootCandidateNodeIds).toEqual(['downstream-open']);
+    expect(graph.currentRootNodeId).toBe('downstream-open');
+    expect(screen.getByTestId('task-current-root-card')).toHaveTextContent('下游可执行节点');
+    expect(screen.queryByText('暂无未阻塞节点')).not.toBeInTheDocument();
+    expect(screen.getByTestId('task-current-root-card')).toHaveTextContent(
+      '共 1 个未阻塞节点 · 当前按稳定顺序排第 1 个',
+    );
+  });
+
+  it('does not pick a node whose hard dependency is unfinished', () => {
+    const hardSource = makeTask({
+      id: 'hard-source',
+      title: '硬依赖前置',
+      status: 'in_progress',
+      createdAt: 10,
+      updatedAt: 10,
+    });
+    const hardTarget = makeTask({
+      id: 'hard-target',
+      title: '硬依赖目标',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [{ taskId: 'hard-source', type: 'hard' }],
+    });
+
+    const { graph } = renderCurrentRootCard([hardTarget, hardSource]);
+
+    expect(graph.currentRootNodeId).toBe('hard-source');
+    expect(graph.currentRootCandidateNodeIds).toEqual(['hard-source']);
+    expect(screen.getByTestId('task-current-root-card')).toHaveTextContent('硬依赖前置');
+    expect(screen.getByTestId('task-current-root-card')).not.toHaveTextContent('硬依赖目标');
+  });
+
+  it('does not pick a node whose soft dependency is not started', () => {
+    const softSource = makeTask({
+      id: 'soft-source',
+      title: '软依赖前置',
+      status: 'not_started',
+      createdAt: 10,
+      updatedAt: 10,
+    });
+    const softTarget = makeTask({
+      id: 'soft-target',
+      title: '软依赖目标',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [{ taskId: 'soft-source', type: 'soft' }],
+    });
+
+    const { graph } = renderCurrentRootCard([softTarget, softSource]);
+
+    expect(graph.currentRootNodeId).toBe('soft-source');
+    expect(graph.currentRootCandidateNodeIds).toEqual(['soft-source']);
+    expect(screen.getByTestId('task-current-root-card')).toHaveTextContent('软依赖前置');
+    expect(screen.getByTestId('task-current-root-card')).not.toHaveTextContent('软依赖目标');
+  });
+});

--- a/tests/unit/ui/task-dag-graph.issue394.test.ts
+++ b/tests/unit/ui/task-dag-graph.issue394.test.ts
@@ -96,6 +96,29 @@ describe('buildTaskGraph issue-394（任务 DAG 图基础层）', () => {
     expect(graph.currentRootNodeId).toBe('live')
   })
 
+  it('selects an unblocked unfinished node even when all structural roots are terminal', () => {
+    const completedRoot = makeTask({
+      id: 'done',
+      title: 'Completed Root',
+      status: 'completed',
+      createdAt: 10,
+      updatedAt: 10,
+    })
+    const executableChild = makeTask({
+      id: 'child',
+      title: 'Executable Child',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [{ taskId: 'done', type: 'hard' }],
+    })
+
+    const graph = buildTaskGraph([executableChild, completedRoot])
+
+    expect(graph.rootNodeIds).toEqual(['done'])
+    expect(graph.currentRootCandidateNodeIds).toEqual(['child'])
+    expect(graph.currentRootNodeId).toBe('child')
+  })
+
   it('selects the first unfinished root by stable order when roots are parallel', () => {
     const firstRoot = makeTask({ id: 'alpha', title: 'Alpha', createdAt: 10, updatedAt: 90 })
     const secondRoot = makeTask({ id: 'beta', title: 'Beta', createdAt: 20, updatedAt: 40 })

--- a/tests/unit/ui/task-dag-page.issue394.test.tsx
+++ b/tests/unit/ui/task-dag-page.issue394.test.tsx
@@ -127,6 +127,35 @@ describe('TaskDagPage issue-394（任务 DAG 只读视图）', () => {
     expect(flowApiMocks.setCenter).toHaveBeenCalled();
   });
 
+  it('uses unblocked unfinished node as current root when structural roots are terminal', async () => {
+    listTasksMock.mockResolvedValue([
+      makeTask({
+        id: 'done-root',
+        title: '已完成根节点',
+        status: 'completed',
+        createdAt: 10,
+        updatedAt: 10,
+      }),
+      makeTask({
+        id: 'downstream-open',
+        title: '下游可执行节点',
+        createdAt: 20,
+        updatedAt: 20,
+        dependsOn: [{ taskId: 'done-root', type: 'hard' }],
+      }),
+    ]);
+
+    render(<TaskDagPage />);
+
+    await waitFor(() => {
+      expect(listTasksMock).toHaveBeenCalledWith(true);
+    });
+
+    expect(await screen.findByTestId('task-dag-current-root-summary')).toHaveTextContent('下游可执行节点');
+    expect(screen.getByTestId('task-dag-current-root-summary')).toHaveTextContent('未阻塞节点 1 个');
+    expect(screen.queryByText('暂无未阻塞节点')).not.toBeInTheDocument();
+  });
+
   it('updates the side panel when selecting another node', async () => {
     render(<TaskDagPage />);
 


### PR DESCRIPTION
## Summary
- change current root selection to use unblocked + non-terminal nodes in stable topological order
- keep structural root semantics (`rootNodeIds`) unchanged, and expose unblocked candidate ids for UI rendering
- update current-root card and DAG summary copy/counts to match the new definition
- add regression tests for graph derivation, card rendering, and DAG summary

## Verification
- npx vitest run tests/unit/ui/task-current-root-card.issue411.test.tsx tests/unit/ui/task-dag-graph.issue394.test.ts tests/unit/ui/tasks-page-today-view.test.tsx tests/unit/ui/task-dag-page.issue394.test.tsx
- npx tsc --noEmit
- bun run build

refs #411
