### PR TITLE
feat(rt/task): migrate task source of truth to RT SQLite

### DIFF
--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -782,6 +782,20 @@ impl AppState {
 
         let data_dir = resolve_data_dir();
         let eventlog_store = Arc::new(EventLogStore::new(data_dir));
+        let task_store = env::var("EXOMIND_RT_TASK_SQLITE_PATH")
+            .ok()
+            .map(PathBuf::from)
+            .map(|path| {
+                task::TaskStore::with_sqlite_path(&path).unwrap_or_else(|error| {
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %error,
+                        "task sqlite init failed, falling back to in-memory store (Task SQLite 初始化失败，降级到内存存储)"
+                    );
+                    task::TaskStore::new()
+                })
+            })
+            .unwrap_or_else(task::TaskStore::new);
 
         Self {
             port,
@@ -793,7 +807,7 @@ impl AppState {
             auth_secret,
             mdns: None,
             pairing: Arc::new(pairing::PairingManager::new()),
-            task_store: Arc::new(task::TaskStore::new()),
+            task_store: Arc::new(task_store),
             energy_registry: energy::EnergyRegistry::new(),
             life_agents: std::collections::HashMap::new(),
             eventlog_store,

--- a/crates/exomind-runtime/src/routes/eventlog.rs
+++ b/crates/exomind-runtime/src/routes/eventlog.rs
@@ -178,6 +178,7 @@ mod tests {
             pairing: Arc::new(crate::pairing::PairingManager::new()),
             task_store: Arc::new(crate::task::TaskStore::new()),
             energy_registry: crate::energy::EnergyRegistry::new(),
+            life_agents: std::collections::HashMap::new(),
             eventlog_store: store,
             #[cfg(not(target_os = "android"))]
             pty_manager: Arc::new(crate::pty::PtyManager::new(Arc::clone(&signal_pool), host_id)),

--- a/crates/exomind-runtime/src/routes/tasks.rs
+++ b/crates/exomind-runtime/src/routes/tasks.rs
@@ -2,7 +2,8 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use serde::Deserialize;
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use serde::{Deserialize, Serialize};
 
 use crate::signal::types::SignalEvent;
 use crate::task::{CreateTaskInput, Task, TaskStatus, TransitionInput, UpdateTaskInput};
@@ -14,6 +15,50 @@ use crate::AppState;
 struct ListQuery {
     #[serde(default)]
     status: Option<TaskStatus>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ImportQuery {
+    #[serde(default)]
+    strategy: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TaskBackupJsonPayload {
+    version: u32,
+    tasks: Vec<Task>,
+}
+
+#[derive(Debug, Serialize)]
+struct TaskBackupSqlitePayload {
+    version: u32,
+    file_name: String,
+    content_base64: String,
+    task_count: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct TaskBackupSqliteImportPayload {
+    content_base64: String,
+}
+
+#[derive(Debug, Serialize)]
+struct TaskImportResult {
+    imported: usize,
+    skipped: usize,
+    total: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct TaskBackendStatusResponse {
+    backend: &'static str,
+    supports_json_backup: bool,
+    supports_sqlite_snapshot: bool,
+}
+
+enum TaskImportStrategy {
+    Merge,
+    Overwrite,
 }
 
 // ── Handlers ────────────────────────────────────────────────────
@@ -125,6 +170,75 @@ async fn delete_task(
     Ok(Json(task))
 }
 
+async fn export_tasks_json(
+    State(state): State<AppState>,
+) -> Json<TaskBackupJsonPayload> {
+    Json(TaskBackupJsonPayload {
+        version: 1,
+        tasks: state.task_store.list(),
+    })
+}
+
+async fn export_tasks_sqlite(
+    State(state): State<AppState>,
+) -> Result<Json<TaskBackupSqlitePayload>, (StatusCode, String)> {
+    let bytes = state
+        .task_store
+        .sqlite_snapshot_bytes()
+        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?
+        .ok_or_else(|| {
+            (
+                StatusCode::CONFLICT,
+                "task sqlite snapshot is unavailable on non-sqlite backend".to_string(),
+            )
+        })?;
+
+    Ok(Json(TaskBackupSqlitePayload {
+        version: 1,
+        file_name: "exomind-tasks.sqlite".to_string(),
+        content_base64: STANDARD.encode(bytes),
+        task_count: state.task_store.len(),
+    }))
+}
+
+async fn import_tasks_json(
+    State(state): State<AppState>,
+    Query(query): Query<ImportQuery>,
+    Json(payload): Json<TaskBackupJsonPayload>,
+) -> Result<Json<TaskImportResult>, (StatusCode, String)> {
+    let strategy = parse_import_strategy(query.strategy.as_deref())?;
+    let result = apply_task_import(&state, payload.tasks, strategy)?;
+    Ok(Json(result))
+}
+
+async fn import_tasks_sqlite(
+    State(state): State<AppState>,
+    Query(query): Query<ImportQuery>,
+    Json(payload): Json<TaskBackupSqliteImportPayload>,
+) -> Result<Json<TaskImportResult>, (StatusCode, String)> {
+    let strategy = parse_import_strategy(query.strategy.as_deref())?;
+    let bytes = STANDARD
+        .decode(payload.content_base64)
+        .map_err(|error| (StatusCode::BAD_REQUEST, format!("invalid sqlite snapshot: {error}")))?;
+    let imported_tasks = read_tasks_from_sqlite_snapshot(&bytes)?;
+    let result = apply_task_import(&state, imported_tasks, strategy)?;
+    Ok(Json(result))
+}
+
+async fn task_backend_status(
+    State(state): State<AppState>,
+) -> Json<TaskBackendStatusResponse> {
+    let supports_sqlite_snapshot = matches!(
+        state.task_store.backend_kind(),
+        crate::task::TaskStoreBackendKind::Sqlite
+    );
+    Json(TaskBackendStatusResponse {
+        backend: if supports_sqlite_snapshot { "rt-sqlite" } else { "memory" },
+        supports_json_backup: true,
+        supports_sqlite_snapshot,
+    })
+}
+
 // ── Helpers ─────────────────────────────────────────────────────
 
 fn publish_task_signal(state: &AppState, topic: &str, task: &Task) {
@@ -142,11 +256,92 @@ fn publish_task_signal(state: &AppState, topic: &str, task: &Task) {
     state.signal_pool.publish(event);
 }
 
+fn parse_import_strategy(raw: Option<&str>) -> Result<TaskImportStrategy, (StatusCode, String)> {
+    match raw.unwrap_or("merge") {
+        "merge" => Ok(TaskImportStrategy::Merge),
+        "overwrite" => Ok(TaskImportStrategy::Overwrite),
+        value => Err((
+            StatusCode::BAD_REQUEST,
+            format!("unsupported task import strategy: {value}"),
+        )),
+    }
+}
+
+fn apply_task_import(
+    state: &AppState,
+    incoming: Vec<Task>,
+    strategy: TaskImportStrategy,
+) -> Result<TaskImportResult, (StatusCode, String)> {
+    let existing = state.task_store.list();
+    let result = match strategy {
+        TaskImportStrategy::Overwrite => {
+            state
+                .task_store
+                .replace_all(&incoming)
+                .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;
+            TaskImportResult {
+                imported: incoming.len(),
+                skipped: 0,
+                total: incoming.len(),
+            }
+        }
+        TaskImportStrategy::Merge => {
+            let mut merged = std::collections::BTreeMap::new();
+            for task in &existing {
+                merged.insert(task.id.clone(), task.clone());
+            }
+
+            let mut imported = 0usize;
+            let mut skipped = 0usize;
+            for task in incoming {
+                if merged.contains_key(&task.id) {
+                    skipped += 1;
+                } else {
+                    imported += 1;
+                }
+                merged.insert(task.id.clone(), task);
+            }
+
+            let next = merged.into_values().collect::<Vec<_>>();
+            state
+                .task_store
+                .replace_all(&next)
+                .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;
+
+            TaskImportResult {
+                imported,
+                skipped,
+                total: next.len(),
+            }
+        }
+    };
+
+    Ok(result)
+}
+
+fn read_tasks_from_sqlite_snapshot(bytes: &[u8]) -> Result<Vec<Task>, (StatusCode, String)> {
+    let temp_path = std::env::temp_dir().join(format!("exomind-task-import-{}.sqlite", uuid::Uuid::new_v4()));
+    std::fs::write(&temp_path, bytes)
+        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;
+
+    let store = crate::task::TaskStore::with_sqlite_path(&temp_path)
+        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;
+    let tasks = store.list();
+
+    let _ = std::fs::remove_file(&temp_path);
+    Ok(tasks)
+}
+
 // ── Router ──────────────────────────────────────────────────────
 
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/tasks", get(list_tasks).post(create_task))
+        .route("/tasks/backend/status", get(task_backend_status))
+        .route("/tasks/backup/json", get(export_tasks_json))
+        .route("/tasks/backup/sqlite", get(export_tasks_sqlite))
+        .route("/tasks/import/json", post(import_tasks_json))
+        .route("/tasks/import/sqlite", post(import_tasks_sqlite))
         .route("/tasks/:id", get(get_task).put(update_task).delete(delete_task))
         .route("/tasks/:id/transition", post(transition_task))
 }
@@ -156,15 +351,22 @@ pub fn router() -> Router<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::engine::general_purpose::STANDARD;
     use crate::signal::SignalPool;
+    use crate::task::TaskPriority;
     use axum::body::Body;
     use axum::http::Request;
     use http_body_util::BodyExt;
     use serde_json::Value;
     use std::sync::Arc;
+    use tempfile::tempdir;
     use tower::util::ServiceExt;
 
     fn test_state() -> AppState {
+        test_state_with_task_store(Arc::new(crate::task::TaskStore::new()))
+    }
+
+    fn test_state_with_task_store(task_store: Arc<crate::task::TaskStore>) -> AppState {
         let signal_pool = Arc::new(SignalPool::new(None));
         let host_id = "tasks-test-host".to_string();
         AppState {
@@ -177,7 +379,7 @@ mod tests {
             auth_secret: None,
             mdns: None,
             pairing: Arc::new(crate::pairing::PairingManager::new()),
-            task_store: Arc::new(crate::task::TaskStore::new()),
+            task_store,
             energy_registry: crate::energy::EnergyRegistry::new(),
             life_agents: std::collections::HashMap::new(),
             eventlog_store: Arc::new(crate::eventlog::EventLogStore::new(
@@ -242,12 +444,15 @@ mod tests {
         let task = state.task_store.create(CreateTaskInput {
             title: "Test".to_string(),
             description: None,
+            done_condition: None,
             priority: None,
             tags: vec![],
             source: None,
             parent_id: None,
+            depends_on: vec![],
             due_at: None,
             estimated_minutes: None,
+            time_block_ids: vec![],
         });
         let app = test_router(state);
 
@@ -289,12 +494,15 @@ mod tests {
         let task = state.task_store.create(CreateTaskInput {
             title: "Original".to_string(),
             description: None,
+            done_condition: None,
             priority: None,
             tags: vec![],
             source: None,
             parent_id: None,
+            depends_on: vec![],
             due_at: None,
             estimated_minutes: None,
+            time_block_ids: vec![],
         });
         let _rx = state.signal_pool.subscribe();
         let app = test_router(state);
@@ -323,12 +531,15 @@ mod tests {
         let task = state.task_store.create(CreateTaskInput {
             title: "My task".to_string(),
             description: None,
+            done_condition: None,
             priority: None,
             tags: vec![],
             source: None,
             parent_id: None,
+            depends_on: vec![],
             due_at: None,
             estimated_minutes: None,
+            time_block_ids: vec![],
         });
         let _rx = state.signal_pool.subscribe();
         let app = test_router(state);
@@ -356,12 +567,15 @@ mod tests {
         let task = state.task_store.create(CreateTaskInput {
             title: "Task".to_string(),
             description: None,
+            done_condition: None,
             priority: None,
             tags: vec![],
             source: None,
             parent_id: None,
+            depends_on: vec![],
             due_at: None,
             estimated_minutes: None,
+            time_block_ids: vec![],
         });
         let app = test_router(state);
 
@@ -386,12 +600,15 @@ mod tests {
         let task = state.task_store.create(CreateTaskInput {
             title: "To abandon".to_string(),
             description: None,
+            done_condition: None,
             priority: None,
             tags: vec![],
             source: None,
             parent_id: None,
+            depends_on: vec![],
             due_at: None,
             estimated_minutes: None,
+            time_block_ids: vec![],
         });
         // Must transition to in_progress first (not_started → abandoned is invalid)
         state.task_store.transition(&task.id, TaskStatus::InProgress).unwrap();
@@ -420,22 +637,28 @@ mod tests {
         let t1 = state.task_store.create(CreateTaskInput {
             title: "Task 1".to_string(),
             description: None,
+            done_condition: None,
             priority: None,
             tags: vec![],
             source: None,
             parent_id: None,
+            depends_on: vec![],
             due_at: None,
             estimated_minutes: None,
+            time_block_ids: vec![],
         });
         state.task_store.create(CreateTaskInput {
             title: "Task 2".to_string(),
             description: None,
+            done_condition: None,
             priority: None,
             tags: vec![],
             source: None,
             parent_id: None,
+            depends_on: vec![],
             due_at: None,
             estimated_minutes: None,
+            time_block_ids: vec![],
         });
         state.task_store.transition(&t1.id, TaskStatus::InProgress).unwrap();
 
@@ -455,5 +678,230 @@ mod tests {
         let tasks: Vec<Value> = serde_json::from_slice(&body).unwrap();
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0]["title"], "Task 1");
+    }
+
+    #[tokio::test]
+    async fn exports_task_json_backup() {
+        let state = test_state();
+        state.task_store.create(CreateTaskInput {
+            title: "Backup Task".to_string(),
+            description: Some("Export me".to_string()),
+            done_condition: Some("done".to_string()),
+            priority: Some(TaskPriority::High),
+            tags: vec!["backup".to_string()],
+            source: Some("test".to_string()),
+            parent_id: None,
+            depends_on: vec![],
+            due_at: Some(1_700_000_000_000),
+            estimated_minutes: Some(25),
+            time_block_ids: vec!["block-1".to_string()],
+        });
+        let app = test_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/tasks/backup/json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let payload: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(payload["version"], 1);
+        assert_eq!(payload["tasks"].as_array().map(|items| items.len()), Some(1));
+        assert_eq!(payload["tasks"][0]["done_condition"], "done");
+        assert_eq!(payload["tasks"][0]["time_block_ids"][0], "block-1");
+    }
+
+    #[tokio::test]
+    async fn imports_task_json_backup_with_merge_strategy() {
+        let state = test_state();
+        let existing = state.task_store.create(CreateTaskInput {
+            title: "Existing".to_string(),
+            description: None,
+            done_condition: None,
+            priority: None,
+            tags: vec![],
+            source: None,
+            parent_id: None,
+            depends_on: vec![],
+            due_at: None,
+            estimated_minutes: None,
+            time_block_ids: vec![],
+        });
+        let app = test_router(state.clone());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/tasks/import/json?strategy=merge")
+                    .header("content-type", "application/json")
+                    .body(Body::from(format!(
+                        r#"{{
+                            "version": 1,
+                            "tasks": [
+                                {{
+                                    "id": "{}",
+                                    "title": "Existing replaced",
+                                    "description": null,
+                                    "done_condition": null,
+                                    "status": "not_started",
+                                    "priority": "medium",
+                                    "tags": [],
+                                    "source": null,
+                                    "parent_id": null,
+                                    "depends_on": [],
+                                    "due_at": null,
+                                    "estimated_minutes": null,
+                                    "time_block_ids": [],
+                                    "created_at": 1000,
+                                    "updated_at": 2000,
+                                    "completed_at": null
+                                }},
+                                {{
+                                    "id": "task-import-2",
+                                    "title": "Imported task",
+                                    "description": null,
+                                    "done_condition": "ship",
+                                    "status": "not_started",
+                                    "priority": "high",
+                                    "tags": ["rt"],
+                                    "source": "backup",
+                                    "parent_id": null,
+                                    "depends_on": [],
+                                    "due_at": null,
+                                    "estimated_minutes": 30,
+                                    "time_block_ids": ["block-9"],
+                                    "created_at": 3000,
+                                    "updated_at": 4000,
+                                    "completed_at": null
+                                }}
+                            ]
+                        }}"#,
+                        existing.id
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let result: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["imported"], 1);
+        assert_eq!(result["skipped"], 1);
+        assert_eq!(result["total"], 2);
+
+        let tasks = state.task_store.list();
+        assert_eq!(tasks.len(), 2);
+        assert!(tasks.iter().any(|task| task.title == "Imported task"));
+        assert!(tasks.iter().any(|task| task.title == "Existing replaced"));
+    }
+
+    #[tokio::test]
+    async fn exports_task_sqlite_snapshot() {
+        let dir = tempdir().unwrap();
+        let sqlite_path = dir.path().join("tasks.sqlite");
+        let task_store = Arc::new(crate::task::TaskStore::with_sqlite_path(&sqlite_path).unwrap());
+        task_store.create(CreateTaskInput {
+            title: "SQLite backup".to_string(),
+            description: None,
+            done_condition: None,
+            priority: None,
+            tags: vec![],
+            source: None,
+            parent_id: None,
+            depends_on: vec![],
+            due_at: None,
+            estimated_minutes: None,
+            time_block_ids: vec![],
+        });
+        let app = test_router(test_state_with_task_store(task_store));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/tasks/backup/sqlite")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let payload: Value = serde_json::from_slice(&body).unwrap();
+        let encoded = payload["content_base64"].as_str().expect("base64 snapshot");
+        let bytes = STANDARD.decode(encoded).expect("valid sqlite bytes");
+        assert!(!bytes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn imports_task_sqlite_snapshot_with_overwrite_strategy() {
+        let dir = tempdir().unwrap();
+        let sqlite_path = dir.path().join("tasks.sqlite");
+        let task_store = Arc::new(crate::task::TaskStore::with_sqlite_path(&sqlite_path).unwrap());
+        task_store.create(CreateTaskInput {
+            title: "Old task".to_string(),
+            description: None,
+            done_condition: None,
+            priority: None,
+            tags: vec![],
+            source: None,
+            parent_id: None,
+            depends_on: vec![],
+            due_at: None,
+            estimated_minutes: None,
+            time_block_ids: vec![],
+        });
+
+        let import_dir = tempdir().unwrap();
+        let import_sqlite_path = import_dir.path().join("import.sqlite");
+        let import_store = crate::task::TaskStore::with_sqlite_path(&import_sqlite_path).unwrap();
+        import_store.create(CreateTaskInput {
+            title: "Imported sqlite task".to_string(),
+            description: Some("from snapshot".to_string()),
+            done_condition: None,
+            priority: Some(TaskPriority::High),
+            tags: vec!["sqlite".to_string()],
+            source: Some("backup".to_string()),
+            parent_id: None,
+            depends_on: vec![],
+            due_at: None,
+            estimated_minutes: Some(50),
+            time_block_ids: vec!["block-3".to_string()],
+        });
+        let import_bytes = std::fs::read(import_sqlite_path).unwrap();
+        let app = test_router(test_state_with_task_store(task_store.clone()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/tasks/import/sqlite?strategy=overwrite")
+                    .header("content-type", "application/json")
+                    .body(Body::from(format!(
+                        r#"{{"content_base64":"{}"}}"#,
+                        STANDARD.encode(import_bytes)
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let result: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["imported"], 1);
+        assert_eq!(result["skipped"], 0);
+        assert_eq!(result["total"], 1);
+        let tasks = task_store.list();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].title, "Imported sqlite task");
+        assert_eq!(tasks[0].time_block_ids, vec!["block-3".to_string()]);
     }
 }

--- a/crates/exomind-runtime/src/task/actor.rs
+++ b/crates/exomind-runtime/src/task/actor.rs
@@ -69,12 +69,15 @@ fn handle_auto_created(pool: &SignalPool, store: &TaskStore, event: &SignalEvent
     let task = store.create(CreateTaskInput {
         title: parsed.title,
         description: parsed.note,
+        done_condition: None,
         priority: None,
         tags: vec![],
         source: Some("classifier".to_string()),
         parent_id: None,
+        depends_on: vec![],
         due_at: None,
         estimated_minutes: None,
+        time_block_ids: vec![],
     });
 
     let created_event = SignalEvent {

--- a/crates/exomind-runtime/src/task/mod.rs
+++ b/crates/exomind-runtime/src/task/mod.rs
@@ -1,6 +1,10 @@
 pub mod actor;
+pub mod sqlite_store;
 pub mod store;
 pub mod types;
 
-pub use store::TaskStore;
-pub use types::{CreateTaskInput, Task, TaskPriority, TaskStatus, TransitionInput, UpdateTaskInput};
+pub use store::{TaskStore, TaskStoreBackendKind};
+pub use types::{
+    CreateTaskInput, Task, TaskDependency, TaskDependencyType, TaskPriority, TaskStatus,
+    TransitionInput, UpdateTaskInput,
+};

--- a/crates/exomind-runtime/src/task/sqlite_store.rs
+++ b/crates/exomind-runtime/src/task/sqlite_store.rs
@@ -1,0 +1,451 @@
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+use super::store::TaskStoreError;
+use super::types::{CreateTaskInput, Task, TaskDependency, TaskPriority, TaskStatus, UpdateTaskInput};
+
+pub struct SqliteTaskStore {
+    path: PathBuf,
+    connection: Mutex<Connection>,
+}
+
+impl SqliteTaskStore {
+    pub fn open(path: &Path) -> Result<Self, TaskStoreError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let connection = Connection::open(path)?;
+        let store = Self {
+            path: path.to_path_buf(),
+            connection: Mutex::new(connection),
+        };
+        store.init()?;
+        Ok(store)
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn create(&self, input: CreateTaskInput) -> Result<Task, TaskStoreError> {
+        let now = chrono::Utc::now().timestamp_millis() as u64;
+        let task = Task {
+            id: uuid::Uuid::new_v4().to_string(),
+            title: input.title,
+            description: input.description,
+            done_condition: input.done_condition,
+            status: TaskStatus::NotStarted,
+            priority: input.priority.unwrap_or_default(),
+            tags: input.tags,
+            source: input.source,
+            parent_id: input.parent_id,
+            depends_on: input.depends_on,
+            due_at: input.due_at,
+            estimated_minutes: input.estimated_minutes,
+            time_block_ids: input.time_block_ids,
+            created_at: now,
+            updated_at: now,
+            completed_at: None,
+        };
+
+        self.insert_task(&task)?;
+
+        Ok(task)
+    }
+
+    pub fn get(&self, id: &str) -> Result<Option<Task>, TaskStoreError> {
+        let connection = self.connection();
+        let mut statement = connection.prepare(
+            "SELECT
+                id, title, description, done_condition, status, priority, tags_json, source,
+                parent_id, depends_on_json, due_at, estimated_minutes, time_block_ids_json,
+                created_at, updated_at, completed_at
+             FROM tasks
+             WHERE id = ?1",
+        )?;
+
+        statement
+            .query_row(params![id], map_task_row)
+            .optional()
+            .map_err(TaskStoreError::from)
+    }
+
+    pub fn list(&self) -> Result<Vec<Task>, TaskStoreError> {
+        let connection = self.connection();
+        let mut statement = connection.prepare(
+            "SELECT
+                id, title, description, done_condition, status, priority, tags_json, source,
+                parent_id, depends_on_json, due_at, estimated_minutes, time_block_ids_json,
+                created_at, updated_at, completed_at
+             FROM tasks
+             ORDER BY created_at DESC, id DESC",
+        )?;
+        let rows = statement.query_map([], map_task_row)?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(TaskStoreError::from)
+    }
+
+    pub fn list_by_status(&self, status: &TaskStatus) -> Result<Vec<Task>, TaskStoreError> {
+        let connection = self.connection();
+        let mut statement = connection.prepare(
+            "SELECT
+                id, title, description, done_condition, status, priority, tags_json, source,
+                parent_id, depends_on_json, due_at, estimated_minutes, time_block_ids_json,
+                created_at, updated_at, completed_at
+             FROM tasks
+             WHERE status = ?1
+             ORDER BY created_at DESC, id DESC",
+        )?;
+        let rows = statement.query_map(params![task_status_to_db(status)], map_task_row)?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(TaskStoreError::from)
+    }
+
+    pub fn update(&self, id: &str, input: UpdateTaskInput) -> Result<Task, TaskStoreError> {
+        let mut task = self
+            .get(id)?
+            .ok_or_else(|| TaskStoreError::NotFound(id.to_string()))?;
+
+        if task.status.is_terminal() {
+            return Err(TaskStoreError::TerminalState(task.status));
+        }
+
+        if let Some(title) = input.title {
+            task.title = title;
+        }
+        if let Some(description) = input.description {
+            task.description = Some(description);
+        }
+        if let Some(done_condition) = input.done_condition {
+            task.done_condition = Some(done_condition);
+        }
+        if let Some(priority) = input.priority {
+            task.priority = priority;
+        }
+        if let Some(tags) = input.tags {
+            task.tags = tags;
+        }
+        if let Some(depends_on) = input.depends_on {
+            task.depends_on = depends_on;
+        }
+        if let Some(due_at) = input.due_at {
+            task.due_at = Some(due_at);
+        }
+        if let Some(estimated_minutes) = input.estimated_minutes {
+            task.estimated_minutes = Some(estimated_minutes);
+        }
+        if let Some(parent_id) = input.parent_id {
+            task.parent_id = Some(parent_id);
+        }
+        if let Some(time_block_ids) = input.time_block_ids {
+            task.time_block_ids = time_block_ids;
+        }
+        task.updated_at = chrono::Utc::now().timestamp_millis() as u64;
+
+        self.persist_task(&task)?;
+        Ok(task)
+    }
+
+    pub fn transition(
+        &self,
+        id: &str,
+        new_status: TaskStatus,
+    ) -> Result<(TaskStatus, Task), TaskStoreError> {
+        let mut task = self
+            .get(id)?
+            .ok_or_else(|| TaskStoreError::NotFound(id.to_string()))?;
+
+        if !task.status.can_transition_to(&new_status) {
+            return Err(TaskStoreError::InvalidTransition {
+                from: task.status,
+                to: new_status,
+            });
+        }
+
+        let old_status = task.status;
+        let now = chrono::Utc::now().timestamp_millis() as u64;
+        task.status = new_status;
+        task.updated_at = now;
+        task.completed_at = task.status.is_terminal().then_some(now);
+
+        self.persist_task(&task)?;
+        Ok((old_status, task))
+    }
+
+    pub fn abandon(&self, id: &str) -> Result<Task, TaskStoreError> {
+        let (_, task) = self.transition(id, TaskStatus::Abandoned)?;
+        Ok(task)
+    }
+
+    pub fn remove(&self, id: &str) -> Result<Option<Task>, TaskStoreError> {
+        let existing = self.get(id)?;
+        if existing.is_none() {
+            return Ok(None);
+        }
+
+        let connection = self.connection();
+        connection.execute("DELETE FROM tasks WHERE id = ?1", params![id])?;
+        Ok(existing)
+    }
+
+    pub fn len(&self) -> Result<usize, TaskStoreError> {
+        let connection = self.connection();
+        let count: i64 = connection.query_row("SELECT COUNT(1) FROM tasks", [], |row| row.get(0))?;
+        Ok(count as usize)
+    }
+
+    pub fn upsert(&self, task: &Task) -> Result<(), TaskStoreError> {
+        let connection = self.connection();
+        connection.execute(
+            "INSERT INTO tasks (
+                id, title, description, done_condition, status, priority, tags_json, source,
+                parent_id, depends_on_json, due_at, estimated_minutes, time_block_ids_json,
+                created_at, updated_at, completed_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
+            ON CONFLICT(id) DO UPDATE SET
+                title = excluded.title,
+                description = excluded.description,
+                done_condition = excluded.done_condition,
+                status = excluded.status,
+                priority = excluded.priority,
+                tags_json = excluded.tags_json,
+                source = excluded.source,
+                parent_id = excluded.parent_id,
+                depends_on_json = excluded.depends_on_json,
+                due_at = excluded.due_at,
+                estimated_minutes = excluded.estimated_minutes,
+                time_block_ids_json = excluded.time_block_ids_json,
+                created_at = excluded.created_at,
+                updated_at = excluded.updated_at,
+                completed_at = excluded.completed_at",
+            params![
+                task.id,
+                task.title,
+                task.description,
+                task.done_condition,
+                task_status_to_db(&task.status),
+                task_priority_to_db(&task.priority),
+                serde_json::to_string(&task.tags)?,
+                task.source,
+                task.parent_id,
+                serde_json::to_string(&task.depends_on)?,
+                task.due_at,
+                task.estimated_minutes,
+                serde_json::to_string(&task.time_block_ids)?,
+                task.created_at,
+                task.updated_at,
+                task.completed_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn replace_all(&self, tasks: &[Task]) -> Result<(), TaskStoreError> {
+        let mut connection = self.connection();
+        let tx = connection.transaction()?;
+        tx.execute("DELETE FROM tasks", [])?;
+        for task in tasks {
+            insert_task_in_transaction(&tx, task)?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn snapshot_bytes(&self) -> Result<Vec<u8>, TaskStoreError> {
+        std::fs::read(&self.path).map_err(TaskStoreError::from)
+    }
+
+    fn init(&self) -> Result<(), TaskStoreError> {
+        let connection = self.connection();
+        connection.execute_batch(
+            "CREATE TABLE IF NOT EXISTS tasks (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                description TEXT NULL,
+                done_condition TEXT NULL,
+                status TEXT NOT NULL,
+                priority TEXT NOT NULL,
+                tags_json TEXT NOT NULL,
+                source TEXT NULL,
+                parent_id TEXT NULL,
+                depends_on_json TEXT NOT NULL,
+                due_at INTEGER NULL,
+                estimated_minutes INTEGER NULL,
+                time_block_ids_json TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                completed_at INTEGER NULL
+            );",
+        )?;
+        Ok(())
+    }
+
+    fn persist_task(&self, task: &Task) -> Result<(), TaskStoreError> {
+        self.upsert(task)
+    }
+
+    fn connection(&self) -> std::sync::MutexGuard<'_, Connection> {
+        match self.connection.lock() {
+            Ok(lock) => lock,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    fn insert_task(&self, task: &Task) -> Result<(), TaskStoreError> {
+        let connection = self.connection();
+        connection.execute(
+            "INSERT INTO tasks (
+                id, title, description, done_condition, status, priority, tags_json, source,
+                parent_id, depends_on_json, due_at, estimated_minutes, time_block_ids_json,
+                created_at, updated_at, completed_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+            params![
+                task.id,
+                task.title,
+                task.description,
+                task.done_condition,
+                task_status_to_db(&task.status),
+                task_priority_to_db(&task.priority),
+                serde_json::to_string(&task.tags)?,
+                task.source,
+                task.parent_id,
+                serde_json::to_string(&task.depends_on)?,
+                task.due_at,
+                task.estimated_minutes,
+                serde_json::to_string(&task.time_block_ids)?,
+                task.created_at,
+                task.updated_at,
+                task.completed_at,
+            ],
+        )?;
+        Ok(())
+    }
+}
+
+fn map_task_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Task> {
+    let status: String = row.get(4)?;
+    let priority: String = row.get(5)?;
+    let tags_json: String = row.get(6)?;
+    let depends_on_json: String = row.get(9)?;
+    let time_block_ids_json: String = row.get(12)?;
+    let tags: Vec<String> = serde_json::from_str(&tags_json).map_err(map_json_error)?;
+    let depends_on: Vec<TaskDependency> =
+        serde_json::from_str(&depends_on_json).map_err(map_json_error)?;
+    let time_block_ids: Vec<String> =
+        serde_json::from_str(&time_block_ids_json).map_err(map_json_error)?;
+
+    Ok(Task {
+        id: row.get(0)?,
+        title: row.get(1)?,
+        description: row.get(2)?,
+        done_condition: row.get(3)?,
+        status: parse_task_status(&status).map_err(map_task_status_error)?,
+        priority: parse_task_priority(&priority).map_err(map_task_priority_error)?,
+        tags,
+        source: row.get(7)?,
+        parent_id: row.get(8)?,
+        depends_on,
+        due_at: row.get(10)?,
+        estimated_minutes: row.get(11)?,
+        time_block_ids,
+        created_at: row.get(13)?,
+        updated_at: row.get(14)?,
+        completed_at: row.get(15)?,
+    })
+}
+
+
+fn task_status_to_db(status: &TaskStatus) -> &'static str {
+    match status {
+        TaskStatus::NotStarted => "not_started",
+        TaskStatus::InProgress => "in_progress",
+        TaskStatus::Suspended => "suspended",
+        TaskStatus::Completed => "completed",
+        TaskStatus::Abandoned => "abandoned",
+    }
+}
+
+fn parse_task_status(value: &str) -> Result<TaskStatus, TaskStoreError> {
+    match value {
+        "not_started" => Ok(TaskStatus::NotStarted),
+        "in_progress" => Ok(TaskStatus::InProgress),
+        "suspended" => Ok(TaskStatus::Suspended),
+        "completed" => Ok(TaskStatus::Completed),
+        "abandoned" => Ok(TaskStatus::Abandoned),
+        _ => Err(TaskStoreError::InvalidStoredStatus(value.to_string())),
+    }
+}
+
+fn task_priority_to_db(priority: &TaskPriority) -> &'static str {
+    match priority {
+        TaskPriority::Low => "low",
+        TaskPriority::Medium => "medium",
+        TaskPriority::High => "high",
+    }
+}
+
+fn parse_task_priority(value: &str) -> Result<TaskPriority, TaskStoreError> {
+    match value {
+        "low" => Ok(TaskPriority::Low),
+        "medium" => Ok(TaskPriority::Medium),
+        "high" => Ok(TaskPriority::High),
+        _ => Err(TaskStoreError::InvalidStoredPriority(value.to_string())),
+    }
+}
+
+fn map_task_status_error(error: TaskStoreError) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(
+        0,
+        rusqlite::types::Type::Text,
+        Box::new(error),
+    )
+}
+
+fn map_task_priority_error(error: TaskStoreError) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(
+        0,
+        rusqlite::types::Type::Text,
+        Box::new(error),
+    )
+}
+
+fn map_json_error(error: serde_json::Error) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(
+        0,
+        rusqlite::types::Type::Text,
+        Box::new(error),
+    )
+}
+
+fn insert_task_in_transaction(
+    tx: &rusqlite::Transaction<'_>,
+    task: &Task,
+) -> Result<(), TaskStoreError> {
+    tx.execute(
+        "INSERT INTO tasks (
+            id, title, description, done_condition, status, priority, tags_json, source,
+            parent_id, depends_on_json, due_at, estimated_minutes, time_block_ids_json,
+            created_at, updated_at, completed_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+        params![
+            task.id,
+            task.title,
+            task.description,
+            task.done_condition,
+            task_status_to_db(&task.status),
+            task_priority_to_db(&task.priority),
+            serde_json::to_string(&task.tags)?,
+            task.source,
+            task.parent_id,
+            serde_json::to_string(&task.depends_on)?,
+            task.due_at,
+            task.estimated_minutes,
+            serde_json::to_string(&task.time_block_ids)?,
+            task.created_at,
+            task.updated_at,
+            task.completed_at,
+        ],
+    )?;
+    Ok(())
+}

--- a/crates/exomind-runtime/src/task/store.rs
+++ b/crates/exomind-runtime/src/task/store.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::RwLock;
 
 use thiserror::Error;
 
+use super::sqlite_store::SqliteTaskStore;
 use super::types::*;
 
 #[derive(Debug, Error)]
@@ -13,62 +15,114 @@ pub enum TaskStoreError {
     InvalidTransition { from: TaskStatus, to: TaskStatus },
     #[error("task is in terminal state: {0:?}")]
     TerminalState(TaskStatus),
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("invalid stored task status: {0}")]
+    InvalidStoredStatus(String),
+    #[error("invalid stored task priority: {0}")]
+    InvalidStoredPriority(String),
+}
+
+enum TaskStoreBackend {
+    Memory(RwLock<HashMap<String, Task>>),
+    Sqlite(SqliteTaskStore),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskStoreBackendKind {
+    Memory,
+    Sqlite,
 }
 
 pub struct TaskStore {
-    tasks: RwLock<HashMap<String, Task>>,
+    backend: TaskStoreBackend,
 }
 
 impl TaskStore {
     pub fn new() -> Self {
         Self {
-            tasks: RwLock::new(HashMap::new()),
+            backend: TaskStoreBackend::Memory(RwLock::new(HashMap::new())),
         }
     }
 
+    pub fn with_sqlite_path(path: &Path) -> Result<Self, TaskStoreError> {
+        Ok(Self {
+            backend: TaskStoreBackend::Sqlite(SqliteTaskStore::open(path)?),
+        })
+    }
+
     pub fn create(&self, input: CreateTaskInput) -> Task {
+        if let TaskStoreBackend::Sqlite(store) = &self.backend {
+            return store.create(input).expect("sqlite task creation should succeed");
+        }
+
         let now = chrono::Utc::now().timestamp_millis() as u64;
         let task = Task {
             id: uuid::Uuid::new_v4().to_string(),
             title: input.title,
             description: input.description,
+            done_condition: input.done_condition,
             status: TaskStatus::NotStarted,
             priority: input.priority.unwrap_or_default(),
             tags: input.tags,
             source: input.source,
             parent_id: input.parent_id,
+            depends_on: input.depends_on,
             due_at: input.due_at,
             estimated_minutes: input.estimated_minutes,
+            time_block_ids: input.time_block_ids,
             created_at: now,
             updated_at: now,
             completed_at: None,
         };
 
         let result = task.clone();
-        self.tasks.write().unwrap().insert(task.id.clone(), task);
+        self.memory_tasks().write().unwrap().insert(task.id.clone(), task);
         result
     }
 
     pub fn get(&self, id: &str) -> Option<Task> {
-        self.tasks.read().unwrap().get(id).cloned()
+        match &self.backend {
+            TaskStoreBackend::Memory(tasks) => tasks.read().unwrap().get(id).cloned(),
+            TaskStoreBackend::Sqlite(store) => store.get(id).expect("sqlite task lookup should succeed"),
+        }
     }
 
     pub fn list(&self) -> Vec<Task> {
-        let tasks = self.tasks.read().unwrap();
-        let mut list: Vec<Task> = tasks.values().cloned().collect();
-        list.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-        list
+        match &self.backend {
+            TaskStoreBackend::Memory(tasks) => {
+                let tasks = tasks.read().unwrap();
+                let mut list: Vec<Task> = tasks.values().cloned().collect();
+                list.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+                list
+            }
+            TaskStoreBackend::Sqlite(store) => store.list().expect("sqlite task list should succeed"),
+        }
     }
 
     pub fn list_by_status(&self, status: &TaskStatus) -> Vec<Task> {
-        self.list()
-            .into_iter()
-            .filter(|t| &t.status == status)
-            .collect()
+        match &self.backend {
+            TaskStoreBackend::Memory(_) => self
+                .list()
+                .into_iter()
+                .filter(|t| &t.status == status)
+                .collect(),
+            TaskStoreBackend::Sqlite(store) => store
+                .list_by_status(status)
+                .expect("sqlite status filter should succeed"),
+        }
     }
 
     pub fn update(&self, id: &str, input: UpdateTaskInput) -> Result<Task, TaskStoreError> {
-        let mut tasks = self.tasks.write().unwrap();
+        if let TaskStoreBackend::Sqlite(store) = &self.backend {
+            return store.update(id, input);
+        }
+
+        let mut tasks = self.memory_tasks().write().unwrap();
         let task = tasks
             .get_mut(id)
             .ok_or_else(|| TaskStoreError::NotFound(id.to_string()))?;
@@ -83,11 +137,17 @@ impl TaskStore {
         if let Some(description) = input.description {
             task.description = Some(description);
         }
+        if let Some(done_condition) = input.done_condition {
+            task.done_condition = Some(done_condition);
+        }
         if let Some(priority) = input.priority {
             task.priority = priority;
         }
         if let Some(tags) = input.tags {
             task.tags = tags;
+        }
+        if let Some(depends_on) = input.depends_on {
+            task.depends_on = depends_on;
         }
         if let Some(due_at) = input.due_at {
             task.due_at = Some(due_at);
@@ -97,6 +157,9 @@ impl TaskStore {
         }
         if let Some(parent_id) = input.parent_id {
             task.parent_id = Some(parent_id);
+        }
+        if let Some(time_block_ids) = input.time_block_ids {
+            task.time_block_ids = time_block_ids;
         }
 
         task.updated_at = chrono::Utc::now().timestamp_millis() as u64;
@@ -109,7 +172,11 @@ impl TaskStore {
         id: &str,
         new_status: TaskStatus,
     ) -> Result<(TaskStatus, Task), TaskStoreError> {
-        let mut tasks = self.tasks.write().unwrap();
+        if let TaskStoreBackend::Sqlite(store) = &self.backend {
+            return store.transition(id, new_status);
+        }
+
+        let mut tasks = self.memory_tasks().write().unwrap();
         let task = tasks
             .get_mut(id)
             .ok_or_else(|| TaskStoreError::NotFound(id.to_string()))?;
@@ -135,23 +202,81 @@ impl TaskStore {
 
     /// Abandon a task (set status to Abandoned). Convenience for DELETE endpoint.
     pub fn abandon(&self, id: &str) -> Result<Task, TaskStoreError> {
+        if let TaskStoreBackend::Sqlite(store) = &self.backend {
+            return store.abandon(id);
+        }
         let (_, task) = self.transition(id, TaskStatus::Abandoned)?;
         Ok(task)
     }
 
     /// Hard remove from store. Returns the removed task if it existed.
     pub fn remove(&self, id: &str) -> Option<Task> {
-        self.tasks.write().unwrap().remove(id)
+        match &self.backend {
+            TaskStoreBackend::Memory(tasks) => tasks.write().unwrap().remove(id),
+            TaskStoreBackend::Sqlite(store) => store.remove(id).expect("sqlite task removal should succeed"),
+        }
     }
 
     pub fn len(&self) -> usize {
-        self.tasks.read().unwrap().len()
+        match &self.backend {
+            TaskStoreBackend::Memory(tasks) => tasks.read().unwrap().len(),
+            TaskStoreBackend::Sqlite(store) => store.len().expect("sqlite task len should succeed"),
+        }
+    }
+
+    pub fn upsert(&self, task: Task) -> Result<Task, TaskStoreError> {
+        match &self.backend {
+            TaskStoreBackend::Memory(tasks) => {
+                tasks.write().unwrap().insert(task.id.clone(), task.clone());
+                Ok(task)
+            }
+            TaskStoreBackend::Sqlite(store) => {
+                store.upsert(&task)?;
+                Ok(task)
+            }
+        }
+    }
+
+    pub fn replace_all(&self, tasks: &[Task]) -> Result<(), TaskStoreError> {
+        match &self.backend {
+            TaskStoreBackend::Memory(memory) => {
+                let mut guard = memory.write().unwrap();
+                guard.clear();
+                for task in tasks {
+                    guard.insert(task.id.clone(), task.clone());
+                }
+                Ok(())
+            }
+            TaskStoreBackend::Sqlite(store) => store.replace_all(tasks),
+        }
+    }
+
+    pub fn sqlite_snapshot_bytes(&self) -> Result<Option<Vec<u8>>, TaskStoreError> {
+        match &self.backend {
+            TaskStoreBackend::Memory(_) => Ok(None),
+            TaskStoreBackend::Sqlite(store) => store.snapshot_bytes().map(Some),
+        }
+    }
+
+    pub fn backend_kind(&self) -> TaskStoreBackendKind {
+        match &self.backend {
+            TaskStoreBackend::Memory(_) => TaskStoreBackendKind::Memory,
+            TaskStoreBackend::Sqlite(_) => TaskStoreBackendKind::Sqlite,
+        }
+    }
+
+    fn memory_tasks(&self) -> &RwLock<HashMap<String, Task>> {
+        match &self.backend {
+            TaskStoreBackend::Memory(tasks) => tasks,
+            TaskStoreBackend::Sqlite(_) => unreachable!("memory-only helper used on sqlite backend"),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     fn make_store() -> TaskStore {
         TaskStore::new()
@@ -161,13 +286,82 @@ mod tests {
         CreateTaskInput {
             title: title.to_string(),
             description: None,
+            done_condition: None,
             priority: None,
             tags: vec![],
             source: None,
             parent_id: None,
+            depends_on: vec![],
             due_at: None,
             estimated_minutes: None,
+            time_block_ids: vec![],
         }
+    }
+
+    #[test]
+    fn sqlite_store_persists_tasks_across_reopen() {
+        let dir = tempdir().unwrap();
+        let sqlite_path = dir.path().join("tasks.sqlite");
+
+        let store = TaskStore::with_sqlite_path(&sqlite_path).unwrap();
+        let created = store.create(create_input("Persist me"));
+        drop(store);
+
+        let reopened = TaskStore::with_sqlite_path(&sqlite_path).unwrap();
+        let loaded = reopened.get(&created.id).expect("task should persist in sqlite");
+        assert_eq!(loaded.title, "Persist me");
+        assert_eq!(reopened.len(), 1);
+    }
+
+    #[test]
+    fn sqlite_store_roundtrips_extended_task_fields() {
+        let dir = tempdir().unwrap();
+        let sqlite_path = dir.path().join("tasks.sqlite");
+
+        let store = TaskStore::with_sqlite_path(&sqlite_path).unwrap();
+        let created = store.create(CreateTaskInput {
+            title: "Extended".to_string(),
+            description: Some("Task body".to_string()),
+            priority: Some(TaskPriority::High),
+            tags: vec!["rt".to_string(), "sqlite".to_string()],
+            source: Some("frontend:test".to_string()),
+            parent_id: Some("parent-1".to_string()),
+            due_at: Some(1_700_000_000_000),
+            estimated_minutes: Some(45),
+            done_condition: Some("all checks green".to_string()),
+            depends_on: vec![],
+            time_block_ids: vec![],
+        });
+        let updated = store
+            .update(
+                &created.id,
+                UpdateTaskInput {
+                    title: None,
+                    description: None,
+                    priority: None,
+                    tags: None,
+                    due_at: None,
+                    estimated_minutes: None,
+                    parent_id: None,
+                    done_condition: Some("ship RT sqlite".to_string()),
+                    depends_on: Some(vec![TaskDependency {
+                        task_id: "dep-1".to_string(),
+                        relation_type: TaskDependencyType::Hard,
+                    }]),
+                    time_block_ids: Some(vec!["block-1".to_string(), "block-2".to_string()]),
+                },
+            )
+            .unwrap();
+        assert_eq!(updated.done_condition.as_deref(), Some("ship RT sqlite"));
+        drop(store);
+
+        let reopened = TaskStore::with_sqlite_path(&sqlite_path).unwrap();
+        let loaded = reopened.get(&created.id).expect("extended task should persist");
+        assert_eq!(loaded.done_condition.as_deref(), Some("ship RT sqlite"));
+        assert_eq!(loaded.depends_on.len(), 1);
+        assert_eq!(loaded.depends_on[0].task_id, "dep-1");
+        assert_eq!(loaded.depends_on[0].relation_type, TaskDependencyType::Hard);
+        assert_eq!(loaded.time_block_ids, vec!["block-1".to_string(), "block-2".to_string()]);
     }
 
     #[test]
@@ -223,11 +417,14 @@ mod tests {
                 UpdateTaskInput {
                     title: Some("Updated".to_string()),
                     description: Some("A description".to_string()),
+                    done_condition: None,
                     priority: Some(TaskPriority::High),
                     tags: Some(vec!["urgent".to_string()]),
+                    depends_on: None,
                     due_at: None,
                     estimated_minutes: Some(60),
                     parent_id: None,
+                    time_block_ids: None,
                 },
             )
             .unwrap();
@@ -248,11 +445,14 @@ mod tests {
             UpdateTaskInput {
                 title: Some("X".to_string()),
                 description: None,
+                done_condition: None,
                 priority: None,
                 tags: None,
+                depends_on: None,
                 due_at: None,
                 estimated_minutes: None,
                 parent_id: None,
+                time_block_ids: None,
             },
         );
         assert!(matches!(result, Err(TaskStoreError::NotFound(_))));
@@ -270,11 +470,14 @@ mod tests {
             UpdateTaskInput {
                 title: Some("Try update".to_string()),
                 description: None,
+                done_condition: None,
                 priority: None,
                 tags: None,
+                depends_on: None,
                 due_at: None,
                 estimated_minutes: None,
                 parent_id: None,
+                time_block_ids: None,
             },
         );
         assert!(matches!(result, Err(TaskStoreError::TerminalState(_))));

--- a/crates/exomind-runtime/src/task/types.rs
+++ b/crates/exomind-runtime/src/task/types.rs
@@ -47,6 +47,20 @@ impl Default for TaskPriority {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskDependencyType {
+    Soft,
+    Hard,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskDependency {
+    pub task_id: String,
+    #[serde(rename = "type")]
+    pub relation_type: TaskDependencyType,
+}
+
 /// A task in the ExoMind runtime.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Task {
@@ -54,6 +68,8 @@ pub struct Task {
     pub title: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub done_condition: Option<String>,
     pub status: TaskStatus,
     pub priority: TaskPriority,
     #[serde(default)]
@@ -62,10 +78,14 @@ pub struct Task {
     pub source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<String>,
+    #[serde(default)]
+    pub depends_on: Vec<TaskDependency>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub due_at: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub estimated_minutes: Option<u32>,
+    #[serde(default)]
+    pub time_block_ids: Vec<String>,
     pub created_at: u64,
     pub updated_at: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -79,6 +99,8 @@ pub struct CreateTaskInput {
     #[serde(default)]
     pub description: Option<String>,
     #[serde(default)]
+    pub done_condition: Option<String>,
+    #[serde(default)]
     pub priority: Option<TaskPriority>,
     #[serde(default)]
     pub tags: Vec<String>,
@@ -87,9 +109,13 @@ pub struct CreateTaskInput {
     #[serde(default)]
     pub parent_id: Option<String>,
     #[serde(default)]
+    pub depends_on: Vec<TaskDependency>,
+    #[serde(default)]
     pub due_at: Option<u64>,
     #[serde(default)]
     pub estimated_minutes: Option<u32>,
+    #[serde(default)]
+    pub time_block_ids: Vec<String>,
 }
 
 /// Input for updating an existing task.
@@ -100,15 +126,21 @@ pub struct UpdateTaskInput {
     #[serde(default)]
     pub description: Option<String>,
     #[serde(default)]
+    pub done_condition: Option<String>,
+    #[serde(default)]
     pub priority: Option<TaskPriority>,
     #[serde(default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
+    pub depends_on: Option<Vec<TaskDependency>>,
     #[serde(default)]
     pub due_at: Option<u64>,
     #[serde(default)]
     pub estimated_minutes: Option<u32>,
     #[serde(default)]
     pub parent_id: Option<String>,
+    #[serde(default)]
+    pub time_block_ids: Option<Vec<String>>,
 }
 
 /// Input for transitioning task status.
@@ -162,13 +194,19 @@ mod tests {
             id: "t-1".to_string(),
             title: "Test".to_string(),
             description: None,
+            done_condition: Some("Definition of done".to_string()),
             status: TaskStatus::NotStarted,
             priority: TaskPriority::High,
             tags: vec!["dev".to_string()],
             source: Some("mcp".to_string()),
             parent_id: None,
+            depends_on: vec![TaskDependency {
+                task_id: "dep-1".to_string(),
+                relation_type: TaskDependencyType::Hard,
+            }],
             due_at: None,
             estimated_minutes: Some(30),
+            time_block_ids: vec!["block-1".to_string()],
             created_at: 1000,
             updated_at: 1000,
             completed_at: None,
@@ -176,8 +214,13 @@ mod tests {
         let json = serde_json::to_string(&task).unwrap();
         assert!(json.contains("\"not_started\""));
         assert!(json.contains("\"high\""));
+        assert!(json.contains("\"done_condition\":\"Definition of done\""));
+        assert!(json.contains("\"depends_on\""));
         let back: Task = serde_json::from_str(&json).unwrap();
         assert_eq!(back.status, TaskStatus::NotStarted);
         assert_eq!(back.priority, TaskPriority::High);
+        assert_eq!(back.done_condition.as_deref(), Some("Definition of done"));
+        assert_eq!(back.depends_on.len(), 1);
+        assert_eq!(back.time_block_ids, vec!["block-1".to_string()]);
     }
 }

--- a/crates/exomind-runtime/tests/task_runtime_sqlite_persistence.rs
+++ b/crates/exomind-runtime/tests/task_runtime_sqlite_persistence.rs
@@ -1,0 +1,53 @@
+use exomind_runtime::{AppState, task::CreateTaskInput};
+use tempfile::tempdir;
+
+#[test]
+fn app_state_runtime_reuses_task_sqlite_storage() {
+    let dir = tempdir().unwrap();
+    let sqlite_path = dir.path().join("runtime-task.sqlite");
+
+    // SAFETY: test-scoped env mutation; no concurrent reliance on this key in the same test.
+    unsafe {
+        std::env::set_var("EXOMIND_RT_TASK_SQLITE_PATH", &sqlite_path);
+    }
+
+    let state = AppState::new_runtime(
+        0,
+        "task-runtime-host".to_string(),
+        None,
+        None,
+        false,
+        None,
+    );
+    let created = state.task_store.create(CreateTaskInput {
+        title: "Persist from runtime".to_string(),
+        description: None,
+        done_condition: None,
+        priority: None,
+        tags: vec![],
+        source: None,
+        parent_id: None,
+        depends_on: vec![],
+        due_at: None,
+        estimated_minutes: None,
+        time_block_ids: vec![],
+    });
+    drop(state);
+
+    let reopened = AppState::new_runtime(
+        0,
+        "task-runtime-host".to_string(),
+        None,
+        None,
+        false,
+        None,
+    );
+    let loaded = reopened.task_store.get(&created.id);
+
+    // SAFETY: clear test env after assertion.
+    unsafe {
+        std::env::remove_var("EXOMIND_RT_TASK_SQLITE_PATH");
+    }
+
+    assert!(loaded.is_some(), "runtime should reopen persisted task storage");
+}

--- a/docs/plans/2026-03-11-issue-481-rt-task-sqlite-plan.md
+++ b/docs/plans/2026-03-11-issue-481-rt-task-sqlite-plan.md
@@ -1,0 +1,247 @@
+# RT Task SQLite Migration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 把任务系统真实数据源迁移到 `RT + SQLite`，并让前端任务读写、任务导入导出、开发者调试信息都围绕 RT 任务后端工作。
+
+**Architecture:** 保持现有 `RT /tasks` HTTP 路由为任务 API 外观（API surface，接口外观），把 `TaskStore` 从内存实现升级为 `SQLite-first` 持久化实现，同时新增前端 `TaskRtAdapter` 替换 `TaskPouchAdapter`。Settings 不改 EventLog 备份语义，只新增“任务数据”独立导入导出链路，支持 `JSON` 与 `SQLite snapshot`。
+
+**Tech Stack:** Rust (`axum`, `rusqlite`), TypeScript, React, Tauri, Vitest.
+
+---
+
+### Task 1: RT TaskStore 升级为 SQLite-first
+
+**Files:**
+- Create: `crates/exomind-runtime/src/task/sqlite_store.rs`
+- Modify: `crates/exomind-runtime/src/task/store.rs`
+- Modify: `crates/exomind-runtime/src/task/types.rs`
+- Modify: `crates/exomind-runtime/src/lib.rs`
+- Modify: `src-tauri/src/lib.rs`
+- Test: `crates/exomind-runtime/src/task/store.rs`
+- Test: `crates/exomind-runtime/src/routes/tasks.rs`
+
+**Step 1: 写失败测试**
+
+覆盖：
+- RT task store 在 SQLite 模式下重启后数据仍存在
+- `depends_on / time_block_ids / done_condition / estimated_minutes` 能 roundtrip
+- `transition / abandon / update` 在 SQLite 模式下保持现有行为
+
+**Step 2: 运行测试确认失败**
+
+Run:
+```powershell
+cargo test -p exomind-runtime task --manifest-path src-tauri/Cargo.toml -- --nocapture
+```
+
+**Step 3: 实现最小 SQLite task store**
+
+要求：
+- `TaskStore::new()` 继续保留内存实现，服务测试
+- 新增 `TaskStore::with_sqlite_path(...)`
+- 任务表覆盖前端现有核心字段
+- 生产运行时默认走 SQLite 路径
+
+**Step 4: 将 runtime startup 接到 task sqlite 路径**
+
+要求：
+- `RuntimeStartOptions` 增加 `task_storage_path`
+- Tauri setup 预置 `EXOMIND_RT_TASK_SQLITE_PATH`
+
+**Step 5: 回归测试**
+
+Run:
+```powershell
+cargo test -p exomind-runtime task --manifest-path src-tauri/Cargo.toml -- --nocapture
+```
+
+### Task 2: 扩展 /tasks 路由与任务备份 API
+
+**Files:**
+- Modify: `crates/exomind-runtime/src/routes/tasks.rs`
+- Modify: `crates/exomind-runtime/src/task/store.rs`
+- Modify: `crates/exomind-runtime/src/task/types.rs`
+- Test: `crates/exomind-runtime/src/routes/tasks.rs`
+
+**Step 1: 写失败测试**
+
+覆盖：
+- `/tasks` 返回的 payload 与前端 `TaskNode` 所需字段对应
+- `GET /tasks/backup/json`
+- `GET /tasks/backup/sqlite`
+- `POST /tasks/import/json`
+- `POST /tasks/import/sqlite`
+- `merge / overwrite` 语义正确
+
+**Step 2: 运行测试确认失败**
+
+Run:
+```powershell
+cargo test -p exomind-runtime routes::tasks --manifest-path src-tauri/Cargo.toml -- --nocapture
+```
+
+**Step 3: 实现最小备份协议**
+
+要求：
+- JSON payload 版本化
+- SQLite snapshot 走 base64 + metadata 响应，供前端下载
+- import 返回导入计数和总量
+
+**Step 4: 回归测试**
+
+Run:
+```powershell
+cargo test -p exomind-runtime routes::tasks --manifest-path src-tauri/Cargo.toml -- --nocapture
+```
+
+### Task 3: 前端任务读写切到 RT
+
+**Files:**
+- Create: `src/lib/adapters/task-rt-adapter.ts`
+- Modify: `src/lib/environment/bootstrap.ts`
+- Modify: `src/lib/services/task.service.ts`
+- Modify: `src/App.tsx`
+- Optionally modify: `src/ui/app/components/TaskSyncCoordinator.tsx`
+- Test: `tests/unit/adapters/task-rt-adapter.test.ts`
+- Test: `tests/unit/app/app-router-context.startup.test.tsx`
+
+**Step 1: 写失败测试**
+
+覆盖：
+- `TaskRtAdapter` 能 list / get / create / update / transition / abandon
+- snake_case <-> camelCase 映射正确
+- App 不再挂载 `TaskSyncCoordinator`
+- `TaskService` 的变更能通知 UI 监听器
+
+**Step 2: 运行测试确认失败**
+
+Run:
+```powershell
+npx vitest run tests/unit/adapters/task-rt-adapter.test.ts tests/unit/app/app-router-context.startup.test.tsx
+```
+
+**Step 3: 实现最小 cutover**
+
+要求：
+- 默认任务 backend 改为 RT adapter
+- 本地 task mutation 后触发 `onTaskChange`
+- 不再依赖 task Pouch live sync
+
+**Step 4: 回归测试**
+
+Run:
+```powershell
+npx vitest run tests/unit/adapters/task-rt-adapter.test.ts tests/unit/app/app-router-context.startup.test.tsx
+```
+
+### Task 4: Settings 增加任务 JSON / SQLite 导入导出
+
+**Files:**
+- Create: `src/lib/services/task-backup.service.ts`
+- Modify: `src/ui/app/pages/SettingsPage.tsx`
+- Modify: `src-tauri/src/commands/file_commands.rs`
+- Modify: `src-tauri/src/lib.rs`
+- Test: `tests/unit/settings/task-import-export.issue481.test.tsx`
+
+**Step 1: 写失败测试**
+
+覆盖：
+- Settings 能导出任务 JSON
+- Settings 能导出任务 SQLite snapshot
+- Settings 能导入任务 JSON
+- Settings 能导入任务 SQLite snapshot
+- 不影响现有 EventLog 备份按钮语义
+
+**Step 2: 运行测试确认失败**
+
+Run:
+```powershell
+npx vitest run tests/unit/settings/task-import-export.issue481.test.tsx
+```
+
+**Step 3: 实现最小 UI 与服务**
+
+要求：
+- 任务数据入口独立于 EventLog 备份入口
+- Tauri 与 Web 都能走同一套导入导出逻辑
+- Tauri 文件命令支持除 `.json` 外的任务快照文件
+
+**Step 4: 回归测试**
+
+Run:
+```powershell
+npx vitest run tests/unit/settings/task-import-export.issue481.test.tsx
+```
+
+### Task 5: 开发者模式调试信息
+
+**Files:**
+- Modify: `src/ui/app/pages/SettingsPage.tsx`
+- Optionally create: `src/lib/services/task-backend-status.service.ts`
+- Test: `tests/unit/settings/task-backend-diagnostics.issue481.test.tsx`
+
+**Step 1: 写失败测试**
+
+覆盖：
+- 开发者模式开启时显示 `Task backend`
+- 显示当前任务导入导出格式能力
+- 非开发者模式时不显示
+
+**Step 2: 运行测试确认失败**
+
+Run:
+```powershell
+npx vitest run tests/unit/settings/task-backend-diagnostics.issue481.test.tsx
+```
+
+**Step 3: 实现最小诊断视图**
+
+要求：
+- 能看出当前是否 `rt-sqlite`
+- 能看出任务备份支持 `json/sqlite`
+
+**Step 4: 回归测试**
+
+Run:
+```powershell
+npx vitest run tests/unit/settings/task-backend-diagnostics.issue481.test.tsx
+```
+
+### Task 6: 全链路验证与联调
+
+**Files:**
+- Verify only
+
+**Step 1: 类型检查**
+
+```powershell
+npx tsc --noEmit
+```
+
+**Step 2: 跑相关单测**
+
+```powershell
+npx vitest run tests/unit/adapters/task-rt-adapter.test.ts tests/unit/settings/task-import-export.issue481.test.tsx tests/unit/settings/task-backend-diagnostics.issue481.test.tsx tests/unit/app/app-router-context.startup.test.tsx
+cargo test -p exomind-runtime task --manifest-path src-tauri/Cargo.toml -- --nocapture
+```
+
+**Step 3: 构建验证**
+
+```powershell
+bun run build
+```
+
+**Step 4: 启动桌面端联调**
+
+```powershell
+bun run tauri dev
+```
+
+**Step 5: 人工验收点**
+
+- 创建任务后刷新应用仍然存在
+- 编辑估时 / 依赖 / 状态变更后刷新仍然存在
+- Settings 能导出 / 导入任务 JSON
+- Settings 能导出 / 导入任务 SQLite snapshot
+- 开发者模式能显示任务后端为 `rt-sqlite`

--- a/src-tauri/src/commands/file_commands.rs
+++ b/src-tauri/src/commands/file_commands.rs
@@ -499,6 +499,57 @@ pub fn save_json_file(
     Ok(Some(saved))
 }
 
+/// 保存二进制内容到系统文件选择路径
+#[tauri::command]
+pub fn save_binary_file(
+    app: AppHandle,
+    content: Vec<u8>,
+    default_name: String,
+    filters: Option<Vec<String>>,
+) -> FileResult<Option<String>> {
+    let mut dialog = app
+        .dialog()
+        .file()
+        .set_file_name(&default_name);
+
+    if let Some(filters) = filters.as_ref() {
+        if !filters.is_empty() {
+            let owned_filters: Vec<String> = filters
+                .iter()
+                .map(|value| value.trim().trim_start_matches('.').to_string())
+                .filter(|value| !value.is_empty())
+                .collect();
+            let filter_refs: Vec<&str> = owned_filters.iter().map(String::as_str).collect();
+            if !filter_refs.is_empty() {
+                dialog = dialog.add_filter("Binary", &filter_refs);
+            }
+        }
+    }
+
+    let file_path = dialog.blocking_save_file();
+
+    let Some(file_path) = file_path else {
+        return Ok(None);
+    };
+
+    let saved = persist_export_content_for_selected_file(
+        file_path,
+        &content,
+        |path, bytes| fs::write(path, bytes),
+        |uri_like, bytes| {
+            let mut options = OpenOptions::new();
+            options.write(true).create(true).truncate(true);
+
+            let mut file = app.fs().open(uri_like.clone(), options)?;
+            use std::io::Write;
+            file.write_all(bytes)?;
+            Ok(())
+        },
+    )?;
+
+    Ok(Some(saved))
+}
+
 /// 从系统文件选择器选择 JSON 文件并读取内容
 #[tauri::command]
 pub fn pick_json_file(app: AppHandle) -> FileResult<Option<PickedJsonFile>> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,7 +15,8 @@ use commands::eventlog_commands::{
 };
 use commands::file_commands::{
     append_file, append_to_markdown, delete_file, export_messages_to_markdown, file_exists,
-    list_files, pick_json_file, read_file, read_file_binary, save_json_file, write_file,
+    list_files, pick_json_file, read_file, read_file_binary, save_binary_file, save_json_file,
+    write_file,
 };
 use commands::runtime_commands::{
     ensure_runtime_started, runtime_service_reachable_address, runtime_service_start,
@@ -71,7 +72,9 @@ pub fn run() {
                 eprintln!("[tauri/setup] failed to prewarm voice overlay window: {error}");
             }
 
-            if std::env::var_os("EXOMIND_RT_SIGNAL_SQLITE_PATH").is_none() {
+            if std::env::var_os("EXOMIND_RT_SIGNAL_SQLITE_PATH").is_none()
+                || std::env::var_os("EXOMIND_RT_TASK_SQLITE_PATH").is_none()
+            {
                 match app.path().app_data_dir() {
                     Ok(app_data_dir) => {
                         let runtime_dir = app_data_dir.join("runtime");
@@ -80,19 +83,28 @@ pub fn run() {
                                 "[tauri/setup] failed to create runtime data dir for signal sqlite: {error}"
                             );
                         } else {
-                            let signal_sqlite_path = runtime_dir.join("signal-pool.sqlite");
-                            // SAFETY: setup runs before the embedded runtime starts and before worker threads read this env var.
-                            unsafe {
-                                std::env::set_var(
-                                    "EXOMIND_RT_SIGNAL_SQLITE_PATH",
-                                    signal_sqlite_path,
-                                );
+                            if std::env::var_os("EXOMIND_RT_SIGNAL_SQLITE_PATH").is_none() {
+                                let signal_sqlite_path = runtime_dir.join("signal-pool.sqlite");
+                                // SAFETY: setup runs before the embedded runtime starts and before worker threads read this env var.
+                                unsafe {
+                                    std::env::set_var(
+                                        "EXOMIND_RT_SIGNAL_SQLITE_PATH",
+                                        signal_sqlite_path,
+                                    );
+                                }
+                            }
+                            if std::env::var_os("EXOMIND_RT_TASK_SQLITE_PATH").is_none() {
+                                let task_sqlite_path = runtime_dir.join("tasks.sqlite");
+                                // SAFETY: setup runs before the embedded runtime starts and before worker threads read this env var.
+                                unsafe {
+                                    std::env::set_var("EXOMIND_RT_TASK_SQLITE_PATH", task_sqlite_path);
+                                }
                             }
                         }
                     }
                     Err(error) => {
                         eprintln!(
-                            "[tauri/setup] failed to resolve app data dir for signal sqlite: {error}"
+                            "[tauri/setup] failed to resolve app data dir for runtime sqlite files: {error}"
                         );
                     }
                 }
@@ -130,6 +142,7 @@ pub fn run() {
             append_file,
             append_to_markdown,
             export_messages_to_markdown,
+            save_binary_file,
             save_json_file,
             pick_json_file,
             get_device_id,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import { appRouter } from "@/routes";
 import { ThemeController } from "@/components/ThemeController";
 import { Toaster } from "@/components/ui/toaster";
 import { TimeBlockSyncCoordinator } from "@/ui/app/components/TimeBlockSyncCoordinator";
-import { TaskSyncCoordinator } from "@/ui/app/components/TaskSyncCoordinator";
 import { ReminderSyncCoordinator } from "@/ui/app/components/ReminderSyncCoordinator";
 import {
   initUpdateChecker,
@@ -34,7 +33,6 @@ function App() {
     <>
       <ThemeController />
       <TimeBlockSyncCoordinator />
-      <TaskSyncCoordinator />
       <ReminderSyncCoordinator />
       <RouterProvider router={appRouter} />
       <Toaster />

--- a/src/lib/adapters/task-rt-adapter.ts
+++ b/src/lib/adapters/task-rt-adapter.ts
@@ -1,0 +1,220 @@
+import { getSelectedRuntimeTarget, type RuntimeTarget } from '@/config/runtime-target';
+import type { ITaskPort, CreateTaskInput, UpdateTaskInput } from '@/lib/environment/interfaces/task.port';
+import type { Dependency, TaskNode, TaskStatus } from '@/lib/types/task';
+import { canTransition } from '@/lib/types/task';
+
+type RuntimeFetch = typeof fetch;
+
+interface RuntimeTaskDependencyPayload {
+  task_id: string;
+  type: 'soft' | 'hard';
+}
+
+interface RuntimeTaskPayload {
+  id: string;
+  title: string;
+  description?: string | null;
+  done_condition?: string | null;
+  status: TaskStatus;
+  priority: 'low' | 'medium' | 'high';
+  tags?: string[];
+  source?: string | null;
+  parent_id?: string | null;
+  depends_on?: RuntimeTaskDependencyPayload[];
+  due_at?: number | null;
+  estimated_minutes?: number | null;
+  time_block_ids?: string[];
+  created_at: number;
+  updated_at: number;
+  completed_at?: number | null;
+}
+
+export interface TaskRtAdapterOptions {
+  fetchImpl?: RuntimeFetch;
+  resolveTarget?: () => RuntimeTarget;
+}
+
+const ALL_STATUSES: TaskStatus[] = ['not_started', 'in_progress', 'suspended', 'completed', 'abandoned'];
+
+function formatHostForUrl(host: string): string {
+  if (host.includes(':') && !host.startsWith('[')) {
+    return `[${host}]`;
+  }
+  return host;
+}
+
+function buildBaseUrl(target: RuntimeTarget): string {
+  return `http://${formatHostForUrl(target.host)}:${target.port}`;
+}
+
+function toRuntimeDependency(dependency: Dependency): RuntimeTaskDependencyPayload {
+  return {
+    task_id: dependency.taskId,
+    type: dependency.type,
+  };
+}
+
+function toRuntimeTaskNode(task: RuntimeTaskPayload): TaskNode {
+  return {
+    id: task.id,
+    title: task.title,
+    description: task.description ?? undefined,
+    doneCondition: task.done_condition ?? undefined,
+    status: task.status,
+    priority: task.priority,
+    dueAt: task.due_at ?? undefined,
+    source: task.source ?? undefined,
+    parentId: task.parent_id ?? undefined,
+    dependsOn: (task.depends_on ?? []).map((dependency) => ({
+      taskId: dependency.task_id,
+      type: dependency.type,
+    })),
+    tags: task.tags ?? [],
+    estimatedMinutes: task.estimated_minutes ?? undefined,
+    timeBlockIds: task.time_block_ids ?? [],
+    createdAt: task.created_at,
+    updatedAt: task.updated_at,
+    completedAt: task.completed_at ?? undefined,
+  };
+}
+
+function toRuntimeCreatePayload(input: CreateTaskInput): Record<string, unknown> {
+  return {
+    title: input.title,
+    ...(input.description !== undefined ? { description: input.description } : {}),
+    ...(input.doneCondition !== undefined ? { done_condition: input.doneCondition } : {}),
+    ...(input.priority !== undefined ? { priority: input.priority } : {}),
+    ...(input.dueAt !== undefined ? { due_at: input.dueAt } : {}),
+    ...(input.source !== undefined ? { source: input.source } : {}),
+    ...(input.parentId !== undefined ? { parent_id: input.parentId } : {}),
+    ...(input.tags !== undefined ? { tags: input.tags } : {}),
+    ...(input.estimatedMinutes !== undefined ? { estimated_minutes: input.estimatedMinutes } : {}),
+    depends_on: [],
+    time_block_ids: [],
+  };
+}
+
+function toRuntimeUpdatePayload(input: UpdateTaskInput): Record<string, unknown> {
+  return {
+    ...(input.title !== undefined ? { title: input.title } : {}),
+    ...(input.description !== undefined ? { description: input.description } : {}),
+    ...(input.doneCondition !== undefined ? { done_condition: input.doneCondition } : {}),
+    ...(input.priority !== undefined ? { priority: input.priority } : {}),
+    ...(input.dueAt !== undefined ? { due_at: input.dueAt } : {}),
+    ...(input.source !== undefined ? { source: input.source } : {}),
+    ...(input.parentId !== undefined ? { parent_id: input.parentId } : {}),
+    ...(input.dependsOn !== undefined ? { depends_on: input.dependsOn.map(toRuntimeDependency) } : {}),
+    ...(input.tags !== undefined ? { tags: input.tags } : {}),
+    ...(input.estimatedMinutes !== undefined ? { estimated_minutes: input.estimatedMinutes } : {}),
+    ...(input.timeBlockIds !== undefined ? { time_block_ids: input.timeBlockIds } : {}),
+  };
+}
+
+export class TaskRtAdapter implements ITaskPort {
+  private readonly fetchImpl: RuntimeFetch;
+  private readonly resolveTarget: () => RuntimeTarget;
+
+  constructor(options: TaskRtAdapterOptions = {}) {
+    this.fetchImpl = options.fetchImpl ?? ((input, init) => globalThis.fetch(input, init));
+    this.resolveTarget = options.resolveTarget ?? (() => getSelectedRuntimeTarget());
+  }
+
+  async listTasks(includeAbandoned = false): Promise<TaskNode[]> {
+    const tasks = await this.requestJson<RuntimeTaskPayload[]>('/tasks');
+    const mapped = tasks.map(toRuntimeTaskNode);
+    return includeAbandoned ? mapped : mapped.filter((task) => task.status !== 'abandoned');
+  }
+
+  async getTaskById(id: string): Promise<TaskNode | null> {
+    const response = await this.fetchImpl(`${this.baseUrl()}/tasks/${encodeURIComponent(id)}`, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+    if (response.status === 404) {
+      return null;
+    }
+    if (!response.ok) {
+      throw new Error(`RT get task failed: ${response.status}`);
+    }
+    return toRuntimeTaskNode(await response.json() as RuntimeTaskPayload);
+  }
+
+  async createTask(input: CreateTaskInput): Promise<TaskNode> {
+    const task = await this.requestJson<RuntimeTaskPayload>('/tasks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify(toRuntimeCreatePayload(input)),
+    });
+    return toRuntimeTaskNode(task);
+  }
+
+  async updateTask(id: string, input: UpdateTaskInput): Promise<TaskNode | null> {
+    const response = await this.fetchImpl(`${this.baseUrl()}/tasks/${encodeURIComponent(id)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify(toRuntimeUpdatePayload(input)),
+    });
+    if (response.status === 404) {
+      return null;
+    }
+    if (!response.ok) {
+      throw new Error(`RT update task failed: ${response.status}`);
+    }
+    return toRuntimeTaskNode(await response.json() as RuntimeTaskPayload);
+  }
+
+  async abandonTask(id: string): Promise<TaskNode | null> {
+    const response = await this.fetchImpl(`${this.baseUrl()}/tasks/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+      headers: { Accept: 'application/json' },
+    });
+    if (response.status === 404) {
+      return null;
+    }
+    if (!response.ok) {
+      throw new Error(`RT abandon task failed: ${response.status}`);
+    }
+    return toRuntimeTaskNode(await response.json() as RuntimeTaskPayload);
+  }
+
+  async transitionTask(id: string, to: TaskStatus): Promise<TaskNode | null> {
+    const response = await this.fetchImpl(`${this.baseUrl()}/tasks/${encodeURIComponent(id)}/transition`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ status: to }),
+    });
+    if (response.status === 404) {
+      return null;
+    }
+    if (!response.ok) {
+      throw new Error(`RT transition task failed: ${response.status}`);
+    }
+    return toRuntimeTaskNode(await response.json() as RuntimeTaskPayload);
+  }
+
+  async getAvailableTransitions(id: string): Promise<TaskStatus[]> {
+    const task = await this.getTaskById(id);
+    if (!task) {
+      return [];
+    }
+    return ALL_STATUSES.filter((status) => canTransition(task.status, status));
+  }
+
+  private async requestJson<T>(path: string, init?: RequestInit): Promise<T> {
+    const response = await this.fetchImpl(`${this.baseUrl()}${path}`, {
+      ...init,
+      headers: {
+        Accept: 'application/json',
+        ...(init?.headers ?? {}),
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`RT request failed: ${response.status}`);
+    }
+    return response.json() as Promise<T>;
+  }
+
+  private baseUrl(): string {
+    return buildBaseUrl(this.resolveTarget());
+  }
+}

--- a/src/lib/environment/bootstrap.ts
+++ b/src/lib/environment/bootstrap.ts
@@ -4,7 +4,7 @@ import { MeMockAdapter } from '@/lib/adapters/mock/me-mock-adapter';
 import { AgentWebAdapter } from '@/lib/adapters/agent-web-adapter';
 import { AgentMockAdapter } from '@/lib/adapters/mock/agent-mock-adapter';
 import { TaskMockAdapter } from '@/lib/adapters/mock/task-mock-adapter';
-import { TaskPouchAdapter } from '@/lib/adapters/task-pouch-adapter';
+import { TaskRtAdapter } from '@/lib/adapters/task-rt-adapter';
 import { VolcanoEngineASRAdapter } from '../adapters/asr/volcano-engine-asr';
 import { TauriClipboardAdapter } from '../adapters/clipboard-tauri-adapter';
 import { WebClipboardAdapter } from '../adapters/clipboard-web-adapter';
@@ -41,7 +41,7 @@ export interface RuntimeBootstrapOptions {
  * Tauri 存储适配器占位实现
  *
  * 当前沿用 WebStorageAdapter 能力，
- * 后续 Task 将替换为真正的 Tauri 存储实现。
+ * 任务数据已改由 RT SQLite 提供真实数据源。
  */
 export class TauriStorageAdapter extends WebStorageAdapter {}
 
@@ -66,7 +66,7 @@ export function createRuntimeBootstrap(options: RuntimeBootstrapOptions = {}): R
   const asr = new VolcanoEngineASRAdapter();
   const clipboard: IClipboardPort = runtime === 'tauri' ? new TauriClipboardAdapter() : new WebClipboardAdapter();
   const useMockData = options.useMockData ?? getUseMockDataEnabled();
-  const task: ITaskPort = useMockData ? new TaskMockAdapter() : new TaskPouchAdapter();
+  const task: ITaskPort = useMockData ? new TaskMockAdapter() : new TaskRtAdapter();
   const me: IMePort = useMockData ? new MeMockAdapter() : new MeWebAdapter();
   const agent: IAgentPort = useMockData ? new AgentMockAdapter() : new AgentWebAdapter();
 

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -10,6 +10,18 @@ export type { TimeBlockService } from './timeblock.service';
 
 export { TaskServiceImpl, getTaskService } from './task.service';
 export type { TaskService } from './task.service';
+export {
+  TaskBackupServiceImpl,
+  getTaskBackupService,
+  resetTaskBackupServiceForTests,
+} from './task-backup.service';
+export type {
+  TaskBackendStatus,
+  TaskExportJsonResult,
+  TaskExportSqliteResult,
+  TaskImportResult,
+  TaskImportStrategy,
+} from './task-backup.service';
 
 export { TaskTimerServiceImpl, getTaskTimerService } from './task-timer.service';
 export type { TaskTimerService } from './task-timer.service';

--- a/src/lib/services/task-backup.service.ts
+++ b/src/lib/services/task-backup.service.ts
@@ -1,0 +1,171 @@
+import { getSelectedRuntimeTarget, type RuntimeTarget } from '@/config/runtime-target';
+import { bytesToBase64 } from '@/lib/asr/volcano-config';
+
+type RuntimeFetch = typeof fetch;
+export type TaskImportStrategy = 'merge' | 'overwrite';
+
+export interface TaskBackendStatus {
+  backend: string;
+  supportsJsonBackup: boolean;
+  supportsSqliteSnapshot: boolean;
+}
+
+export interface TaskExportJsonResult {
+  fileName: string;
+  content: string;
+  taskCount: number;
+}
+
+export interface TaskExportSqliteResult {
+  fileName: string;
+  bytes: Uint8Array;
+  taskCount: number;
+}
+
+export interface TaskImportResult {
+  imported: number;
+  skipped: number;
+  total: number;
+}
+
+interface TaskBackupJsonPayload {
+  version: number;
+  tasks: unknown[];
+}
+
+interface TaskBackupSqlitePayload {
+  version: number;
+  file_name: string;
+  content_base64: string;
+  task_count: number;
+}
+
+export interface TaskBackupServiceOptions {
+  fetchImpl?: RuntimeFetch;
+  resolveTarget?: () => RuntimeTarget;
+}
+
+function formatHostForUrl(host: string): string {
+  if (host.includes(':') && !host.startsWith('[')) {
+    return `[${host}]`;
+  }
+  return host;
+}
+
+function buildBaseUrl(target: RuntimeTarget): string {
+  return `http://${formatHostForUrl(target.host)}:${target.port}`;
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  if (typeof Buffer !== 'undefined') {
+    return new Uint8Array(Buffer.from(value, 'base64'));
+  }
+
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function buildTaskJsonFileName(): string {
+  const day = new Date().toISOString().slice(0, 10);
+  return `exomind-tasks-${day}.json`;
+}
+
+export class TaskBackupServiceImpl {
+  private readonly fetchImpl: RuntimeFetch;
+  private readonly resolveTarget: () => RuntimeTarget;
+
+  constructor(options: TaskBackupServiceOptions = {}) {
+    this.fetchImpl = options.fetchImpl ?? ((input, init) => globalThis.fetch(input, init));
+    this.resolveTarget = options.resolveTarget ?? (() => getSelectedRuntimeTarget());
+  }
+
+  async getBackendStatus(): Promise<TaskBackendStatus> {
+    const payload = await this.requestJson<{
+      backend: string;
+      supports_json_backup: boolean;
+      supports_sqlite_snapshot: boolean;
+    }>('/tasks/backend/status');
+
+    return {
+      backend: payload.backend,
+      supportsJsonBackup: payload.supports_json_backup,
+      supportsSqliteSnapshot: payload.supports_sqlite_snapshot,
+    };
+  }
+
+  async exportTasksAsJson(): Promise<TaskExportJsonResult> {
+    const payload = await this.requestJson<TaskBackupJsonPayload>('/tasks/backup/json');
+    return {
+      fileName: buildTaskJsonFileName(),
+      content: JSON.stringify(payload, null, 2),
+      taskCount: Array.isArray(payload.tasks) ? payload.tasks.length : 0,
+    };
+  }
+
+  async exportTasksAsSqliteSnapshot(): Promise<TaskExportSqliteResult> {
+    const payload = await this.requestJson<TaskBackupSqlitePayload>('/tasks/backup/sqlite');
+    return {
+      fileName: payload.file_name,
+      bytes: base64ToBytes(payload.content_base64),
+      taskCount: payload.task_count,
+    };
+  }
+
+  async importTasksFromJson(content: string, strategy: TaskImportStrategy): Promise<TaskImportResult> {
+    return this.requestJson<TaskImportResult>(`/tasks/import/json?strategy=${strategy}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: content,
+    });
+  }
+
+  async importTasksFromSqliteSnapshot(
+    bytes: Uint8Array,
+    strategy: TaskImportStrategy,
+  ): Promise<TaskImportResult> {
+    return this.requestJson<TaskImportResult>(`/tasks/import/sqlite?strategy=${strategy}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({
+        content_base64: bytesToBase64(bytes),
+      }),
+    });
+  }
+
+  private async requestJson<T>(path: string, init?: RequestInit): Promise<T> {
+    const response = await this.fetchImpl(`${this.baseUrl()}${path}`, {
+      ...init,
+      headers: {
+        Accept: 'application/json',
+        ...(init?.headers ?? {}),
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Task backup request failed: ${response.status}`);
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  private baseUrl(): string {
+    return buildBaseUrl(this.resolveTarget());
+  }
+}
+
+let taskBackupServiceInstance: TaskBackupServiceImpl | null = null;
+
+export function getTaskBackupService(): TaskBackupServiceImpl {
+  if (!taskBackupServiceInstance) {
+    taskBackupServiceInstance = new TaskBackupServiceImpl();
+  }
+  return taskBackupServiceInstance;
+}
+
+export function resetTaskBackupServiceForTests(): void {
+  taskBackupServiceInstance = null;
+}

--- a/src/lib/services/task.service.ts
+++ b/src/lib/services/task.service.ts
@@ -1,8 +1,6 @@
 import { ExoMindEnvironment } from '@/lib/environment/environment'
 import type { ITaskPort, CreateTaskInput, UpdateTaskInput } from '@/lib/environment/interfaces/task.port'
 import type { TaskNode, TaskStatus } from '@/lib/types/task'
-import { getTaskStorage } from '@/lib/storage/task-storage'
-import { getCurrentUserId } from '@/lib/storage/event-storage'
 
 type TaskEnvironmentLike = {
   task: ITaskPort
@@ -36,15 +34,10 @@ export interface TaskService {
 
 export class TaskServiceImpl implements TaskService {
   private readonly env: TaskEnvironmentLike
-  private syncUnsubscribe: (() => void) | null = null
   private changeListeners = new Set<() => void>()
 
   constructor(env?: TaskEnvironmentLike) {
     this.env = env ?? ExoMindEnvironment.getInstance()
-  }
-
-  private getStorage() {
-    return getTaskStorage(getCurrentUserId())
   }
 
   listTasks(includeAbandoned = false) {
@@ -60,15 +53,25 @@ export class TaskServiceImpl implements TaskService {
       const parent = await this.env.task.getTaskById(input.parentId)
       if (!parent) throw new Error(`Parent task ${input.parentId} not found`)
     }
-    return this.env.task.createTask(input)
+    const created = await this.env.task.createTask(input)
+    this.notifyChangeListeners()
+    return created
   }
 
-  updateTask(id: string, input: UpdateTaskInput) {
-    return this.env.task.updateTask(id, input)
+  async updateTask(id: string, input: UpdateTaskInput) {
+    const updated = await this.env.task.updateTask(id, input)
+    if (updated) {
+      this.notifyChangeListeners()
+    }
+    return updated
   }
 
-  abandonTask(id: string) {
-    return this.env.task.abandonTask(id)
+  async abandonTask(id: string) {
+    const task = await this.env.task.abandonTask(id)
+    if (task) {
+      this.notifyChangeListeners()
+    }
+    return task
   }
 
   async transitionTask(id: string, to: TaskStatus): Promise<TaskNode | null> {
@@ -80,7 +83,11 @@ export class TaskServiceImpl implements TaskService {
         throw new Error(`Cannot transition to in_progress: hard dependencies not met [${ids}]`)
       }
     }
-    return this.env.task.transitionTask(id, to)
+    const transitioned = await this.env.task.transitionTask(id, to)
+    if (transitioned) {
+      this.notifyChangeListeners()
+    }
+    return transitioned
   }
 
   getAvailableTransitions(id: string) {
@@ -110,7 +117,7 @@ export class TaskServiceImpl implements TaskService {
     if (existing) {
       if (existing.type === type) return task
       const updated = task.dependsOn.map((d) => (d.taskId === depTaskId ? { ...d, type } : d))
-      return this.env.task.updateTask(taskId, { dependsOn: updated })
+      return this.updateTask(taskId, { dependsOn: updated })
     }
 
     // 环检测
@@ -119,14 +126,14 @@ export class TaskServiceImpl implements TaskService {
     }
 
     const newDeps = [...task.dependsOn, { taskId: depTaskId, type }]
-    return this.env.task.updateTask(taskId, { dependsOn: newDeps })
+    return this.updateTask(taskId, { dependsOn: newDeps })
   }
 
   async removeDependency(taskId: string, depTaskId: string): Promise<TaskNode | null> {
     const task = await this.env.task.getTaskById(taskId)
     if (!task) return null
     const newDeps = task.dependsOn.filter((d) => d.taskId !== depTaskId)
-    return this.env.task.updateTask(taskId, { dependsOn: newDeps })
+    return this.updateTask(taskId, { dependsOn: newDeps })
   }
 
   async checkDependenciesMet(taskId: string): Promise<DependencyCheckResult> {
@@ -151,23 +158,12 @@ export class TaskServiceImpl implements TaskService {
 
   /* ── Sync ── */
 
-  async startSync(remoteUrl: string): Promise<void> {
-    const storage = this.getStorage()
-    // Subscribe to remote changes to notify UI
-    if (!this.syncUnsubscribe) {
-      this.syncUnsubscribe = storage.onRemoteChange(() => {
-        this.notifyChangeListeners()
-      })
-    }
-    await storage.syncToRemote(remoteUrl)
+  async startSync(_remoteUrl: string): Promise<void> {
+    // Legacy no-op: task data no longer depends on PouchDB live sync.
   }
 
   async stopSync(): Promise<void> {
-    if (this.syncUnsubscribe) {
-      this.syncUnsubscribe()
-      this.syncUnsubscribe = null
-    }
-    await this.getStorage().stopSync()
+    // Legacy no-op: task data no longer depends on PouchDB live sync.
   }
 
   onTaskChange(callback: () => void): () => void {

--- a/src/ui/app/pages/SettingsPage.tsx
+++ b/src/ui/app/pages/SettingsPage.tsx
@@ -4,7 +4,7 @@ import { invoke, isTauri } from '@tauri-apps/api/core';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer';
 import { Switch } from '@/components/ui/switch';
-import { getEventLogService } from '@/lib/services';
+import { getEventLogService, getTaskBackupService } from '@/lib/services';
 import {
   getSyncServerUrlOverride,
   resolveSyncServerUrl,
@@ -309,10 +309,16 @@ export function SettingsPage() {
   const [llmBaseUrlDraft, setLlmBaseUrlDraft] = useState(() => getLLMBaseUrl());
   const [llmModelDraft, setLlmModelDraft] = useState(() => getLLMModel());
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const taskFileInputRef = useRef<HTMLInputElement | null>(null);
   const [importStrategy] = useState<ImportStrategy>('merge');
   const [statusMessage, setStatusMessage] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const [loading, setLoading] = useState(false);
+  const [taskBackendStatus, setTaskBackendStatus] = useState<{
+    backend: string;
+    supportsJsonBackup: boolean;
+    supportsSqliteSnapshot: boolean;
+  } | null>(null);
   const [comingSoonVisible, setComingSoonVisible] = useState(false);
   const comingSoonTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [activeDesktopTab, setActiveDesktopTab] = useState<DesktopTabKey>('theme');
@@ -397,7 +403,7 @@ export function SettingsPage() {
         return;
       }
 
-      downloadJsonFallback(json, defaultName);
+      downloadFileFallback(json, 'application/json;charset=utf-8', defaultName);
       setStatusMessage(`导出成功，共 ${count} 条事件。`);
     } catch (error) {
       const message = error instanceof Error ? error.message : '未知错误';
@@ -407,8 +413,8 @@ export function SettingsPage() {
     }
   };
 
-  const downloadJsonFallback = (json: string, filename: string) => {
-    const blob = new Blob([json], { type: 'application/json;charset=utf-8' });
+  const downloadFileFallback = (content: BlobPart, mimeType: string, filename: string) => {
+    const blob = new Blob([content], { type: mimeType });
     const url = URL.createObjectURL(blob);
     const anchor = document.createElement('a');
     anchor.href = url;
@@ -467,6 +473,106 @@ export function SettingsPage() {
     } catch (error) {
       const message = error instanceof Error ? error.message : '未知错误';
       setErrorMessage(`导入失败：${message}`);
+    }
+  };
+
+  const handleExportTaskJson = async () => {
+    clearNotice();
+    setLoading(true);
+    try {
+      const result = await getTaskBackupService().exportTasksAsJson();
+      const isRunningInTauri = await isTauri();
+      if (isRunningInTauri) {
+        const savedPath = await invoke<string | null>('save_json_file', {
+          content: result.content,
+          defaultName: result.fileName,
+        });
+        if (!savedPath) {
+          setStatusMessage('已取消保存。');
+          return;
+        }
+        setStatusMessage(`任务导出成功（JSON），共 ${result.taskCount} 条任务。保存路径：${savedPath}`);
+        return;
+      }
+
+      downloadFileFallback(result.content, 'application/json;charset=utf-8', result.fileName);
+      setStatusMessage(`任务导出成功（JSON），共 ${result.taskCount} 条任务。`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '未知错误';
+      setErrorMessage(`任务导出失败：${message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleExportTaskSqlite = async () => {
+    clearNotice();
+    setLoading(true);
+    try {
+      const result = await getTaskBackupService().exportTasksAsSqliteSnapshot();
+      const isRunningInTauri = await isTauri();
+      if (isRunningInTauri) {
+        const savedPath = await invoke<string | null>('save_binary_file', {
+          content: Array.from(result.bytes),
+          defaultName: result.fileName,
+          filters: ['sqlite', 'db'],
+        });
+        if (!savedPath) {
+          setStatusMessage('已取消保存。');
+          return;
+        }
+        setStatusMessage(`任务导出成功（SQLite），共 ${result.taskCount} 条任务。保存路径：${savedPath}`);
+        return;
+      }
+
+      downloadFileFallback(result.bytes, 'application/octet-stream', result.fileName);
+      setStatusMessage(`任务导出成功（SQLite），共 ${result.taskCount} 条任务。`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '未知错误';
+      setErrorMessage(`任务导出失败：${message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleImportTaskData = () => {
+    clearNotice();
+    taskFileInputRef.current?.click();
+  };
+
+  const handleTaskImportFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setLoading(true);
+    try {
+      const lowerName = file.name.toLowerCase();
+      const backupService = getTaskBackupService();
+
+      if (lowerName.endsWith('.json')) {
+        const content = await file.text();
+        const result = await backupService.importTasksFromJson(content, importStrategy);
+        setStatusMessage(
+          `任务导入成功：新增 ${result.imported} 条，跳过 ${result.skipped} 条，当前共 ${result.total} 条。来源：${file.name}`
+        );
+        return;
+      }
+
+      if (lowerName.endsWith('.sqlite') || lowerName.endsWith('.db')) {
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const result = await backupService.importTasksFromSqliteSnapshot(bytes, importStrategy);
+        setStatusMessage(
+          `任务导入成功：新增 ${result.imported} 条，跳过 ${result.skipped} 条，当前共 ${result.total} 条。来源：${file.name}`
+        );
+        return;
+      }
+
+      throw new Error('仅支持 .json / .sqlite / .db 任务备份文件');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '未知错误';
+      setErrorMessage(`任务导入失败：${message}`);
+    } finally {
+      e.target.value = '';
+      setLoading(false);
     }
   };
 
@@ -728,6 +834,31 @@ export function SettingsPage() {
       setFeedbackPreferencesState(nextPreferences);
     });
   }, []);
+
+  useEffect(() => {
+    if (!developerMode) {
+      setTaskBackendStatus(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    void getTaskBackupService().getBackendStatus()
+      .then((status) => {
+        if (!cancelled) {
+          setTaskBackendStatus(status);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setTaskBackendStatus(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [developerMode]);
 
   const handleCountdownEndModeChange = (mode: CountdownEndMode) => {
     setTimerPreferencesState(updateTimerPreferences({ countdownEndMode: mode }));
@@ -1454,6 +1585,24 @@ export function SettingsPage() {
                     onClick={() => setPairingDialogOpen(true)}
                     right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
                   />
+                  {taskBackendStatus && (
+                    <>
+                      <Divider />
+                      <div className="px-4 py-[14px]">
+                        <p className="text-sm text-[#1C1917] dark:text-[#FAFAF9]">任务后端：{taskBackendStatus.backend}</p>
+                        <p className="mt-1 text-xs text-[#A8A29E]">
+                          任务备份：
+                          {taskBackendStatus.supportsJsonBackup && taskBackendStatus.supportsSqliteSnapshot
+                            ? 'JSON / SQLite'
+                            : taskBackendStatus.supportsJsonBackup
+                              ? 'JSON'
+                              : taskBackendStatus.supportsSqliteSnapshot
+                                ? 'SQLite'
+                                : '不可用'}
+                        </p>
+                      </div>
+                    </>
+                  )}
                 </>
               )}
             </SectionCard>
@@ -1479,6 +1628,27 @@ export function SettingsPage() {
                   right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
                 />
               </div>
+              <Divider />
+              <SettingRow
+                icon={<Download className="h-[18px] w-[18px] text-[#78716C]" />}
+                label="导出任务 JSON"
+                onClick={handleExportTaskJson}
+                right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
+              />
+              <Divider />
+              <SettingRow
+                icon={<Download className="h-[18px] w-[18px] text-[#78716C]" />}
+                label="导出任务 SQLite"
+                onClick={handleExportTaskSqlite}
+                right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
+              />
+              <Divider />
+              <SettingRow
+                icon={<Upload className="h-[18px] w-[18px] text-[#78716C]" />}
+                label="导入任务数据"
+                onClick={handleImportTaskData}
+                right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
+              />
             </SectionCard>
           </section>
 
@@ -1578,6 +1748,14 @@ export function SettingsPage() {
         accept=".json"
         className="hidden"
         onChange={handleFileInputChange}
+      />
+      <input
+        ref={taskFileInputRef}
+        data-testid="new-settings-task-import-input"
+        type="file"
+        accept=".json,.sqlite,.db"
+        className="hidden"
+        onChange={handleTaskImportFileChange}
       />
 
       {isDesktopVcLayout ? renderDesktopVcContent() : (
@@ -2075,6 +2253,27 @@ export function SettingsPage() {
               onClick={handleImportBackup}
               right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
             />
+            <Divider />
+            <SettingRow
+              icon={<Download className="h-[18px] w-[18px] text-[#78716C]" />}
+              label="导出任务 JSON"
+              onClick={handleExportTaskJson}
+              right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
+            />
+            <Divider />
+            <SettingRow
+              icon={<Download className="h-[18px] w-[18px] text-[#78716C]" />}
+              label="导出任务 SQLite"
+              onClick={handleExportTaskSqlite}
+              right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
+            />
+            <Divider />
+            <SettingRow
+              icon={<Upload className="h-[18px] w-[18px] text-[#78716C]" />}
+              label="导入任务数据"
+              onClick={handleImportTaskData}
+              right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
+            />
           </SectionCard>
         </section>
 
@@ -2147,6 +2346,24 @@ export function SettingsPage() {
                   onClick={() => setPairingDialogOpen(true)}
                   right={<ChevronRight className="h-4 w-4 text-[#D6D3D1] dark:text-[#57534E]" />}
                 />
+                {taskBackendStatus && (
+                  <>
+                    <Divider />
+                    <div className="px-4 py-[14px]">
+                      <p className="text-sm text-[#1C1917] dark:text-[#FAFAF9]">任务后端：{taskBackendStatus.backend}</p>
+                      <p className="mt-1 text-xs text-[#A8A29E]">
+                        任务备份：
+                        {taskBackendStatus.supportsJsonBackup && taskBackendStatus.supportsSqliteSnapshot
+                          ? 'JSON / SQLite'
+                          : taskBackendStatus.supportsJsonBackup
+                            ? 'JSON'
+                            : taskBackendStatus.supportsSqliteSnapshot
+                              ? 'SQLite'
+                              : '不可用'}
+                      </p>
+                    </div>
+                  </>
+                )}
               </>
             )}
           </SectionCard>

--- a/tests/unit/adapters/task-rt-adapter.test.ts
+++ b/tests/unit/adapters/task-rt-adapter.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TaskRtAdapter } from '@/lib/adapters/task-rt-adapter';
+
+describe('TaskRtAdapter（RT 任务适配器）', () => {
+  it('maps runtime task payload to frontend TaskNode', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ([
+        {
+          id: 'task-1',
+          title: 'RT Task',
+          description: 'from runtime',
+          done_condition: 'ship feature',
+          status: 'not_started',
+          priority: 'high',
+          tags: ['rt'],
+          source: 'runtime:test',
+          parent_id: 'parent-1',
+          depends_on: [{ task_id: 'dep-1', type: 'hard' }],
+          due_at: 1700000000000,
+          estimated_minutes: 45,
+          time_block_ids: ['block-1'],
+          created_at: 1700000000001,
+          updated_at: 1700000000002,
+          completed_at: null,
+        },
+      ]),
+    }));
+
+    const adapter = new TaskRtAdapter({
+      fetchImpl,
+      resolveTarget: () => ({ mode: 'embedded', host: '127.0.0.1', port: 9124 }),
+    });
+
+    const tasks = await adapter.listTasks(true);
+
+    expect(tasks).toEqual([
+      {
+        id: 'task-1',
+        title: 'RT Task',
+        description: 'from runtime',
+        doneCondition: 'ship feature',
+        status: 'not_started',
+        priority: 'high',
+        tags: ['rt'],
+        source: 'runtime:test',
+        parentId: 'parent-1',
+        dependsOn: [{ taskId: 'dep-1', type: 'hard' }],
+        dueAt: 1700000000000,
+        estimatedMinutes: 45,
+        timeBlockIds: ['block-1'],
+        createdAt: 1700000000001,
+        updatedAt: 1700000000002,
+      },
+    ]);
+    expect(fetchImpl).toHaveBeenCalledWith('http://127.0.0.1:9124/tasks', expect.any(Object));
+  });
+
+  it('serializes frontend task updates to runtime payload', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: 'task-1',
+        title: 'Updated Task',
+        description: 'from runtime',
+        done_condition: 'ship feature',
+        status: 'not_started',
+        priority: 'medium',
+        tags: ['rt'],
+        source: 'runtime:test',
+        parent_id: 'parent-1',
+        depends_on: [{ task_id: 'dep-1', type: 'soft' }],
+        due_at: null,
+        estimated_minutes: 25,
+        time_block_ids: ['block-1', 'block-2'],
+        created_at: 1700000000001,
+        updated_at: 1700000000002,
+        completed_at: null,
+      }),
+    }));
+
+    const adapter = new TaskRtAdapter({
+      fetchImpl,
+      resolveTarget: () => ({ mode: 'embedded', host: '127.0.0.1', port: 9124 }),
+    });
+
+    await adapter.updateTask('task-1', {
+      doneCondition: 'ship feature',
+      dependsOn: [{ taskId: 'dep-1', type: 'soft' }],
+      timeBlockIds: ['block-1', 'block-2'],
+      estimatedMinutes: 25,
+    });
+
+    const [, requestInit] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(requestInit?.method).toBe('PUT');
+    expect(JSON.parse(String(requestInit?.body))).toEqual({
+      done_condition: 'ship feature',
+      depends_on: [{ task_id: 'dep-1', type: 'soft' }],
+      time_block_ids: ['block-1', 'block-2'],
+      estimated_minutes: 25,
+    });
+  });
+});

--- a/tests/unit/app/app-router-context.startup.test.tsx
+++ b/tests/unit/app/app-router-context.startup.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
 import App from '@/App';
 
 const destroyVoiceShortcutService = vi.fn();
@@ -101,5 +103,10 @@ describe('App startup router context', () => {
 
     expect(hasRouterContextWarning(warnSpy.mock.calls)).toBe(false);
     expect(hasRouterContextWarning(errorSpy.mock.calls)).toBe(false);
+  });
+
+  it('does not mount legacy TaskSyncCoordinator after RT task cutover（任务切到 RT 后不再挂载旧同步协调器）', () => {
+    const source = fs.readFileSync(path.resolve('src/App.tsx'), 'utf-8');
+    expect(source).not.toContain('TaskSyncCoordinator');
   });
 });

--- a/tests/unit/components/settings/setup-settings-mocks.tsx
+++ b/tests/unit/components/settings/setup-settings-mocks.tsx
@@ -17,6 +17,25 @@ vi.mock('@/lib/services', () => ({
     exportEventsAsJson: vi.fn().mockResolvedValue('[]'),
     importEventsFromJson: vi.fn().mockResolvedValue({ imported: 0, skipped: 0 }),
   })),
+  getTaskBackupService: vi.fn(() => ({
+    exportTasksAsJson: vi.fn().mockResolvedValue({
+      fileName: 'exomind-tasks.json',
+      content: '{"version":1,"tasks":[]}',
+      taskCount: 0,
+    }),
+    exportTasksAsSqliteSnapshot: vi.fn().mockResolvedValue({
+      fileName: 'exomind-tasks.sqlite',
+      bytes: new Uint8Array(),
+      taskCount: 0,
+    }),
+    importTasksFromJson: vi.fn().mockResolvedValue({ imported: 0, skipped: 0, total: 0 }),
+    importTasksFromSqliteSnapshot: vi.fn().mockResolvedValue({ imported: 0, skipped: 0, total: 0 }),
+    getBackendStatus: vi.fn().mockResolvedValue({
+      backend: 'rt-sqlite',
+      supportsJsonBackup: true,
+      supportsSqliteSnapshot: true,
+    }),
+  })),
 }));
 
 vi.mock('@/config/port-env', () => ({

--- a/tests/unit/settings/settings-export-runtime.issue222.test.tsx
+++ b/tests/unit/settings/settings-export-runtime.issue222.test.tsx
@@ -22,6 +22,25 @@ vi.mock('@/lib/services', () => ({
     exportEventsAsJson: mocks.exportEventsAsJson,
     importEventsFromJson: mocks.importEventsFromJson,
   }),
+  getTaskBackupService: () => ({
+    exportTasksAsJson: vi.fn().mockResolvedValue({
+      fileName: 'exomind-tasks.json',
+      content: '{"version":1,"tasks":[]}',
+      taskCount: 0,
+    }),
+    exportTasksAsSqliteSnapshot: vi.fn().mockResolvedValue({
+      fileName: 'exomind-tasks.sqlite',
+      bytes: new Uint8Array(),
+      taskCount: 0,
+    }),
+    importTasksFromJson: vi.fn().mockResolvedValue({ imported: 0, skipped: 0, total: 0 }),
+    importTasksFromSqliteSnapshot: vi.fn().mockResolvedValue({ imported: 0, skipped: 0, total: 0 }),
+    getBackendStatus: vi.fn().mockResolvedValue({
+      backend: 'rt-sqlite',
+      supportsJsonBackup: true,
+      supportsSqliteSnapshot: true,
+    }),
+  }),
 }));
 
 vi.mock('@/config/port-env', () => ({

--- a/tests/unit/settings/settings-mock-data-toggle.issue213.test.tsx
+++ b/tests/unit/settings/settings-mock-data-toggle.issue213.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 const mocks = vi.hoisted(() => ({
   setUseMockDataEnabled: vi.fn(),
@@ -14,6 +14,25 @@ vi.mock('@/lib/services', () => ({
   getEventLogService: () => ({
     exportEventsAsJson: vi.fn().mockResolvedValue('{}'),
     importEventsFromJson: vi.fn().mockResolvedValue({ imported: 0, skipped: 0, total: 0 }),
+  }),
+  getTaskBackupService: () => ({
+    exportTasksAsJson: vi.fn().mockResolvedValue({
+      fileName: 'exomind-tasks.json',
+      content: '{"version":1,"tasks":[]}',
+      taskCount: 0,
+    }),
+    exportTasksAsSqliteSnapshot: vi.fn().mockResolvedValue({
+      fileName: 'exomind-tasks.sqlite',
+      bytes: new Uint8Array(),
+      taskCount: 0,
+    }),
+    importTasksFromJson: vi.fn().mockResolvedValue({ imported: 0, skipped: 0, total: 0 }),
+    importTasksFromSqliteSnapshot: vi.fn().mockResolvedValue({ imported: 0, skipped: 0, total: 0 }),
+    getBackendStatus: vi.fn().mockResolvedValue({
+      backend: 'rt-sqlite',
+      supportsJsonBackup: true,
+      supportsSqliteSnapshot: true,
+    }),
   }),
 }));
 
@@ -65,14 +84,19 @@ describe('settings mock-data toggle issue-213（设置页测试数据开关）',
     vi.clearAllMocks();
   });
 
-  it('shows use-mock-data toggle when developer mode is enabled（开发者模式显示测试数据开关）', () => {
+  it('shows use-mock-data toggle when developer mode is enabled（开发者模式显示测试数据开关）', async () => {
     render(<SettingsPage />);
-    expect(screen.getByText('使用测试数据')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('使用测试数据')).toBeInTheDocument();
+    });
   });
 
-  it('calls setUseMockDataEnabled after toggle click（点击后更新 mock 开关）', () => {
+  it('calls setUseMockDataEnabled after toggle click（点击后更新 mock 开关）', async () => {
     const reloadSpy = vi.spyOn(window.location, 'reload').mockImplementation(() => {});
     render(<SettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByText('使用测试数据')).toBeInTheDocument();
+    });
     const switchEl = screen.getByTestId('new-settings-use-mock-data-switch');
     fireEvent.click(switchEl);
     expect(mocks.setUseMockDataEnabled).toHaveBeenCalledWith(true);

--- a/tests/unit/settings/settings-timer-card.issue182.test.tsx
+++ b/tests/unit/settings/settings-timer-card.issue182.test.tsx
@@ -17,6 +17,25 @@ vi.mock('@/lib/services', () => ({
     exportEventsAsJson: vi.fn(),
     importEventsFromJson: vi.fn(),
   }),
+  getTaskBackupService: () => ({
+    exportTasksAsJson: vi.fn().mockResolvedValue({
+      fileName: 'exomind-tasks.json',
+      content: '{"version":1,"tasks":[]}',
+      taskCount: 0,
+    }),
+    exportTasksAsSqliteSnapshot: vi.fn().mockResolvedValue({
+      fileName: 'exomind-tasks.sqlite',
+      bytes: new Uint8Array(),
+      taskCount: 0,
+    }),
+    importTasksFromJson: vi.fn().mockResolvedValue({ imported: 0, skipped: 0, total: 0 }),
+    importTasksFromSqliteSnapshot: vi.fn().mockResolvedValue({ imported: 0, skipped: 0, total: 0 }),
+    getBackendStatus: vi.fn().mockResolvedValue({
+      backend: 'rt-sqlite',
+      supportsJsonBackup: true,
+      supportsSqliteSnapshot: true,
+    }),
+  }),
 }));
 
 vi.mock('@/config/port-env', () => ({

--- a/tests/unit/settings/task-backend-diagnostics.issue481.test.tsx
+++ b/tests/unit/settings/task-backend-diagnostics.issue481.test.tsx
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const developerModeState = {
+  enabled: true,
+};
+
+const mocks = vi.hoisted(() => ({
+  exportEventsAsJson: vi.fn(),
+  importEventsFromJson: vi.fn(),
+  exportTasksAsJson: vi.fn(),
+  exportTasksAsSqliteSnapshot: vi.fn(),
+  importTasksFromJson: vi.fn(),
+  importTasksFromSqliteSnapshot: vi.fn(),
+  getTaskBackendStatus: vi.fn(),
+  isTauri: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: mocks.isTauri,
+  invoke: mocks.invoke,
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/lib/services', () => ({
+  getEventLogService: () => ({
+    exportEventsAsJson: mocks.exportEventsAsJson,
+    importEventsFromJson: mocks.importEventsFromJson,
+  }),
+  getTaskBackupService: () => ({
+    exportTasksAsJson: mocks.exportTasksAsJson,
+    exportTasksAsSqliteSnapshot: mocks.exportTasksAsSqliteSnapshot,
+    importTasksFromJson: mocks.importTasksFromJson,
+    importTasksFromSqliteSnapshot: mocks.importTasksFromSqliteSnapshot,
+    getBackendStatus: mocks.getTaskBackendStatus,
+  }),
+}));
+
+vi.mock('@/config/port-env', () => ({
+  getSyncServerUrlOverride: () => null,
+  resolveSyncServerUrl: () => 'http://127.0.0.1:6984',
+  setSyncServerUrlOverride: vi.fn(),
+}));
+
+vi.mock('@/config/theme', () => ({
+  getThemePreference: () => 'system',
+  setThemePreference: vi.fn(),
+}));
+
+vi.mock('@/config/developer-mode', () => ({
+  getDeveloperModeEnabled: () => developerModeState.enabled,
+  setDeveloperModeEnabled: vi.fn((next: boolean) => { developerModeState.enabled = next; }),
+}));
+
+vi.mock('@/config/agent-page-enabled', () => ({
+  getAgentPageEnabled: () => false,
+  setAgentPageEnabled: vi.fn(),
+}));
+
+vi.mock('@/config/desktop-adaptive', () => ({
+  getDesktopAdaptiveEnabled: () => true,
+  setDesktopAdaptiveEnabled: vi.fn(),
+}));
+
+vi.mock('@/config/mock-data', () => ({
+  getUseMockDataEnabled: () => false,
+  setUseMockDataEnabled: vi.fn(),
+  subscribeUseMockDataChanges: () => () => {},
+}));
+
+vi.mock('@/config/timer-preferences', () => ({
+  getTimerPreferences: () => ({
+    countdownEndMode: 'soft',
+    countdownEndSoundEnabled: false,
+    countdownEndSoundPresetId: 'timer-end-ring-10',
+  }),
+  subscribeTimerPreferencesChanges: () => () => {},
+  updateTimerPreferences: (partial: Record<string, unknown>) => ({
+    countdownEndMode: 'soft',
+    countdownEndSoundEnabled: false,
+    countdownEndSoundPresetId: 'timer-end-ring-10',
+    ...partial,
+  }),
+}));
+
+vi.mock('@/config/devtools-mode', () => ({
+  getDevtoolsEnabled: () => false,
+  setDevtoolsEnabled: vi.fn(),
+  subscribeDevtoolsChanges: () => () => {},
+}));
+
+vi.mock('@/config/command-palette-enabled', () => ({
+  getCommandPaletteEnabled: () => false,
+  setCommandPaletteEnabled: vi.fn(),
+  subscribeCommandPaletteEnabledChanges: () => () => {},
+}));
+
+vi.mock('@/config/voice-transcript-send-mode', () => ({
+  getVoiceTranscriptSendMode: () => 'insert',
+  setVoiceTranscriptSendMode: vi.fn(),
+  subscribeVoiceTranscriptSendModeChanges: () => () => {},
+}));
+
+vi.mock('@/config/voice-shortcut-hotkey', () => ({
+  VOICE_SHORTCUT_HOTKEY_VALUES: ['Alt+Q', 'Alt+W', 'Ctrl+Space'],
+  getVoiceShortcutHotkey: () => 'Alt+Q',
+  setVoiceShortcutHotkey: vi.fn(),
+  subscribeVoiceShortcutHotkeyChanges: () => () => {},
+}));
+
+vi.mock('@/config/voice-shortcut-send-mode', () => ({
+  getVoiceShortcutSendMode: () => 'insert-only',
+  setVoiceShortcutSendMode: vi.fn(),
+  subscribeVoiceShortcutSendModeChanges: () => () => {},
+}));
+
+vi.mock('@/config/voice-shortcut-mic-prewarm', () => ({
+  getVoiceShortcutMicPrewarmEnabled: () => true,
+  setVoiceShortcutMicPrewarmEnabled: vi.fn(),
+}));
+
+vi.mock('@/config/voice-overlay-preferences', () => ({
+  DEFAULT_VOICE_OVERLAY_BOTTOM_OFFSET: 56,
+  getVoiceOverlayOpacity: () => 62,
+  getVoiceOverlayShowDiagnostics: () => false,
+  getVoiceOverlayTranscriptLines: () => 3,
+  getVoiceOverlayBottomOffset: () => 56,
+  MAX_VOICE_OVERLAY_OPACITY: 92,
+  MIN_VOICE_OVERLAY_OPACITY: 32,
+  MAX_VOICE_OVERLAY_BOTTOM_OFFSET: 160,
+  subscribeVoiceOverlayBottomOffsetChanges: () => () => {},
+  subscribeVoiceOverlayShowDiagnosticsChanges: () => () => {},
+  subscribeVoiceOverlayTranscriptLinesChanges: () => () => {},
+  setVoiceOverlayOpacity: vi.fn(),
+  setVoiceOverlayShowDiagnostics: vi.fn(),
+  setVoiceOverlayTranscriptLines: vi.fn(),
+  setVoiceOverlayBottomOffset: vi.fn(),
+  MAX_VOICE_OVERLAY_TRANSCRIPT_LINES: 5,
+  MIN_VOICE_OVERLAY_BOTTOM_OFFSET: 24,
+  MIN_VOICE_OVERLAY_TRANSCRIPT_LINES: 1,
+}));
+
+vi.mock('@/config/voice-shortcut-asr-provider', () => ({
+  getVoiceShortcutAsrProvider: () => 'volcano',
+  getVoiceShortcutAsrProviderLabel: () => 'Volcano',
+  setVoiceShortcutAsrProvider: vi.fn(),
+  subscribeVoiceShortcutAsrProviderChanges: () => () => {},
+}));
+
+vi.mock('@/lib/asr/volcano-config', () => ({
+  DEFAULT_VOLCANO_RESOURCE_ID: 'volc.default',
+  VOLCANO_RESOURCE_PRESETS: [{ value: 'volc.default', label: 'Volcano Default' }],
+  getVolcanoResourceId: () => 'volc.default',
+  setVolcanoResourceId: vi.fn((value: string) => value),
+}));
+
+vi.mock('@/config/feedback-preferences', () => ({
+  getFeedbackPreferences: () => ({
+    timingInfoEnabled: false,
+    statisticsEnabled: false,
+    quickFeedbackEnabled: true,
+  }),
+  setFeedbackPreferences: vi.fn(),
+  subscribeFeedbackPreferencesChanges: () => () => {},
+}));
+
+vi.mock('@/config/version-build-info', () => ({
+  resolveVersionBuildInfo: () => ({
+    appVersion: '0.3.6',
+    buildHash: 'issue481',
+  }),
+}));
+
+vi.mock('@/lib/debug/devtools-runtime', () => ({
+  syncDevtoolsWithSettings: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/media/timer-end-sounds', () => ({
+  TIMER_END_SOUND_PRESETS: [],
+  getTimerEndSoundPresetById: vi.fn(() => ({ label: 'Bell' })),
+}));
+
+vi.mock('@/ui/app/components/UserCard', () => ({
+  UserCard: () => <div data-testid="mock-user-card" />,
+}));
+
+vi.mock('@/ui/app/components/MoreSection', () => ({
+  MoreSection: () => null,
+}));
+
+vi.mock('@/ui/app/components/LegalSection', () => ({
+  LegalSection: () => null,
+}));
+
+vi.mock('@/ui/app/components/AboutSection', () => ({
+  AboutSection: () => null,
+}));
+
+import { SettingsPage } from '@/ui/app/pages/SettingsPage';
+
+describe('SettingsPage task backend diagnostics (issue-481)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    mocks.exportEventsAsJson.mockResolvedValue(JSON.stringify({ events: [] }));
+    mocks.importEventsFromJson.mockResolvedValue({ imported: 0, skipped: 0, total: 0 });
+    mocks.getTaskBackendStatus.mockResolvedValue({
+      backend: 'rt-sqlite',
+      supportsJsonBackup: true,
+      supportsSqliteSnapshot: true,
+    });
+    mocks.isTauri.mockResolvedValue(false);
+    mocks.invoke.mockResolvedValue(null);
+  });
+
+  it('shows task backend diagnostics in developer mode', async () => {
+    developerModeState.enabled = true;
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('任务后端：rt-sqlite')).toBeInTheDocument();
+    });
+    expect(screen.getByText('任务备份：JSON / SQLite')).toBeInTheDocument();
+  });
+
+  it('hides task backend diagnostics when developer mode is off', () => {
+    developerModeState.enabled = false;
+    render(<SettingsPage />);
+
+    expect(screen.queryByText(/任务后端：/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/任务备份：/)).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/settings/task-import-export.issue481.test.tsx
+++ b/tests/unit/settings/task-import-export.issue481.test.tsx
@@ -1,0 +1,357 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mocks = vi.hoisted(() => ({
+  exportEventsAsJson: vi.fn(),
+  importEventsFromJson: vi.fn(),
+  exportTasksAsJson: vi.fn(),
+  exportTasksAsSqliteSnapshot: vi.fn(),
+  importTasksFromJson: vi.fn(),
+  importTasksFromSqliteSnapshot: vi.fn(),
+  getTaskBackendStatus: vi.fn(),
+  isTauri: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: mocks.isTauri,
+  invoke: mocks.invoke,
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/lib/services', () => ({
+  getEventLogService: () => ({
+    exportEventsAsJson: mocks.exportEventsAsJson,
+    importEventsFromJson: mocks.importEventsFromJson,
+  }),
+  getTaskBackupService: () => ({
+    exportTasksAsJson: mocks.exportTasksAsJson,
+    exportTasksAsSqliteSnapshot: mocks.exportTasksAsSqliteSnapshot,
+    importTasksFromJson: mocks.importTasksFromJson,
+    importTasksFromSqliteSnapshot: mocks.importTasksFromSqliteSnapshot,
+    getBackendStatus: mocks.getTaskBackendStatus,
+  }),
+}));
+
+vi.mock('@/config/port-env', () => ({
+  getSyncServerUrlOverride: () => null,
+  resolveSyncServerUrl: () => 'http://127.0.0.1:6984',
+  setSyncServerUrlOverride: vi.fn(),
+}));
+
+vi.mock('@/config/theme', () => ({
+  getThemePreference: () => 'system',
+  setThemePreference: vi.fn(),
+}));
+
+vi.mock('@/config/developer-mode', () => ({
+  getDeveloperModeEnabled: () => false,
+  setDeveloperModeEnabled: vi.fn(),
+}));
+
+vi.mock('@/config/agent-page-enabled', () => ({
+  getAgentPageEnabled: () => false,
+  setAgentPageEnabled: vi.fn(),
+}));
+
+vi.mock('@/config/desktop-adaptive', () => ({
+  getDesktopAdaptiveEnabled: () => true,
+  setDesktopAdaptiveEnabled: vi.fn(),
+}));
+
+vi.mock('@/config/mock-data', () => ({
+  getUseMockDataEnabled: () => false,
+  setUseMockDataEnabled: vi.fn(),
+  subscribeUseMockDataChanges: () => () => {},
+}));
+
+vi.mock('@/config/timer-preferences', () => ({
+  getTimerPreferences: () => ({
+    countdownEndMode: 'soft',
+    countdownEndSoundEnabled: false,
+    countdownEndSoundPresetId: 'timer-end-ring-10',
+  }),
+  subscribeTimerPreferencesChanges: () => () => {},
+  updateTimerPreferences: (partial: Record<string, unknown>) => ({
+    countdownEndMode: 'soft',
+    countdownEndSoundEnabled: false,
+    countdownEndSoundPresetId: 'timer-end-ring-10',
+    ...partial,
+  }),
+}));
+
+vi.mock('@/config/devtools-mode', () => ({
+  getDevtoolsEnabled: () => false,
+  setDevtoolsEnabled: vi.fn(),
+  subscribeDevtoolsChanges: () => () => {},
+}));
+
+vi.mock('@/config/command-palette-enabled', () => ({
+  getCommandPaletteEnabled: () => false,
+  setCommandPaletteEnabled: vi.fn(),
+  subscribeCommandPaletteEnabledChanges: () => () => {},
+}));
+
+vi.mock('@/config/voice-transcript-send-mode', () => ({
+  getVoiceTranscriptSendMode: () => 'insert',
+  setVoiceTranscriptSendMode: vi.fn(),
+  subscribeVoiceTranscriptSendModeChanges: () => () => {},
+}));
+
+vi.mock('@/config/voice-shortcut-hotkey', () => ({
+  VOICE_SHORTCUT_HOTKEY_VALUES: ['Alt+Q', 'Alt+W', 'Ctrl+Space'],
+  getVoiceShortcutHotkey: () => 'Alt+Q',
+  setVoiceShortcutHotkey: vi.fn(),
+  subscribeVoiceShortcutHotkeyChanges: () => () => {},
+}));
+
+vi.mock('@/config/voice-shortcut-send-mode', () => ({
+  getVoiceShortcutSendMode: () => 'insert-only',
+  setVoiceShortcutSendMode: vi.fn(),
+  subscribeVoiceShortcutSendModeChanges: () => () => {},
+}));
+
+vi.mock('@/config/voice-shortcut-mic-prewarm', () => ({
+  getVoiceShortcutMicPrewarmEnabled: () => true,
+  setVoiceShortcutMicPrewarmEnabled: vi.fn(),
+}));
+
+vi.mock('@/config/voice-overlay-preferences', () => ({
+  DEFAULT_VOICE_OVERLAY_BOTTOM_OFFSET: 56,
+  getVoiceOverlayOpacity: () => 62,
+  getVoiceOverlayShowDiagnostics: () => false,
+  getVoiceOverlayTranscriptLines: () => 3,
+  getVoiceOverlayBottomOffset: () => 56,
+  MAX_VOICE_OVERLAY_OPACITY: 92,
+  MIN_VOICE_OVERLAY_OPACITY: 32,
+  MAX_VOICE_OVERLAY_BOTTOM_OFFSET: 160,
+  subscribeVoiceOverlayBottomOffsetChanges: () => () => {},
+  subscribeVoiceOverlayShowDiagnosticsChanges: () => () => {},
+  subscribeVoiceOverlayTranscriptLinesChanges: () => () => {},
+  setVoiceOverlayOpacity: vi.fn(),
+  setVoiceOverlayShowDiagnostics: vi.fn(),
+  setVoiceOverlayTranscriptLines: vi.fn(),
+  setVoiceOverlayBottomOffset: vi.fn(),
+  MAX_VOICE_OVERLAY_TRANSCRIPT_LINES: 5,
+  MIN_VOICE_OVERLAY_BOTTOM_OFFSET: 24,
+  MIN_VOICE_OVERLAY_TRANSCRIPT_LINES: 1,
+}));
+
+vi.mock('@/config/voice-shortcut-asr-provider', () => ({
+  getVoiceShortcutAsrProvider: () => 'volcano',
+  getVoiceShortcutAsrProviderLabel: () => 'Volcano',
+  setVoiceShortcutAsrProvider: vi.fn(),
+  subscribeVoiceShortcutAsrProviderChanges: () => () => {},
+}));
+
+vi.mock('@/lib/asr/volcano-config', () => ({
+  DEFAULT_VOLCANO_RESOURCE_ID: 'volc.default',
+  VOLCANO_RESOURCE_PRESETS: [{ value: 'volc.default', label: 'Volcano Default' }],
+  getVolcanoResourceId: () => 'volc.default',
+  setVolcanoResourceId: vi.fn((value: string) => value),
+}));
+
+vi.mock('@/config/feedback-preferences', () => ({
+  getFeedbackPreferences: () => ({
+    timingInfoEnabled: false,
+    statisticsEnabled: false,
+    quickFeedbackEnabled: true,
+  }),
+  setFeedbackPreferences: vi.fn(),
+  subscribeFeedbackPreferencesChanges: () => () => {},
+}));
+
+vi.mock('@/config/version-build-info', () => ({
+  resolveVersionBuildInfo: () => ({
+    appVersion: '0.3.6',
+    buildHash: 'issue481',
+  }),
+}));
+
+vi.mock('@/lib/debug/devtools-runtime', () => ({
+  syncDevtoolsWithSettings: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/media/timer-end-sounds', () => ({
+  TIMER_END_SOUND_PRESETS: [],
+  getTimerEndSoundPresetById: vi.fn(() => ({ label: 'Bell' })),
+}));
+
+vi.mock('@/ui/app/components/UserCard', () => ({
+  UserCard: () => <div data-testid="mock-user-card" />,
+}));
+
+vi.mock('@/ui/app/components/MoreSection', () => ({
+  MoreSection: () => null,
+}));
+
+vi.mock('@/ui/app/components/LegalSection', () => ({
+  LegalSection: () => null,
+}));
+
+vi.mock('@/ui/app/components/AboutSection', () => ({
+  AboutSection: () => null,
+}));
+
+import { SettingsPage } from '@/ui/app/pages/SettingsPage';
+
+const createObjectURLMock = vi.fn(() => 'blob:task-backup');
+const revokeObjectURLMock = vi.fn();
+
+Object.defineProperty(URL, 'createObjectURL', {
+  value: createObjectURLMock,
+  writable: true,
+});
+
+Object.defineProperty(URL, 'revokeObjectURL', {
+  value: revokeObjectURLMock,
+  writable: true,
+});
+
+describe('SettingsPage task import/export (issue-481)', () => {
+  let anchorClickSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    mocks.exportEventsAsJson.mockResolvedValue(JSON.stringify({ events: [] }));
+    mocks.importEventsFromJson.mockResolvedValue({ imported: 0, skipped: 0, total: 0 });
+    mocks.exportTasksAsJson.mockResolvedValue({
+      fileName: 'exomind-tasks-2026-03-11.json',
+      content: JSON.stringify({ version: 1, tasks: [] }),
+      taskCount: 0,
+    });
+    mocks.exportTasksAsSqliteSnapshot.mockResolvedValue({
+      fileName: 'exomind-tasks.sqlite',
+      bytes: new Uint8Array([1, 2, 3]),
+      taskCount: 1,
+    });
+    mocks.importTasksFromJson.mockResolvedValue({ imported: 1, skipped: 0, total: 1 });
+    mocks.importTasksFromSqliteSnapshot.mockResolvedValue({ imported: 2, skipped: 0, total: 2 });
+    mocks.getTaskBackendStatus.mockResolvedValue({
+      backend: 'rt-sqlite',
+      supportsJsonBackup: true,
+      supportsSqliteSnapshot: true,
+    });
+    mocks.isTauri.mockResolvedValue(false);
+    mocks.invoke.mockResolvedValue(null);
+    anchorClickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    anchorClickSpy.mockRestore();
+  });
+
+  it('exports task backup as JSON', async () => {
+    render(<SettingsPage />);
+    fireEvent.click(screen.getByRole('button', { name: '导出任务 JSON' }));
+
+    await waitFor(() => {
+      expect(mocks.exportTasksAsJson).toHaveBeenCalledTimes(1);
+    });
+    expect(anchorClickSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('任务导出成功（JSON），共 0 条任务。')).toBeInTheDocument();
+  });
+
+  it('uses tauri native save command for JSON export in tauri runtime', async () => {
+    mocks.isTauri.mockResolvedValue(true);
+    mocks.invoke.mockResolvedValue('D:/Downloads/exomind-tasks-2026-03-11.json');
+
+    render(<SettingsPage />);
+    fireEvent.click(screen.getByRole('button', { name: '导出任务 JSON' }));
+
+    await waitFor(() => {
+      expect(
+        mocks.invoke.mock.calls.some(([command, payload]) =>
+          command === 'save_json_file'
+          && JSON.stringify(payload) === JSON.stringify({
+            content: JSON.stringify({ version: 1, tasks: [] }),
+            defaultName: 'exomind-tasks-2026-03-11.json',
+          })
+        )
+      ).toBe(true);
+    });
+
+    expect(anchorClickSpy).not.toHaveBeenCalled();
+    expect(screen.getByText(/任务导出成功（JSON），共 0 条任务。保存路径：/)).toBeInTheDocument();
+  });
+
+  it('exports task backup as SQLite snapshot', async () => {
+    render(<SettingsPage />);
+    fireEvent.click(screen.getByRole('button', { name: '导出任务 SQLite' }));
+
+    await waitFor(() => {
+      expect(mocks.exportTasksAsSqliteSnapshot).toHaveBeenCalledTimes(1);
+    });
+    expect(anchorClickSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('任务导出成功（SQLite），共 1 条任务。')).toBeInTheDocument();
+  });
+
+  it('uses tauri native save command for SQLite export in tauri runtime', async () => {
+    mocks.isTauri.mockResolvedValue(true);
+    mocks.invoke.mockResolvedValue('D:/Downloads/exomind-tasks.sqlite');
+
+    render(<SettingsPage />);
+    fireEvent.click(screen.getByRole('button', { name: '导出任务 SQLite' }));
+
+    await waitFor(() => {
+      expect(
+        mocks.invoke.mock.calls.some(([command, payload]) =>
+          command === 'save_binary_file'
+          && JSON.stringify(payload) === JSON.stringify({
+            content: [1, 2, 3],
+            defaultName: 'exomind-tasks.sqlite',
+            filters: ['sqlite', 'db'],
+          })
+        )
+      ).toBe(true);
+    });
+
+    expect(anchorClickSpy).not.toHaveBeenCalled();
+    expect(screen.getByText(/任务导出成功（SQLite），共 1 条任务。保存路径：/)).toBeInTheDocument();
+  });
+
+  it('imports task backup from JSON file', async () => {
+    render(<SettingsPage />);
+    fireEvent.click(screen.getByRole('button', { name: '导入任务数据' }));
+
+    const input = screen.getByTestId('new-settings-task-import-input') as HTMLInputElement;
+    const file = new File([JSON.stringify({ version: 1, tasks: [] })], 'tasks.json', {
+      type: 'application/json',
+    });
+    await fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(mocks.importTasksFromJson).toHaveBeenCalledWith(expect.stringContaining('"tasks"'), 'merge');
+    });
+    expect(screen.getByText(/任务导入成功：新增 1 条，跳过 0 条，当前共 1 条。来源：tasks\.json/)).toBeInTheDocument();
+  });
+
+  it('imports task backup from SQLite snapshot file', async () => {
+    render(<SettingsPage />);
+    fireEvent.click(screen.getByRole('button', { name: '导入任务数据' }));
+
+    const input = screen.getByTestId('new-settings-task-import-input') as HTMLInputElement;
+    const file = new File([new Uint8Array([1, 2, 3, 4])], 'tasks.sqlite', {
+      type: 'application/octet-stream',
+    });
+    await fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(mocks.importTasksFromSqliteSnapshot).toHaveBeenCalledWith(expect.any(Uint8Array), 'merge');
+    });
+    expect(screen.getByText(/任务导入成功：新增 2 条，跳过 0 条，当前共 2 条。来源：tasks\.sqlite/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- migrate task source of truth from frontend PouchDB to RT SQLite
- add RT task backup/import APIs plus Settings JSON/SQLite task import-export actions
- surface task backend diagnostics in developer mode and remove legacy task sync coordinator

## Scope
- task-only migration for #481
- does not migrate EventLog or TimeBlock storage
- unblocks the task-side backend prerequisite for #480

## Test Plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run tests/unit/adapters/task-rt-adapter.test.ts tests/unit/app/app-router-context.startup.test.tsx tests/unit/settings/task-import-export.issue481.test.tsx tests/unit/settings/task-backend-diagnostics.issue481.test.tsx tests/unit/settings/settings-export-runtime.issue222.test.tsx tests/unit/settings/settings-mock-data-toggle.issue213.test.tsx tests/unit/settings/settings-timer-card.issue182.test.tsx`
- [x] `cargo test -p exomind-runtime task --manifest-path src-tauri/Cargo.toml -- --nocapture`
- [x] `cargo test -p exomind-runtime routes::tasks --manifest-path src-tauri/Cargo.toml -- --nocapture`
- [x] `bun run build`
- [x] manual validation in Tauri dev: task create persists after restart; task JSON/SQLite export/import paths usable

Closes #481
Related #480