### PR TITLE
feat(agent-ui): Phase 2 — Agent energy visualization + dormant state

### DIFF
--- a/src/lib/types/agent-hub.ts
+++ b/src/lib/types/agent-hub.ts
@@ -38,7 +38,7 @@ export interface AgentHubRightPanelContext {
 
 // Node type（节点类型）and status（运行状态）
 export type AgentHubNodeType = 'input' | 'agent' | 'actor' | 'output';
-export type AgentHubNodeStatus = 'running' | 'idle' | 'warning' | 'offline';
+export type AgentHubNodeStatus = 'running' | 'idle' | 'warning' | 'offline' | 'dormant' | 'critical' | 'dying';
 export type AgentHubNodeLayer = 'top' | 'middle' | 'bottom';
 
 export interface AgentHubNode {
@@ -73,6 +73,7 @@ export interface AgentHubListItem {
   status: AgentHubNodeStatus;
   icon: string;
   badgeText?: string;
+  energy?: AgentEnergySnapshot;
 }
 
 export interface AgentHubListSection {

--- a/src/services/runtime-client.ts
+++ b/src/services/runtime-client.ts
@@ -504,6 +504,30 @@ export class RuntimeClient {
     };
   }
 
+  async getAllEnergy(
+    host: RuntimeHostRecord,
+  ): Promise<RuntimeClientResult<AgentEnergySnapshot[]>> {
+    const response = await this.getJson(`${buildBaseUrl(host)}/energy`);
+    if (!response.ok) {
+      return response;
+    }
+
+    if (!Array.isArray(response.data)) {
+      return {
+        ok: false,
+        error: {
+          code: 'invalid_payload',
+          message: 'invalid /energy payload（/energy 响应格式无效）',
+        },
+      };
+    }
+
+    return {
+      ok: true,
+      data: response.data as AgentEnergySnapshot[],
+    };
+  }
+
   async getAgentEnergy(
     host: RuntimeHostRecord,
     agentId: string,

--- a/src/services/runtime-manager.ts
+++ b/src/services/runtime-manager.ts
@@ -183,6 +183,8 @@ export class RuntimeManager {
         energyMap.set(snap.agent_id, snap);
       }
     }
+    // DEBUG: Phase 2 energy pipeline
+    console.log('[RuntimeManager] energy fetch:', energyResult.ok ? `${energyMap.size} agents` : `FAILED: ${JSON.stringify(energyResult)}`);
 
     if (!agentsResult.ok) {
       return {

--- a/src/services/runtime-manager.ts
+++ b/src/services/runtime-manager.ts
@@ -1,4 +1,4 @@
-import type { RuntimeHostRecord } from '@/lib/types/agent-hub';
+import type { AgentEnergySnapshot, RuntimeHostRecord } from '@/lib/types/agent-hub';
 import type { RuntimeTopologyResponse } from '@/lib/types/runtime-topology';
 import { DEFAULT_EXTERNAL_RUNTIME_PORT, formatRuntimeTargetAddress } from '@/config/runtime-target';
 import {
@@ -16,6 +16,7 @@ export interface RuntimeAggregatedAgent extends RuntimeAgentSummary {
   sourceHostId: string;
   sourceHostName: string;
   sourceHostAddress: string;
+  energy?: AgentEnergySnapshot;
 }
 
 export interface RuntimeHostSnapshot {
@@ -36,7 +37,7 @@ export interface RuntimeManagerSnapshot {
 export interface RuntimeManagerOptions {
   hostService?: Pick<RuntimeHostService, 'listHosts' | 'addHost' | 'removeHost'>
     & Partial<Pick<RuntimeHostService, 'mergeHostMetadata'>>;
-  runtimeClient?: Pick<RuntimeClient, 'getAgents' | 'getTopology'>;
+  runtimeClient?: Pick<RuntimeClient, 'getAgents' | 'getTopology' | 'getAllEnergy'>;
   runtimeMeshSyncService?: Pick<RuntimeMeshSyncService, 'ensurePeerPair'>;
   now?: () => Date;
 }
@@ -116,7 +117,7 @@ function parseHostAddress(hostAddress: string): { host: string; port: number } {
 export class RuntimeManager {
   private readonly hostService: Pick<RuntimeHostService, 'listHosts' | 'addHost' | 'removeHost'>
     & Partial<Pick<RuntimeHostService, 'mergeHostMetadata'>>;
-  private readonly runtimeClient: Pick<RuntimeClient, 'getAgents' | 'getTopology'>;
+  private readonly runtimeClient: Pick<RuntimeClient, 'getAgents' | 'getTopology' | 'getAllEnergy'>;
   private readonly runtimeMeshSyncService: Pick<RuntimeMeshSyncService, 'ensurePeerPair'>;
   private readonly now: () => Date;
 
@@ -165,14 +166,23 @@ export class RuntimeManager {
 
   private async buildHostSnapshot(host: RuntimeHostRecord): Promise<RuntimeHostSnapshot> {
     const topologyStartedAtMs = Date.now();
-    const [agentsResult, topologyEnvelope] = await Promise.all([
+    const [agentsResult, topologyEnvelope, energyResult] = await Promise.all([
       this.runtimeClient.getAgents(host),
       this.runtimeClient.getTopology(host).then((result) => ({
         result,
         latencyMs: Math.max(1, Date.now() - topologyStartedAtMs),
       })),
+      this.runtimeClient.getAllEnergy(host).catch(() => ({ ok: false as const, error: { code: 'network' as const, message: 'energy fetch failed' } })),
     ]);
     const topologyResult = topologyEnvelope.result;
+
+    // Build energy lookup map by agent_id
+    const energyMap = new Map<string, AgentEnergySnapshot>();
+    if (energyResult.ok) {
+      for (const snap of energyResult.data) {
+        energyMap.set(snap.agent_id, snap);
+      }
+    }
 
     if (!agentsResult.ok) {
       return {
@@ -190,6 +200,7 @@ export class RuntimeManager {
       sourceHostId: host.id,
       sourceHostName: host.name,
       sourceHostAddress: `${host.host}:${host.port}`,
+      energy: energyMap.get(agent.id),
     }));
 
     if (!topologyResult.ok) {

--- a/src/services/runtime-manager.ts
+++ b/src/services/runtime-manager.ts
@@ -183,8 +183,6 @@ export class RuntimeManager {
         energyMap.set(snap.agent_id, snap);
       }
     }
-    // DEBUG: Phase 2 energy pipeline
-    console.log('[RuntimeManager] energy fetch:', energyResult.ok ? `${energyMap.size} agents` : `FAILED: ${JSON.stringify(energyResult)}`);
 
     if (!agentsResult.ok) {
       return {

--- a/src/ui/app/pages/AgentsPage.tsx
+++ b/src/ui/app/pages/AgentsPage.tsx
@@ -126,6 +126,7 @@ import {
   formatRuntimeEventPayload,
   getConversationMessageTestId,
 } from './agents/conversation-runtime';
+import { EnergyBar } from './agents/AgentDetailPage';
 import { WorkspaceTabs } from './agents/WorkspaceTabs';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -2311,6 +2312,7 @@ export function AgentsPage() {
   // T8: AgentDetail / ActorDetail 右侧栏
   const [agentDetail, setAgentDetail] = useState<AgentDetailData | null>(null);
   const [isDetailLoading, setIsDetailLoading] = useState(false);
+  const [panelEnergy, setPanelEnergy] = useState<AgentEnergySnapshot | null>(null);
 
   useEffect(() => {
     if (rightPanel.state === 'AGENT_DETAIL' || rightPanel.state === 'ACTOR_DETAIL') {
@@ -2319,6 +2321,7 @@ export function AgentsPage() {
       const runtimeEntityId = resolveRuntimeEntityId(nodeId);
       setIsDetailLoading(true);
       setAgentDetail(null);
+      setPanelEnergy(null);
       const service = getAgentHubService();
       const loader = rightPanel.state === 'AGENT_DETAIL'
         ? service.getAgentDetail(runtimeEntityId)
@@ -2331,8 +2334,33 @@ export function AgentsPage() {
       });
     } else {
       setAgentDetail(null);
+      setPanelEnergy(null);
     }
   }, [rightPanel.state, rightPanel.nodeId]);
+
+  // Energy polling for right panel (2s interval)
+  useEffect(() => {
+    if (rightPanel.state !== 'AGENT_DETAIL' || !rightPanel.nodeId) return;
+    const nodeId = rightPanel.nodeId;
+    const runtimeEntityId = resolveRuntimeEntityId(nodeId);
+    const preferredHostId = extractPreferredHostId(nodeId);
+    let disposed = false;
+
+    const client = new RuntimeClient();
+    const poll = async () => {
+      const host = findPreferredRuntimeHostForAgent(runtimeHostSnapshots, runtimeEntityId, preferredHostId);
+      if (!host || disposed) return;
+      const snap = await client.getAgentEnergy(host, runtimeEntityId);
+      if (!disposed && snap) setPanelEnergy(snap);
+    };
+
+    void poll();
+    const timer = setInterval(poll, 2000);
+    return () => {
+      disposed = true;
+      clearInterval(timer);
+    };
+  }, [rightPanel.state, rightPanel.nodeId, runtimeHostSnapshots]);
 
   useEffect(() => {
     if (!selectedProviderProfileId) return;
@@ -3531,7 +3559,13 @@ export function AgentsPage() {
                       ? 'border border-brand-accent/20 bg-brand-accent/10 text-brand-accent'
                       : 'border border-border-subtle bg-background text-strong';
                     const EntityIcon = nodeType === 'agent' ? Brain : Sparkles;
-                    const detailStatus = agentDetail?.status ?? node?.status ?? 'unknown';
+                    const detailStatus = panelEnergy?.is_dormant
+                      ? 'dormant'
+                      : panelEnergy?.phase === 'dying'
+                        ? 'dying'
+                        : panelEnergy?.phase === 'critical'
+                          ? 'critical'
+                          : (agentDetail?.status ?? node?.status ?? 'unknown');
                     const detailStatusClass: Record<string, string> = {
                       online: 'border-transparent bg-success/15 text-success',
                       available: 'border-transparent bg-success/15 text-success',
@@ -3541,6 +3575,9 @@ export function AgentsPage() {
                       error: 'border-transparent bg-destructive/15 text-destructive',
                       busy: 'border-transparent bg-warning/15 text-warning',
                       warning: 'border-transparent bg-warning/15 text-warning',
+                      dormant: 'border-[#6B7280]/20 bg-[#6B7280]/10 text-[#6B7280]',
+                      critical: 'border-transparent bg-[#F97316]/15 text-[#F97316]',
+                      dying: 'border-transparent bg-destructive/15 text-destructive',
                     };
 
                     return (
@@ -3631,6 +3668,8 @@ export function AgentsPage() {
                             ))}
                           </div>
                         ) : null}
+
+                        {panelEnergy && <EnergyBar energy={panelEnergy} />}
 
                         {!isDetailLoading && agentDetail?.triggerRules.length ? (
                           <Card className="rounded-xl border-border-card bg-card shadow-sm">

--- a/src/ui/app/pages/AgentsPage.tsx
+++ b/src/ui/app/pages/AgentsPage.tsx
@@ -2350,12 +2350,8 @@ export function AgentsPage() {
     const poll = async () => {
       const host = findPreferredRuntimeHostForAgent(runtimeHostSnapshots, runtimeEntityId, preferredHostId)
         ?? activeSignalRouteHost;
-      if (!host || disposed) {
-        console.log('[EnergyPoll] no host or disposed', { host: !!host, disposed });
-        return;
-      }
+      if (!host || disposed) return;
       const snap = await client.getAgentEnergy(host, runtimeEntityId);
-      console.log('[EnergyPoll] result:', snap ? `${snap.current}/${snap.max} (${snap.phase})` : 'null');
       if (!disposed && snap) setPanelEnergy(snap);
     };
 
@@ -2973,15 +2969,13 @@ export function AgentsPage() {
     const refreshInterval = setInterval(() => {
       void (async () => {
         try {
-          console.log('[8s-POLL] refreshing...');
           const nextRuntimeSnapshot = await getRuntimeManager().refreshSnapshot();
           if (disposed) return;
-          console.log('[8s-POLL] agents:', nextRuntimeSnapshot.agents.length, 'energy:', nextRuntimeSnapshot.agents.filter(a => a.energy).length);
           applyRuntimeSnapshot(nextRuntimeSnapshot);
           await refreshSignalRoutesFromSnapshot(nextRuntimeSnapshot, () => disposed);
           await fetchPtyAgentsRef.current();
-        } catch (err) {
-          console.error('[8s-POLL] ERROR:', err);
+        } catch {
+          // Ignore polling errors（轮询错误不打断页面渲染）
         }
       })();
     }, 8000);

--- a/src/ui/app/pages/AgentsPage.tsx
+++ b/src/ui/app/pages/AgentsPage.tsx
@@ -66,6 +66,7 @@ import type {
   AgentConversationMessage,
   AgentDetailData,
   AgentDeviceGroup,
+  AgentEnergySnapshot,
   AgentHubListItem,
   AgentHubListSection,
   AgentHubNodeStatus,
@@ -294,7 +295,18 @@ function getAddOptionIcon(optionId: AddNodeOption['id']): LucideIcon {
   return Plus;
 }
 
-function mapRuntimeStatusToNodeStatus(status: string): AgentHubNodeStatus {
+const ENERGY_PHASE_COLORS: Record<string, string> = {
+  normal: '#22C55E',
+  slowing: '#EAB308',
+  critical: '#F97316',
+  dying: '#EF4444',
+  dormant: '#6B7280',
+};
+
+function mapRuntimeStatusToNodeStatus(status: string, energy?: { phase: string; is_dormant: boolean }): AgentHubNodeStatus {
+  if (energy?.is_dormant) return 'dormant';
+  if (energy?.phase === 'dying') return 'dying';
+  if (energy?.phase === 'critical') return 'critical';
   if (status === 'available' || status === 'running') return 'running';
   if (status === 'busy') return 'warning';
   if (status === 'error') return 'warning';
@@ -348,9 +360,10 @@ function buildListSectionsFromRuntimeAgents(agents: RuntimeAggregatedAgent[]): A
         type: 'agent',
         name: agent.name,
         description: `来源 ${agent.sourceHostAddress}${agent.description ? ` · ${agent.description}` : ''}`,
-        status: mapRuntimeStatusToNodeStatus(agent.status),
+        status: mapRuntimeStatusToNodeStatus(agent.status, agent.energy),
         icon: 'brain',
         badgeText: agent.sourceHostName,
+        energy: agent.energy,
       })),
     };
   });
@@ -1906,11 +1919,18 @@ function NodesTabView({
               idle: '空闲',
               warning: '警告',
               offline: '离线',
+              dormant: '休眠',
+              critical: '危险',
+              dying: '濒死',
             };
+            const isDormant = item.status === 'dormant';
+            const energyPhase = item.energy?.phase ?? 'normal';
+            const energyColor = ENERGY_PHASE_COLORS[energyPhase] ?? '#6B7280';
+            const energyPercent = item.energy ? Math.round(item.energy.ratio * 100) : null;
             return (
               <div
                 key={item.id}
-                className="flex cursor-pointer items-center gap-3 bg-white px-4 py-3 transition-colors hover:bg-[#FAF7F5] dark:bg-[#0C0A09] dark:hover:bg-[#1C1917]"
+                className={`flex cursor-pointer items-center gap-3 bg-white px-4 py-3 transition-colors hover:bg-[#FAF7F5] dark:bg-[#0C0A09] dark:hover:bg-[#1C1917] ${isDormant ? 'opacity-50 grayscale' : ''}`}
                 onClick={() => onNodeClick(item)}
               >
                 {/* Icon */}
@@ -1940,16 +1960,32 @@ function NodesTabView({
                 </div>
                 {/* 内容 */}
                 <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <span className="truncate text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">
-                      {item.name}
-                    </span>
-                    {item.badgeText && (
-                      <span className="shrink-0 rounded-full bg-[#F5F0ED] px-1.5 py-0.5 text-[10px] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]">
-                        {item.badgeText}
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span className="truncate text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">
+                        {item.name}
+                      </span>
+                      {item.badgeText && (
+                        <span className="shrink-0 rounded-full bg-[#F5F0ED] px-1.5 py-0.5 text-[10px] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]">
+                          {item.badgeText}
+                        </span>
+                      )}
+                    </div>
+                    {energyPercent != null && (
+                      <span className="shrink-0 text-[10px] font-medium" style={{ color: energyColor }}>
+                        {energyPercent}%
                       </span>
                     )}
                   </div>
+                  {/* Mini energy bar */}
+                  {item.energy && (
+                    <div className="mt-1 h-[2px] w-full overflow-hidden rounded-full bg-[#E7E3E0] dark:bg-[#292524]">
+                      <div
+                        className="h-full rounded-full transition-all duration-700 ease-out"
+                        style={{ width: `${energyPercent ?? 0}%`, backgroundColor: energyColor }}
+                      />
+                    </div>
+                  )}
                   {item.description && (
                     <p className="mt-0.5 truncate text-xs text-[#78716C] dark:text-[#A8A29E]">
                       {item.description}
@@ -1963,9 +1999,13 @@ function NodesTabView({
                       ? 'bg-[#22C55E]/15 text-[#22C55E]'
                       : item.status === 'warning'
                         ? 'bg-[#F59E0B]/15 text-[#F59E0B]'
-                        : item.status === 'offline'
+                        : item.status === 'offline' || item.status === 'dying'
                           ? 'bg-[#EF4444]/15 text-[#EF4444]'
-                          : 'bg-[#57534E]/30 text-[#78716C]'
+                          : item.status === 'critical'
+                            ? 'bg-[#F97316]/15 text-[#F97316]'
+                            : item.status === 'dormant'
+                              ? 'bg-[#6B7280]/15 text-[#6B7280]'
+                              : 'bg-[#57534E]/30 text-[#78716C]'
                   }`}
                 >
                   {statusLabel[item.status]}

--- a/src/ui/app/pages/AgentsPage.tsx
+++ b/src/ui/app/pages/AgentsPage.tsx
@@ -2348,9 +2348,14 @@ export function AgentsPage() {
 
     const client = new RuntimeClient();
     const poll = async () => {
-      const host = findPreferredRuntimeHostForAgent(runtimeHostSnapshots, runtimeEntityId, preferredHostId);
-      if (!host || disposed) return;
+      const host = findPreferredRuntimeHostForAgent(runtimeHostSnapshots, runtimeEntityId, preferredHostId)
+        ?? activeSignalRouteHost;
+      if (!host || disposed) {
+        console.log('[EnergyPoll] no host or disposed', { host: !!host, disposed });
+        return;
+      }
       const snap = await client.getAgentEnergy(host, runtimeEntityId);
+      console.log('[EnergyPoll] result:', snap ? `${snap.current}/${snap.max} (${snap.phase})` : 'null');
       if (!disposed && snap) setPanelEnergy(snap);
     };
 
@@ -2360,7 +2365,7 @@ export function AgentsPage() {
       disposed = true;
       clearInterval(timer);
     };
-  }, [rightPanel.state, rightPanel.nodeId, runtimeHostSnapshots]);
+  }, [rightPanel.state, rightPanel.nodeId, runtimeHostSnapshots, activeSignalRouteHost]);
 
   useEffect(() => {
     if (!selectedProviderProfileId) return;
@@ -2808,12 +2813,27 @@ export function AgentsPage() {
     try {
       const routeService = new SignalRouteService({ host });
       const runtimeClient = new RuntimeClient();
-      const [routes, agentsResult, historyResponse] = await Promise.all([
+      const [routes, agentsResult, historyResponse, energyResult] = await Promise.all([
         routeService.listRoutes(),
         runtimeClient.getAgents(host),
         fetch(`http://${host.host}:${host.port}/signals/history?limit=120`),
+        runtimeClient.getAllEnergy(host).catch(() => ({ ok: false as const, error: { code: 'network' as const, message: 'energy fetch failed' } })),
       ]);
-      const agents = agentsResult.ok ? mapRuntimeAgentsForHost(host, agentsResult.data) : [];
+
+      // Build energy lookup map
+      const energyMap = new Map<string, AgentEnergySnapshot>();
+      if (energyResult.ok) {
+        for (const snap of energyResult.data) {
+          energyMap.set(snap.agent_id, snap);
+        }
+      }
+
+      const agents = agentsResult.ok
+        ? mapRuntimeAgentsForHost(host, agentsResult.data).map((agent) => ({
+            ...agent,
+            energy: energyMap.get(agent.id),
+          }))
+        : [];
       const history = historyResponse.ok
         ? ((await historyResponse.json()) as SignalEvent[])
         : [];
@@ -2953,13 +2973,15 @@ export function AgentsPage() {
     const refreshInterval = setInterval(() => {
       void (async () => {
         try {
+          console.log('[8s-POLL] refreshing...');
           const nextRuntimeSnapshot = await getRuntimeManager().refreshSnapshot();
           if (disposed) return;
+          console.log('[8s-POLL] agents:', nextRuntimeSnapshot.agents.length, 'energy:', nextRuntimeSnapshot.agents.filter(a => a.energy).length);
           applyRuntimeSnapshot(nextRuntimeSnapshot);
           await refreshSignalRoutesFromSnapshot(nextRuntimeSnapshot, () => disposed);
           await fetchPtyAgentsRef.current();
-        } catch {
-          // Ignore polling errors（轮询错误不打断页面渲染）
+        } catch (err) {
+          console.error('[8s-POLL] ERROR:', err);
         }
       })();
     }, 8000);

--- a/src/ui/app/pages/AgentsPage.tsx
+++ b/src/ui/app/pages/AgentsPage.tsx
@@ -296,7 +296,7 @@ function getAddOptionIcon(optionId: AddNodeOption['id']): LucideIcon {
   return Plus;
 }
 
-const ENERGY_PHASE_COLORS: Record<string, string> = {
+export const ENERGY_PHASE_COLORS: Record<string, string> = {
   normal: '#22C55E',
   slowing: '#EAB308',
   critical: '#F97316',
@@ -304,7 +304,7 @@ const ENERGY_PHASE_COLORS: Record<string, string> = {
   dormant: '#6B7280',
 };
 
-function mapRuntimeStatusToNodeStatus(status: string, energy?: { phase: string; is_dormant: boolean }): AgentHubNodeStatus {
+export function mapRuntimeStatusToNodeStatus(status: string, energy?: { phase: string; is_dormant: boolean }): AgentHubNodeStatus {
   if (energy?.is_dormant) return 'dormant';
   if (energy?.phase === 'dying') return 'dying';
   if (energy?.phase === 'critical') return 'critical';
@@ -341,7 +341,7 @@ function getHostStatusBadgeClass(connectionState: RuntimeHostSnapshot['connectio
   return 'bg-[#F59E0B20] text-[#D97706]';
 }
 
-function buildListSectionsFromRuntimeAgents(agents: RuntimeAggregatedAgent[]): AgentHubListSection[] {
+export function buildListSectionsFromRuntimeAgents(agents: RuntimeAggregatedAgent[]): AgentHubListSection[] {
   const groupedByHost = new Map<string, RuntimeAggregatedAgent[]>();
   for (const agent of agents) {
     const key = JSON.stringify([agent.sourceHostId, agent.sourceHostName]);

--- a/src/ui/app/pages/agents/AgentDetailPage.tsx
+++ b/src/ui/app/pages/agents/AgentDetailPage.tsx
@@ -6,7 +6,7 @@ import { getRuntimeHostService } from '@/lib/services/runtime-host.service';
 import { useIsDesktop } from '@/ui/app/hooks/useIsDesktop';
 import { WorkspaceTabs } from './WorkspaceTabs';
 
-const PHASE_LABELS: Record<string, string> = {
+export const PHASE_LABELS: Record<string, string> = {
   normal: '正常',
   slowing: '降频中',
   critical: '能量不足',
@@ -14,7 +14,7 @@ const PHASE_LABELS: Record<string, string> = {
   dormant: '休眠',
 };
 
-const PHASE_COLORS: Record<string, string> = {
+export const PHASE_COLORS: Record<string, string> = {
   normal: '#22C55E',
   slowing: '#EAB308',
   critical: '#F97316',
@@ -22,7 +22,7 @@ const PHASE_COLORS: Record<string, string> = {
   dormant: '#6B7280',
 };
 
-function EnergyBar({ energy }: { energy: AgentEnergySnapshot }) {
+export function EnergyBar({ energy }: { energy: AgentEnergySnapshot }) {
   const percent = Math.round(energy.ratio * 100);
   const color = PHASE_COLORS[energy.phase] ?? '#6B7280';
   const label = PHASE_LABELS[energy.phase] ?? energy.phase;

--- a/tests/unit/ui/agent-hub/agents-page.energy.test.tsx
+++ b/tests/unit/ui/agent-hub/agents-page.energy.test.tsx
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { AgentEnergySnapshot } from '@/lib/types/agent-hub';
+import type { RuntimeAggregatedAgent } from '@/services/runtime-manager';
+import {
+  buildListSectionsFromRuntimeAgents,
+  ENERGY_PHASE_COLORS,
+  mapRuntimeStatusToNodeStatus,
+} from '@/ui/app/pages/AgentsPage';
+
+vi.mock('@xyflow/react', () => ({
+  ReactFlow: () => null,
+  Background: () => null,
+  Controls: () => null,
+  Handle: () => null,
+  Position: { Left: 'left', Right: 'right' },
+  useNodesState: <T,>(initialNodes: T[]) => [initialNodes, vi.fn(), vi.fn()] as const,
+  MarkerType: { ArrowClosed: 'arrowclosed' },
+}));
+
+function makeEnergy(overrides: Partial<AgentEnergySnapshot> = {}): AgentEnergySnapshot {
+  return {
+    agent_id: 'test-agent',
+    current: 80,
+    max: 100,
+    ratio: 0.8,
+    tick_cost: 1,
+    phase: 'normal',
+    is_dormant: false,
+    ...overrides,
+  };
+}
+
+function makeAgent(overrides: Partial<RuntimeAggregatedAgent> = {}): RuntimeAggregatedAgent {
+  return {
+    id: 'agent-1',
+    name: 'Test Agent',
+    description: 'A test agent',
+    status: 'available',
+    sourceHostId: 'host-1',
+    sourceHostName: 'localhost',
+    sourceHostAddress: '127.0.0.1:1949',
+    ...overrides,
+  };
+}
+
+describe('mapRuntimeStatusToNodeStatus', () => {
+  it('returns running for available status without energy', () => {
+    expect(mapRuntimeStatusToNodeStatus('available')).toBe('running');
+  });
+
+  it('returns running for running status without energy', () => {
+    expect(mapRuntimeStatusToNodeStatus('running')).toBe('running');
+  });
+
+  it('returns warning for busy status', () => {
+    expect(mapRuntimeStatusToNodeStatus('busy')).toBe('warning');
+  });
+
+  it('returns idle for unknown status', () => {
+    expect(mapRuntimeStatusToNodeStatus('unknown')).toBe('idle');
+  });
+
+  it('returns dormant when energy.is_dormant is true', () => {
+    expect(mapRuntimeStatusToNodeStatus('available', { phase: 'dormant', is_dormant: true })).toBe('dormant');
+  });
+
+  it('returns dying when energy.phase is dying', () => {
+    expect(mapRuntimeStatusToNodeStatus('available', { phase: 'dying', is_dormant: false })).toBe('dying');
+  });
+
+  it('returns critical when energy.phase is critical', () => {
+    expect(mapRuntimeStatusToNodeStatus('available', { phase: 'critical', is_dormant: false })).toBe('critical');
+  });
+
+  it('dormant takes priority over dying phase', () => {
+    expect(mapRuntimeStatusToNodeStatus('available', { phase: 'dying', is_dormant: true })).toBe('dormant');
+  });
+
+  it('returns running when energy.phase is normal', () => {
+    expect(mapRuntimeStatusToNodeStatus('available', { phase: 'normal', is_dormant: false })).toBe('running');
+  });
+
+  it('returns running when energy.phase is slowing', () => {
+    expect(mapRuntimeStatusToNodeStatus('running', { phase: 'slowing', is_dormant: false })).toBe('running');
+  });
+});
+
+describe('buildListSectionsFromRuntimeAgents', () => {
+  it('returns empty array for no agents', () => {
+    expect(buildListSectionsFromRuntimeAgents([])).toEqual([]);
+  });
+
+  it('merges energy data into list items', () => {
+    const energy = makeEnergy({ agent_id: 'agent-1', ratio: 0.65, phase: 'slowing' });
+    const agents = [makeAgent({ energy })];
+
+    const sections = buildListSectionsFromRuntimeAgents(agents);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].items).toHaveLength(1);
+
+    const item = sections[0].items[0];
+    expect(item.energy).toBeDefined();
+    expect(item.energy?.ratio).toBe(0.65);
+    expect(item.energy?.phase).toBe('slowing');
+  });
+
+  it('sets dormant status when energy.is_dormant is true', () => {
+    const energy = makeEnergy({ is_dormant: true, phase: 'dormant', ratio: 0 });
+    const agents = [makeAgent({ energy })];
+
+    const sections = buildListSectionsFromRuntimeAgents(agents);
+    expect(sections[0].items[0].status).toBe('dormant');
+  });
+
+  it('sets critical status when energy.phase is critical', () => {
+    const energy = makeEnergy({ phase: 'critical', ratio: 0.1 });
+    const agents = [makeAgent({ energy })];
+
+    const sections = buildListSectionsFromRuntimeAgents(agents);
+    expect(sections[0].items[0].status).toBe('critical');
+  });
+
+  it('sets dying status when energy.phase is dying', () => {
+    const energy = makeEnergy({ phase: 'dying', ratio: 0.02 });
+    const agents = [makeAgent({ energy })];
+
+    const sections = buildListSectionsFromRuntimeAgents(agents);
+    expect(sections[0].items[0].status).toBe('dying');
+  });
+
+  it('passes undefined energy when agent has no energy data', () => {
+    const agents = [makeAgent()];
+    const sections = buildListSectionsFromRuntimeAgents(agents);
+    expect(sections[0].items[0].energy).toBeUndefined();
+    expect(sections[0].items[0].status).toBe('running');
+  });
+
+  it('groups agents by host and preserves energy per agent', () => {
+    const energy1 = makeEnergy({ agent_id: 'a1', ratio: 0.9, phase: 'normal' });
+    const energy2 = makeEnergy({ agent_id: 'a2', ratio: 0.3, phase: 'critical' });
+    const agents = [
+      makeAgent({ id: 'a1', name: 'Agent One', energy: energy1 }),
+      makeAgent({ id: 'a2', name: 'Agent Two', energy: energy2 }),
+    ];
+
+    const sections = buildListSectionsFromRuntimeAgents(agents);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].items).toHaveLength(2);
+    expect(sections[0].items[0].energy?.ratio).toBe(0.9);
+    expect(sections[0].items[1].energy?.ratio).toBe(0.3);
+    expect(sections[0].items[1].status).toBe('critical');
+  });
+});
+
+describe('ENERGY_PHASE_COLORS', () => {
+  it('has all expected phase colors', () => {
+    expect(ENERGY_PHASE_COLORS.normal).toBe('#22C55E');
+    expect(ENERGY_PHASE_COLORS.slowing).toBe('#EAB308');
+    expect(ENERGY_PHASE_COLORS.critical).toBe('#F97316');
+    expect(ENERGY_PHASE_COLORS.dying).toBe('#EF4444');
+    expect(ENERGY_PHASE_COLORS.dormant).toBe('#6B7280');
+  });
+});


### PR DESCRIPTION
## Summary
- Add energy data pipeline: `RuntimeClient.getAllEnergy()` → `RuntimeManager` 8s polling → UI
- Agent list shows mini energy bars with phase-based colors (green/yellow/orange/red/gray)
- Agent detail right panel has real-time 2s energy polling with full EnergyBar component
- Dormant agents shown with grayscale + dormant badge
- Status mapping extended for dormant/critical/dying states

## Changed Files (6 files, clean diff)
- `src/lib/types/agent-hub.ts` — extend `AgentHubNodeStatus` + `AgentHubListItem.energy`
- `src/services/runtime-client.ts` — add `getAllEnergy()` calling `GET /energy`
- `src/services/runtime-manager.ts` — parallel energy fetch in `buildHostSnapshot()`
- `src/ui/app/pages/AgentsPage.tsx` — list energy bars + right panel polling + dormant style
- `src/ui/app/pages/agents/AgentDetailPage.tsx` — export `EnergyBar` component
- `tests/unit/ui/agent-hub/agents-page.energy.test.tsx` — 18 unit tests

## Test Plan
- [x] Unit tests for `mapRuntimeStatusToNodeStatus` (dormant/critical/dying priority)
- [x] Unit tests for `buildListSectionsFromRuntimeAgents` (energy merge)
- [x] Unit tests for `ENERGY_PHASE_COLORS` completeness
- [ ] Manual: /agents list shows mini energy bars with phase colors
- [ ] Manual: Right panel energy bar updates every ~2s
- [ ] Manual: Energy → 0 shows dormant (gray, badge)

## Fix: Scope Mismatch (reviewer feedback)
Rebased from clean `origin/dev` (fa55a10). Previous diff included unrelated cursor/android/tauri changes from dirty local dev base. Now only 6 files, 301 lines.

Closes #440

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>