### PR TITLE
feat(signal-pool): persist RouteTable and Journal in SQLite for runtime (#420)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,6 +1084,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "reqwest 0.12.28",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",
@@ -1084,6 +1097,18 @@ dependencies = [
  "tracing",
  "uuid",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1686,6 +1711,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1698,6 +1732,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -2249,6 +2292,17 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3797,6 +3851,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -5529,6 +5597,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,6 +1095,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -2534,6 +2535,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4319,6 +4329,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5039,6 +5058,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiff"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5382,6 +5410,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5597,6 +5651,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/crates/exomind-runtime/Cargo.toml
+++ b/crates/exomind-runtime/Cargo.toml
@@ -34,8 +34,8 @@ mdns-sd = "0.11"
 sha2 = "0.10"
 percent-encoding = "2"
 rand = "0.8"
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [dev-dependencies]
 http-body-util = "0.1"
 tower = { version = "0.5", features = ["util"] }
-

--- a/crates/exomind-runtime/Cargo.toml
+++ b/crates/exomind-runtime/Cargo.toml
@@ -39,3 +39,4 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 [dev-dependencies]
 http-body-util = "0.1"
 tower = { version = "0.5", features = ["util"] }
+tracing-subscriber = { version = "0.3", features = ["fmt"] }

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -639,7 +639,18 @@ impl AppState {
         let default_routes_path =
             resolve_default_signal_routes_path().map(|path| path.to_string_lossy().to_string());
         let signal_pool = Arc::new(match signal_storage_path {
-            Some(path) => SignalPool::with_sqlite_path(default_routes_path.as_deref(), &path),
+            Some(path) => match SignalPool::with_sqlite_path(default_routes_path.as_deref(), &path)
+            {
+                Ok(pool) => pool,
+                Err(error) => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %error,
+                        "signal sqlite init failed, falling back to in-memory pool (Signal SQLite 初始化失败，降级到内存池)"
+                    );
+                    SignalPool::new(default_routes_path.as_deref())
+                }
+            },
             None => SignalPool::new(default_routes_path.as_deref()),
         });
         let mesh = Arc::new(MeshState::new(
@@ -959,6 +970,52 @@ mod tests {
                 .and_then(|value| value.to_str().ok()),
             Some("*")
         );
+    }
+
+    #[test]
+    fn new_runtime_falls_back_when_signal_sqlite_init_fails() {
+        let dir = std::env::temp_dir().join(format!(
+            "exomind-runtime-invalid-sqlite-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let blocked_parent = dir.join("not-a-directory");
+        std::fs::write(&blocked_parent, "file blocks sqlite parent").unwrap();
+        let invalid_sqlite_path = blocked_parent.join("signal-pool.sqlite");
+
+        let runtime = std::panic::catch_unwind(|| {
+            AppState::new_runtime(
+                0,
+                "host-invalid-sqlite".to_string(),
+                None,
+                Some(invalid_sqlite_path.clone()),
+                false,
+                None,
+            )
+        })
+        .expect("runtime should degrade instead of panicking when sqlite init fails");
+
+        let initial_route_count = runtime.signal_pool.routes().get_all().len();
+        let now = chrono::Utc::now().to_rfc3339();
+        let route_id = uuid::Uuid::new_v4().to_string();
+        runtime.signal_pool.routes().add(crate::signal::SignalRoute {
+            id: route_id.clone(),
+            enabled: true,
+            topic: "runtime.fallback.topic".to_string(),
+            target_type: crate::signal::TargetType::Agent,
+            target_ref: "fallback-agent".to_string(),
+            created_at: now.clone(),
+            updated_at: now,
+        }).unwrap();
+
+        assert_eq!(
+            runtime.signal_pool.routes().get_all().len(),
+            initial_route_count + 1
+        );
+        assert!(runtime.signal_pool.routes().get_by_id(&route_id).is_some());
+
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 
     #[tokio::test]

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -80,6 +80,8 @@ pub struct RuntimeStartOptions {
     pub ts_agent_workdir: Option<PathBuf>,
     /// optional mesh state path（可选 peer/interest 持久化路径）.
     pub mesh_state_path: Option<PathBuf>,
+    /// optional signal sqlite path（可选 SignalPool SQLite 路径）.
+    pub signal_storage_path: Option<PathBuf>,
     /// optional bearer token secret for HTTP auth（可选 Bearer Token 鉴权密钥）.
     pub auth_secret: Option<String>,
     /// enable mDNS service discovery for LAN peer auto-detection（启用 mDNS 局域网自动发现）.
@@ -111,7 +113,12 @@ impl Default for RuntimeStartOptions {
             ts_agent_command: env::var("EXOMIND_RT_AGENT_CMD")
                 .unwrap_or_else(|_| "bun".to_string()),
             ts_agent_workdir: env::var("EXOMIND_RT_AGENT_WORKDIR").ok().map(PathBuf::from),
-            mesh_state_path: env::var("EXOMIND_RT_MESH_STATE_PATH").ok().map(PathBuf::from),
+            mesh_state_path: env::var("EXOMIND_RT_MESH_STATE_PATH")
+                .ok()
+                .map(PathBuf::from),
+            signal_storage_path: env::var("EXOMIND_RT_SIGNAL_SQLITE_PATH")
+                .ok()
+                .map(PathBuf::from),
             auth_secret: env::var("EXOMIND_RT_SECRET").ok(),
             enable_mdns,
         }
@@ -181,7 +188,10 @@ pub struct RuntimePublishRequest {
 }
 
 impl RuntimeHandle {
-    fn build_signal_event(default_origin_host_id: &str, request: RuntimePublishRequest) -> signal::types::SignalEvent {
+    fn build_signal_event(
+        default_origin_host_id: &str,
+        request: RuntimePublishRequest,
+    ) -> signal::types::SignalEvent {
         signal::types::SignalEvent {
             schema_version: 1,
             id: uuid::Uuid::new_v4().to_string(),
@@ -376,6 +386,7 @@ pub async fn start_with_options(
         local_addr.port(),
         options.host_id.clone(),
         options.mesh_state_path.clone(),
+        options.signal_storage_path.clone(),
         true,
         options.auth_secret.clone(),
     );
@@ -485,7 +496,10 @@ fn resolve_project_root(options: &RuntimeStartOptions) -> PathBuf {
     resolve_project_root_from(options.ts_agent_workdir.as_deref(), current_dir.as_deref())
 }
 
-fn resolve_project_root_from(ts_agent_workdir: Option<&Path>, current_dir: Option<&Path>) -> PathBuf {
+fn resolve_project_root_from(
+    ts_agent_workdir: Option<&Path>,
+    current_dir: Option<&Path>,
+) -> PathBuf {
     const REVIEWER_ENTRY: &str = "packages/ts-agent-cli/agents/reviewer/index.ts";
     const CLASSIFIER_ENTRY: &str = "packages/ts-agent-cli/agents/classifier/index.ts";
 
@@ -579,11 +593,10 @@ pub fn app_with_state(state: AppState) -> Router {
         .allow_headers(Any);
 
     // Protected routes — auth middleware applied here.
-    let protected = routes::router()
-        .route_layer(axum::middleware::from_fn_with_state(
-            state.clone(),
-            auth::require_auth,
-        ));
+    let protected = routes::router().route_layer(axum::middleware::from_fn_with_state(
+        state.clone(),
+        auth::require_auth,
+    ));
 
     Router::new()
         .route("/health", get(health))
@@ -608,13 +621,14 @@ pub struct AppState {
 
 impl AppState {
     pub fn new(port: u16) -> Self {
-        Self::new_runtime(port, default_runtime_host_id(port), None, false, None)
+        Self::new_runtime(port, default_runtime_host_id(port), None, None, false, None)
     }
 
     pub fn new_runtime(
         port: u16,
         host_id: String,
         mesh_persist_path: Option<PathBuf>,
+        signal_storage_path: Option<PathBuf>,
         enable_mesh_relay: bool,
         auth_secret: Option<String>,
     ) -> Self {
@@ -624,13 +638,17 @@ impl AppState {
 
         let default_routes_path =
             resolve_default_signal_routes_path().map(|path| path.to_string_lossy().to_string());
-        let signal_pool = Arc::new(SignalPool::new(default_routes_path.as_deref()));
+        let signal_pool = Arc::new(match signal_storage_path {
+            Some(path) => SignalPool::with_sqlite_path(default_routes_path.as_deref(), &path),
+            None => SignalPool::new(default_routes_path.as_deref()),
+        });
         let mesh = Arc::new(MeshState::new(
             host_id.clone(),
             Arc::clone(&signal_pool),
             mesh_persist_path,
         ));
-        let mesh_relay = enable_mesh_relay.then(|| Arc::new(MeshRelayManager::new(Arc::clone(&mesh))));
+        let mesh_relay =
+            enable_mesh_relay.then(|| Arc::new(MeshRelayManager::new(Arc::clone(&mesh))));
 
         Self {
             port,
@@ -720,7 +738,11 @@ mod tests {
             host_id: host_id.clone(),
             registry,
             signal_pool: Arc::clone(&signal_pool),
-            mesh: Arc::new(mesh::MeshState::new(host_id, Arc::clone(&signal_pool), None)),
+            mesh: Arc::new(mesh::MeshState::new(
+                host_id,
+                Arc::clone(&signal_pool),
+                None,
+            )),
             mesh_relay: None,
             auth_secret: None,
             mdns: None,
@@ -1226,7 +1248,8 @@ mod tests {
         registry.register(Arc::new(TempSessionAgent::new_with_one_session()));
         let signal_pool = Arc::new(signal::SignalPool::new(None));
 
-        let router = routes::router().with_state(app_state_with_registry(3010, registry, signal_pool));
+        let router =
+            routes::router().with_state(app_state_with_registry(3010, registry, signal_pool));
 
         let get_response = router
             .clone()
@@ -1322,10 +1345,21 @@ mod tests {
         let fake_cwd = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/non-existent-cwd");
         let resolved = resolve_default_signal_routes_path_from(Some(fake_cwd.as_path()));
 
-        assert!(resolved.is_some(), "should resolve default routes from workspace root");
+        assert!(
+            resolved.is_some(),
+            "should resolve default routes from workspace root"
+        );
         let resolved_path = resolved.expect("resolved path should exist");
-        assert!(resolved_path.exists(), "resolved path must exist: {}", resolved_path.display());
-        assert!(resolved_path.to_string_lossy().contains("config/signal-routes.default.json"));
+        assert!(
+            resolved_path.exists(),
+            "resolved path must exist: {}",
+            resolved_path.display()
+        );
+        assert!(
+            resolved_path
+                .to_string_lossy()
+                .contains("config/signal-routes.default.json")
+        );
     }
 
     #[test]

--- a/crates/exomind-runtime/src/mesh/mod.rs
+++ b/crates/exomind-runtime/src/mesh/mod.rs
@@ -412,7 +412,7 @@ impl MeshState {
         reason: Option<String>,
     ) {
         let now = now_rfc3339();
-        self.signal_pool.journal().append(DeliveryRecord {
+        if let Err(error) = self.signal_pool.journal().append(DeliveryRecord {
             event_id: event_id.to_string(),
             route_id: format!("mesh:{peer_id}"),
             target_ref: peer_id.to_string(),
@@ -420,7 +420,14 @@ impl MeshState {
             reason,
             started_at: now.clone(),
             finished_at: now,
-        });
+        }) {
+            tracing::warn!(
+                event_id = %event_id,
+                peer_id = %peer_id,
+                error = %error,
+                "mesh delivery journal append failed (网格投递日志追加失败)"
+            );
+        }
     }
 
     fn persist(&self) {

--- a/crates/exomind-runtime/src/routes/signals.rs
+++ b/crates/exomind-runtime/src/routes/signals.rs
@@ -168,7 +168,7 @@ async fn list_routes(State(state): State<AppState>) -> Json<Vec<SignalRoute>> {
 async fn create_route(
     State(state): State<AppState>,
     Json(req): Json<CreateRouteRequest>,
-) -> (StatusCode, Json<SignalRoute>) {
+) -> Result<(StatusCode, Json<SignalRoute>), StatusCode> {
     let now = chrono::Utc::now().to_rfc3339();
     let route = SignalRoute {
         id: uuid::Uuid::new_v4().to_string(),
@@ -181,12 +181,19 @@ async fn create_route(
     };
 
     let response = route.clone();
-    state.signal_pool.routes().add(route);
+    state.signal_pool.routes().add(route).map_err(|error| {
+        tracing::warn!(
+            route_id = %response.id,
+            error = %error,
+            "signal route persistence failed on create (路由持久化失败)"
+        );
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
     if let Some(mesh_relay) = &state.mesh_relay {
         mesh_relay.sync_local_interests_to_all_peers().await;
     }
 
-    (StatusCode::CREATED, Json(response))
+    Ok((StatusCode::CREATED, Json(response)))
 }
 
 /// PUT /signal-routes/{id}
@@ -195,20 +202,31 @@ async fn update_route(
     State(state): State<AppState>,
     Json(req): Json<UpdateRouteRequest>,
 ) -> Result<Json<SignalRoute>, StatusCode> {
-    let updated = state.signal_pool.routes().update(&id, |route| {
-        if let Some(topic) = &req.topic {
-            route.topic = topic.clone();
-        }
-        if let Some(target_type) = &req.target_type {
-            route.target_type = target_type.clone();
-        }
-        if let Some(target_ref) = &req.target_ref {
-            route.target_ref = target_ref.clone();
-        }
-        if let Some(enabled) = req.enabled {
-            route.enabled = enabled;
-        }
-    });
+    let updated = state
+        .signal_pool
+        .routes()
+        .update(&id, |route| {
+            if let Some(topic) = &req.topic {
+                route.topic = topic.clone();
+            }
+            if let Some(target_type) = &req.target_type {
+                route.target_type = target_type.clone();
+            }
+            if let Some(target_ref) = &req.target_ref {
+                route.target_ref = target_ref.clone();
+            }
+            if let Some(enabled) = req.enabled {
+                route.enabled = enabled;
+            }
+        })
+        .map_err(|error| {
+            tracing::warn!(
+                route_id = %id,
+                error = %error,
+                "signal route persistence failed on update (路由持久化失败)"
+            );
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     if !updated {
         return Err(StatusCode::NOT_FOUND);
@@ -231,7 +249,19 @@ async fn delete_route(
     Path(id): Path<String>,
     State(state): State<AppState>,
 ) -> StatusCode {
-    if state.signal_pool.routes().delete(&id) {
+    let deleted = match state.signal_pool.routes().delete(&id) {
+        Ok(deleted) => deleted,
+        Err(error) => {
+            tracing::warn!(
+                route_id = %id,
+                error = %error,
+                "signal route persistence failed on delete (路由持久化失败)"
+            );
+            return StatusCode::INTERNAL_SERVER_ERROR;
+        }
+    };
+
+    if deleted {
         if let Some(mesh_relay) = &state.mesh_relay {
             mesh_relay.sync_local_interests_to_all_peers().await;
         }
@@ -683,7 +713,8 @@ mod tests {
             target_ref: "ui".to_string(),
             created_at: now.clone(),
             updated_at: now,
-        });
+        })
+        .unwrap();
 
         assert!(
             routes_target_stream_subscriber(
@@ -707,7 +738,8 @@ mod tests {
             target_ref: "eventlog".to_string(),
             created_at: now.clone(),
             updated_at: now,
-        });
+        })
+        .unwrap();
 
         assert!(
             !routes_target_stream_subscriber(

--- a/crates/exomind-runtime/src/signal/bus.rs
+++ b/crates/exomind-runtime/src/signal/bus.rs
@@ -62,7 +62,14 @@ impl SignalBus {
                 finished_at: chrono::Utc::now().to_rfc3339(),
             };
 
-            journal.append(record.clone());
+            if let Err(error) = journal.append(record.clone()) {
+                tracing::warn!(
+                    event_id = %record.event_id,
+                    route_id = %record.route_id,
+                    error = %error,
+                    "signal journal append failed during publish (日志追加失败)"
+                );
+            }
             records.push(record);
         }
 
@@ -108,7 +115,8 @@ mod tests {
             target_ref: "classifier".to_string(),
             created_at: now.clone(),
             updated_at: now.clone(),
-        });
+        })
+        .unwrap();
         table.add(crate::signal::types::SignalRoute {
             id: "route-ui".to_string(),
             enabled: true,
@@ -117,7 +125,8 @@ mod tests {
             target_ref: "ui".to_string(),
             created_at: now.clone(),
             updated_at: now,
-        });
+        })
+        .unwrap();
         table
     }
 

--- a/crates/exomind-runtime/src/signal/journal.rs
+++ b/crates/exomind-runtime/src/signal/journal.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 use std::sync::{Arc, RwLock};
 
-use super::sqlite_store::SqliteSignalStore;
+use super::sqlite_store::{SignalStoreError, SqliteSignalStore};
 use super::types::DeliveryRecord;
 
 const DEFAULT_CAPACITY: usize = 1000;
@@ -31,23 +31,25 @@ impl Journal {
         }
     }
 
-    pub(crate) fn with_sqlite_store(store: Arc<SqliteSignalStore>) -> Self {
-        let initial = store
-            .load_recent_journal(DEFAULT_CAPACITY)
-            .unwrap_or_default();
+    pub(crate) fn with_sqlite_store(store: Arc<SqliteSignalStore>) -> Result<Self, SignalStoreError> {
+        let initial = store.load_recent_journal(DEFAULT_CAPACITY)?;
         let mut records = VecDeque::with_capacity(DEFAULT_CAPACITY);
         for record in initial {
             records.push_back(record);
         }
 
-        Self {
+        Ok(Self {
             records: RwLock::new(records),
             capacity: DEFAULT_CAPACITY,
             store: Some(store),
-        }
+        })
     }
 
-    pub fn append(&self, record: DeliveryRecord) {
+    pub fn append(&self, record: DeliveryRecord) -> Result<(), SignalStoreError> {
+        if let Some(store) = &self.store {
+            store.append_journal(&record)?;
+        }
+
         let mut records = match self.records.write() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
@@ -55,12 +57,8 @@ impl Journal {
         if records.len() >= self.capacity {
             records.pop_front();
         }
-        records.push_back(record.clone());
-        drop(records);
-
-        if let Some(store) = &self.store {
-            let _ = store.append_journal(&record);
-        }
+        records.push_back(record);
+        Ok(())
     }
 
     pub fn recent(&self, limit: usize) -> Vec<DeliveryRecord> {
@@ -87,14 +85,25 @@ impl Journal {
 
     pub fn all_records(&self) -> Vec<DeliveryRecord> {
         if let Some(store) = &self.store {
-            return store
-                .load_all_journal()
-                .unwrap_or_else(|_| self.recent(self.capacity));
+            return match store.load_all_journal() {
+                Ok(records) => records,
+                Err(error) => {
+                    tracing::warn!(
+                        error = %error,
+                        "signal journal reload failed, falling back to memory cache (日志重载失败，回退到内存缓存)"
+                    );
+                    self.recent(self.capacity)
+                }
+            };
         }
         self.recent(self.capacity)
     }
 
-    pub fn replace_all(&self, records: Vec<DeliveryRecord>) {
+    pub fn replace_all(&self, records: Vec<DeliveryRecord>) -> Result<(), SignalStoreError> {
+        if let Some(store) = &self.store {
+            store.replace_journal(&records)?;
+        }
+
         let mut buffer = VecDeque::with_capacity(self.capacity);
         let start = records.len().saturating_sub(self.capacity);
         for record in records.iter().skip(start) {
@@ -106,11 +115,21 @@ impl Journal {
             Err(poisoned) => poisoned.into_inner(),
         };
         *current = buffer;
-        drop(current);
+        Ok(())
+    }
 
-        if let Some(store) = &self.store {
-            let _ = store.replace_journal(&records);
+    pub(crate) fn replace_all_in_memory(&self, records: Vec<DeliveryRecord>) {
+        let mut buffer = VecDeque::with_capacity(self.capacity);
+        let start = records.len().saturating_sub(self.capacity);
+        for record in records.iter().skip(start) {
+            buffer.push_back(record.clone());
         }
+
+        let mut current = match self.records.write() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        *current = buffer;
     }
 }
 
@@ -134,9 +153,9 @@ mod tests {
     #[test]
     fn append_and_recent() {
         let journal = Journal::new();
-        journal.append(make_record("evt-1"));
-        journal.append(make_record("evt-2"));
-        journal.append(make_record("evt-3"));
+        journal.append(make_record("evt-1")).unwrap();
+        journal.append(make_record("evt-2")).unwrap();
+        journal.append(make_record("evt-3")).unwrap();
 
         let recent = journal.recent(2);
         assert_eq!(recent.len(), 2);
@@ -147,7 +166,7 @@ mod tests {
     #[test]
     fn recent_returns_all_when_limit_exceeds_length() {
         let journal = Journal::new();
-        journal.append(make_record("evt-1"));
+        journal.append(make_record("evt-1")).unwrap();
 
         let recent = journal.recent(100);
         assert_eq!(recent.len(), 1);
@@ -156,10 +175,10 @@ mod tests {
     #[test]
     fn ring_buffer_evicts_oldest() {
         let journal = Journal::with_capacity(3);
-        journal.append(make_record("evt-1"));
-        journal.append(make_record("evt-2"));
-        journal.append(make_record("evt-3"));
-        journal.append(make_record("evt-4"));
+        journal.append(make_record("evt-1")).unwrap();
+        journal.append(make_record("evt-2")).unwrap();
+        journal.append(make_record("evt-3")).unwrap();
+        journal.append(make_record("evt-4")).unwrap();
 
         assert_eq!(journal.len(), 3);
         let recent = journal.recent(10);

--- a/crates/exomind-runtime/src/signal/journal.rs
+++ b/crates/exomind-runtime/src/signal/journal.rs
@@ -1,14 +1,15 @@
 use std::collections::VecDeque;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
+use super::sqlite_store::SqliteSignalStore;
 use super::types::DeliveryRecord;
 
 const DEFAULT_CAPACITY: usize = 1000;
 
-/// Ring buffer storing delivery records for observability.
 pub struct Journal {
     records: RwLock<VecDeque<DeliveryRecord>>,
     capacity: usize,
+    store: Option<Arc<SqliteSignalStore>>,
 }
 
 impl Default for Journal {
@@ -26,25 +27,45 @@ impl Journal {
         Self {
             records: RwLock::new(VecDeque::with_capacity(capacity)),
             capacity,
+            store: None,
         }
     }
 
-    /// Append a delivery record. Evicts oldest if at capacity.
+    pub(crate) fn with_sqlite_store(store: Arc<SqliteSignalStore>) -> Self {
+        let initial = store
+            .load_recent_journal(DEFAULT_CAPACITY)
+            .unwrap_or_default();
+        let mut records = VecDeque::with_capacity(DEFAULT_CAPACITY);
+        for record in initial {
+            records.push_back(record);
+        }
+
+        Self {
+            records: RwLock::new(records),
+            capacity: DEFAULT_CAPACITY,
+            store: Some(store),
+        }
+    }
+
     pub fn append(&self, record: DeliveryRecord) {
         let mut records = match self.records.write() {
-            Ok(r) => r,
+            Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
         if records.len() >= self.capacity {
             records.pop_front();
         }
-        records.push_back(record);
+        records.push_back(record.clone());
+        drop(records);
+
+        if let Some(store) = &self.store {
+            let _ = store.append_journal(&record);
+        }
     }
 
-    /// Return the most recent `limit` records (newest last).
     pub fn recent(&self, limit: usize) -> Vec<DeliveryRecord> {
         let records = match self.records.read() {
-            Ok(r) => r,
+            Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
         let len = records.len();
@@ -52,10 +73,9 @@ impl Journal {
         records.iter().skip(skip).cloned().collect()
     }
 
-    /// Return total number of records currently held.
     pub fn len(&self) -> usize {
         let records = match self.records.read() {
-            Ok(r) => r,
+            Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
         records.len()
@@ -63,6 +83,34 @@ impl Journal {
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    pub fn all_records(&self) -> Vec<DeliveryRecord> {
+        if let Some(store) = &self.store {
+            return store
+                .load_all_journal()
+                .unwrap_or_else(|_| self.recent(self.capacity));
+        }
+        self.recent(self.capacity)
+    }
+
+    pub fn replace_all(&self, records: Vec<DeliveryRecord>) {
+        let mut buffer = VecDeque::with_capacity(self.capacity);
+        let start = records.len().saturating_sub(self.capacity);
+        for record in records.iter().skip(start) {
+            buffer.push_back(record.clone());
+        }
+
+        let mut current = match self.records.write() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        *current = buffer;
+        drop(current);
+
+        if let Some(store) = &self.store {
+            let _ = store.replace_journal(&records);
+        }
     }
 }
 

--- a/crates/exomind-runtime/src/signal/mod.rs
+++ b/crates/exomind-runtime/src/signal/mod.rs
@@ -1,87 +1,122 @@
-pub mod actors;
+﻿pub mod actors;
 pub mod bus;
 pub mod journal;
 pub mod route_table;
+pub mod sqlite_store;
 pub mod types;
 pub mod window;
 
 pub use bus::SignalBus;
 pub use journal::Journal;
 pub use route_table::RouteTable;
+pub use sqlite_store::{SignalPoolSnapshot, SignalStoreError};
 pub use types::*;
 pub use window::WindowCache;
 
 use std::path::Path;
+use std::sync::Arc;
 use tokio::sync::broadcast;
 
-/// SignalPool: top-level facade composing Bus, RouteTable, Journal, WindowCache.
+use sqlite_store::SqliteSignalStore;
+
 pub struct SignalPool {
     bus: SignalBus,
     route_table: RouteTable,
     journal: Journal,
     window: WindowCache,
+    store: Option<Arc<SqliteSignalStore>>,
 }
 
 impl SignalPool {
-    /// Create a new SignalPool.
-    ///
-    /// `config_path` points to the default (innate) routes JSON file.
-    /// If the file does not exist, an empty route table is used.
     pub fn new(config_path: Option<&str>) -> Self {
         let default_path = config_path.map(std::path::PathBuf::from);
         let default_ref = default_path
             .as_ref()
-            .filter(|p| p.exists())
-            .map(|p| p.as_path());
+            .filter(|path| path.exists())
+            .map(|path| path.as_path());
 
         Self {
             bus: SignalBus::new(),
             route_table: RouteTable::new(default_ref, None),
             journal: Journal::new(),
             window: WindowCache::new(),
+            store: None,
         }
     }
 
-    /// Create a SignalPool with a custom persist path for user routes.
     pub fn with_persist_path(config_path: Option<&str>, persist_path: &Path) -> Self {
         let default_path = config_path.map(std::path::PathBuf::from);
         let default_ref = default_path
             .as_ref()
-            .filter(|p| p.exists())
-            .map(|p| p.as_path());
+            .filter(|path| path.exists())
+            .map(|path| path.as_path());
 
         Self {
             bus: SignalBus::new(),
             route_table: RouteTable::new(default_ref, Some(persist_path.to_path_buf())),
             journal: Journal::new(),
             window: WindowCache::new(),
+            store: None,
         }
     }
 
-    /// Publish an event through the signal pool.
+    pub fn with_sqlite_path(config_path: Option<&str>, sqlite_path: &Path) -> Self {
+        let default_path = config_path.map(std::path::PathBuf::from);
+        let default_ref = default_path
+            .as_ref()
+            .filter(|path| path.exists())
+            .map(|path| path.as_path());
+
+        let store = Arc::new(
+            SqliteSignalStore::open(sqlite_path)
+                .unwrap_or_else(|error| panic!("signal sqlite store should initialize: {error}")),
+        );
+
+        Self {
+            bus: SignalBus::new(),
+            route_table: RouteTable::with_sqlite_store(default_ref, Arc::clone(&store)),
+            journal: Journal::with_sqlite_store(Arc::clone(&store)),
+            window: WindowCache::new(),
+            store: Some(store),
+        }
+    }
+
     pub fn publish(&self, event: SignalEvent) -> Vec<DeliveryRecord> {
         self.bus
             .publish(event, &self.route_table, &self.journal, &self.window)
     }
 
-    /// Subscribe to the broadcast channel for real-time events.
     pub fn subscribe(&self) -> broadcast::Receiver<SignalEvent> {
         self.bus.subscribe()
     }
 
-    /// Access the route table for CRUD operations.
     pub fn routes(&self) -> &RouteTable {
         &self.route_table
     }
 
-    /// Access the delivery journal.
     pub fn journal(&self) -> &Journal {
         &self.journal
     }
 
-    /// Access the event window cache.
     pub fn window(&self) -> &WindowCache {
         &self.window
+    }
+
+    pub fn export_snapshot(&self) -> Result<SignalPoolSnapshot, SignalStoreError> {
+        if let Some(store) = &self.store {
+            return store.export_snapshot();
+        }
+
+        Ok(SignalPoolSnapshot {
+            routes: self.route_table.get_all(),
+            journal: self.journal.all_records(),
+        })
+    }
+
+    pub fn import_snapshot(&self, snapshot: SignalPoolSnapshot) -> Result<(), SignalStoreError> {
+        self.route_table.replace_all(snapshot.routes);
+        self.journal.replace_all(snapshot.journal);
+        Ok(())
     }
 }
 
@@ -118,8 +153,6 @@ mod tests {
     #[test]
     fn full_publish_flow() {
         let pool = SignalPool::new(None);
-
-        // Add a route.
         let now = chrono::Utc::now().to_rfc3339();
         pool.routes().add(SignalRoute {
             id: "r1".to_string(),
@@ -131,9 +164,7 @@ mod tests {
             updated_at: now,
         });
 
-        // Subscribe so broadcast succeeds.
         let _rx = pool.subscribe();
-
         let event = make_event("test.topic");
         let event_id = event.id.clone();
         let records = pool.publish(event);
@@ -163,30 +194,5 @@ mod tests {
         assert_eq!(pool.routes().get_all().len(), 2);
 
         std::fs::remove_dir_all(&dir).unwrap();
-    }
-
-    #[tokio::test]
-    async fn subscriber_receives_events() {
-        let pool = SignalPool::new(None);
-
-        let now = chrono::Utc::now().to_rfc3339();
-        pool.routes().add(SignalRoute {
-            id: "r1".to_string(),
-            enabled: true,
-            topic: "x".to_string(),
-            target_type: TargetType::Actor,
-            target_ref: "eventlog".to_string(),
-            created_at: now.clone(),
-            updated_at: now,
-        });
-
-        let mut rx = pool.subscribe();
-
-        let event = make_event("x");
-        let event_id = event.id.clone();
-        pool.publish(event);
-
-        let received = rx.recv().await.unwrap();
-        assert_eq!(received.id, event_id);
     }
 }

--- a/crates/exomind-runtime/src/signal/mod.rs
+++ b/crates/exomind-runtime/src/signal/mod.rs
@@ -60,25 +60,25 @@ impl SignalPool {
         }
     }
 
-    pub fn with_sqlite_path(config_path: Option<&str>, sqlite_path: &Path) -> Self {
+    pub fn with_sqlite_path(
+        config_path: Option<&str>,
+        sqlite_path: &Path,
+    ) -> Result<Self, SignalStoreError> {
         let default_path = config_path.map(std::path::PathBuf::from);
         let default_ref = default_path
             .as_ref()
             .filter(|path| path.exists())
             .map(|path| path.as_path());
 
-        let store = Arc::new(
-            SqliteSignalStore::open(sqlite_path)
-                .unwrap_or_else(|error| panic!("signal sqlite store should initialize: {error}")),
-        );
+        let store = Arc::new(SqliteSignalStore::open(sqlite_path)?);
 
-        Self {
+        Ok(Self {
             bus: SignalBus::new(),
-            route_table: RouteTable::with_sqlite_store(default_ref, Arc::clone(&store)),
-            journal: Journal::with_sqlite_store(Arc::clone(&store)),
+            route_table: RouteTable::with_sqlite_store(default_ref, Arc::clone(&store))?,
+            journal: Journal::with_sqlite_store(Arc::clone(&store))?,
             window: WindowCache::new(),
             store: Some(store),
-        }
+        })
     }
 
     pub fn publish(&self, event: SignalEvent) -> Vec<DeliveryRecord> {
@@ -114,8 +114,15 @@ impl SignalPool {
     }
 
     pub fn import_snapshot(&self, snapshot: SignalPoolSnapshot) -> Result<(), SignalStoreError> {
-        self.route_table.replace_all(snapshot.routes);
-        self.journal.replace_all(snapshot.journal);
+        if let Some(store) = &self.store {
+            store.import_snapshot(&snapshot)?;
+            self.route_table.replace_all_in_memory(snapshot.routes);
+            self.journal.replace_all_in_memory(snapshot.journal);
+            return Ok(());
+        }
+
+        self.route_table.replace_all(snapshot.routes)?;
+        self.journal.replace_all(snapshot.journal)?;
         Ok(())
     }
 }
@@ -162,7 +169,8 @@ mod tests {
             target_ref: "echo".to_string(),
             created_at: now.clone(),
             updated_at: now,
-        });
+        })
+        .unwrap();
 
         let _rx = pool.subscribe();
         let event = make_event("test.topic");

--- a/crates/exomind-runtime/src/signal/route_table.rs
+++ b/crates/exomind-runtime/src/signal/route_table.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
-use super::sqlite_store::SqliteSignalStore;
+use super::sqlite_store::{SignalStoreError, SqliteSignalStore};
 use super::types::{SignalRoute, TargetType};
 
 enum RoutePersistBackend {
@@ -37,30 +37,32 @@ impl RouteTable {
     pub(crate) fn with_sqlite_store(
         default_path: Option<&Path>,
         store: Arc<SqliteSignalStore>,
-    ) -> Self {
+    ) -> Result<Self, SignalStoreError> {
         let legacy_path = store.path().with_file_name("routes.json");
-        let _ = store.import_legacy_routes_if_needed(&legacy_path);
-        let persisted_routes = store.load_routes().unwrap_or_default();
+        store.import_legacy_routes_if_needed(&legacy_path)?;
+        let persisted_routes = store.load_routes()?;
         let all_routes = if persisted_routes.is_empty() {
             load_default_routes(default_path)
         } else {
             persisted_routes
         };
 
-        Self {
+        Ok(Self {
             routes: RwLock::new(build_route_map(all_routes)),
             persist_backend: RoutePersistBackend::Sqlite(store),
-        }
+        })
     }
 
-    pub fn add(&self, route: SignalRoute) {
-        let topic = route.topic.clone();
+    pub fn add(&self, route: SignalRoute) -> Result<(), SignalStoreError> {
         let mut map = match self.routes.write() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
-        map.entry(topic).or_default().push(route);
-        self.persist_locked(&map);
+        let mut next = map.clone();
+        next.entry(route.topic.clone()).or_default().push(route);
+        self.persist_locked(&next)?;
+        *map = next;
+        Ok(())
     }
 
     pub fn get_all(&self) -> Vec<SignalRoute> {
@@ -79,17 +81,22 @@ impl RouteTable {
         map.values().flatten().find(|route| route.id == id).cloned()
     }
 
-    pub fn update(&self, id: &str, mut updater: impl FnMut(&mut SignalRoute)) -> bool {
+    pub fn update(
+        &self,
+        id: &str,
+        mut updater: impl FnMut(&mut SignalRoute),
+    ) -> Result<bool, SignalStoreError> {
         let mut map = match self.routes.write() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
+        let mut next = map.clone();
 
         let mut found = false;
         let mut old_topic: Option<String> = None;
         let mut updated_route: Option<SignalRoute> = None;
 
-        for (topic, routes) in map.iter_mut() {
+        for (topic, routes) in next.iter_mut() {
             if let Some(route) = routes.iter_mut().find(|route| route.id == id) {
                 old_topic = Some(topic.clone());
                 updater(route);
@@ -103,32 +110,34 @@ impl RouteTable {
         if let (Some(old), Some(route)) = (&old_topic, &updated_route)
             && *old != route.topic
         {
-            if let Some(routes) = map.get_mut(old.as_str()) {
+            if let Some(routes) = next.get_mut(old.as_str()) {
                 routes.retain(|candidate| candidate.id != id);
                 if routes.is_empty() {
-                    map.remove(old.as_str());
+                    next.remove(old.as_str());
                 }
             }
-            map.entry(route.topic.clone())
+            next.entry(route.topic.clone())
                 .or_default()
                 .push(route.clone());
         }
 
         if found {
-            self.persist_locked(&map);
+            self.persist_locked(&next)?;
+            *map = next;
         }
-        found
+        Ok(found)
     }
 
-    pub fn delete(&self, id: &str) -> bool {
+    pub fn delete(&self, id: &str) -> Result<bool, SignalStoreError> {
         let mut map = match self.routes.write() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
+        let mut next = map.clone();
 
         let mut found = false;
         let mut empty_topics = Vec::new();
-        for (topic, routes) in map.iter_mut() {
+        for (topic, routes) in next.iter_mut() {
             let before = routes.len();
             routes.retain(|route| route.id != id);
             if routes.len() < before {
@@ -140,13 +149,14 @@ impl RouteTable {
         }
 
         for topic in empty_topics {
-            map.remove(&topic);
+            next.remove(&topic);
         }
 
         if found {
-            self.persist_locked(&map);
+            self.persist_locked(&next)?;
+            *map = next;
         }
-        found
+        Ok(found)
     }
 
     pub fn match_routes(&self, topic: &str) -> Vec<SignalRoute> {
@@ -177,27 +187,38 @@ impl RouteTable {
         result
     }
 
-    pub fn replace_all(&self, routes: Vec<SignalRoute>) {
+    pub fn replace_all(&self, routes: Vec<SignalRoute>) -> Result<(), SignalStoreError> {
+        let mut map = match self.routes.write() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let next = build_route_map(routes);
+        self.persist_locked(&next)?;
+        *map = next;
+        Ok(())
+    }
+
+    pub(crate) fn replace_all_in_memory(&self, routes: Vec<SignalRoute>) {
         let mut map = match self.routes.write() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
         *map = build_route_map(routes);
-        self.persist_locked(&map);
     }
 
-    fn persist_locked(&self, map: &HashMap<String, Vec<SignalRoute>>) {
+    fn persist_locked(
+        &self,
+        map: &HashMap<String, Vec<SignalRoute>>,
+    ) -> Result<(), SignalStoreError> {
         let all_routes: Vec<SignalRoute> = map.values().flatten().cloned().collect();
         match &self.persist_backend {
-            RoutePersistBackend::None => {}
+            RoutePersistBackend::None => Ok(()),
             RoutePersistBackend::Json(path) => {
-                if let Ok(json) = serde_json::to_string_pretty(&all_routes) {
-                    let _ = std::fs::write(path, json);
-                }
+                let json = serde_json::to_string_pretty(&all_routes)?;
+                std::fs::write(path, json)?;
+                Ok(())
             }
-            RoutePersistBackend::Sqlite(store) => {
-                let _ = store.replace_routes(&all_routes);
-            }
+            RoutePersistBackend::Sqlite(store) => store.replace_routes(&all_routes),
         }
     }
 }
@@ -270,8 +291,10 @@ mod tests {
     #[test]
     fn add_and_get_all() {
         let table = RouteTable::new(None, None);
-        table.add(make_route("user.input.text", "classifier"));
-        table.add(make_route("session.end", "reviewer"));
+        table
+            .add(make_route("user.input.text", "classifier"))
+            .unwrap();
+        table.add(make_route("session.end", "reviewer")).unwrap();
         assert_eq!(table.get_all().len(), 2);
     }
 
@@ -280,7 +303,7 @@ mod tests {
         let table = RouteTable::new(None, None);
         let route = make_route("test.topic", "target-a");
         let id = route.id.clone();
-        table.add(route);
+        table.add(route).unwrap();
 
         let found = table.get_by_id(&id);
         assert!(found.is_some());
@@ -298,9 +321,9 @@ mod tests {
         let table = RouteTable::new(None, None);
         let route = make_route("topic", "target");
         let id = route.id.clone();
-        table.add(route);
+        table.add(route).unwrap();
 
-        assert!(table.delete(&id));
+        assert!(table.delete(&id).unwrap());
         assert!(table.get_by_id(&id).is_none());
         assert_eq!(table.get_all().len(), 0);
     }
@@ -308,7 +331,7 @@ mod tests {
     #[test]
     fn delete_returns_false_for_missing() {
         let table = RouteTable::new(None, None);
-        assert!(!table.delete("nonexistent"));
+        assert!(!table.delete("nonexistent").unwrap());
     }
 
     #[test]
@@ -316,26 +339,28 @@ mod tests {
         let table = RouteTable::new(None, None);
         let route = make_route("topic", "old-target");
         let id = route.id.clone();
-        table.add(route);
+        table.add(route).unwrap();
 
         let updated = table.update(&id, |route| {
             route.target_ref = "new-target".to_string();
         });
-        assert!(updated);
+        assert!(updated.unwrap());
         assert_eq!(table.get_by_id(&id).unwrap().target_ref, "new-target");
     }
 
     #[test]
     fn update_returns_false_for_missing() {
         let table = RouteTable::new(None, None);
-        assert!(!table.update("nonexistent", |_| {}));
+        assert!(!table.update("nonexistent", |_| {}).unwrap());
     }
 
     #[test]
     fn match_routes_exact_and_wildcard() {
         let table = RouteTable::new(None, None);
-        table.add(make_route("user.input.text", "classifier"));
-        table.add(make_route("*", "ui"));
+        table
+            .add(make_route("user.input.text", "classifier"))
+            .unwrap();
+        table.add(make_route("*", "ui")).unwrap();
 
         let matched = table.match_routes("user.input.text");
         assert_eq!(matched.len(), 2);
@@ -351,7 +376,7 @@ mod tests {
     #[test]
     fn match_routes_wildcard_topic_does_not_double_match() {
         let table = RouteTable::new(None, None);
-        table.add(make_route("*", "ui"));
+        table.add(make_route("*", "ui")).unwrap();
 
         let matched = table.match_routes("*");
         assert_eq!(matched.len(), 1);
@@ -362,7 +387,7 @@ mod tests {
         let table = RouteTable::new(None, None);
         let mut route = make_route("topic", "target");
         route.enabled = false;
-        table.add(route);
+        table.add(route).unwrap();
 
         let matched = table.match_routes("topic");
         assert_eq!(matched.len(), 0);
@@ -397,7 +422,7 @@ mod tests {
         let table = RouteTable::new(None, Some(persist_path.clone()));
         let route = make_route("test", "target-persist");
         let id = route.id.clone();
-        table.add(route);
+        table.add(route).unwrap();
 
         let table2 = RouteTable::new(None, Some(persist_path));
         let reloaded = table2.get_by_id(&id);

--- a/crates/exomind-runtime/src/signal/route_table.rs
+++ b/crates/exomind-runtime/src/signal/route_table.rs
@@ -1,19 +1,21 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
+use super::sqlite_store::SqliteSignalStore;
 use super::types::{SignalRoute, TargetType};
 
-/// Persistent route table backed by a JSON file.
-pub struct RouteTable {
-    /// Routes indexed by topic for fast lookup.
-    routes: RwLock<HashMap<String, Vec<SignalRoute>>>,
-    /// Path to the user-mutable routes file (written on CRUD).
-    persist_path: Option<PathBuf>,
+enum RoutePersistBackend {
+    None,
+    Json(PathBuf),
+    Sqlite(Arc<SqliteSignalStore>),
 }
 
-/// Minimal JSON shape accepted in default-routes config files.
-/// Fields like `id`, `enabled`, `created_at`, `updated_at` are auto-generated.
+pub struct RouteTable {
+    routes: RwLock<HashMap<String, Vec<SignalRoute>>>,
+    persist_backend: RoutePersistBackend,
+}
+
 #[derive(serde::Deserialize)]
 struct DefaultRouteEntry {
     topic: String,
@@ -22,92 +24,73 @@ struct DefaultRouteEntry {
 }
 
 impl RouteTable {
-    /// Create a new RouteTable, optionally loading innate routes from `default_path`
-    /// and user routes from `persist_path`.
     pub fn new(default_path: Option<&Path>, persist_path: Option<PathBuf>) -> Self {
-        let mut all_routes: Vec<SignalRoute> = Vec::new();
-
-        // Load innate (default) routes.
-        if let Some(path) = default_path
-            && let Ok(data) = std::fs::read_to_string(path)
-            && let Ok(entries) = serde_json::from_str::<Vec<DefaultRouteEntry>>(&data)
-        {
-            let now = chrono::Utc::now().to_rfc3339();
-            for entry in entries {
-                all_routes.push(SignalRoute {
-                    id: uuid::Uuid::new_v4().to_string(),
-                    enabled: true,
-                    topic: entry.topic,
-                    target_type: entry.target_type,
-                    target_ref: entry.target_ref,
-                    created_at: now.clone(),
-                    updated_at: now.clone(),
-                });
-            }
-        }
-
-        // Load persisted user routes (overrides nothing, just appends).
-        if let Some(ref path) = persist_path
-            && let Ok(data) = std::fs::read_to_string(path)
-            && let Ok(persisted) = serde_json::from_str::<Vec<SignalRoute>>(&data)
-        {
-            all_routes.extend(persisted);
-        }
-
-        let mut map: HashMap<String, Vec<SignalRoute>> = HashMap::new();
-        for route in all_routes {
-            map.entry(route.topic.clone()).or_default().push(route);
-        }
-
+        let all_routes = load_routes_from_default_and_json(default_path, persist_path.as_deref());
         Self {
-            routes: RwLock::new(map),
-            persist_path,
+            routes: RwLock::new(build_route_map(all_routes)),
+            persist_backend: persist_path
+                .map(RoutePersistBackend::Json)
+                .unwrap_or(RoutePersistBackend::None),
         }
     }
 
-    /// Add a new route and persist.
+    pub(crate) fn with_sqlite_store(
+        default_path: Option<&Path>,
+        store: Arc<SqliteSignalStore>,
+    ) -> Self {
+        let legacy_path = store.path().with_file_name("routes.json");
+        let _ = store.import_legacy_routes_if_needed(&legacy_path);
+        let persisted_routes = store.load_routes().unwrap_or_default();
+        let all_routes = if persisted_routes.is_empty() {
+            load_default_routes(default_path)
+        } else {
+            persisted_routes
+        };
+
+        Self {
+            routes: RwLock::new(build_route_map(all_routes)),
+            persist_backend: RoutePersistBackend::Sqlite(store),
+        }
+    }
+
     pub fn add(&self, route: SignalRoute) {
         let topic = route.topic.clone();
         let mut map = match self.routes.write() {
-            Ok(m) => m,
+            Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
         map.entry(topic).or_default().push(route);
         self.persist_locked(&map);
     }
 
-    /// Get all routes across all topics.
     pub fn get_all(&self) -> Vec<SignalRoute> {
         let map = match self.routes.read() {
-            Ok(m) => m,
+            Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
         map.values().flatten().cloned().collect()
     }
 
-    /// Get a route by its ID.
     pub fn get_by_id(&self, id: &str) -> Option<SignalRoute> {
         let map = match self.routes.read() {
-            Ok(m) => m,
+            Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
-        map.values().flatten().find(|r| r.id == id).cloned()
+        map.values().flatten().find(|route| route.id == id).cloned()
     }
 
-    /// Update an existing route. Returns true if found and updated.
     pub fn update(&self, id: &str, mut updater: impl FnMut(&mut SignalRoute)) -> bool {
         let mut map = match self.routes.write() {
-            Ok(m) => m,
+            Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
 
-        // Find the route across all topics.
         let mut found = false;
         let mut old_topic: Option<String> = None;
         let mut updated_route: Option<SignalRoute> = None;
 
         for (topic, routes) in map.iter_mut() {
-            if let Some(route) = routes.iter_mut().find(|r| r.id == id) {
+            if let Some(route) = routes.iter_mut().find(|route| route.id == id) {
                 old_topic = Some(topic.clone());
                 updater(route);
                 route.updated_at = chrono::Utc::now().to_rfc3339();
@@ -117,18 +100,18 @@ impl RouteTable {
             }
         }
 
-        // If topic changed, relocate.
         if let (Some(old), Some(route)) = (&old_topic, &updated_route)
             && *old != route.topic
         {
             if let Some(routes) = map.get_mut(old.as_str()) {
-                routes.retain(|r| r.id != id);
+                routes.retain(|candidate| candidate.id != id);
                 if routes.is_empty() {
                     map.remove(old.as_str());
                 }
             }
-            let new_topic = route.topic.clone();
-            map.entry(new_topic).or_default().push(route.clone());
+            map.entry(route.topic.clone())
+                .or_default()
+                .push(route.clone());
         }
 
         if found {
@@ -137,19 +120,17 @@ impl RouteTable {
         found
     }
 
-    /// Delete a route by ID. Returns true if found and deleted.
     pub fn delete(&self, id: &str) -> bool {
         let mut map = match self.routes.write() {
-            Ok(m) => m,
+            Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
 
         let mut found = false;
         let mut empty_topics = Vec::new();
-
         for (topic, routes) in map.iter_mut() {
             let before = routes.len();
-            routes.retain(|r| r.id != id);
+            routes.retain(|route| route.id != id);
             if routes.len() < before {
                 found = true;
                 if routes.is_empty() {
@@ -168,31 +149,27 @@ impl RouteTable {
         found
     }
 
-    /// Match routes for a given topic: exact match + wildcard "*".
     pub fn match_routes(&self, topic: &str) -> Vec<SignalRoute> {
         let map = match self.routes.read() {
-            Ok(m) => m,
+            Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         };
 
         let mut result = Vec::new();
-
-        // Exact match.
         if let Some(routes) = map.get(topic) {
-            for r in routes {
-                if r.enabled {
-                    result.push(r.clone());
+            for route in routes {
+                if route.enabled {
+                    result.push(route.clone());
                 }
             }
         }
 
-        // Wildcard match (skip if topic is already "*").
         if topic != "*"
             && let Some(wildcard_routes) = map.get("*")
         {
-            for r in wildcard_routes {
-                if r.enabled {
-                    result.push(r.clone());
+            for route in wildcard_routes {
+                if route.enabled {
+                    result.push(route.clone());
                 }
             }
         }
@@ -200,16 +177,77 @@ impl RouteTable {
         result
     }
 
-    /// Persist current state to the persist_path.
+    pub fn replace_all(&self, routes: Vec<SignalRoute>) {
+        let mut map = match self.routes.write() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        *map = build_route_map(routes);
+        self.persist_locked(&map);
+    }
+
     fn persist_locked(&self, map: &HashMap<String, Vec<SignalRoute>>) {
-        if let Some(ref path) = self.persist_path {
-            let all: Vec<&SignalRoute> = map.values().flatten().collect();
-            if let Ok(json) = serde_json::to_string_pretty(&all) {
-                // Best-effort write; ignore errors.
-                let _ = std::fs::write(path, json);
+        let all_routes: Vec<SignalRoute> = map.values().flatten().cloned().collect();
+        match &self.persist_backend {
+            RoutePersistBackend::None => {}
+            RoutePersistBackend::Json(path) => {
+                if let Ok(json) = serde_json::to_string_pretty(&all_routes) {
+                    let _ = std::fs::write(path, json);
+                }
+            }
+            RoutePersistBackend::Sqlite(store) => {
+                let _ = store.replace_routes(&all_routes);
             }
         }
     }
+}
+
+fn load_routes_from_default_and_json(
+    default_path: Option<&Path>,
+    persist_path: Option<&Path>,
+) -> Vec<SignalRoute> {
+    let mut all_routes = load_default_routes(default_path);
+
+    if let Some(path) = persist_path
+        && let Ok(data) = std::fs::read_to_string(path)
+        && let Ok(persisted) = serde_json::from_str::<Vec<SignalRoute>>(&data)
+    {
+        all_routes.extend(persisted);
+    }
+
+    all_routes
+}
+
+fn load_default_routes(default_path: Option<&Path>) -> Vec<SignalRoute> {
+    let mut routes = Vec::new();
+    if let Some(path) = default_path
+        && let Ok(data) = std::fs::read_to_string(path)
+        && let Ok(entries) = serde_json::from_str::<Vec<DefaultRouteEntry>>(&data)
+    {
+        let now = chrono::Utc::now().to_rfc3339();
+        for entry in entries {
+            routes.push(SignalRoute {
+                id: uuid::Uuid::new_v4().to_string(),
+                enabled: true,
+                topic: entry.topic,
+                target_type: entry.target_type,
+                target_ref: entry.target_ref,
+                created_at: now.clone(),
+                updated_at: now.clone(),
+            });
+        }
+    }
+    routes
+}
+
+fn build_route_map(routes: Vec<SignalRoute>) -> HashMap<String, Vec<SignalRoute>> {
+    let mut map = HashMap::new();
+    for route in routes {
+        map.entry(route.topic.clone())
+            .or_insert_with(Vec::new)
+            .push(route);
+    }
+    map
 }
 
 #[cfg(test)]
@@ -280,8 +318,8 @@ mod tests {
         let id = route.id.clone();
         table.add(route);
 
-        let updated = table.update(&id, |r| {
-            r.target_ref = "new-target".to_string();
+        let updated = table.update(&id, |route| {
+            route.target_ref = "new-target".to_string();
         });
         assert!(updated);
         assert_eq!(table.get_by_id(&id).unwrap().target_ref, "new-target");
@@ -302,7 +340,10 @@ mod tests {
         let matched = table.match_routes("user.input.text");
         assert_eq!(matched.len(), 2);
 
-        let refs: Vec<&str> = matched.iter().map(|r| r.target_ref.as_str()).collect();
+        let refs: Vec<&str> = matched
+            .iter()
+            .map(|route| route.target_ref.as_str())
+            .collect();
         assert!(refs.contains(&"classifier"));
         assert!(refs.contains(&"ui"));
     }
@@ -312,7 +353,6 @@ mod tests {
         let table = RouteTable::new(None, None);
         table.add(make_route("*", "ui"));
 
-        // Querying for "*" itself should only return once.
         let matched = table.match_routes("*");
         assert_eq!(matched.len(), 1);
     }
@@ -354,13 +394,11 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let persist_path = dir.join("routes.json");
 
-        // Create table and add a route.
         let table = RouteTable::new(None, Some(persist_path.clone()));
         let route = make_route("test", "target-persist");
         let id = route.id.clone();
         table.add(route);
 
-        // Reload from persisted file.
         let table2 = RouteTable::new(None, Some(persist_path));
         let reloaded = table2.get_by_id(&id);
         assert!(reloaded.is_some());

--- a/crates/exomind-runtime/src/signal/sqlite_store.rs
+++ b/crates/exomind-runtime/src/signal/sqlite_store.rs
@@ -1,0 +1,371 @@
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::types::{DeliveryRecord, DeliveryStatus, SignalRoute, TargetType};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignalPoolSnapshot {
+    pub routes: Vec<SignalRoute>,
+    pub journal: Vec<DeliveryRecord>,
+}
+
+#[derive(Debug, Error)]
+pub enum SignalStoreError {
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("invalid target type: {value}")]
+    InvalidTargetType { value: String },
+    #[error("invalid delivery status: {value}")]
+    InvalidDeliveryStatus { value: String },
+}
+
+pub struct SqliteSignalStore {
+    path: PathBuf,
+    connection: Mutex<Connection>,
+}
+
+impl SqliteSignalStore {
+    pub fn open(path: &Path) -> Result<Self, SignalStoreError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let connection = Connection::open(path)?;
+        let store = Self {
+            path: path.to_path_buf(),
+            connection: Mutex::new(connection),
+        };
+        store.init()?;
+        Ok(store)
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn load_routes(&self) -> Result<Vec<SignalRoute>, SignalStoreError> {
+        let connection = match self.connection.lock() {
+            Ok(lock) => lock,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let mut statement = connection.prepare(
+            "SELECT id, enabled, topic, target_type, target_ref, created_at, updated_at
+             FROM signal_routes
+             ORDER BY rowid ASC",
+        )?;
+        let rows = statement.query_map([], |row| {
+            let target_type: String = row.get(3)?;
+            Ok(SignalRoute {
+                id: row.get(0)?,
+                enabled: row.get::<_, i64>(1)? != 0,
+                topic: row.get(2)?,
+                target_type: parse_target_type(&target_type).map_err(map_target_type_error)?,
+                target_ref: row.get(4)?,
+                created_at: row.get(5)?,
+                updated_at: row.get(6)?,
+            })
+        })?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(SignalStoreError::from)
+    }
+
+    pub fn replace_routes(&self, routes: &[SignalRoute]) -> Result<(), SignalStoreError> {
+        let mut connection = match self.connection.lock() {
+            Ok(lock) => lock,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let tx = connection.transaction()?;
+        tx.execute("DELETE FROM signal_routes", [])?;
+        for route in routes {
+            tx.execute(
+                "INSERT INTO signal_routes
+                 (id, enabled, topic, target_type, target_ref, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    route.id,
+                    if route.enabled { 1 } else { 0 },
+                    route.topic,
+                    target_type_to_db(&route.target_type),
+                    route.target_ref,
+                    route.created_at,
+                    route.updated_at,
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn has_routes(&self) -> Result<bool, SignalStoreError> {
+        let connection = match self.connection.lock() {
+            Ok(lock) => lock,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let count: i64 =
+            connection.query_row("SELECT COUNT(1) FROM signal_routes", [], |row| row.get(0))?;
+        Ok(count > 0)
+    }
+
+    pub fn append_journal(&self, record: &DeliveryRecord) -> Result<(), SignalStoreError> {
+        let connection = match self.connection.lock() {
+            Ok(lock) => lock,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        connection.execute(
+            "INSERT INTO signal_journal
+             (event_id, route_id, target_ref, status, reason, started_at, finished_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                record.event_id,
+                record.route_id,
+                record.target_ref,
+                delivery_status_to_db(&record.status),
+                record.reason,
+                record.started_at,
+                record.finished_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn load_recent_journal(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<DeliveryRecord>, SignalStoreError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let connection = match self.connection.lock() {
+            Ok(lock) => lock,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let mut statement = connection.prepare(
+            "SELECT event_id, route_id, target_ref, status, reason, started_at, finished_at
+             FROM signal_journal
+             ORDER BY seq DESC
+             LIMIT ?1",
+        )?;
+        let rows = statement.query_map(params![limit as i64], |row| {
+            let status: String = row.get(3)?;
+            Ok(DeliveryRecord {
+                event_id: row.get(0)?,
+                route_id: row.get(1)?,
+                target_ref: row.get(2)?,
+                status: parse_delivery_status(&status).map_err(map_delivery_status_error)?,
+                reason: row.get(4)?,
+                started_at: row.get(5)?,
+                finished_at: row.get(6)?,
+            })
+        })?;
+
+        let mut collected = rows.collect::<Result<Vec<_>, _>>()?;
+        collected.reverse();
+        Ok(collected)
+    }
+
+    pub fn load_all_journal(&self) -> Result<Vec<DeliveryRecord>, SignalStoreError> {
+        let connection = match self.connection.lock() {
+            Ok(lock) => lock,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let mut statement = connection.prepare(
+            "SELECT event_id, route_id, target_ref, status, reason, started_at, finished_at
+             FROM signal_journal
+             ORDER BY seq ASC",
+        )?;
+        let rows = statement.query_map([], |row| {
+            let status: String = row.get(3)?;
+            Ok(DeliveryRecord {
+                event_id: row.get(0)?,
+                route_id: row.get(1)?,
+                target_ref: row.get(2)?,
+                status: parse_delivery_status(&status).map_err(map_delivery_status_error)?,
+                reason: row.get(4)?,
+                started_at: row.get(5)?,
+                finished_at: row.get(6)?,
+            })
+        })?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(SignalStoreError::from)
+    }
+
+    pub fn replace_journal(&self, records: &[DeliveryRecord]) -> Result<(), SignalStoreError> {
+        let mut connection = match self.connection.lock() {
+            Ok(lock) => lock,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let tx = connection.transaction()?;
+        tx.execute("DELETE FROM signal_journal", [])?;
+        for record in records {
+            tx.execute(
+                "INSERT INTO signal_journal
+                 (event_id, route_id, target_ref, status, reason, started_at, finished_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    record.event_id,
+                    record.route_id,
+                    record.target_ref,
+                    delivery_status_to_db(&record.status),
+                    record.reason,
+                    record.started_at,
+                    record.finished_at,
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn export_snapshot(&self) -> Result<SignalPoolSnapshot, SignalStoreError> {
+        Ok(SignalPoolSnapshot {
+            routes: self.load_routes()?,
+            journal: self.load_all_journal()?,
+        })
+    }
+
+    pub fn import_snapshot(&self, snapshot: &SignalPoolSnapshot) -> Result<(), SignalStoreError> {
+        self.replace_routes(&snapshot.routes)?;
+        self.replace_journal(&snapshot.journal)?;
+        Ok(())
+    }
+
+    pub fn import_legacy_routes_if_needed(
+        &self,
+        legacy_path: &Path,
+    ) -> Result<(), SignalStoreError> {
+        if self.has_routes()? || self.meta_flag("legacy_routes_imported")? || !legacy_path.is_file()
+        {
+            return Ok(());
+        }
+
+        let data = std::fs::read_to_string(legacy_path)?;
+        let routes = match serde_json::from_str::<Vec<SignalRoute>>(&data) {
+            Ok(routes) => routes,
+            Err(_) => return Ok(()),
+        };
+
+        self.replace_routes(&routes)?;
+        self.set_meta_flag("legacy_routes_imported", true)?;
+        Ok(())
+    }
+
+    fn init(&self) -> Result<(), SignalStoreError> {
+        let connection = match self.connection.lock() {
+            Ok(lock) => lock,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        connection.execute_batch(
+            "CREATE TABLE IF NOT EXISTS signal_routes (
+                id TEXT PRIMARY KEY,
+                enabled INTEGER NOT NULL,
+                topic TEXT NOT NULL,
+                target_type TEXT NOT NULL,
+                target_ref TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS signal_journal (
+                seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_id TEXT NOT NULL,
+                route_id TEXT NOT NULL,
+                target_ref TEXT NOT NULL,
+                status TEXT NOT NULL,
+                reason TEXT NULL,
+                started_at TEXT NOT NULL,
+                finished_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS signal_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );",
+        )?;
+        Ok(())
+    }
+
+    fn meta_flag(&self, key: &str) -> Result<bool, SignalStoreError> {
+        let connection = match self.connection.lock() {
+            Ok(lock) => lock,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let value = connection
+            .query_row(
+                "SELECT value FROM signal_meta WHERE key = ?1",
+                params![key],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        Ok(matches!(value.as_deref(), Some("true")))
+    }
+
+    fn set_meta_flag(&self, key: &str, value: bool) -> Result<(), SignalStoreError> {
+        let connection = match self.connection.lock() {
+            Ok(lock) => lock,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        connection.execute(
+            "INSERT INTO signal_meta (key, value) VALUES (?1, ?2)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![key, if value { "true" } else { "false" }],
+        )?;
+        Ok(())
+    }
+}
+
+fn target_type_to_db(target_type: &TargetType) -> &'static str {
+    match target_type {
+        TargetType::Actor => "actor",
+        TargetType::Agent => "agent",
+        TargetType::Frontend => "frontend",
+        TargetType::Remote => "remote",
+    }
+}
+
+fn parse_target_type(value: &str) -> Result<TargetType, SignalStoreError> {
+    match value {
+        "actor" => Ok(TargetType::Actor),
+        "agent" => Ok(TargetType::Agent),
+        "frontend" => Ok(TargetType::Frontend),
+        "remote" => Ok(TargetType::Remote),
+        _ => Err(SignalStoreError::InvalidTargetType {
+            value: value.to_string(),
+        }),
+    }
+}
+
+fn delivery_status_to_db(status: &DeliveryStatus) -> &'static str {
+    match status {
+        DeliveryStatus::Sent => "sent",
+        DeliveryStatus::Failed => "failed",
+        DeliveryStatus::Skipped => "skipped",
+    }
+}
+
+fn parse_delivery_status(value: &str) -> Result<DeliveryStatus, SignalStoreError> {
+    match value {
+        "sent" => Ok(DeliveryStatus::Sent),
+        "failed" => Ok(DeliveryStatus::Failed),
+        "skipped" => Ok(DeliveryStatus::Skipped),
+        _ => Err(SignalStoreError::InvalidDeliveryStatus {
+            value: value.to_string(),
+        }),
+    }
+}
+
+fn map_target_type_error(error: SignalStoreError) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(error))
+}
+
+fn map_delivery_status_error(error: SignalStoreError) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(error))
+}

--- a/crates/exomind-runtime/src/signal/sqlite_store.rs
+++ b/crates/exomind-runtime/src/signal/sqlite_store.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, Transaction, params};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -84,23 +84,7 @@ impl SqliteSignalStore {
             Err(poisoned) => poisoned.into_inner(),
         };
         let tx = connection.transaction()?;
-        tx.execute("DELETE FROM signal_routes", [])?;
-        for route in routes {
-            tx.execute(
-                "INSERT INTO signal_routes
-                 (id, enabled, topic, target_type, target_ref, created_at, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-                params![
-                    route.id,
-                    if route.enabled { 1 } else { 0 },
-                    route.topic,
-                    target_type_to_db(&route.target_type),
-                    route.target_ref,
-                    route.created_at,
-                    route.updated_at,
-                ],
-            )?;
-        }
+        replace_routes_in_tx(&tx, routes)?;
         tx.commit()?;
         Ok(())
     }
@@ -206,23 +190,7 @@ impl SqliteSignalStore {
             Err(poisoned) => poisoned.into_inner(),
         };
         let tx = connection.transaction()?;
-        tx.execute("DELETE FROM signal_journal", [])?;
-        for record in records {
-            tx.execute(
-                "INSERT INTO signal_journal
-                 (event_id, route_id, target_ref, status, reason, started_at, finished_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-                params![
-                    record.event_id,
-                    record.route_id,
-                    record.target_ref,
-                    delivery_status_to_db(&record.status),
-                    record.reason,
-                    record.started_at,
-                    record.finished_at,
-                ],
-            )?;
-        }
+        replace_journal_in_tx(&tx, records)?;
         tx.commit()?;
         Ok(())
     }
@@ -235,8 +203,14 @@ impl SqliteSignalStore {
     }
 
     pub fn import_snapshot(&self, snapshot: &SignalPoolSnapshot) -> Result<(), SignalStoreError> {
-        self.replace_routes(&snapshot.routes)?;
-        self.replace_journal(&snapshot.journal)?;
+        let mut connection = match self.connection.lock() {
+            Ok(lock) => lock,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let tx = connection.transaction()?;
+        replace_routes_in_tx(&tx, &snapshot.routes)?;
+        replace_journal_in_tx(&tx, &snapshot.journal)?;
+        tx.commit()?;
         Ok(())
     }
 
@@ -368,4 +342,52 @@ fn map_target_type_error(error: SignalStoreError) -> rusqlite::Error {
 
 fn map_delivery_status_error(error: SignalStoreError) -> rusqlite::Error {
     rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(error))
+}
+
+fn replace_routes_in_tx(
+    tx: &Transaction<'_>,
+    routes: &[SignalRoute],
+) -> Result<(), rusqlite::Error> {
+    tx.execute("DELETE FROM signal_routes", [])?;
+    for route in routes {
+        tx.execute(
+            "INSERT INTO signal_routes
+             (id, enabled, topic, target_type, target_ref, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                route.id,
+                if route.enabled { 1 } else { 0 },
+                route.topic,
+                target_type_to_db(&route.target_type),
+                route.target_ref,
+                route.created_at,
+                route.updated_at,
+            ],
+        )?;
+    }
+    Ok(())
+}
+
+fn replace_journal_in_tx(
+    tx: &Transaction<'_>,
+    records: &[DeliveryRecord],
+) -> Result<(), rusqlite::Error> {
+    tx.execute("DELETE FROM signal_journal", [])?;
+    for record in records {
+        tx.execute(
+            "INSERT INTO signal_journal
+             (event_id, route_id, target_ref, status, reason, started_at, finished_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                record.event_id,
+                record.route_id,
+                record.target_ref,
+                delivery_status_to_db(&record.status),
+                record.reason,
+                record.started_at,
+                record.finished_at,
+            ],
+        )?;
+    }
+    Ok(())
 }

--- a/crates/exomind-runtime/tests/runtime_ts_agents.rs
+++ b/crates/exomind-runtime/tests/runtime_ts_agents.rs
@@ -49,18 +49,10 @@ async fn runtime_spawns_reviewer_and_classifier_with_rt_url() {
     let root = make_temp_root("rt-ts-agents");
     let reviewer = root.join("packages/ts-agent-cli/agents/reviewer/index.ts");
     let classifier = root.join("packages/ts-agent-cli/agents/classifier/index.ts");
-    fs::create_dir_all(
-        reviewer
-            .parent()
-            .expect("reviewer parent should exist"),
-    )
-    .expect("should create reviewer directory");
-    fs::create_dir_all(
-        classifier
-            .parent()
-            .expect("classifier parent should exist"),
-    )
-    .expect("should create classifier directory");
+    fs::create_dir_all(reviewer.parent().expect("reviewer parent should exist"))
+        .expect("should create reviewer directory");
+    fs::create_dir_all(classifier.parent().expect("classifier parent should exist"))
+        .expect("should create classifier directory");
     write_agent_script(&reviewer, "reviewer");
     write_agent_script(&classifier, "classifier");
 
@@ -79,6 +71,7 @@ async fn runtime_spawns_reviewer_and_classifier_with_rt_url() {
         ts_agent_command: "bun".to_string(),
         ts_agent_workdir: Some(root.clone()),
         mesh_state_path: None,
+        signal_storage_path: None,
         auth_secret: None,
         enable_mdns: false,
     })

--- a/crates/exomind-runtime/tests/signal_actors_integration.rs
+++ b/crates/exomind-runtime/tests/signal_actors_integration.rs
@@ -46,7 +46,7 @@ fn add_route(pool: &SignalPool, id: &str, topic: &str, target_type: TargetType, 
         target_ref: target_ref.to_string(),
         created_at: now.clone(),
         updated_at: now,
-    });
+    }).unwrap();
 }
 
 // ─── Task Actor Tests ───────────────────────────────────────────

--- a/crates/exomind-runtime/tests/signal_sqlite_failure_handling.rs
+++ b/crates/exomind-runtime/tests/signal_sqlite_failure_handling.rs
@@ -1,0 +1,262 @@
+use exomind_runtime::signal::{
+    DeliveryRecord, DeliveryStatus, SignalEvent, SignalPool, SignalPoolSnapshot, SignalRoute,
+    TargetType,
+};
+use rusqlite::Connection;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use tracing::subscriber::with_default;
+use tracing_subscriber::fmt::MakeWriter;
+
+fn temp_signal_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("exomind-{name}-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).expect("temp dir should be created");
+    dir
+}
+
+fn open_signal_pool(sqlite_path: &Path) -> SignalPool {
+    SignalPool::with_sqlite_path(None, sqlite_path)
+        .expect("sqlite-backed signal pool should initialize")
+}
+
+fn make_route(topic: &str, target_ref: &str) -> SignalRoute {
+    let now = chrono::Utc::now().to_rfc3339();
+    SignalRoute {
+        id: uuid::Uuid::new_v4().to_string(),
+        enabled: true,
+        topic: topic.to_string(),
+        target_type: TargetType::Agent,
+        target_ref: target_ref.to_string(),
+        created_at: now.clone(),
+        updated_at: now,
+    }
+}
+
+fn make_record(event_id: &str, route_id: &str, target_ref: &str) -> DeliveryRecord {
+    DeliveryRecord {
+        event_id: event_id.to_string(),
+        route_id: route_id.to_string(),
+        target_ref: target_ref.to_string(),
+        status: DeliveryStatus::Sent,
+        reason: None,
+        started_at: "2026-01-01T00:00:00Z".to_string(),
+        finished_at: "2026-01-01T00:00:01Z".to_string(),
+    }
+}
+
+fn make_event(topic: &str) -> SignalEvent {
+    SignalEvent {
+        schema_version: 1,
+        id: uuid::Uuid::new_v4().to_string(),
+        topic: topic.to_string(),
+        ts: chrono::Utc::now().timestamp_millis() as u64,
+        source: "test".to_string(),
+        origin_host_id: "host-read-only".to_string(),
+        hop: 0,
+        trace_id: None,
+        payload: serde_json::json!({"message": "readonly publish"}),
+    }
+}
+
+#[derive(Clone, Default)]
+struct SharedLogBuffer {
+    inner: Arc<Mutex<Vec<u8>>>,
+}
+
+impl SharedLogBuffer {
+    fn into_string(&self) -> String {
+        String::from_utf8(
+            self.inner
+                .lock()
+                .expect("log buffer lock should succeed")
+                .clone(),
+        )
+        .expect("captured logs should be valid utf-8")
+    }
+}
+
+struct SharedLogWriter {
+    inner: Arc<Mutex<Vec<u8>>>,
+}
+
+impl Write for SharedLogWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner
+            .lock()
+            .expect("log writer lock should succeed")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for SharedLogBuffer {
+    type Writer = SharedLogWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        SharedLogWriter {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+fn capture_warn_logs(action: impl FnOnce()) -> String {
+    let buffer = SharedLogBuffer::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_max_level(tracing::Level::WARN)
+        .with_writer(buffer.clone())
+        .finish();
+
+    with_default(subscriber, action);
+    buffer.into_string()
+}
+
+fn make_sqlite_read_only(path: &Path) -> std::fs::Permissions {
+    let original = std::fs::metadata(path)
+        .expect("sqlite file should exist")
+        .permissions();
+    let mut read_only = original.clone();
+    read_only.set_readonly(true);
+    std::fs::set_permissions(path, read_only).expect("sqlite file should become read-only");
+    original
+}
+
+fn restore_permissions(path: &Path, permissions: std::fs::Permissions) {
+    std::fs::set_permissions(path, permissions).expect("sqlite file permissions should restore");
+}
+
+#[test]
+fn route_add_returns_error_when_sqlite_is_read_only() {
+    let dir = temp_signal_dir("signal-sqlite-route-warning");
+    let sqlite_path = dir.join("signal-pool.sqlite");
+
+    drop(open_signal_pool(&sqlite_path));
+    let original_permissions = make_sqlite_read_only(&sqlite_path);
+
+    let reopened = open_signal_pool(&sqlite_path);
+    assert!(
+        reopened
+            .routes()
+            .add(make_route("read.only.topic", "warning-agent"))
+            .is_err(),
+        "route add should surface sqlite write failure on a read-only database"
+    );
+
+    drop(reopened);
+    restore_permissions(&sqlite_path, original_permissions);
+    std::fs::remove_dir_all(dir).expect("temp dir should be removed");
+}
+
+#[test]
+fn publish_logs_warning_when_journal_append_fails_on_read_only_sqlite() {
+    let dir = temp_signal_dir("signal-sqlite-journal-append-warning");
+    let sqlite_path = dir.join("signal-pool.sqlite");
+
+    let pool = open_signal_pool(&sqlite_path);
+    pool.routes()
+        .add(make_route("readonly.publish", "warning-agent"))
+        .expect("seed route should persist");
+    drop(pool);
+
+    let original_permissions = make_sqlite_read_only(&sqlite_path);
+
+    let reopened = open_signal_pool(&sqlite_path);
+    let _rx = reopened.subscribe();
+    let logs = capture_warn_logs(|| {
+        let _ = reopened.publish(make_event("readonly.publish"));
+    });
+
+    assert!(
+        logs.contains("signal journal append failed during publish")
+            && logs.contains("日志追加失败"),
+        "expected publish path to log journal append failure, got: {logs}"
+    );
+
+    drop(reopened);
+    restore_permissions(&sqlite_path, original_permissions);
+    std::fs::remove_dir_all(dir).expect("temp dir should be removed");
+}
+
+#[test]
+fn journal_replace_all_returns_error_when_sqlite_is_read_only() {
+    let dir = temp_signal_dir("signal-sqlite-journal-replace-warning");
+    let sqlite_path = dir.join("signal-pool.sqlite");
+
+    drop(open_signal_pool(&sqlite_path));
+    let original_permissions = make_sqlite_read_only(&sqlite_path);
+
+    let reopened = open_signal_pool(&sqlite_path);
+    assert!(
+        reopened
+            .journal()
+            .replace_all(vec![make_record(
+                "evt-read-only-replace",
+                "route-2",
+                "target-2",
+            )])
+            .is_err(),
+        "journal replace_all should surface sqlite write failure on a read-only database"
+    );
+
+    drop(reopened);
+    restore_permissions(&sqlite_path, original_permissions);
+    std::fs::remove_dir_all(dir).expect("temp dir should be removed");
+}
+
+#[test]
+fn snapshot_import_rolls_back_routes_when_journal_insert_fails() {
+    let dir = temp_signal_dir("signal-sqlite-atomic-import");
+    let sqlite_path = dir.join("signal-pool.sqlite");
+
+    let pool = open_signal_pool(&sqlite_path);
+    let original_route = make_route("existing.topic", "existing-agent");
+    let original_record = make_record("evt-existing", &original_route.id, "existing-agent");
+    pool.routes().add(original_route.clone()).unwrap();
+    pool.journal().append(original_record.clone()).unwrap();
+    drop(pool);
+
+    let connection = Connection::open(&sqlite_path).expect("sqlite should open for trigger setup");
+    connection
+        .execute_batch(
+            "CREATE TRIGGER fail_signal_journal_insert
+             BEFORE INSERT ON signal_journal
+             BEGIN
+                 SELECT RAISE(ABORT, 'journal blocked for test');
+             END;",
+        )
+        .expect("journal failure trigger should be created");
+    drop(connection);
+
+    let reopened = open_signal_pool(&sqlite_path);
+    let import_result = reopened.import_snapshot(SignalPoolSnapshot {
+        routes: vec![make_route("incoming.topic", "incoming-agent")],
+        journal: vec![make_record("evt-incoming", "route-incoming", "incoming-agent")],
+    });
+
+    assert!(
+        import_result.is_err(),
+        "snapshot import should fail when journal insertion is blocked"
+    );
+
+    drop(reopened);
+
+    let verified = open_signal_pool(&sqlite_path);
+    let snapshot = verified
+        .export_snapshot()
+        .expect("snapshot export should succeed after failed import");
+    assert_eq!(snapshot.routes.len(), 1);
+    assert_eq!(snapshot.routes[0].id, original_route.id);
+    assert_eq!(snapshot.routes[0].topic, "existing.topic");
+    assert_eq!(snapshot.journal.len(), 1);
+    assert_eq!(snapshot.journal[0].event_id, original_record.event_id);
+    assert_eq!(snapshot.journal[0].route_id, original_record.route_id);
+    drop(verified);
+
+    std::fs::remove_dir_all(dir).expect("temp dir should be removed");
+}

--- a/crates/exomind-runtime/tests/signal_sqlite_journal.rs
+++ b/crates/exomind-runtime/tests/signal_sqlite_journal.rs
@@ -41,9 +41,11 @@ fn persists_delivery_records_in_sqlite_after_publish() {
     let dir = temp_signal_dir("signal-sqlite-journal");
     let sqlite_path = dir.join("signal-pool.sqlite");
 
-    let pool = SignalPool::with_sqlite_path(None, &sqlite_path);
+    let pool = SignalPool::with_sqlite_path(None, &sqlite_path)
+        .expect("sqlite-backed signal pool should initialize");
     pool.routes()
-        .add(make_route("user.input.text", "classifier"));
+        .add(make_route("user.input.text", "classifier"))
+        .expect("route should persist");
     let _rx = pool.subscribe();
 
     let event = make_event("user.input.text");
@@ -53,7 +55,8 @@ fn persists_delivery_records_in_sqlite_after_publish() {
     assert_eq!(records[0].status, DeliveryStatus::Sent);
     drop(pool);
 
-    let reopened = SignalPool::with_sqlite_path(None, &sqlite_path);
+    let reopened = SignalPool::with_sqlite_path(None, &sqlite_path)
+        .expect("sqlite-backed signal pool should reopen");
     let journal = reopened.journal().recent(10);
     assert_eq!(journal.len(), 1);
     assert_eq!(journal[0].event_id, event_id);
@@ -67,10 +70,12 @@ fn persists_delivery_records_in_sqlite_after_publish() {
 fn exports_and_imports_signal_pool_snapshot() {
     let source_dir = temp_signal_dir("signal-sqlite-export-source");
     let source_sqlite = source_dir.join("signal-pool.sqlite");
-    let source_pool = SignalPool::with_sqlite_path(None, &source_sqlite);
+    let source_pool = SignalPool::with_sqlite_path(None, &source_sqlite)
+        .expect("source sqlite-backed signal pool should initialize");
     source_pool
         .routes()
-        .add(make_route("knowledge.item.captured", "journal-agent"));
+        .add(make_route("knowledge.item.captured", "journal-agent"))
+        .expect("source route should persist");
     let _rx = source_pool.subscribe();
     source_pool.publish(make_event("knowledge.item.captured"));
 
@@ -83,13 +88,15 @@ fn exports_and_imports_signal_pool_snapshot() {
 
     let target_dir = temp_signal_dir("signal-sqlite-export-target");
     let target_sqlite = target_dir.join("signal-pool.sqlite");
-    let target_pool = SignalPool::with_sqlite_path(None, &target_sqlite);
+    let target_pool = SignalPool::with_sqlite_path(None, &target_sqlite)
+        .expect("target sqlite-backed signal pool should initialize");
     target_pool
         .import_snapshot(round_tripped)
         .expect("sqlite-backed pool should import a snapshot");
     drop(target_pool);
 
-    let reopened = SignalPool::with_sqlite_path(None, &target_sqlite);
+    let reopened = SignalPool::with_sqlite_path(None, &target_sqlite)
+        .expect("target sqlite-backed signal pool should reopen");
     assert_eq!(reopened.routes().get_all().len(), 1);
     assert_eq!(reopened.journal().recent(10).len(), 1);
     drop(reopened);

--- a/crates/exomind-runtime/tests/signal_sqlite_journal.rs
+++ b/crates/exomind-runtime/tests/signal_sqlite_journal.rs
@@ -1,0 +1,100 @@
+use exomind_runtime::signal::{
+    DeliveryStatus, SignalEvent, SignalPool, SignalPoolSnapshot, SignalRoute, TargetType,
+};
+use std::path::PathBuf;
+
+fn temp_signal_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("exomind-{name}-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).expect("temp dir should be created");
+    dir
+}
+
+fn make_route(topic: &str, target_ref: &str) -> SignalRoute {
+    let now = chrono::Utc::now().to_rfc3339();
+    SignalRoute {
+        id: uuid::Uuid::new_v4().to_string(),
+        enabled: true,
+        topic: topic.to_string(),
+        target_type: TargetType::Agent,
+        target_ref: target_ref.to_string(),
+        created_at: now.clone(),
+        updated_at: now,
+    }
+}
+
+fn make_event(topic: &str) -> SignalEvent {
+    SignalEvent {
+        schema_version: 1,
+        id: uuid::Uuid::new_v4().to_string(),
+        topic: topic.to_string(),
+        ts: chrono::Utc::now().timestamp_millis() as u64,
+        source: "test".to_string(),
+        origin_host_id: "rt-test".to_string(),
+        hop: 0,
+        trace_id: None,
+        payload: serde_json::json!({"message": "hello sqlite"}),
+    }
+}
+
+#[test]
+fn persists_delivery_records_in_sqlite_after_publish() {
+    let dir = temp_signal_dir("signal-sqlite-journal");
+    let sqlite_path = dir.join("signal-pool.sqlite");
+
+    let pool = SignalPool::with_sqlite_path(None, &sqlite_path);
+    pool.routes()
+        .add(make_route("user.input.text", "classifier"));
+    let _rx = pool.subscribe();
+
+    let event = make_event("user.input.text");
+    let event_id = event.id.clone();
+    let records = pool.publish(event);
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].status, DeliveryStatus::Sent);
+    drop(pool);
+
+    let reopened = SignalPool::with_sqlite_path(None, &sqlite_path);
+    let journal = reopened.journal().recent(10);
+    assert_eq!(journal.len(), 1);
+    assert_eq!(journal[0].event_id, event_id);
+    assert_eq!(journal[0].route_id, records[0].route_id);
+    drop(reopened);
+
+    std::fs::remove_dir_all(dir).expect("temp dir should be removed");
+}
+
+#[test]
+fn exports_and_imports_signal_pool_snapshot() {
+    let source_dir = temp_signal_dir("signal-sqlite-export-source");
+    let source_sqlite = source_dir.join("signal-pool.sqlite");
+    let source_pool = SignalPool::with_sqlite_path(None, &source_sqlite);
+    source_pool
+        .routes()
+        .add(make_route("knowledge.item.captured", "journal-agent"));
+    let _rx = source_pool.subscribe();
+    source_pool.publish(make_event("knowledge.item.captured"));
+
+    let snapshot = source_pool
+        .export_snapshot()
+        .expect("sqlite-backed pool should export a snapshot");
+    let serialized = serde_json::to_string_pretty(&snapshot).expect("snapshot should serialize");
+    let round_tripped: SignalPoolSnapshot =
+        serde_json::from_str(&serialized).expect("snapshot should deserialize");
+
+    let target_dir = temp_signal_dir("signal-sqlite-export-target");
+    let target_sqlite = target_dir.join("signal-pool.sqlite");
+    let target_pool = SignalPool::with_sqlite_path(None, &target_sqlite);
+    target_pool
+        .import_snapshot(round_tripped)
+        .expect("sqlite-backed pool should import a snapshot");
+    drop(target_pool);
+
+    let reopened = SignalPool::with_sqlite_path(None, &target_sqlite);
+    assert_eq!(reopened.routes().get_all().len(), 1);
+    assert_eq!(reopened.journal().recent(10).len(), 1);
+    drop(reopened);
+    drop(source_pool);
+
+    std::fs::remove_dir_all(source_dir).expect("source temp dir should be removed");
+    std::fs::remove_dir_all(target_dir).expect("target temp dir should be removed");
+}

--- a/crates/exomind-runtime/tests/signal_sqlite_migration.rs
+++ b/crates/exomind-runtime/tests/signal_sqlite_migration.rs
@@ -34,12 +34,14 @@ fn migrates_legacy_route_json_into_sqlite() {
     )
     .expect("legacy route json should be written");
 
-    let migrated = SignalPool::with_sqlite_path(None, &sqlite_path);
+    let migrated = SignalPool::with_sqlite_path(None, &sqlite_path)
+        .expect("sqlite-backed signal pool should initialize");
     assert!(migrated.routes().get_by_id(&legacy_route_id).is_some());
     drop(migrated);
 
     std::fs::remove_file(&legacy_path).expect("legacy json should be removed after migration test");
-    let reopened = SignalPool::with_sqlite_path(None, &sqlite_path);
+    let reopened = SignalPool::with_sqlite_path(None, &sqlite_path)
+        .expect("sqlite-backed signal pool should reopen");
     let routes = reopened.routes().get_all();
     assert_eq!(
         routes

--- a/crates/exomind-runtime/tests/signal_sqlite_migration.rs
+++ b/crates/exomind-runtime/tests/signal_sqlite_migration.rs
@@ -1,0 +1,54 @@
+use exomind_runtime::signal::{SignalPool, SignalRoute, TargetType};
+use std::path::PathBuf;
+
+fn temp_signal_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("exomind-{name}-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).expect("temp dir should be created");
+    dir
+}
+
+fn make_route(topic: &str, target_ref: &str) -> SignalRoute {
+    let now = chrono::Utc::now().to_rfc3339();
+    SignalRoute {
+        id: uuid::Uuid::new_v4().to_string(),
+        enabled: true,
+        topic: topic.to_string(),
+        target_type: TargetType::Agent,
+        target_ref: target_ref.to_string(),
+        created_at: now.clone(),
+        updated_at: now,
+    }
+}
+
+#[test]
+fn migrates_legacy_route_json_into_sqlite() {
+    let dir = temp_signal_dir("signal-sqlite-migration");
+    let sqlite_path = dir.join("signal-pool.sqlite");
+    let legacy_path = dir.join("routes.json");
+    let legacy_route = make_route("legacy.topic", "legacy-agent");
+    let legacy_route_id = legacy_route.id.clone();
+
+    std::fs::write(
+        &legacy_path,
+        serde_json::to_string_pretty(&vec![legacy_route]).expect("legacy json should serialize"),
+    )
+    .expect("legacy route json should be written");
+
+    let migrated = SignalPool::with_sqlite_path(None, &sqlite_path);
+    assert!(migrated.routes().get_by_id(&legacy_route_id).is_some());
+    drop(migrated);
+
+    std::fs::remove_file(&legacy_path).expect("legacy json should be removed after migration test");
+    let reopened = SignalPool::with_sqlite_path(None, &sqlite_path);
+    let routes = reopened.routes().get_all();
+    assert_eq!(
+        routes
+            .iter()
+            .filter(|route| route.id == legacy_route_id)
+            .count(),
+        1
+    );
+    drop(reopened);
+
+    std::fs::remove_dir_all(dir).expect("temp dir should be removed");
+}

--- a/crates/exomind-runtime/tests/signal_sqlite_routes.rs
+++ b/crates/exomind-runtime/tests/signal_sqlite_routes.rs
@@ -28,13 +28,15 @@ fn persists_user_routes_in_sqlite_after_restart() {
     let dir = temp_signal_dir("signal-sqlite-routes");
     let sqlite_path = dir.join("signal-pool.sqlite");
 
-    let pool = SignalPool::with_sqlite_path(None, &sqlite_path);
+    let pool = SignalPool::with_sqlite_path(None, &sqlite_path)
+        .expect("sqlite-backed signal pool should initialize");
     let route = make_route("user.input.text", "classifier");
     let route_id = route.id.clone();
-    pool.routes().add(route);
+    pool.routes().add(route).expect("route should persist");
     drop(pool);
 
-    let reopened = SignalPool::with_sqlite_path(None, &sqlite_path);
+    let reopened = SignalPool::with_sqlite_path(None, &sqlite_path)
+        .expect("sqlite-backed signal pool should reopen");
     let persisted = reopened
         .routes()
         .get_by_id(&route_id)

--- a/crates/exomind-runtime/tests/signal_sqlite_routes.rs
+++ b/crates/exomind-runtime/tests/signal_sqlite_routes.rs
@@ -1,0 +1,111 @@
+use exomind_runtime::signal::{SignalPool, SignalRoute, TargetType};
+use exomind_runtime::{RuntimeStartOptions, start_with_options};
+use reqwest::Client;
+use serde_json::json;
+use std::path::PathBuf;
+
+fn temp_signal_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("exomind-{name}-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).expect("temp dir should be created");
+    dir
+}
+
+fn make_route(topic: &str, target_ref: &str) -> SignalRoute {
+    let now = chrono::Utc::now().to_rfc3339();
+    SignalRoute {
+        id: uuid::Uuid::new_v4().to_string(),
+        enabled: true,
+        topic: topic.to_string(),
+        target_type: TargetType::Agent,
+        target_ref: target_ref.to_string(),
+        created_at: now.clone(),
+        updated_at: now,
+    }
+}
+
+#[test]
+fn persists_user_routes_in_sqlite_after_restart() {
+    let dir = temp_signal_dir("signal-sqlite-routes");
+    let sqlite_path = dir.join("signal-pool.sqlite");
+
+    let pool = SignalPool::with_sqlite_path(None, &sqlite_path);
+    let route = make_route("user.input.text", "classifier");
+    let route_id = route.id.clone();
+    pool.routes().add(route);
+    drop(pool);
+
+    let reopened = SignalPool::with_sqlite_path(None, &sqlite_path);
+    let persisted = reopened
+        .routes()
+        .get_by_id(&route_id)
+        .expect("route should persist in sqlite after restart");
+    assert_eq!(persisted.target_ref, "classifier");
+    drop(reopened);
+
+    std::fs::remove_dir_all(dir).expect("temp dir should be removed");
+}
+
+#[tokio::test]
+async fn runtime_reuses_signal_sqlite_path_between_restarts() {
+    let dir = temp_signal_dir("runtime-signal-sqlite-routes");
+    let sqlite_path = dir.join("runtime-signal-pool.sqlite");
+    let host_id = format!("rt-sqlite-{}", uuid::Uuid::new_v4());
+    let options = RuntimeStartOptions {
+        bind_host: "127.0.0.1".to_string(),
+        port: 0,
+        host_id,
+        spawn_builtin_actors: false,
+        spawn_ts_agents: false,
+        signal_storage_path: Some(sqlite_path.clone()),
+        ..Default::default()
+    };
+
+    let client = Client::new();
+    let mut runtime = start_with_options(options.clone())
+        .await
+        .expect("runtime should start with sqlite storage");
+    let base_url = format!("http://127.0.0.1:{}", runtime.port());
+
+    let created = client
+        .post(format!("{base_url}/signal-routes"))
+        .json(&json!({
+            "topic": "runtime.route.created",
+            "target_type": "agent",
+            "target_ref": "runtime-agent"
+        }))
+        .send()
+        .await
+        .expect("create route request should succeed")
+        .error_for_status()
+        .expect("create route response should be successful")
+        .json::<SignalRoute>()
+        .await
+        .expect("created route payload should parse");
+
+    runtime.stop().await.expect("runtime should stop cleanly");
+    drop(runtime);
+
+    let mut restarted = start_with_options(options)
+        .await
+        .expect("runtime should restart with same sqlite storage");
+    let restarted_base_url = format!("http://127.0.0.1:{}", restarted.port());
+    let routes = client
+        .get(format!("{restarted_base_url}/signal-routes"))
+        .send()
+        .await
+        .expect("list routes request should succeed")
+        .error_for_status()
+        .expect("list routes response should be successful")
+        .json::<Vec<SignalRoute>>()
+        .await
+        .expect("routes payload should parse");
+
+    assert!(routes.iter().any(|route| route.id == created.id));
+
+    restarted
+        .stop()
+        .await
+        .expect("restarted runtime should stop cleanly");
+    drop(restarted);
+    std::fs::remove_dir_all(dir).expect("temp dir should be removed");
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod commands;
 
+use commands::asr_commands::{volcano_asr_check_config, volcano_asr_recognize};
 use commands::device_commands::get_device_id;
 use commands::eventlog_commands::{
     eventlog_append, eventlog_clear, eventlog_get, eventlog_list, eventlog_mirror_status,
@@ -11,16 +12,15 @@ use commands::file_commands::{
     append_file, append_to_markdown, delete_file, export_messages_to_markdown, file_exists,
     list_files, pick_json_file, read_file, read_file_binary, save_json_file, write_file,
 };
-use commands::shortcut_commands::{
-    ensure_voice_overlay_window, register_voice_shortcut, simulate_paste, voice_overlay_hide, voice_overlay_show,
-    voice_shortcut_get, voice_shortcut_set, VoiceShortcutState,
-};
 use commands::runtime_commands::{
-    ensure_runtime_started, runtime_service_reachable_address, runtime_service_start,
-    runtime_service_status, runtime_service_stop, signal_publish_fast, RuntimeProcessState,
+    RuntimeProcessState, ensure_runtime_started, runtime_service_reachable_address,
+    runtime_service_start, runtime_service_status, runtime_service_stop, signal_publish_fast,
 };
-use commands::ws_commands::{ws_connect, ws_disconnect, ws_get_state, ws_send, WsClientState};
-use commands::asr_commands::{volcano_asr_recognize, volcano_asr_check_config};
+use commands::shortcut_commands::{
+    VoiceShortcutState, ensure_voice_overlay_window, register_voice_shortcut, simulate_paste,
+    voice_overlay_hide, voice_overlay_show, voice_shortcut_get, voice_shortcut_set,
+};
+use commands::ws_commands::{WsClientState, ws_connect, ws_disconnect, ws_get_state, ws_send};
 use tauri::Manager;
 
 #[tauri::command]
@@ -59,11 +59,40 @@ pub fn run() {
                 eprintln!("[tauri/setup] failed to prewarm voice overlay window: {error}");
             }
 
+            if std::env::var_os("EXOMIND_RT_SIGNAL_SQLITE_PATH").is_none() {
+                match app.path().app_data_dir() {
+                    Ok(app_data_dir) => {
+                        let runtime_dir = app_data_dir.join("runtime");
+                        if let Err(error) = std::fs::create_dir_all(&runtime_dir) {
+                            eprintln!(
+                                "[tauri/setup] failed to create runtime data dir for signal sqlite: {error}"
+                            );
+                        } else {
+                            let signal_sqlite_path = runtime_dir.join("signal-pool.sqlite");
+                            // SAFETY: setup runs before the embedded runtime starts and before worker threads read this env var.
+                            unsafe {
+                                std::env::set_var(
+                                    "EXOMIND_RT_SIGNAL_SQLITE_PATH",
+                                    signal_sqlite_path,
+                                );
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        eprintln!(
+                            "[tauri/setup] failed to resolve app data dir for signal sqlite: {error}"
+                        );
+                    }
+                }
+            }
+
             let runtime_state = runtime_process_state_for_setup.clone();
             let runtime_port = resolve_embedded_runtime_port();
             tauri::async_runtime::spawn(async move {
                 // Keep embedded runtime port aligned with EXOMIND_RT_PORT（与前端端口配置保持一致）.
-                if let Err(error) = ensure_runtime_started(runtime_state, None, Some(runtime_port)).await {
+                if let Err(error) =
+                    ensure_runtime_started(runtime_state, None, Some(runtime_port)).await
+                {
                     eprintln!(
                         "[tauri/setup] failed to auto-start embedded runtime on {}: {error}",
                         runtime_port


### PR DESCRIPTION
## Summary

- persist runtime `SignalRouteTable` and `SignalJournal` in SQLite
- keep `SignalWindowCache` in-memory, and add snapshot import/export at `SignalPool` store boundary
- wire native runtime / Tauri startup to `EXOMIND_RT_SIGNAL_SQLITE_PATH`
- add migration coverage for legacy `routes.json` import into SQLite
- track pure Web / WASM follow-up separately in #433

## Scope

- included: native runtime / Tauri signal storage
- excluded: pure Web / WASM storage implementation

## Validation

- `cargo test -p exomind-runtime --manifest-path src-tauri/Cargo.toml`
- `npx tsc --noEmit`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `bun run build`

## Notes

- default native runtime signal DB path is `app_data_dir()/runtime/signal-pool.sqlite`
- snapshot import/export is covered by the new SQLite signal tests

Closes #420
Related: #433