### PR TITLE
feat: 完成 phase 3 生命周期与信号流 (#444)

### DIFF
--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -23,12 +23,12 @@ pub mod energy;
 pub mod eventlog;
 pub mod mesh;
 pub mod pairing;
+#[cfg(not(target_os = "android"))]
+pub mod pty;
 pub mod routes;
 pub mod signal;
 pub mod task;
 pub mod tick;
-#[cfg(not(target_os = "android"))]
-pub mod pty;
 
 pub const RUNTIME_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const DEFAULT_RT_PORT: u16 = 1949;
@@ -205,8 +205,7 @@ pub struct RuntimeHandle {
     ts_agents: Vec<TsAgentProcess>,
     #[cfg(not(target_os = "android"))]
     pty_manager: Arc<pty::PtyManager>,
-    tick_cancel: Arc<std::sync::atomic::AtomicBool>,
-    tick_tasks: Vec<JoinHandle<()>>,
+    tick_manager: Arc<tick::TickManager>,
 }
 
 /// Publish request for in-process fast path（进程内快速发布请求）.
@@ -304,11 +303,7 @@ impl RuntimeHandle {
             let _ = tx.send(());
         }
 
-        self.tick_cancel.store(true, std::sync::atomic::Ordering::Relaxed);
-        for task in self.tick_tasks.drain(..) {
-            task.abort();
-            let _ = task.await;
-        }
+        self.tick_manager.stop_all().await;
 
         for task in &self.actor_tasks {
             task.abort();
@@ -383,10 +378,7 @@ impl Drop for RuntimeHandle {
         if let Some(tx) = self.shutdown_tx.take() {
             let _ = tx.send(());
         }
-        self.tick_cancel.store(true, std::sync::atomic::Ordering::Relaxed);
-        for task in self.tick_tasks.drain(..) {
-            task.abort();
-        }
+        self.tick_manager.abort_all();
         for task in self.actor_tasks.drain(..) {
             task.abort();
         }
@@ -465,9 +457,15 @@ pub async fn start_with_options(
 
     let mut actor_tasks = Vec::new();
     if options.spawn_builtin_actors {
-        actor_tasks.push(signal::actors::task_classifier_actor::spawn_task_actor(Arc::clone(
-            &state.signal_pool,
-        )));
+        actor_tasks.push(
+            signal::actors::signal_dispatcher_actor::spawn_signal_dispatcher_actor(
+                Arc::clone(&state.signal_pool),
+                state.registry.clone(),
+            ),
+        );
+        actor_tasks.push(signal::actors::task_classifier_actor::spawn_task_actor(
+            Arc::clone(&state.signal_pool),
+        ));
         actor_tasks.push(signal::actors::eventlog_actor::spawn_eventlog_actor(
             Arc::clone(&state.signal_pool),
         ));
@@ -487,7 +485,9 @@ pub async fn start_with_options(
     if options.spawn_builtin_actors {
         let heartbeat = Arc::new(agent::heartbeat::HeartbeatAgent::new("heartbeat"));
         state.registry.register(heartbeat);
-        state.energy_registry.register("heartbeat", energy::AgentEnergy::new(100, 10));
+        state
+            .energy_registry
+            .register("heartbeat", energy::AgentEnergy::new(100, 10));
 
         // Register cognitive life agent
         let data_dir = options
@@ -497,19 +497,23 @@ pub async fn start_with_options(
         match agent::workspace::AgentWorkspace::init("life-alpha", &data_dir) {
             Ok(workspace) => {
                 let soul = workspace.load_soul().unwrap_or_default();
-                let cognition = Box::new(agent::llm_cognition::LlmCognition::new("life-alpha", soul));
+                let cognition =
+                    Box::new(agent::llm_cognition::LlmCognition::new("life-alpha", soul));
                 let life_agent = Arc::new(agent::life::CognitiveLifeAgent::new(
                     "life-alpha",
                     "认知生命体 Alpha",
                     workspace,
                     cognition,
                 ));
-                state.registry.register(Arc::clone(&life_agent) as Arc<dyn agent::Agent>);
-                state.life_agents.insert("life-alpha".to_string(), life_agent);
-                state.energy_registry.register(
-                    "life-alpha",
-                    energy::AgentEnergy::new(200, 5),
-                );
+                state
+                    .registry
+                    .register(Arc::clone(&life_agent) as Arc<dyn agent::Agent>);
+                state
+                    .life_agents
+                    .insert("life-alpha".to_string(), life_agent);
+                state
+                    .energy_registry
+                    .register("life-alpha", energy::AgentEnergy::new(200, 5));
             }
             Err(e) => {
                 tracing::warn!("failed to init life agent workspace: {e}");
@@ -517,15 +521,10 @@ pub async fn start_with_options(
         }
     }
 
-    // Start tick scheduler for all agents with tick_interval_secs > 0
-    let tick_cancel = Arc::new(std::sync::atomic::AtomicBool::new(false));
-    let tick_tasks = tick::start_all_ticks(
-        &state.registry,
-        &state.energy_registry,
-        &state.signal_pool,
-        &options.host_id,
-        Arc::clone(&tick_cancel),
-    );
+    // Start tick scheduler for all agents with tick_interval_secs > 0.
+    // 启动所有启用 tick 的 agent 生命周期循环。
+    let tick_manager = Arc::clone(&state.tick_manager);
+    tick_manager.start_all_ticks();
 
     #[cfg(not(target_os = "android"))]
     let pty_manager = Arc::clone(&state.pty_manager);
@@ -557,8 +556,7 @@ pub async fn start_with_options(
         ts_agents,
         #[cfg(not(target_os = "android"))]
         pty_manager,
-        tick_cancel,
-        tick_tasks,
+        tick_manager,
     })
 }
 
@@ -718,6 +716,7 @@ pub struct AppState {
     pub pairing: Arc<pairing::PairingManager>,
     pub task_store: Arc<task::TaskStore>,
     pub energy_registry: energy::EnergyRegistry,
+    pub tick_manager: Arc<tick::TickManager>,
     /// Typed reference to CognitiveLifeAgent instances for workspace API access.
     pub life_agents: std::collections::HashMap<String, Arc<agent::life::CognitiveLifeAgent>>,
     pub eventlog_store: Arc<EventLogStore>,
@@ -796,6 +795,13 @@ impl AppState {
                 })
             })
             .unwrap_or_else(task::TaskStore::new);
+        let energy_registry = energy::EnergyRegistry::new();
+        let tick_manager = Arc::new(tick::TickManager::new(
+            host_id.clone(),
+            registry.clone(),
+            energy_registry.clone(),
+            Arc::clone(&signal_pool),
+        ));
 
         Self {
             port,
@@ -808,7 +814,8 @@ impl AppState {
             mdns: None,
             pairing: Arc::new(pairing::PairingManager::new()),
             task_store: Arc::new(task_store),
-            energy_registry: energy::EnergyRegistry::new(),
+            energy_registry,
+            tick_manager,
             life_agents: std::collections::HashMap::new(),
             eventlog_store,
             #[cfg(not(target_os = "android"))]
@@ -886,6 +893,8 @@ mod tests {
         signal_pool: Arc<signal::SignalPool>,
     ) -> AppState {
         let host_id = format!("lib-test-{port}");
+        let registry_clone = registry.clone();
+        let energy_registry = energy::EnergyRegistry::new();
         AppState {
             port,
             host_id: host_id.clone(),
@@ -901,7 +910,13 @@ mod tests {
             mdns: None,
             pairing: Arc::new(pairing::PairingManager::new()),
             task_store: Arc::new(task::TaskStore::new()),
-            energy_registry: energy::EnergyRegistry::new(),
+            energy_registry: energy_registry.clone(),
+            tick_manager: Arc::new(tick::TickManager::new(
+                host_id.clone(),
+                registry_clone,
+                energy_registry,
+                Arc::clone(&signal_pool),
+            )),
             life_agents: std::collections::HashMap::new(),
             eventlog_store: Arc::new(eventlog::EventLogStore::new(
                 std::env::temp_dir().join("exomind-test-lib"),
@@ -1155,15 +1170,19 @@ mod tests {
         let initial_route_count = runtime.signal_pool.routes().get_all().len();
         let now = chrono::Utc::now().to_rfc3339();
         let route_id = uuid::Uuid::new_v4().to_string();
-        runtime.signal_pool.routes().add(crate::signal::SignalRoute {
-            id: route_id.clone(),
-            enabled: true,
-            topic: "runtime.fallback.topic".to_string(),
-            target_type: crate::signal::TargetType::Agent,
-            target_ref: "fallback-agent".to_string(),
-            created_at: now.clone(),
-            updated_at: now,
-        }).unwrap();
+        runtime
+            .signal_pool
+            .routes()
+            .add(crate::signal::SignalRoute {
+                id: route_id.clone(),
+                enabled: true,
+                topic: "runtime.fallback.topic".to_string(),
+                target_type: crate::signal::TargetType::Agent,
+                target_ref: "fallback-agent".to_string(),
+                created_at: now.clone(),
+                updated_at: now,
+            })
+            .unwrap();
 
         assert_eq!(
             runtime.signal_pool.routes().get_all().len(),

--- a/crates/exomind-runtime/src/routes/energy.rs
+++ b/crates/exomind-runtime/src/routes/energy.rs
@@ -1,10 +1,24 @@
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
 
-use crate::energy::AgentEnergySnapshot;
 use crate::AppState;
+use crate::energy::AgentEnergySnapshot;
+use crate::signal::types::SignalEvent;
+
+#[derive(Debug, Deserialize)]
+struct RefillEnergyRequest {
+    amount: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct RefillEnergyResponse {
+    energy: AgentEnergySnapshot,
+    revived: bool,
+    tick_spawned: bool,
+}
 
 /// GET /agents/:id/energy
 async fn get_agent_energy(
@@ -19,58 +33,133 @@ async fn get_agent_energy(
 }
 
 /// GET /energy — all agent energy snapshots
-async fn list_energy(
-    State(state): State<AppState>,
-) -> Json<Vec<AgentEnergySnapshot>> {
+async fn list_energy(State(state): State<AppState>) -> Json<Vec<AgentEnergySnapshot>> {
     Json(state.energy_registry.all_snapshots())
+}
+
+/// POST /agents/:id/energy/refill
+async fn refill_agent_energy(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+    Json(request): Json<RefillEnergyRequest>,
+) -> Result<Json<RefillEnergyResponse>, StatusCode> {
+    let energy = state
+        .energy_registry
+        .get(&id)
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let was_dormant = energy.is_dormant();
+    let refill_amount = request.amount.unwrap_or_else(|| energy.max());
+    energy.refill(refill_amount);
+    let snapshot = energy.snapshot(&id);
+
+    let revived = was_dormant && !snapshot.is_dormant;
+    let tick_spawned = if revived {
+        let spawned = state.tick_manager.spawn_tick_for_agent(&id);
+        state.signal_pool.publish(SignalEvent {
+            schema_version: 1,
+            id: uuid::Uuid::new_v4().to_string(),
+            topic: "agent.revived".to_string(),
+            ts: chrono::Utc::now().timestamp_millis() as u64,
+            source: "rt:energy-refill".to_string(),
+            origin_host_id: state.host_id.clone(),
+            hop: 0,
+            trace_id: None,
+            payload: serde_json::json!({
+                "agent_id": id,
+                "amount": refill_amount,
+                "energy": {
+                    "current": snapshot.current,
+                    "max": snapshot.max,
+                    "ratio": snapshot.ratio,
+                    "phase": snapshot.phase,
+                },
+                "tick_spawned": spawned,
+            }),
+        });
+        spawned
+    } else {
+        false
+    };
+
+    Ok(Json(RefillEnergyResponse {
+        energy: snapshot,
+        revived,
+        tick_spawned,
+    }))
 }
 
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/energy", get(list_energy))
         .route("/agents/:id/energy", get(get_agent_energy))
+        .route("/agents/:id/energy/refill", post(refill_agent_energy))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::{Agent, ChatChunk, ChatRequest};
     use crate::energy::{AgentEnergy, EnergyRegistry};
     use crate::signal::SignalPool;
     use axum::body::Body;
     use axum::http::Request;
+    use futures_util::future::BoxFuture;
+    use futures_util::stream::{self, BoxStream, StreamExt};
     use http_body_util::BodyExt;
     use serde_json::Value;
     use std::sync::Arc;
     use tower::util::ServiceExt;
 
+    struct ReviveTickAgent;
+
+    impl Agent for ReviveTickAgent {
+        fn id(&self) -> &str {
+            "revive-test"
+        }
+        fn name(&self) -> &str {
+            "Revive Test"
+        }
+        fn description(&self) -> &str {
+            "Route refill revive test agent"
+        }
+        fn chat_stream(&self, _request: ChatRequest) -> BoxStream<'static, ChatChunk> {
+            stream::empty().boxed()
+        }
+        fn tick_interval_secs(&self) -> u64 {
+            1
+        }
+        fn on_tick(
+            &self,
+            _energy: &crate::energy::AgentEnergySnapshot,
+        ) -> BoxFuture<'_, Vec<SignalEvent>> {
+            Box::pin(async { Vec::new() })
+        }
+    }
+
     fn test_state() -> AppState {
+        let mut state =
+            AppState::new_runtime(0, "energy-test".to_string(), None, None, false, None);
         let signal_pool = Arc::new(SignalPool::new(None));
         let host_id = "energy-test".to_string();
         let energy_registry = EnergyRegistry::new();
         energy_registry.register("heartbeat", AgentEnergy::new(1000, 10));
-        AppState {
-            port: 0,
-            host_id: host_id.clone(),
-            registry: crate::agent::AgentRegistry::new(),
-            signal_pool: Arc::clone(&signal_pool),
-            mesh: Arc::new(crate::mesh::MeshState::new(
-                host_id.clone(),
-                Arc::clone(&signal_pool),
-                None,
-            )),
-            mesh_relay: None,
-            auth_secret: None,
-            mdns: None,
-            pairing: Arc::new(crate::pairing::PairingManager::new()),
-            task_store: Arc::new(crate::task::TaskStore::new()),
-            energy_registry,
-            life_agents: std::collections::HashMap::new(),
-            eventlog_store: Arc::new(crate::eventlog::EventLogStore::new(
-                std::env::temp_dir().join("exomind-test-energy"),
-            )),
-            #[cfg(not(target_os = "android"))]
-            pty_manager: Arc::new(crate::pty::PtyManager::new(Arc::clone(&signal_pool), host_id)),
-        }
+        state.host_id = host_id.clone();
+        state.registry = crate::agent::AgentRegistry::new();
+        state.signal_pool = Arc::clone(&signal_pool);
+        state.mesh = Arc::new(crate::mesh::MeshState::new(
+            host_id.clone(),
+            Arc::clone(&signal_pool),
+            None,
+        ));
+        state.energy_registry = energy_registry;
+        state.tick_manager = Arc::new(crate::tick::TickManager::new(
+            host_id,
+            state.registry.clone(),
+            state.energy_registry.clone(),
+            Arc::clone(&signal_pool),
+        ));
+        state
     }
 
     #[tokio::test]
@@ -136,5 +225,95 @@ mod tests {
         let snapshots: Vec<Value> = serde_json::from_slice(&body).unwrap();
         assert_eq!(snapshots.len(), 1);
         assert_eq!(snapshots[0]["agent_id"], "heartbeat");
+    }
+
+    #[tokio::test]
+    async fn refill_unknown_agent_returns_404() {
+        let state = test_state();
+        let app = router().with_state(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/agents/unknown/energy/refill")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::json!({ "amount": 10 }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn refill_revives_dormant_agent_and_restarts_tick() {
+        let state = test_state();
+        state.registry.register(Arc::new(ReviveTickAgent));
+        state
+            .energy_registry
+            .register("revive-test", AgentEnergy::new(10, 10));
+
+        let mut rx = state.signal_pool.subscribe();
+        assert_eq!(state.tick_manager.start_all_ticks(), 1);
+
+        tokio::time::timeout(std::time::Duration::from_secs(3), async {
+            loop {
+                let event = rx.recv().await.expect("should receive dormant signal");
+                if event.topic == "agent.dormant" && event.payload["agent_id"] == "revive-test" {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("agent should become dormant before refill");
+
+        assert!(
+            state
+                .energy_registry
+                .get("revive-test")
+                .unwrap()
+                .is_dormant(),
+            "agent should be dormant before refill"
+        );
+
+        let app = router().with_state(state.clone());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/agents/revive-test/energy/refill")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::json!({ "amount": 10 }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let payload: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(payload["revived"], true);
+        assert_eq!(payload["tick_spawned"], true);
+        assert_eq!(payload["energy"]["phase"], "normal");
+
+        let mut saw_revived = false;
+        let mut saw_tick_after_refill = false;
+        tokio::time::timeout(std::time::Duration::from_secs(3), async {
+            while !saw_revived || !saw_tick_after_refill {
+                let event = rx.recv().await.expect("should receive revive/tick signals");
+                if event.topic == "agent.revived" && event.payload["agent_id"] == "revive-test" {
+                    saw_revived = true;
+                }
+                if event.topic == "agent.tick" && event.payload["agent_id"] == "revive-test" {
+                    saw_tick_after_refill = true;
+                }
+            }
+        })
+        .await
+        .expect("refill should publish revived and restart tick");
+
+        state.tick_manager.stop_all().await;
     }
 }

--- a/crates/exomind-runtime/src/routes/eventlog.rs
+++ b/crates/exomind-runtime/src/routes/eventlog.rs
@@ -8,8 +8,8 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
-use crate::eventlog::{EventRecord, MirrorStatus};
 use crate::AppState;
+use crate::eventlog::{EventRecord, MirrorStatus};
 
 // ── Request / query types ───────────────────────────────────────
 
@@ -166,22 +166,37 @@ mod tests {
     fn test_state_with_eventlog(store: Arc<EventLogStore>) -> AppState {
         let signal_pool = Arc::new(SignalPool::new(None));
         let host_id = "eventlog-test".to_string();
+        let registry = crate::agent::AgentRegistry::new();
+        let energy_registry = crate::energy::EnergyRegistry::new();
         AppState {
             port: 0,
             host_id: host_id.clone(),
-            registry: crate::agent::AgentRegistry::new(),
+            registry: registry.clone(),
             signal_pool: Arc::clone(&signal_pool),
-            mesh: Arc::new(MeshState::new(host_id.clone(), Arc::clone(&signal_pool), None)),
+            mesh: Arc::new(MeshState::new(
+                host_id.clone(),
+                Arc::clone(&signal_pool),
+                None,
+            )),
             mesh_relay: None,
             auth_secret: None,
             mdns: None,
             pairing: Arc::new(crate::pairing::PairingManager::new()),
             task_store: Arc::new(crate::task::TaskStore::new()),
-            energy_registry: crate::energy::EnergyRegistry::new(),
+            energy_registry: energy_registry.clone(),
+            tick_manager: Arc::new(crate::tick::TickManager::new(
+                host_id.clone(),
+                registry,
+                energy_registry,
+                Arc::clone(&signal_pool),
+            )),
             life_agents: std::collections::HashMap::new(),
             eventlog_store: store,
             #[cfg(not(target_os = "android"))]
-            pty_manager: Arc::new(crate::pty::PtyManager::new(Arc::clone(&signal_pool), host_id)),
+            pty_manager: Arc::new(crate::pty::PtyManager::new(
+                Arc::clone(&signal_pool),
+                host_id,
+            )),
         }
     }
 

--- a/crates/exomind-runtime/src/routes/signals.rs
+++ b/crates/exomind-runtime/src/routes/signals.rs
@@ -3,18 +3,18 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::sse::{Event, Sse};
 use axum::routing::{get, post, put};
 use axum::{Json, Router};
-use futures_util::stream::{self, Stream};
 use futures_util::StreamExt;
+use futures_util::stream::{self, Stream};
 use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::sync::broadcast;
 use tokio::time::{Duration, Instant, Interval};
-use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
+use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
 
-use crate::signal::types::{SignalEvent, SignalRoute, TargetType};
 use crate::AppState;
+use crate::signal::types::{SignalEvent, SignalRoute, TargetType};
 
 // ── Request / Response types ────────────────────────────────────
 
@@ -89,9 +89,7 @@ async fn publish_handler(
         topic: req.topic,
         ts: chrono::Utc::now().timestamp_millis() as u64,
         source: req.source.unwrap_or_else(|| "unknown".to_string()),
-        origin_host_id: req
-            .origin_host_id
-            .unwrap_or_else(|| state.host_id.clone()),
+        origin_host_id: req.origin_host_id.unwrap_or_else(|| state.host_id.clone()),
         hop: 0,
         trace_id: req.trace_id,
         payload: req.payload,
@@ -245,10 +243,7 @@ async fn update_route(
 }
 
 /// DELETE /signal-routes/{id}
-async fn delete_route(
-    Path(id): Path<String>,
-    State(state): State<AppState>,
-) -> StatusCode {
+async fn delete_route(Path(id): Path<String>, State(state): State<AppState>) -> StatusCode {
     let deleted = match state.signal_pool.routes().delete(&id) {
         Ok(deleted) => deleted,
         Err(error) => {
@@ -279,10 +274,7 @@ pub fn router() -> Router<AppState> {
         .route("/signals/stream", get(stream_handler))
         .route("/signals/history", get(history_handler))
         .route("/signal-routes", get(list_routes).post(create_route))
-        .route(
-            "/signal-routes/:id",
-            put(update_route).delete(delete_route),
-        )
+        .route("/signal-routes/:id", put(update_route).delete(delete_route))
 }
 
 // ── SSE stream implementation ───────────────────────────────────
@@ -390,24 +382,39 @@ mod tests {
     fn test_state() -> AppState {
         let signal_pool = Arc::new(SignalPool::new(None));
         let host_id = "signals-test-host".to_string();
+        let registry = crate::agent::AgentRegistry::new();
+        let energy_registry = crate::energy::EnergyRegistry::new();
         AppState {
             port: 0,
             host_id: host_id.clone(),
-            registry: crate::agent::AgentRegistry::new(),
+            registry: registry.clone(),
             signal_pool: Arc::clone(&signal_pool),
-            mesh: Arc::new(MeshState::new(host_id.clone(), Arc::clone(&signal_pool), None)),
+            mesh: Arc::new(MeshState::new(
+                host_id.clone(),
+                Arc::clone(&signal_pool),
+                None,
+            )),
             mesh_relay: None,
             auth_secret: None,
             mdns: None,
             pairing: Arc::new(crate::pairing::PairingManager::new()),
             task_store: Arc::new(crate::task::TaskStore::new()),
-            energy_registry: crate::energy::EnergyRegistry::new(),
+            energy_registry: energy_registry.clone(),
+            tick_manager: Arc::new(crate::tick::TickManager::new(
+                host_id.clone(),
+                registry,
+                energy_registry,
+                Arc::clone(&signal_pool),
+            )),
             life_agents: std::collections::HashMap::new(),
             eventlog_store: Arc::new(crate::eventlog::EventLogStore::new(
                 std::env::temp_dir().join("exomind-test-signals"),
             )),
             #[cfg(not(target_os = "android"))]
-            pty_manager: Arc::new(crate::pty::PtyManager::new(Arc::clone(&signal_pool), host_id)),
+            pty_manager: Arc::new(crate::pty::PtyManager::new(
+                Arc::clone(&signal_pool),
+                host_id,
+            )),
         }
     }
 
@@ -455,9 +462,7 @@ mod tests {
                     .method("POST")
                     .uri("/signals/publish")
                     .header("content-type", "application/json")
-                    .body(Body::from(
-                        r#"{"topic":"test","payload":{}}"#,
-                    ))
+                    .body(Body::from(r#"{"topic":"test","payload":{}}"#))
                     .unwrap(),
             )
             .await
@@ -713,16 +718,18 @@ mod tests {
     fn stream_route_matching_accepts_frontend_ui_targets() {
         let signal_pool = SignalPool::new(None);
         let now = chrono::Utc::now().to_rfc3339();
-        signal_pool.routes().add(SignalRoute {
-            id: "route-ui".to_string(),
-            enabled: true,
-            topic: "eventlog.replication.appended".to_string(),
-            target_type: TargetType::Frontend,
-            target_ref: "ui".to_string(),
-            created_at: now.clone(),
-            updated_at: now,
-        })
-        .unwrap();
+        signal_pool
+            .routes()
+            .add(SignalRoute {
+                id: "route-ui".to_string(),
+                enabled: true,
+                topic: "eventlog.replication.appended".to_string(),
+                target_type: TargetType::Frontend,
+                target_ref: "ui".to_string(),
+                created_at: now.clone(),
+                updated_at: now,
+            })
+            .unwrap();
 
         assert!(
             routes_target_stream_subscriber(
@@ -738,16 +745,18 @@ mod tests {
     fn stream_route_matching_keeps_actor_targets_out_of_sse_subscriber() {
         let signal_pool = SignalPool::new(None);
         let now = chrono::Utc::now().to_rfc3339();
-        signal_pool.routes().add(SignalRoute {
-            id: "route-actor".to_string(),
-            enabled: true,
-            topic: "eventlog.replication.appended".to_string(),
-            target_type: TargetType::Actor,
-            target_ref: "eventlog".to_string(),
-            created_at: now.clone(),
-            updated_at: now,
-        })
-        .unwrap();
+        signal_pool
+            .routes()
+            .add(SignalRoute {
+                id: "route-actor".to_string(),
+                enabled: true,
+                topic: "eventlog.replication.appended".to_string(),
+                target_type: TargetType::Actor,
+                target_ref: "eventlog".to_string(),
+                created_at: now.clone(),
+                updated_at: now,
+            })
+            .unwrap();
 
         assert!(
             !routes_target_stream_subscriber(

--- a/crates/exomind-runtime/src/routes/tasks.rs
+++ b/crates/exomind-runtime/src/routes/tasks.rs
@@ -5,9 +5,9 @@ use axum::{Json, Router};
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde::{Deserialize, Serialize};
 
+use crate::AppState;
 use crate::signal::types::SignalEvent;
 use crate::task::{CreateTaskInput, Task, TaskStatus, TransitionInput, UpdateTaskInput};
-use crate::AppState;
 
 // ── Query types ─────────────────────────────────────────────────
 
@@ -170,9 +170,7 @@ async fn delete_task(
     Ok(Json(task))
 }
 
-async fn export_tasks_json(
-    State(state): State<AppState>,
-) -> Json<TaskBackupJsonPayload> {
+async fn export_tasks_json(State(state): State<AppState>) -> Json<TaskBackupJsonPayload> {
     Json(TaskBackupJsonPayload {
         version: 1,
         tasks: state.task_store.list(),
@@ -217,23 +215,28 @@ async fn import_tasks_sqlite(
     Json(payload): Json<TaskBackupSqliteImportPayload>,
 ) -> Result<Json<TaskImportResult>, (StatusCode, String)> {
     let strategy = parse_import_strategy(query.strategy.as_deref())?;
-    let bytes = STANDARD
-        .decode(payload.content_base64)
-        .map_err(|error| (StatusCode::BAD_REQUEST, format!("invalid sqlite snapshot: {error}")))?;
+    let bytes = STANDARD.decode(payload.content_base64).map_err(|error| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("invalid sqlite snapshot: {error}"),
+        )
+    })?;
     let imported_tasks = read_tasks_from_sqlite_snapshot(&bytes)?;
     let result = apply_task_import(&state, imported_tasks, strategy)?;
     Ok(Json(result))
 }
 
-async fn task_backend_status(
-    State(state): State<AppState>,
-) -> Json<TaskBackendStatusResponse> {
+async fn task_backend_status(State(state): State<AppState>) -> Json<TaskBackendStatusResponse> {
     let supports_sqlite_snapshot = matches!(
         state.task_store.backend_kind(),
         crate::task::TaskStoreBackendKind::Sqlite
     );
     Json(TaskBackendStatusResponse {
-        backend: if supports_sqlite_snapshot { "rt-sqlite" } else { "memory" },
+        backend: if supports_sqlite_snapshot {
+            "rt-sqlite"
+        } else {
+            "memory"
+        },
         supports_json_backup: true,
         supports_sqlite_snapshot,
     })
@@ -320,7 +323,10 @@ fn apply_task_import(
 }
 
 fn read_tasks_from_sqlite_snapshot(bytes: &[u8]) -> Result<Vec<Task>, (StatusCode, String)> {
-    let temp_path = std::env::temp_dir().join(format!("exomind-task-import-{}.sqlite", uuid::Uuid::new_v4()));
+    let temp_path = std::env::temp_dir().join(format!(
+        "exomind-task-import-{}.sqlite",
+        uuid::Uuid::new_v4()
+    ));
     std::fs::write(&temp_path, bytes)
         .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;
 
@@ -342,7 +348,10 @@ pub fn router() -> Router<AppState> {
         .route("/tasks/backup/sqlite", get(export_tasks_sqlite))
         .route("/tasks/import/json", post(import_tasks_json))
         .route("/tasks/import/sqlite", post(import_tasks_sqlite))
-        .route("/tasks/:id", get(get_task).put(update_task).delete(delete_task))
+        .route(
+            "/tasks/:id",
+            get(get_task).put(update_task).delete(delete_task),
+        )
         .route("/tasks/:id/transition", post(transition_task))
 }
 
@@ -351,11 +360,11 @@ pub fn router() -> Router<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use base64::engine::general_purpose::STANDARD;
     use crate::signal::SignalPool;
     use crate::task::TaskPriority;
     use axum::body::Body;
     use axum::http::Request;
+    use base64::engine::general_purpose::STANDARD;
     use http_body_util::BodyExt;
     use serde_json::Value;
     use std::sync::Arc;
@@ -369,24 +378,39 @@ mod tests {
     fn test_state_with_task_store(task_store: Arc<crate::task::TaskStore>) -> AppState {
         let signal_pool = Arc::new(SignalPool::new(None));
         let host_id = "tasks-test-host".to_string();
+        let registry = crate::agent::AgentRegistry::new();
+        let energy_registry = crate::energy::EnergyRegistry::new();
         AppState {
             port: 0,
             host_id: host_id.clone(),
-            registry: crate::agent::AgentRegistry::new(),
+            registry: registry.clone(),
             signal_pool: Arc::clone(&signal_pool),
-            mesh: Arc::new(crate::mesh::MeshState::new(host_id.clone(), Arc::clone(&signal_pool), None)),
+            mesh: Arc::new(crate::mesh::MeshState::new(
+                host_id.clone(),
+                Arc::clone(&signal_pool),
+                None,
+            )),
             mesh_relay: None,
             auth_secret: None,
             mdns: None,
             pairing: Arc::new(crate::pairing::PairingManager::new()),
             task_store,
-            energy_registry: crate::energy::EnergyRegistry::new(),
+            energy_registry: energy_registry.clone(),
+            tick_manager: Arc::new(crate::tick::TickManager::new(
+                host_id.clone(),
+                registry,
+                energy_registry,
+                Arc::clone(&signal_pool),
+            )),
             life_agents: std::collections::HashMap::new(),
             eventlog_store: Arc::new(crate::eventlog::EventLogStore::new(
                 std::env::temp_dir().join("exomind-test-tasks"),
             )),
             #[cfg(not(target_os = "android"))]
-            pty_manager: Arc::new(crate::pty::PtyManager::new(Arc::clone(&signal_pool), host_id)),
+            pty_manager: Arc::new(crate::pty::PtyManager::new(
+                Arc::clone(&signal_pool),
+                host_id,
+            )),
         }
     }
 
@@ -611,7 +635,10 @@ mod tests {
             time_block_ids: vec![],
         });
         // Must transition to in_progress first (not_started → abandoned is invalid)
-        state.task_store.transition(&task.id, TaskStatus::InProgress).unwrap();
+        state
+            .task_store
+            .transition(&task.id, TaskStatus::InProgress)
+            .unwrap();
         let _rx = state.signal_pool.subscribe();
         let app = test_router(state);
 
@@ -660,7 +687,10 @@ mod tests {
             estimated_minutes: None,
             time_block_ids: vec![],
         });
-        state.task_store.transition(&t1.id, TaskStatus::InProgress).unwrap();
+        state
+            .task_store
+            .transition(&t1.id, TaskStatus::InProgress)
+            .unwrap();
 
         let app = test_router(state);
 
@@ -711,7 +741,10 @@ mod tests {
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let payload: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(payload["version"], 1);
-        assert_eq!(payload["tasks"].as_array().map(|items| items.len()), Some(1));
+        assert_eq!(
+            payload["tasks"].as_array().map(|items| items.len()),
+            Some(1)
+        );
         assert_eq!(payload["tasks"][0]["done_condition"], "done");
         assert_eq!(payload["tasks"][0]["time_block_ids"][0], "block-1");
     }

--- a/crates/exomind-runtime/src/signal/actors/mod.rs
+++ b/crates/exomind-runtime/src/signal/actors/mod.rs
@@ -1,2 +1,3 @@
 pub mod eventlog_actor;
+pub mod signal_dispatcher_actor;
 pub mod task_classifier_actor;

--- a/crates/exomind-runtime/src/signal/actors/signal_dispatcher_actor.rs
+++ b/crates/exomind-runtime/src/signal/actors/signal_dispatcher_actor.rs
@@ -1,0 +1,246 @@
+use std::sync::Arc;
+
+use tracing::warn;
+
+use crate::agent::AgentRegistry;
+use crate::signal::SignalPool;
+use crate::signal::types::{SignalEvent, TargetType};
+
+const MAX_SIGNAL_HOP: u8 = 5;
+
+/// Spawn the Signal Dispatcher actor.
+/// Signal Dispatcher（信号分发 Actor）负责把 Agent 目标路由真正落到 `agent.on_signal()`。
+pub fn spawn_signal_dispatcher_actor(
+    pool: Arc<SignalPool>,
+    registry: AgentRegistry,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut rx = pool.subscribe();
+
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    dispatch_signal_event(&pool, &registry, &event).await;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(
+                        skipped,
+                        "signal_dispatcher_actor: broadcast receiver lagged, skipped {skipped} events"
+                    );
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    warn!("signal_dispatcher_actor: broadcast channel closed, shutting down");
+                    break;
+                }
+            }
+        }
+    })
+}
+
+async fn dispatch_signal_event(pool: &SignalPool, registry: &AgentRegistry, event: &SignalEvent) {
+    if event.hop >= MAX_SIGNAL_HOP {
+        return;
+    }
+
+    let matched_routes = pool
+        .routes()
+        .match_routes(&event.topic)
+        .into_iter()
+        .filter(|route| route.target_type == TargetType::Agent)
+        .collect::<Vec<_>>();
+
+    for route in matched_routes {
+        let Some(agent) = registry.get(&route.target_ref) else {
+            continue;
+        };
+
+        let outbound = agent.on_signal(event.clone()).await;
+        let next_hop = event.hop.saturating_add(1);
+
+        for mut response in outbound {
+            if response.hop < next_hop {
+                response.hop = next_hop;
+            }
+            if response.trace_id.is_none() {
+                response.trace_id = event.trace_id.clone();
+            }
+            if response.origin_host_id.is_empty() {
+                response.origin_host_id = event.origin_host_id.clone();
+            }
+            pool.publish(response);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::{Agent, ChatChunk, ChatRequest};
+    use crate::signal::SignalRoute;
+    use futures_util::future::BoxFuture;
+    use futures_util::stream::{self, BoxStream, StreamExt};
+    use serde_json::json;
+    use tokio::sync::Mutex;
+
+    struct EmitterAgent;
+
+    impl Agent for EmitterAgent {
+        fn id(&self) -> &str {
+            "agent-a"
+        }
+        fn name(&self) -> &str {
+            "Agent A"
+        }
+        fn description(&self) -> &str {
+            "Emitter test agent"
+        }
+        fn chat_stream(&self, _request: ChatRequest) -> BoxStream<'static, ChatChunk> {
+            stream::empty().boxed()
+        }
+        fn on_signal(&self, event: SignalEvent) -> BoxFuture<'_, Vec<SignalEvent>> {
+            Box::pin(async move {
+                vec![SignalEvent {
+                    schema_version: 1,
+                    id: uuid::Uuid::new_v4().to_string(),
+                    topic: "signal.pong".to_string(),
+                    ts: chrono::Utc::now().timestamp_millis() as u64,
+                    source: "agent:agent-a".to_string(),
+                    origin_host_id: event.origin_host_id.clone(),
+                    hop: 0,
+                    trace_id: None,
+                    payload: json!({
+                        "from": "agent-a",
+                        "received_topic": event.topic,
+                    }),
+                }]
+            })
+        }
+    }
+
+    struct ReceiverAgent {
+        received: Arc<Mutex<Vec<SignalEvent>>>,
+    }
+
+    impl Agent for ReceiverAgent {
+        fn id(&self) -> &str {
+            "agent-b"
+        }
+        fn name(&self) -> &str {
+            "Agent B"
+        }
+        fn description(&self) -> &str {
+            "Receiver test agent"
+        }
+        fn chat_stream(&self, _request: ChatRequest) -> BoxStream<'static, ChatChunk> {
+            stream::empty().boxed()
+        }
+        fn on_signal(&self, event: SignalEvent) -> BoxFuture<'_, Vec<SignalEvent>> {
+            let received = Arc::clone(&self.received);
+            Box::pin(async move {
+                received.lock().await.push(event);
+                Vec::new()
+            })
+        }
+    }
+
+    fn add_agent_route(pool: &SignalPool, topic: &str, target_ref: &str) {
+        let now = chrono::Utc::now().to_rfc3339();
+        pool.routes()
+            .add(SignalRoute {
+                id: uuid::Uuid::new_v4().to_string(),
+                enabled: true,
+                topic: topic.to_string(),
+                target_type: TargetType::Agent,
+                target_ref: target_ref.to_string(),
+                created_at: now.clone(),
+                updated_at: now,
+            })
+            .unwrap();
+    }
+
+    async fn yield_for_actor() {
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+    }
+
+    #[tokio::test]
+    async fn dispatcher_routes_agent_output_to_next_agent() {
+        let pool = Arc::new(SignalPool::new(None));
+        let registry = AgentRegistry::new();
+        let receiver_events = Arc::new(Mutex::new(Vec::new()));
+
+        registry.register(Arc::new(EmitterAgent));
+        registry.register(Arc::new(ReceiverAgent {
+            received: Arc::clone(&receiver_events),
+        }));
+
+        add_agent_route(&pool, "signal.ping", "agent-a");
+        add_agent_route(&pool, "signal.pong", "agent-b");
+
+        let _handle = spawn_signal_dispatcher_actor(Arc::clone(&pool), registry);
+        yield_for_actor().await;
+
+        pool.publish(SignalEvent {
+            schema_version: 1,
+            id: uuid::Uuid::new_v4().to_string(),
+            topic: "signal.ping".to_string(),
+            ts: chrono::Utc::now().timestamp_millis() as u64,
+            source: "agent:test".to_string(),
+            origin_host_id: "dispatcher-test".to_string(),
+            hop: 0,
+            trace_id: Some("trace-dispatch".to_string()),
+            payload: json!({ "text": "hello" }),
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if receiver_events.lock().await.len() == 1 {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("agent-b should receive forwarded signal");
+
+        let received = receiver_events.lock().await;
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].topic, "signal.pong");
+        assert_eq!(received[0].hop, 1);
+        assert_eq!(received[0].trace_id.as_deref(), Some("trace-dispatch"));
+        assert_eq!(received[0].payload["received_topic"], "signal.ping");
+    }
+
+    #[tokio::test]
+    async fn dispatcher_stops_forwarding_when_hop_reaches_limit() {
+        let pool = Arc::new(SignalPool::new(None));
+        let registry = AgentRegistry::new();
+        let receiver_events = Arc::new(Mutex::new(Vec::new()));
+
+        registry.register(Arc::new(EmitterAgent));
+        registry.register(Arc::new(ReceiverAgent {
+            received: Arc::clone(&receiver_events),
+        }));
+
+        add_agent_route(&pool, "signal.ping", "agent-a");
+        add_agent_route(&pool, "signal.pong", "agent-b");
+
+        let _handle = spawn_signal_dispatcher_actor(Arc::clone(&pool), registry);
+        yield_for_actor().await;
+
+        pool.publish(SignalEvent {
+            schema_version: 1,
+            id: uuid::Uuid::new_v4().to_string(),
+            topic: "signal.ping".to_string(),
+            ts: chrono::Utc::now().timestamp_millis() as u64,
+            source: "agent:test".to_string(),
+            origin_host_id: "dispatcher-test".to_string(),
+            hop: MAX_SIGNAL_HOP,
+            trace_id: Some("trace-limit".to_string()),
+            payload: json!({ "text": "blocked" }),
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert!(receiver_events.lock().await.is_empty());
+    }
+}

--- a/crates/exomind-runtime/src/tick.rs
+++ b/crates/exomind-runtime/src/tick.rs
@@ -1,4 +1,6 @@
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::task::JoinHandle;
 
@@ -6,6 +8,122 @@ use crate::agent::AgentRegistry;
 use crate::energy::{AgentEnergy, EnergyRegistry};
 use crate::signal::SignalPool;
 use crate::signal::types::SignalEvent;
+
+/// TickManager holds per-agent tick tasks so routes can revive agents later.
+/// TickManager（tick 管理器）保存每个 agent 的 tick 任务，供路由层在复活时重启。
+pub struct TickManager {
+    cancel: Arc<AtomicBool>,
+    host_id: String,
+    signal_pool: Arc<SignalPool>,
+    registry: AgentRegistry,
+    energy_registry: EnergyRegistry,
+    tasks: RwLock<HashMap<String, JoinHandle<()>>>,
+}
+
+impl TickManager {
+    pub fn new(
+        host_id: String,
+        registry: AgentRegistry,
+        energy_registry: EnergyRegistry,
+        signal_pool: Arc<SignalPool>,
+    ) -> Self {
+        Self {
+            cancel: Arc::new(AtomicBool::new(false)),
+            host_id,
+            signal_pool,
+            registry,
+            energy_registry,
+            tasks: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Spawn a tick loop for a single agent when missing or already finished.
+    /// 为单个 agent 启动 tick；若已有活跃任务则拒绝重复启动。
+    pub fn spawn_tick_for_agent(&self, agent_id: &str) -> bool {
+        if self.cancel.load(Ordering::Relaxed) {
+            return false;
+        }
+
+        let Some(agent) = self.registry.get(agent_id) else {
+            return false;
+        };
+        let interval = agent.tick_interval_secs();
+        if interval == 0 {
+            return false;
+        }
+
+        let Some(energy) = self.energy_registry.get(agent_id) else {
+            return false;
+        };
+
+        let mut tasks = self.tasks.write().unwrap();
+        if let Some(existing) = tasks.get(agent_id)
+            && !existing.is_finished()
+        {
+            return false;
+        }
+
+        let handle = spawn_agent_tick(
+            agent_id.to_string(),
+            interval,
+            energy,
+            Arc::clone(&self.signal_pool),
+            self.registry.clone(),
+            self.host_id.clone(),
+            Arc::clone(&self.cancel),
+        );
+        tasks.insert(agent_id.to_string(), handle);
+        true
+    }
+
+    /// Start ticks for all registered agents with positive intervals.
+    /// 为所有已注册且启用 tick 的 agent 启动循环。
+    pub fn start_all_ticks(&self) -> usize {
+        self.registry
+            .list()
+            .into_iter()
+            .filter(|summary| summary.tick_interval_secs > 0)
+            .filter(|summary| self.spawn_tick_for_agent(&summary.id))
+            .count()
+    }
+
+    pub fn is_tick_running(&self, agent_id: &str) -> bool {
+        self.tasks
+            .read()
+            .unwrap()
+            .get(agent_id)
+            .map(|handle| !handle.is_finished())
+            .unwrap_or(false)
+    }
+
+    /// Abort all tick tasks and permanently mark the manager as stopping.
+    /// 中止全部 tick 任务，并将管理器标记为停止中。
+    pub fn abort_all(&self) {
+        self.cancel.store(true, Ordering::Relaxed);
+        let handles = {
+            let mut tasks = self.tasks.write().unwrap();
+            tasks.drain().map(|(_, handle)| handle).collect::<Vec<_>>()
+        };
+        for handle in handles {
+            handle.abort();
+        }
+    }
+
+    /// Abort all tick tasks and wait for their shutdown.
+    /// 中止全部 tick 任务并等待退出。
+    pub async fn stop_all(&self) {
+        self.cancel.store(true, Ordering::Relaxed);
+        let handles = {
+            let mut tasks = self.tasks.write().unwrap();
+            tasks.drain().map(|(_, handle)| handle).collect::<Vec<_>>()
+        };
+
+        for handle in handles {
+            handle.abort();
+            let _ = handle.await;
+        }
+    }
+}
 
 /// Spawn a tick loop for a single agent.
 ///
@@ -95,12 +213,7 @@ pub fn spawn_agent_tick(
     })
 }
 
-fn publish_dormant(
-    agent_id: &str,
-    total_ticks: u64,
-    signal_pool: &SignalPool,
-    host_id: &str,
-) {
+fn publish_dormant(agent_id: &str, total_ticks: u64, signal_pool: &SignalPool, host_id: &str) {
     let event = SignalEvent {
         schema_version: 1,
         id: uuid::Uuid::new_v4().to_string(),
@@ -159,19 +272,50 @@ mod tests {
     use super::*;
     use crate::agent::{Agent, AgentRegistry, ChatChunk, ChatRequest};
     use crate::energy::{AgentEnergy, AgentEnergySnapshot};
-    use futures_util::stream::{self, BoxStream, StreamExt};
     use futures_util::future::BoxFuture;
+    use futures_util::stream::{self, BoxStream, StreamExt};
 
     struct TickTestAgent;
 
     impl Agent for TickTestAgent {
-        fn id(&self) -> &str { "tick-test" }
-        fn name(&self) -> &str { "Tick Test" }
-        fn description(&self) -> &str { "Test agent for tick" }
+        fn id(&self) -> &str {
+            "tick-test"
+        }
+        fn name(&self) -> &str {
+            "Tick Test"
+        }
+        fn description(&self) -> &str {
+            "Test agent for tick"
+        }
         fn chat_stream(&self, _req: ChatRequest) -> BoxStream<'static, ChatChunk> {
             stream::empty().boxed()
         }
-        fn tick_interval_secs(&self) -> u64 { 1 }
+        fn tick_interval_secs(&self) -> u64 {
+            1
+        }
+        fn on_tick(&self, _energy: &AgentEnergySnapshot) -> BoxFuture<'_, Vec<SignalEvent>> {
+            Box::pin(async { Vec::new() })
+        }
+    }
+
+    struct IdleTickAgent;
+
+    impl Agent for IdleTickAgent {
+        fn id(&self) -> &str {
+            "idle-tick"
+        }
+        fn name(&self) -> &str {
+            "Idle Tick"
+        }
+        fn description(&self) -> &str {
+            "Agent for TickManager tests"
+        }
+        fn chat_stream(&self, _req: ChatRequest) -> BoxStream<'static, ChatChunk> {
+            stream::empty().boxed()
+        }
+        fn tick_interval_secs(&self) -> u64 {
+            1
+        }
         fn on_tick(&self, _energy: &AgentEnergySnapshot) -> BoxFuture<'_, Vec<SignalEvent>> {
             Box::pin(async { Vec::new() })
         }
@@ -208,7 +352,10 @@ mod tests {
             match timeout {
                 Ok(Ok(event)) => {
                     tick_signals.push(event);
-                    if tick_signals.iter().any(|e: &SignalEvent| e.topic == "agent.dormant") {
+                    if tick_signals
+                        .iter()
+                        .any(|e: &SignalEvent| e.topic == "agent.dormant")
+                    {
                         break;
                     }
                 }
@@ -216,13 +363,59 @@ mod tests {
             }
         }
 
-        let tick_count = tick_signals.iter().filter(|e| e.topic == "agent.tick").count();
-        let dormant_count = tick_signals.iter().filter(|e| e.topic == "agent.dormant").count();
+        let tick_count = tick_signals
+            .iter()
+            .filter(|e| e.topic == "agent.tick")
+            .count();
+        let dormant_count = tick_signals
+            .iter()
+            .filter(|e| e.topic == "agent.dormant")
+            .count();
 
         assert_eq!(tick_count, 3, "should have 3 tick signals");
         assert_eq!(dormant_count, 1, "should have 1 dormant signal");
 
         let energy = energy_registry.get("tick-test").unwrap();
         assert!(energy.is_dormant());
+    }
+
+    #[tokio::test]
+    async fn tick_manager_restarts_finished_agent_tick_without_duplication() {
+        let registry = AgentRegistry::new();
+        registry.register(Arc::new(IdleTickAgent));
+
+        let energy_registry = EnergyRegistry::new();
+        energy_registry.register("idle-tick", AgentEnergy::new(10, 10));
+
+        let signal_pool = Arc::new(SignalPool::new(None));
+        let manager = TickManager::new(
+            "tick-manager-test".to_string(),
+            registry,
+            energy_registry.clone(),
+            signal_pool,
+        );
+
+        assert!(manager.spawn_tick_for_agent("idle-tick"));
+        assert!(
+            !manager.spawn_tick_for_agent("idle-tick"),
+            "manager should reject duplicate active tick（运行中任务不可重复启动）"
+        );
+
+        tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
+
+        let energy = energy_registry.get("idle-tick").unwrap();
+        assert!(
+            energy.is_dormant(),
+            "agent should become dormant after one tick"
+        );
+        assert!(!manager.is_tick_running("idle-tick"));
+
+        energy.refill(10);
+        assert!(
+            manager.spawn_tick_for_agent("idle-tick"),
+            "manager should restart finished tick after refill（充能后应允许重新启动）"
+        );
+
+        manager.stop_all().await;
     }
 }

--- a/crates/exomind-runtime/tests/agent_lifecycle_routes.rs
+++ b/crates/exomind-runtime/tests/agent_lifecycle_routes.rs
@@ -1,41 +1,61 @@
 use axum::body::Body;
 use axum::http::Request;
+use exomind_runtime::AppState;
 use exomind_runtime::agent::AgentRegistry;
 use exomind_runtime::mesh::MeshState;
 use exomind_runtime::routes;
 use exomind_runtime::signal::SignalPool;
-use exomind_runtime::AppState;
 use http_body_util::BodyExt;
 use serde_json::Value;
-use std::sync::Mutex;
 use std::sync::Arc;
+use std::sync::Mutex;
 use tower::ServiceExt;
 
 static CODEX_ENV_LOCK: Mutex<()> = Mutex::new(());
 
-#[tokio::test]
-async fn create_and_delete_runtime_agent_via_http_routes() {
-    let signal_pool = Arc::new(SignalPool::new(None));
-    let host_id = "test-agent-lifecycle".to_string();
-    let state = AppState {
-        port: 3919,
-        host_id: host_id.clone(),
-        registry: AgentRegistry::new(),
+fn test_app_state(port: u16, host_id: &str, signal_pool: Arc<SignalPool>) -> AppState {
+    let registry = AgentRegistry::new();
+    let energy_registry = exomind_runtime::energy::EnergyRegistry::new();
+
+    AppState {
+        port,
+        host_id: host_id.to_string(),
+        registry: registry.clone(),
         signal_pool: Arc::clone(&signal_pool),
-        mesh: Arc::new(MeshState::new(host_id.clone(), Arc::clone(&signal_pool), None)),
+        mesh: Arc::new(MeshState::new(
+            host_id.to_string(),
+            Arc::clone(&signal_pool),
+            None,
+        )),
         mesh_relay: None,
         auth_secret: None,
         mdns: None,
         pairing: Arc::new(exomind_runtime::pairing::PairingManager::new()),
         task_store: Arc::new(exomind_runtime::task::TaskStore::new()),
-        energy_registry: exomind_runtime::energy::EnergyRegistry::new(),
+        energy_registry: energy_registry.clone(),
+        tick_manager: Arc::new(exomind_runtime::tick::TickManager::new(
+            host_id.to_string(),
+            registry,
+            energy_registry,
+            Arc::clone(&signal_pool),
+        )),
         life_agents: std::collections::HashMap::new(),
         eventlog_store: Arc::new(exomind_runtime::eventlog::EventLogStore::new(
             std::env::temp_dir().join("exomind-test-agent-lifecycle"),
         )),
         #[cfg(not(target_os = "android"))]
-        pty_manager: Arc::new(exomind_runtime::pty::PtyManager::new(Arc::clone(&signal_pool), host_id)),
-    };
+        pty_manager: Arc::new(exomind_runtime::pty::PtyManager::new(
+            Arc::clone(&signal_pool),
+            host_id.to_string(),
+        )),
+    }
+}
+
+#[tokio::test]
+async fn create_and_delete_runtime_agent_via_http_routes() {
+    let signal_pool = Arc::new(SignalPool::new(None));
+    let host_id = "test-agent-lifecycle".to_string();
+    let state = test_app_state(3919, &host_id, signal_pool);
     let app = routes::router().with_state(state);
 
     let create_response = app
@@ -55,7 +75,12 @@ async fn create_and_delete_runtime_agent_via_http_routes() {
 
     assert_eq!(create_response.status().as_u16(), 201);
 
-    let created_body = create_response.into_body().collect().await.unwrap().to_bytes();
+    let created_body = create_response
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes();
     let created_payload: Value = serde_json::from_slice(&created_body).unwrap();
     assert_eq!(created_payload["id"], "echo-manual");
 
@@ -71,7 +96,12 @@ async fn create_and_delete_runtime_agent_via_http_routes() {
         .unwrap();
 
     assert_eq!(list_response.status().as_u16(), 200);
-    let list_body = list_response.into_body().collect().await.unwrap().to_bytes();
+    let list_body = list_response
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes();
     let list_payload: Value = serde_json::from_slice(&list_body).unwrap();
     assert_eq!(list_payload.as_array().unwrap().len(), 1);
     assert_eq!(list_payload[0]["id"], "echo-manual");
@@ -94,30 +124,15 @@ async fn create_and_delete_runtime_agent_via_http_routes() {
 async fn create_and_delete_codex_runtime_agent_via_http_routes() {
     let _guard = CODEX_ENV_LOCK.lock().unwrap();
     unsafe {
-        std::env::set_var("EXOMIND_CODEX_COMMAND", env!("CARGO_BIN_EXE_fake-codex-cli"));
+        std::env::set_var(
+            "EXOMIND_CODEX_COMMAND",
+            env!("CARGO_BIN_EXE_fake-codex-cli"),
+        );
     }
 
     let signal_pool = Arc::new(SignalPool::new(None));
     let host_id = "test-codex-lifecycle".to_string();
-    let state = AppState {
-        port: 3920,
-        host_id: host_id.clone(),
-        registry: AgentRegistry::new(),
-        signal_pool: Arc::clone(&signal_pool),
-        mesh: Arc::new(MeshState::new(host_id.clone(), Arc::clone(&signal_pool), None)),
-        mesh_relay: None,
-        auth_secret: None,
-        mdns: None,
-        pairing: Arc::new(exomind_runtime::pairing::PairingManager::new()),
-        task_store: Arc::new(exomind_runtime::task::TaskStore::new()),
-        energy_registry: exomind_runtime::energy::EnergyRegistry::new(),
-        life_agents: std::collections::HashMap::new(),
-        eventlog_store: Arc::new(exomind_runtime::eventlog::EventLogStore::new(
-            std::env::temp_dir().join("exomind-test-agent-lifecycle"),
-        )),
-        #[cfg(not(target_os = "android"))]
-        pty_manager: Arc::new(exomind_runtime::pty::PtyManager::new(Arc::clone(&signal_pool), host_id)),
-    };
+    let state = test_app_state(3920, &host_id, signal_pool);
     let app = routes::router().with_state(state);
 
     let create_response = app
@@ -141,7 +156,12 @@ async fn create_and_delete_codex_runtime_agent_via_http_routes() {
 
     assert_eq!(create_response.status().as_u16(), 201);
 
-    let created_body = create_response.into_body().collect().await.unwrap().to_bytes();
+    let created_body = create_response
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes();
     let created_payload: Value = serde_json::from_slice(&created_body).unwrap();
     assert_eq!(created_payload["id"], "codex-manual");
     assert_eq!(created_payload["name"], "Manual Codex");
@@ -151,25 +171,7 @@ async fn create_and_delete_codex_runtime_agent_via_http_routes() {
 async fn create_and_delete_api_runtime_agent_via_http_routes() {
     let signal_pool = Arc::new(SignalPool::new(None));
     let host_id = "test-api-lifecycle".to_string();
-    let state = AppState {
-        port: 3921,
-        host_id: host_id.clone(),
-        registry: AgentRegistry::new(),
-        signal_pool: Arc::clone(&signal_pool),
-        mesh: Arc::new(MeshState::new(host_id.clone(), Arc::clone(&signal_pool), None)),
-        mesh_relay: None,
-        auth_secret: None,
-        mdns: None,
-        pairing: Arc::new(exomind_runtime::pairing::PairingManager::new()),
-        task_store: Arc::new(exomind_runtime::task::TaskStore::new()),
-        energy_registry: exomind_runtime::energy::EnergyRegistry::new(),
-        life_agents: std::collections::HashMap::new(),
-        eventlog_store: Arc::new(exomind_runtime::eventlog::EventLogStore::new(
-            std::env::temp_dir().join("exomind-test-agent-lifecycle"),
-        )),
-        #[cfg(not(target_os = "android"))]
-        pty_manager: Arc::new(exomind_runtime::pty::PtyManager::new(Arc::clone(&signal_pool), host_id)),
-    };
+    let state = test_app_state(3921, &host_id, signal_pool);
     let app = routes::router().with_state(state);
 
     let create_response = app
@@ -207,30 +209,15 @@ async fn create_and_delete_api_runtime_agent_via_http_routes() {
 async fn codex_runtime_agent_chat_route_streams_typed_events() {
     let _guard = CODEX_ENV_LOCK.lock().unwrap();
     unsafe {
-        std::env::set_var("EXOMIND_CODEX_COMMAND", env!("CARGO_BIN_EXE_fake-codex-cli"));
+        std::env::set_var(
+            "EXOMIND_CODEX_COMMAND",
+            env!("CARGO_BIN_EXE_fake-codex-cli"),
+        );
     }
 
     let signal_pool = Arc::new(SignalPool::new(None));
     let host_id = "test-codex-chat-route".to_string();
-    let state = AppState {
-        port: 3922,
-        host_id: host_id.clone(),
-        registry: AgentRegistry::new(),
-        signal_pool: Arc::clone(&signal_pool),
-        mesh: Arc::new(MeshState::new(host_id.clone(), Arc::clone(&signal_pool), None)),
-        mesh_relay: None,
-        auth_secret: None,
-        mdns: None,
-        pairing: Arc::new(exomind_runtime::pairing::PairingManager::new()),
-        task_store: Arc::new(exomind_runtime::task::TaskStore::new()),
-        energy_registry: exomind_runtime::energy::EnergyRegistry::new(),
-        life_agents: std::collections::HashMap::new(),
-        eventlog_store: Arc::new(exomind_runtime::eventlog::EventLogStore::new(
-            std::env::temp_dir().join("exomind-test-agent-lifecycle"),
-        )),
-        #[cfg(not(target_os = "android"))]
-        pty_manager: Arc::new(exomind_runtime::pty::PtyManager::new(Arc::clone(&signal_pool), host_id)),
-    };
+    let state = test_app_state(3922, &host_id, signal_pool);
     let app = routes::router().with_state(state);
 
     let _create_response = app
@@ -264,11 +251,22 @@ async fn codex_runtime_agent_chat_route_streams_typed_events() {
     }
 
     assert_eq!(chat_response.status().as_u16(), 200);
-    let body_bytes = chat_response.into_body().collect().await.unwrap().to_bytes();
+    let body_bytes = chat_response
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes();
     let body_text = String::from_utf8(body_bytes.to_vec()).unwrap();
 
-    assert!(body_text.contains(r#""type":"session.started""#), "{body_text}");
-    assert!(body_text.contains(r#""type":"output.delta""#), "{body_text}");
+    assert!(
+        body_text.contains(r#""type":"session.started""#),
+        "{body_text}"
+    );
+    assert!(
+        body_text.contains(r#""type":"output.delta""#),
+        "{body_text}"
+    );
     assert!(body_text.contains("xiaoming"), "{body_text}");
     assert!(body_text.contains(r#""type":"done""#), "{body_text}");
 }

--- a/src/services/runtime-client.ts
+++ b/src/services/runtime-client.ts
@@ -45,6 +45,12 @@ export interface RuntimeDeleteAgentResponse {
   id: string;
 }
 
+export interface RuntimeRefillEnergyResponse {
+  energy: AgentEnergySnapshot;
+  revived: boolean;
+  tickSpawned: boolean;
+}
+
 type RuntimeFetch = typeof fetch;
 
 export interface RuntimeClientOptions {
@@ -539,6 +545,40 @@ export class RuntimeClient {
     const data = result.data;
     if (!isObjectRecord(data)) return null;
     return data as unknown as AgentEnergySnapshot;
+  }
+
+  async refillEnergy(
+    host: RuntimeHostRecord,
+    agentId: string,
+    amount: number,
+  ): Promise<RuntimeClientResult<RuntimeRefillEnergyResponse>> {
+    const response = await this.sendJson(
+      `${buildBaseUrl(host)}/agents/${encodeURIComponent(agentId)}/energy/refill`,
+      'POST',
+      { amount },
+    );
+    if (!response.ok) {
+      return response;
+    }
+
+    if (!isObjectRecord(response.data) || !isObjectRecord(response.data.energy)) {
+      return {
+        ok: false,
+        error: {
+          code: 'invalid_payload',
+          message: 'invalid refill energy payload（充能响应格式无效）',
+        },
+      };
+    }
+
+    return {
+      ok: true,
+      data: {
+        energy: response.data.energy as unknown as AgentEnergySnapshot,
+        revived: response.data.revived === true,
+        tickSpawned: response.data.tick_spawned === true,
+      },
+    };
   }
 
   async *streamAgentConversation(

--- a/src/ui/app/pages/AgentsPage.tsx
+++ b/src/ui/app/pages/AgentsPage.tsx
@@ -126,7 +126,7 @@ import {
   formatRuntimeEventPayload,
   getConversationMessageTestId,
 } from './agents/conversation-runtime';
-import { EnergyBar } from './agents/AgentDetailPage';
+import { EnergyBar, PHASE_LABELS } from './agents/AgentDetailPage';
 import { WorkspaceTabs } from './agents/WorkspaceTabs';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -489,10 +489,37 @@ function formatSignalTime(timestampMs: number): string {
   });
 }
 
+function formatRelativeSignalTime(timestampMs: number): string {
+  if (!Number.isFinite(timestampMs) || timestampMs <= 0) {
+    return '--';
+  }
+  const diffMs = Date.now() - timestampMs;
+  if (diffMs < 60_000) {
+    return `${Math.max(1, Math.floor(diffMs / 1000))} 秒前`;
+  }
+  if (diffMs < 3_600_000) {
+    return `${Math.floor(diffMs / 60_000)} 分钟前`;
+  }
+  if (diffMs < 86_400_000) {
+    return `${Math.floor(diffMs / 3_600_000)} 小时前`;
+  }
+  return `${Math.floor(diffMs / 86_400_000)} 天前`;
+}
+
+function signalTopicTint(topic: string): string {
+  if (topic.startsWith('agent.')) return '#0D9488';
+  if (topic.startsWith('task.')) return '#F59E0B';
+  if (topic.startsWith('eventlog.')) return '#1D4ED8';
+  if (topic.startsWith('voice.')) return '#7C3AED';
+  return '#C75B3A';
+}
+
 type SignalFlowNodeData = {
   label: string;
   subtitle: string;
   nodeType: SignalGraphNodeType;
+  energyPhase?: string;
+  isDormant?: boolean;
 };
 
 type SignalFlowNodeType = FlowNode<SignalFlowNodeData, SignalGraphNodeType>;
@@ -513,6 +540,7 @@ function signalNodeTypeBadgeLabel(nodeType: SignalGraphNodeType): string {
 
 function SignalFlowNode({ data }: FlowNodeProps<SignalFlowNodeType>) {
   const tint = nodeTypeTint(data.nodeType);
+  const lifecycleTint = data.energyPhase ? (ENERGY_PHASE_COLORS[data.energyPhase] ?? tint) : tint;
   const handleBaseStyle = {
     width: 8,
     height: 8,
@@ -526,9 +554,9 @@ function SignalFlowNode({ data }: FlowNodeProps<SignalFlowNodeType>) {
       <div className="relative h-[70px] w-[130px]">
         <Handle type="target" position={Position.Left} style={handleBaseStyle} />
         <Handle type="source" position={Position.Right} style={handleBaseStyle} />
-        <div
-          className="absolute left-1/2 top-1/2 h-[64px] w-[64px] -translate-x-1/2 -translate-y-1/2 rotate-45 rounded-md border bg-card"
-          style={{ borderColor: `${tint}80` }}
+      <div
+        className="absolute left-1/2 top-1/2 h-[64px] w-[64px] -translate-x-1/2 -translate-y-1/2 rotate-45 rounded-md border bg-card"
+          style={{ borderColor: `${lifecycleTint}80` }}
         />
         <div className="absolute inset-0 flex flex-col items-center justify-center">
           <p className="max-w-[120px] truncate text-xs font-semibold text-foreground">{data.label}</p>
@@ -549,11 +577,16 @@ function SignalFlowNode({ data }: FlowNodeProps<SignalFlowNodeType>) {
 
   return (
     <div
-      className={`min-w-[120px] border bg-card text-center shadow-sm ${shapeClass}`}
-      style={{ borderColor: `${tint}80` }}
+      className={`relative min-w-[120px] border bg-card text-center shadow-sm ${shapeClass}`}
+      style={{ borderColor: `${lifecycleTint}80`, boxShadow: data.nodeType === 'agent' ? `0 0 0 1px ${lifecycleTint}20` : undefined }}
     >
       <Handle type="target" position={Position.Left} style={handleBaseStyle} />
       <Handle type="source" position={Position.Right} style={handleBaseStyle} />
+      {data.isDormant && (
+        <span className="absolute right-2 top-2 rounded-full bg-[#6B7280]/15 px-1.5 py-0.5 text-[9px] font-semibold text-[#6B7280]">
+          dormant
+        </span>
+      )}
       <p className="truncate text-xs font-semibold text-foreground">{data.label}</p>
       <p className="mt-1 truncate text-[10px] text-muted-foreground">{data.subtitle}</p>
     </div>
@@ -650,8 +683,15 @@ function TopologyView({
       draggable: layoutMode === 'manual',
       data: {
         label: node.label,
-        subtitle: node.status,
+        subtitle: node.type === 'agent'
+          ? [
+              node.status,
+              node.energyPhase ? (PHASE_LABELS[node.energyPhase] ?? node.energyPhase) : null,
+            ].filter(Boolean).join(' · ')
+          : node.status,
         nodeType: node.type,
+        energyPhase: node.energyPhase,
+        isDormant: node.isDormant,
       },
     }));
   }, [graph.nodes, layoutMode]);
@@ -2104,6 +2144,16 @@ function SignalHistoryTabView({
   hostLabel?: string;
   onSelectSignal: (signalId: string) => void;
 }) {
+  const [topicFilter, setTopicFilter] = useState<string>('all');
+  const topicOptions = useMemo(
+    () => ['all', ...Array.from(new Set(events.map((eventItem) => eventItem.topic))).slice(0, 8)],
+    [events],
+  );
+  const filteredEvents = useMemo(
+    () => (topicFilter === 'all' ? events : events.filter((eventItem) => eventItem.topic === topicFilter)),
+    [events, topicFilter],
+  );
+
   return (
     <section data-testid="agent-signal-history-view" className="space-y-3">
       <div className="flex items-center justify-between">
@@ -2115,37 +2165,74 @@ function SignalHistoryTabView({
             </span>
           )}
         </div>
-        <span className="text-xs text-[#78716C] dark:text-[#A8A29E]">{events.length} 条</span>
+        <span className="text-xs text-[#78716C] dark:text-[#A8A29E]">{filteredEvents.length} 条</span>
       </div>
 
-      {events.length === 0 ? (
+      <div className="flex flex-wrap gap-2">
+        {topicOptions.map((topic) => {
+          const active = topicFilter === topic;
+          return (
+            <button
+              key={topic}
+              type="button"
+              onClick={() => setTopicFilter(topic)}
+              className={`rounded-full px-2.5 py-1 text-[10px] font-medium ${
+                active
+                  ? 'bg-[#C75B3A] text-white'
+                  : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'
+              }`}
+            >
+              {topic === 'all' ? '全部主题' : `主题 ${topic}`}
+            </button>
+          );
+        })}
+      </div>
+
+      {filteredEvents.length === 0 ? (
         <div className="rounded-[10px] border border-[#E7E3E0] bg-white px-4 py-8 text-center text-xs text-[#78716C] dark:border-[#292524] dark:bg-[#0C0A09] dark:text-[#A8A29E]">
           暂无信号历史
         </div>
       ) : (
         <div className="divide-y divide-[#E7E3E0] overflow-hidden rounded-[10px] border border-[#E7E3E0] bg-white dark:divide-[#292524] dark:border-[#292524] dark:bg-[#0C0A09]">
-          {events.map((eventItem) => (
-            <button
+          {filteredEvents.map((eventItem) => {
+            const payloadText = formatSignalPayload(eventItem.payload);
+            const tint = signalTopicTint(eventItem.topic);
+
+            return (
+            <div
               key={eventItem.id}
-              type="button"
-              onClick={() => onSelectSignal(`topic:${eventItem.topic}`)}
-              className="flex w-full items-start gap-3 px-4 py-3 text-left hover:bg-[#FAF7F5] dark:hover:bg-[#1C1917]"
+              className="overflow-hidden"
             >
-              <span className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full bg-[#C75B3A]" />
-              <div className="min-w-0 flex-1">
-                <p className="truncate font-mono text-xs text-[#44403C] dark:text-[#D6D3D1]">{eventItem.topic}</p>
-                <p className="mt-1 line-clamp-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
-                  {formatSignalPayload(eventItem.payload)}
-                </p>
-              </div>
-              <div className="shrink-0 text-right">
-                <p className="text-[10px] text-[#78716C] dark:text-[#A8A29E]">
-                  {formatSignalTime(eventItem.ts)}
-                </p>
-                <p className="mt-0.5 text-[10px] text-[#A8A29E] dark:text-[#78716C]">{eventItem.source}</p>
-              </div>
-            </button>
-          ))}
+              <button
+                type="button"
+                onClick={() => onSelectSignal(eventItem.id)}
+                className="flex w-full items-start gap-3 px-4 py-3 text-left hover:bg-[#FAF7F5] dark:hover:bg-[#1C1917]"
+              >
+                <span className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: tint }} />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-mono text-xs text-[#44403C] dark:text-[#D6D3D1]">{eventItem.topic}</p>
+                  <p className="mt-1 line-clamp-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
+                    {payloadText}
+                  </p>
+                </div>
+                <div className="shrink-0 text-right">
+                  <p className="text-[10px] text-[#78716C] dark:text-[#A8A29E]">
+                    {formatRelativeSignalTime(eventItem.ts)}
+                  </p>
+                  <p className="mt-0.5 text-[10px] text-[#A8A29E] dark:text-[#78716C]">{formatSignalTime(eventItem.ts)}</p>
+                  <p className="mt-0.5 text-[10px] text-[#A8A29E] dark:text-[#78716C]">{eventItem.source}</p>
+                </div>
+              </button>
+              <details className="border-t border-[#F5F0ED] px-4 py-2 dark:border-[#1C1917]">
+                <summary className="cursor-pointer text-[11px] text-[#78716C] dark:text-[#A8A29E]">
+                  展开 payload
+                </summary>
+                <pre className="mt-2 overflow-x-auto rounded-lg bg-[#FAF7F5] p-3 text-[10px] text-[#57534E] dark:bg-[#1C1917] dark:text-[#D6D3D1]">
+                  {`Payload:\n${payloadText}`}
+                </pre>
+              </details>
+            </div>
+          )})}
         </div>
       )}
     </section>
@@ -2313,6 +2400,7 @@ export function AgentsPage() {
   const [agentDetail, setAgentDetail] = useState<AgentDetailData | null>(null);
   const [isDetailLoading, setIsDetailLoading] = useState(false);
   const [panelEnergy, setPanelEnergy] = useState<AgentEnergySnapshot | null>(null);
+  const [isPanelRefilling, setIsPanelRefilling] = useState(false);
 
   useEffect(() => {
     if (rightPanel.state === 'AGENT_DETAIL' || rightPanel.state === 'ACTOR_DETAIL') {
@@ -2322,6 +2410,7 @@ export function AgentsPage() {
       setIsDetailLoading(true);
       setAgentDetail(null);
       setPanelEnergy(null);
+      setIsPanelRefilling(false);
       const service = getAgentHubService();
       const loader = rightPanel.state === 'AGENT_DETAIL'
         ? service.getAgentDetail(runtimeEntityId)
@@ -2335,6 +2424,7 @@ export function AgentsPage() {
     } else {
       setAgentDetail(null);
       setPanelEnergy(null);
+      setIsPanelRefilling(false);
     }
   }, [rightPanel.state, rightPanel.nodeId]);
 
@@ -2362,6 +2452,27 @@ export function AgentsPage() {
       clearInterval(timer);
     };
   }, [rightPanel.state, rightPanel.nodeId, runtimeHostSnapshots, activeSignalRouteHost]);
+
+  const handlePanelRefillEnergy = async () => {
+    if (rightPanel.state !== 'AGENT_DETAIL' || !rightPanel.nodeId || !panelEnergy || isPanelRefilling) return;
+    const nodeId = rightPanel.nodeId;
+    const runtimeEntityId = resolveRuntimeEntityId(nodeId);
+    const preferredHostId = extractPreferredHostId(nodeId);
+    const host = findPreferredRuntimeHostForAgent(runtimeHostSnapshots, runtimeEntityId, preferredHostId)
+      ?? activeSignalRouteHost;
+    if (!host) return;
+
+    setIsPanelRefilling(true);
+    try {
+      const client = new RuntimeClient();
+      const result = await client.refillEnergy(host, runtimeEntityId, panelEnergy.max);
+      if (result.ok) {
+        setPanelEnergy(result.data.energy);
+      }
+    } finally {
+      setIsPanelRefilling(false);
+    }
+  };
 
   useEffect(() => {
     if (!selectedProviderProfileId) return;
@@ -3685,7 +3796,13 @@ export function AgentsPage() {
                           </div>
                         ) : null}
 
-                        {panelEnergy && <EnergyBar energy={panelEnergy} />}
+                        {panelEnergy && (
+                          <EnergyBar
+                            energy={panelEnergy}
+                            onRefill={handlePanelRefillEnergy}
+                            isRefilling={isPanelRefilling}
+                          />
+                        )}
 
                         {!isDetailLoading && agentDetail?.triggerRules.length ? (
                           <Card className="rounded-xl border-border-card bg-card shadow-sm">
@@ -3778,10 +3895,11 @@ export function AgentsPage() {
                 <div data-testid="agent-rightpanel-signal-detail" className="flex flex-col gap-3 p-4 text-foreground">
                   {(() => {
                     const nodeId = rightPanel.signalId;
+                    const historyEvent = nodeId ? signalHistory.find((eventItem) => eventItem.id === nodeId) : null;
                     const normalizedNodeId = nodeId?.includes(':')
                       ? nodeId.split(':').slice(1).join(':')
                       : nodeId;
-                    const routeMatchKey = normalizedNodeId ?? nodeId ?? '';
+                    const routeMatchKey = historyEvent?.topic ?? normalizedNodeId ?? nodeId ?? '';
                     const node =
                       (nodeId ? signalGraph.nodes.find((n) => n.id === nodeId) : null) ??
                       (normalizedNodeId
@@ -3805,9 +3923,47 @@ export function AgentsPage() {
                     return (
                       <>
                         <div className="flex flex-col gap-1">
-                          <p className="text-xs font-medium text-muted-foreground">节点 ID</p>
+                          <p className="text-xs font-medium text-muted-foreground">
+                            {historyEvent ? '信号 ID' : '节点 ID'}
+                          </p>
                           <p className="font-mono text-sm text-foreground">{nodeId ?? '—'}</p>
                         </div>
+
+                        {historyEvent && (
+                          <div className="flex flex-col gap-3 rounded-xl border border-border-card bg-card p-3">
+                            <div className="flex items-center gap-2">
+                              <span
+                                className="h-2 w-2 rounded-full"
+                                style={{ backgroundColor: signalTopicTint(historyEvent.topic) }}
+                              />
+                              <p className="font-mono text-xs text-foreground">{historyEvent.topic}</p>
+                            </div>
+                            <div className="grid grid-cols-2 gap-3">
+                              <div className="flex flex-col gap-0.5">
+                                <p className="text-[10px] text-muted-foreground">来源</p>
+                                <p className="text-xs text-foreground">{historyEvent.source}</p>
+                              </div>
+                              <div className="flex flex-col gap-0.5">
+                                <p className="text-[10px] text-muted-foreground">时间</p>
+                                <p className="text-xs text-foreground">{formatSignalTime(historyEvent.ts)}</p>
+                              </div>
+                              <div className="flex flex-col gap-0.5">
+                                <p className="text-[10px] text-muted-foreground">主机</p>
+                                <p className="text-xs text-foreground">{historyEvent.origin_host_id}</p>
+                              </div>
+                              <div className="flex flex-col gap-0.5">
+                                <p className="text-[10px] text-muted-foreground">跳数</p>
+                                <p className="text-xs text-foreground">{historyEvent.hop}</p>
+                              </div>
+                            </div>
+                            <div className="flex flex-col gap-1">
+                              <p className="text-[10px] text-muted-foreground">Payload</p>
+                              <pre className="overflow-x-auto rounded-lg bg-background p-3 text-[10px] text-foreground">
+                                {formatSignalPayload(historyEvent.payload)}
+                              </pre>
+                            </div>
+                          </div>
+                        )}
 
                         {node && (
                           <div className="flex flex-col gap-3">

--- a/src/ui/app/pages/AgentsPage.tsx
+++ b/src/ui/app/pages/AgentsPage.tsx
@@ -2176,6 +2176,7 @@ function SignalHistoryTabView({
               key={topic}
               type="button"
               onClick={() => setTopicFilter(topic)}
+              data-testid={`signal-history-filter-${topic === 'all' ? 'all' : topic}`}
               className={`rounded-full px-2.5 py-1 text-[10px] font-medium ${
                 active
                   ? 'bg-[#C75B3A] text-white'
@@ -2201,11 +2202,13 @@ function SignalHistoryTabView({
             return (
             <div
               key={eventItem.id}
+              data-testid={`signal-history-item-${eventItem.id}`}
               className="overflow-hidden"
             >
               <button
                 type="button"
                 onClick={() => onSelectSignal(eventItem.id)}
+                data-testid={`signal-history-open-${eventItem.id}`}
                 className="flex w-full items-start gap-3 px-4 py-3 text-left hover:bg-[#FAF7F5] dark:hover:bg-[#1C1917]"
               >
                 <span className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: tint }} />
@@ -2223,7 +2226,10 @@ function SignalHistoryTabView({
                   <p className="mt-0.5 text-[10px] text-[#A8A29E] dark:text-[#78716C]">{eventItem.source}</p>
                 </div>
               </button>
-              <details className="border-t border-[#F5F0ED] px-4 py-2 dark:border-[#1C1917]">
+              <details
+                data-testid={`signal-history-payload-${eventItem.id}`}
+                className="border-t border-[#F5F0ED] px-4 py-2 dark:border-[#1C1917]"
+              >
                 <summary className="cursor-pointer text-[11px] text-[#78716C] dark:text-[#A8A29E]">
                   展开 payload
                 </summary>

--- a/src/ui/app/pages/agents-signal-topology.ts
+++ b/src/ui/app/pages/agents-signal-topology.ts
@@ -23,6 +23,9 @@ export interface SignalGraphNode {
   type: SignalGraphNodeType;
   label: string;
   status: string;
+  energyPhase?: string;
+  isDormant?: boolean;
+  energyRatio?: number;
   position: {
     x: number;
     y: number;
@@ -74,11 +77,26 @@ export function buildSignalRouteRows(routes: SignalRoute[], hostLabel?: string):
   }));
 }
 
-function getAgentStatusMap(agents: RuntimeAggregatedAgent[]): Map<string, string> {
-  const map = new Map<string, string>();
+function getAgentMetaMap(agents: RuntimeAggregatedAgent[]): Map<string, {
+  status: string;
+  energyPhase?: string;
+  isDormant?: boolean;
+  energyRatio?: number;
+}> {
+  const map = new Map<string, {
+    status: string;
+    energyPhase?: string;
+    isDormant?: boolean;
+    energyRatio?: number;
+  }>();
   for (const agent of agents) {
     if (!map.has(agent.id)) {
-      map.set(agent.id, agent.status);
+      map.set(agent.id, {
+        status: agent.status,
+        energyPhase: agent.energy?.phase,
+        isDormant: agent.energy?.is_dormant,
+        energyRatio: agent.energy?.ratio,
+      });
     }
   }
   return map;
@@ -118,7 +136,7 @@ function getInputNodeForTopic(topic: string): Pick<SignalGraphNode, 'id' | 'type
 export function buildSignalGraph(routes: SignalRoute[], agents: RuntimeAggregatedAgent[]): SignalGraph {
   const nextNodes = new Map<string, SignalGraphNode>();
   const nextEdges = new Map<string, SignalGraphEdge>();
-  const statusByAgentId = getAgentStatusMap(agents);
+  const metaByAgentId = getAgentMetaMap(agents);
   const rowByType = new Map<SignalGraphNodeType, number>([
     ['signal-input', 0],
     ['topic', 0],
@@ -177,12 +195,16 @@ export function buildSignalGraph(routes: SignalRoute[], agents: RuntimeAggregate
     if (!nextNodes.has(toNodeId)) {
       const kind = route.target_type as SignalGraphNodeType;
       const row = rowByType.get(kind) ?? 0;
-      const status = kind === 'agent' ? (statusByAgentId.get(route.target_ref) ?? 'unknown') : nodeTypeLabel(kind);
+      const agentMeta = kind === 'agent' ? metaByAgentId.get(route.target_ref) : undefined;
+      const status = kind === 'agent' ? (agentMeta?.status ?? 'unknown') : nodeTypeLabel(kind);
       nextNodes.set(toNodeId, {
         id: toNodeId,
         type: kind,
         label: route.target_ref,
         status,
+        energyPhase: agentMeta?.energyPhase,
+        isDormant: agentMeta?.isDormant,
+        energyRatio: agentMeta?.energyRatio,
         position: {
           x: 120 + nodeTypeToColumn(kind) * 240,
           y: 80 + row * 110,
@@ -209,11 +231,15 @@ export function buildSignalGraph(routes: SignalRoute[], agents: RuntimeAggregate
     const agentNodeId = targetNodeId('agent', agent.id);
     if (!nextNodes.has(agentNodeId)) {
       const row = rowByType.get('agent') ?? 0;
+      const agentMeta = metaByAgentId.get(agent.id);
       nextNodes.set(agentNodeId, {
         id: agentNodeId,
         type: 'agent',
         label: agent.id,
-        status: statusByAgentId.get(agent.id) ?? 'unknown',
+        status: agentMeta?.status ?? 'unknown',
+        energyPhase: agentMeta?.energyPhase,
+        isDormant: agentMeta?.isDormant,
+        energyRatio: agentMeta?.energyRatio,
         position: {
           x: 120 + nodeTypeToColumn('agent') * 240,
           y: 80 + row * 110,

--- a/src/ui/app/pages/agents/AgentDetailPage.tsx
+++ b/src/ui/app/pages/agents/AgentDetailPage.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { getAgentHubService } from '@/lib/services';
 import type { AgentDetailData, AgentEnergySnapshot, AgentHubListItem } from '@/lib/types/agent-hub';
 import { getRuntimeHostService } from '@/lib/services/runtime-host.service';
+import { RuntimeClient } from '@/services/runtime-client';
 import { useIsDesktop } from '@/ui/app/hooks/useIsDesktop';
 import { WorkspaceTabs } from './WorkspaceTabs';
 
@@ -22,10 +23,19 @@ export const PHASE_COLORS: Record<string, string> = {
   dormant: '#6B7280',
 };
 
-export function EnergyBar({ energy }: { energy: AgentEnergySnapshot }) {
+export function EnergyBar({
+  energy,
+  onRefill,
+  isRefilling = false,
+}: {
+  energy: AgentEnergySnapshot;
+  onRefill?: () => void;
+  isRefilling?: boolean;
+}) {
   const percent = Math.round(energy.ratio * 100);
   const color = PHASE_COLORS[energy.phase] ?? '#6B7280';
   const label = PHASE_LABELS[energy.phase] ?? energy.phase;
+  const showRefillAction = energy.is_dormant && typeof onRefill === 'function';
 
   return (
     <section className="mt-4">
@@ -34,16 +44,28 @@ export function EnergyBar({ energy }: { energy: AgentEnergySnapshot }) {
         生命能量 (C1)
       </h3>
       <div className="mt-2 rounded-2xl border border-border-card bg-card p-4">
-        <div className="mb-2 flex items-center justify-between">
+        <div className="mb-2 flex items-center justify-between gap-3">
           <span className="text-xs text-muted-foreground">
             {energy.current} / {energy.max}
           </span>
-          <span
-            className="rounded-full px-2 py-0.5 text-xs font-semibold"
-            style={{ color, backgroundColor: `${color}15` }}
-          >
-            {label}
-          </span>
+          <div className="flex items-center gap-2">
+            <span
+              className="rounded-full px-2 py-0.5 text-xs font-semibold"
+              style={{ color, backgroundColor: `${color}15` }}
+            >
+              {label}
+            </span>
+            {showRefillAction && (
+              <button
+                type="button"
+                onClick={onRefill}
+                disabled={isRefilling}
+                className="rounded-full bg-[#C75B3A] px-3 py-1 text-[11px] font-semibold text-white disabled:cursor-not-allowed disabled:bg-[#C75B3A80]"
+              >
+                {isRefilling ? '充能中...' : '充能复活'}
+              </button>
+            )}
+          </div>
         </div>
         <div className="h-3 overflow-hidden rounded-full bg-muted">
           <div
@@ -77,6 +99,7 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
   const [detail, setDetail] = useState<AgentDetailData | null>(null);
   const [loading, setLoading] = useState(true);
   const [energy, setEnergy] = useState<AgentEnergySnapshot | null>(null);
+  const [isRefilling, setIsRefilling] = useState(false);
   const targetId = agentId ?? '';
 
   useEffect(() => {
@@ -86,6 +109,7 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
         if (!disposed) {
           setDetail(null);
           setLoading(false);
+          setIsRefilling(false);
         }
         return;
       }
@@ -139,6 +163,23 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
       clearInterval(timer);
     };
   }, [targetId]);
+
+  const handleRefillEnergy = async () => {
+    if (!targetId || !energy || isRefilling) return;
+    setIsRefilling(true);
+    try {
+      const hosts = await getRuntimeHostService().listHosts();
+      const host = hosts[0];
+      if (!host) return;
+      const client = new RuntimeClient();
+      const result = await client.refillEnergy(host, targetId, energy.max);
+      if (result.ok) {
+        setEnergy(result.data.energy);
+      }
+    } finally {
+      setIsRefilling(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -212,7 +253,7 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
         </div>
       </section>
 
-      {energy && <EnergyBar energy={energy} />}
+      {energy && <EnergyBar energy={energy} onRefill={handleRefillEnergy} isRefilling={isRefilling} />}
 
       {/* Workspace tabs — shown for life agents (those with workspace) */}
       <WorkspaceTabs agentId={targetId} />

--- a/src/ui/app/pages/agents/AgentDetailPage.tsx
+++ b/src/ui/app/pages/agents/AgentDetailPage.tsx
@@ -4,6 +4,7 @@ import { getAgentHubService } from '@/lib/services';
 import type { AgentDetailData, AgentEnergySnapshot, AgentHubListItem } from '@/lib/types/agent-hub';
 import { getRuntimeHostService } from '@/lib/services/runtime-host.service';
 import { RuntimeClient } from '@/services/runtime-client';
+import { findPreferredRuntimeHostForAgent, getRuntimeManager } from '@/services/runtime-manager';
 import { useIsDesktop } from '@/ui/app/hooks/useIsDesktop';
 import { WorkspaceTabs } from './WorkspaceTabs';
 
@@ -94,6 +95,17 @@ function getTargetIcon(target: AgentHubListItem) {
   return Sparkles;
 }
 
+async function resolveAgentRuntimeHost(agentId: string) {
+  const snapshot = await getRuntimeManager().refreshSnapshot();
+  const preferredHost = findPreferredRuntimeHostForAgent(snapshot.hosts, agentId);
+  if (preferredHost) {
+    return preferredHost;
+  }
+
+  const hosts = await getRuntimeHostService().listHosts();
+  return hosts[0] ?? null;
+}
+
 export function AgentDetailPage({ agentId }: { agentId?: string }) {
   const isDesktop = useIsDesktop();
   const [detail, setDetail] = useState<AgentDetailData | null>(null);
@@ -140,17 +152,14 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
   useEffect(() => {
     if (!targetId) return;
     let disposed = false;
+    const client = new RuntimeClient();
 
     const poll = async () => {
       try {
-        const hosts = await getRuntimeHostService().listHosts();
-        if (hosts.length === 0 || disposed) return;
-        const host = hosts[0];
-        const url = `http://${host.host}:${host.port}/agents/${encodeURIComponent(targetId)}/energy`;
-        const resp = await fetch(url, { signal: AbortSignal.timeout(3000) });
-        if (!resp.ok || disposed) return;
-        const snap: AgentEnergySnapshot = await resp.json();
-        if (!disposed) setEnergy(snap);
+        const host = await resolveAgentRuntimeHost(targetId);
+        if (!host || disposed) return;
+        const snap = await client.getAgentEnergy(host, targetId);
+        if (!disposed && snap) setEnergy(snap);
       } catch {
         // ignore polling errors
       }
@@ -168,8 +177,7 @@ export function AgentDetailPage({ agentId }: { agentId?: string }) {
     if (!targetId || !energy || isRefilling) return;
     setIsRefilling(true);
     try {
-      const hosts = await getRuntimeHostService().listHosts();
-      const host = hosts[0];
+      const host = await resolveAgentRuntimeHost(targetId);
       if (!host) return;
       const client = new RuntimeClient();
       const result = await client.refillEnergy(host, targetId, energy.max);

--- a/tests/unit/services/runtime-client.issue201.test.ts
+++ b/tests/unit/services/runtime-client.issue201.test.ts
@@ -226,4 +226,42 @@ describe('runtime client issue-201（Runtime HTTP 客户端）', () => {
       }),
     }));
   });
+
+  it('posts refill energy request and normalizes response（POST 充能请求并解析 revive 响应）', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        energy: {
+          agent_id: 'life-alpha',
+          current: 100,
+          max: 100,
+          ratio: 1,
+          tick_cost: 5,
+          phase: 'normal',
+          is_dormant: false,
+        },
+        revived: true,
+        tick_spawned: true,
+      }),
+    }));
+
+    const client = new RuntimeClient({ fetchImpl });
+    const result = await client.refillEnergy(SAMPLE_HOST, 'life-alpha', 100);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.data.revived).toBe(true);
+    expect(result.data.tickSpawned).toBe(true);
+    expect(result.data.energy.agent_id).toBe('life-alpha');
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://127.0.0.1:1919/agents/life-alpha/energy/refill',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ amount: 100 }),
+      }),
+    );
+  });
 });

--- a/tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx
+++ b/tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { AgentDetailPage } from '@/ui/app/pages/agents/AgentDetailPage';
 import { ActorDetailPage } from '@/ui/app/pages/agents/ActorDetailPage';
 import { AGENT_HUB_MOCK_FIXTURE } from '@/lib/adapters/mock/fixtures/agent-hub';
@@ -9,6 +9,14 @@ const serviceMocks = vi.hoisted(() => ({
   getActorDetail: vi.fn(),
 }));
 
+const runtimeManagerMocks = vi.hoisted(() => ({
+  refreshSnapshot: vi.fn(),
+}));
+
+const runtimeHostServiceMocks = vi.hoisted(() => ({
+  listHosts: vi.fn(),
+}));
+
 vi.mock('@/lib/services', () => ({
   getAgentHubService: () => ({
     getAgentDetail: serviceMocks.getAgentDetail,
@@ -16,10 +24,28 @@ vi.mock('@/lib/services', () => ({
   }),
 }));
 
+vi.mock('@/services/runtime-manager', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/runtime-manager')>();
+  return {
+    ...actual,
+    getRuntimeManager: () => runtimeManagerMocks,
+  };
+});
+
+vi.mock('@/lib/services/runtime-host.service', () => ({
+  getRuntimeHostService: () => runtimeHostServiceMocks,
+}));
+
 describe('agent/actor detail pages issue-204（详情页）', () => {
   beforeEach(() => {
     serviceMocks.getAgentDetail.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.agentDetails['agent-daily']);
     serviceMocks.getActorDetail.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.actorDetails['actor-timer']);
+    runtimeManagerMocks.refreshSnapshot.mockResolvedValue({
+      updatedAt: '2026-03-11T00:00:00.000Z',
+      agents: [],
+      hosts: [],
+    });
+    runtimeHostServiceMocks.listHosts.mockResolvedValue([]);
   });
 
   it('renders agent detail sections and chat CTA（Agent 详情区块与对话入口）', async () => {
@@ -76,5 +102,151 @@ describe('agent/actor detail pages issue-204（详情页）', () => {
 
     expect(screen.queryByText('Actor 详情加载中...')).not.toBeInTheDocument();
     expect(screen.getByText('未找到 Actor 详情')).toBeInTheDocument();
+  });
+
+  it('uses preferred runtime host for energy polling and refill（能量轮询与充能应命中目标 agent 所在主机）', async () => {
+    runtimeManagerMocks.refreshSnapshot.mockResolvedValue({
+      updatedAt: '2026-03-11T00:00:00.000Z',
+      agents: [
+        {
+          id: 'agent-daily',
+          name: '日报 Agent',
+          description: 'Daily summary',
+          status: 'available',
+          sourceHostId: 'host-b',
+          sourceHostName: 'Host B',
+          sourceHostAddress: '10.0.0.2:2999',
+        },
+      ],
+      hosts: [
+        {
+          host: {
+            id: 'host-a',
+            name: 'Host A',
+            host: '10.0.0.1',
+            port: 1999,
+            status: 'unknown',
+            createdAt: '2026-03-11T00:00:00.000Z',
+            updatedAt: '2026-03-11T00:00:00.000Z',
+          },
+          connectionState: 'online',
+          agents: [],
+          topology: null,
+        },
+        {
+          host: {
+            id: 'host-b',
+            name: 'Host B',
+            host: '10.0.0.2',
+            port: 2999,
+            status: 'unknown',
+            createdAt: '2026-03-11T00:00:00.000Z',
+            updatedAt: '2026-03-11T00:00:00.000Z',
+          },
+          connectionState: 'online',
+          agents: [
+            {
+              id: 'agent-daily',
+              name: '日报 Agent',
+              description: 'Daily summary',
+              status: 'available',
+              sourceHostId: 'host-b',
+              sourceHostName: 'Host B',
+              sourceHostAddress: '10.0.0.2:2999',
+            },
+          ],
+          topology: null,
+        },
+      ],
+    });
+
+    runtimeHostServiceMocks.listHosts.mockResolvedValue([
+      {
+        id: 'host-a',
+        name: 'Host A',
+        host: '10.0.0.1',
+        port: 1999,
+        status: 'unknown',
+        createdAt: '2026-03-11T00:00:00.000Z',
+        updatedAt: '2026-03-11T00:00:00.000Z',
+      },
+      {
+        id: 'host-b',
+        name: 'Host B',
+        host: '10.0.0.2',
+        port: 2999,
+        status: 'unknown',
+        createdAt: '2026-03-11T00:00:00.000Z',
+        updatedAt: '2026-03-11T00:00:00.000Z',
+      },
+    ]);
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === 'http://10.0.0.2:2999/agents/agent-daily/energy' && (!init || init.method === 'GET' || init.method === undefined)) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            agent_id: 'agent-daily',
+            current: 0,
+            max: 100,
+            ratio: 0,
+            tick_cost: 5,
+            phase: 'dormant',
+            is_dormant: true,
+          }),
+        } as Response;
+      }
+      if (url === 'http://10.0.0.2:2999/agents/agent-daily/energy/refill' && init?.method === 'POST') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            energy: {
+              agent_id: 'agent-daily',
+              current: 100,
+              max: 100,
+              ratio: 1,
+              tick_cost: 5,
+              phase: 'normal',
+              is_dormant: false,
+            },
+            revived: true,
+            tick_spawned: true,
+          }),
+        } as Response;
+      }
+      return {
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'not found' }),
+      } as Response;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<AgentDetailPage agentId="agent-daily" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '充能复活' })).toBeInTheDocument();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://10.0.0.2:2999/agents/agent-daily/energy',
+      expect.any(Object),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '充能复活' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://10.0.0.2:2999/agents/agent-daily/energy/refill',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    expect(
+      fetchMock.mock.calls.some(([input]) => String(input).startsWith('http://10.0.0.1:1999/agents/agent-daily/energy')),
+    ).toBe(false);
   });
 });

--- a/tests/unit/ui/agent-hub/agent-energy-bar.issue444.test.tsx
+++ b/tests/unit/ui/agent-hub/agent-energy-bar.issue444.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { EnergyBar } from '@/ui/app/pages/agents/AgentDetailPage';
+
+describe('agent energy bar issue-444（Agent 能量条）', () => {
+  it('shows refill button for dormant energy when callback exists（休眠时显示充能按钮）', () => {
+    const onRefill = vi.fn();
+
+    render(
+      <EnergyBar
+        energy={{
+          agent_id: 'life-alpha',
+          current: 0,
+          max: 100,
+          ratio: 0,
+          tick_cost: 5,
+          phase: 'dormant',
+          is_dormant: true,
+        }}
+        onRefill={onRefill}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: '充能复活' });
+    fireEvent.click(button);
+    expect(onRefill).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides refill button for non-dormant energy（非休眠时不显示充能按钮）', () => {
+    render(
+      <EnergyBar
+        energy={{
+          agent_id: 'life-alpha',
+          current: 80,
+          max: 100,
+          ratio: 0.8,
+          tick_cost: 5,
+          phase: 'slowing',
+          is_dormant: false,
+        }}
+        onRefill={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: '充能复活' })).not.toBeInTheDocument();
+  });
+
+  it('shows pending label while refilling（充能中显示进行态）', () => {
+    render(
+      <EnergyBar
+        energy={{
+          agent_id: 'life-alpha',
+          current: 0,
+          max: 100,
+          ratio: 0,
+          tick_cost: 5,
+          phase: 'dormant',
+          is_dormant: true,
+        }}
+        onRefill={vi.fn()}
+        isRefilling
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: '充能中...' })).toBeDisabled();
+  });
+});

--- a/tests/unit/ui/agent-hub/agents-page.signal-history.issue444.test.tsx
+++ b/tests/unit/ui/agent-hub/agents-page.signal-history.issue444.test.tsx
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { AgentsPage } from '@/ui/app/pages/AgentsPage';
+import type { SignalEvent, SignalRoute } from '@/lib/types/signal-pool';
+
+const serviceMocks = vi.hoisted(() => ({
+  getDeviceView: vi.fn(),
+  getAgentDetail: vi.fn(),
+  getActorDetail: vi.fn(),
+  getConversation: vi.fn(),
+  streamConversation: vi.fn(),
+}));
+
+const runtimeManagerMocks = vi.hoisted(() => ({
+  refreshSnapshot: vi.fn(),
+  retryHost: vi.fn(),
+  addHost: vi.fn(),
+  addHostFromAddress: vi.fn(),
+  removeHost: vi.fn(),
+}));
+
+const runtimeControlMocks = vi.hoisted(() => ({
+  startRuntime: vi.fn(),
+  stopRuntime: vi.fn(),
+  getStatus: vi.fn(),
+}));
+
+vi.mock('@xyflow/react', () => ({
+  ReactFlow: () => <div data-testid="mock-react-flow" />,
+  Background: () => null,
+  Controls: () => null,
+  Handle: () => null,
+  Position: { Left: 'left', Right: 'right' },
+  useNodesState: <T,>(initialNodes: T[]) => [initialNodes, vi.fn(), vi.fn()] as const,
+  MarkerType: { ArrowClosed: 'arrowclosed' },
+}));
+
+vi.mock('@/lib/services', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/services')>();
+  return {
+    ...actual,
+    getAgentHubService: () => ({
+      getDeviceView: serviceMocks.getDeviceView,
+      getAgentDetail: serviceMocks.getAgentDetail,
+      getActorDetail: serviceMocks.getActorDetail,
+      getConversation: serviceMocks.getConversation,
+      streamConversation: serviceMocks.streamConversation,
+    }),
+  };
+});
+
+vi.mock('@/services/runtime-manager', () => ({
+  getRuntimeManager: () => runtimeManagerMocks,
+  findPreferredRuntimeHostForAgent: vi.fn(() => null),
+}));
+
+vi.mock('@/lib/services/runtime-control.service', () => ({
+  getRuntimeControlService: () => runtimeControlMocks,
+}));
+
+const SAMPLE_SIGNAL_ROUTES: SignalRoute[] = [
+  {
+    id: 'route-a',
+    enabled: true,
+    topic: 'user.input.text',
+    target_type: 'agent',
+    target_ref: 'echo',
+    created_at: '2026-03-05T00:00:00Z',
+    updated_at: '2026-03-05T00:00:00Z',
+  },
+  {
+    id: 'route-b',
+    enabled: true,
+    topic: 'eventlog.appended',
+    target_type: 'actor',
+    target_ref: 'eventlog',
+    created_at: '2026-03-05T00:00:00Z',
+    updated_at: '2026-03-05T00:00:00Z',
+  },
+];
+
+const SAMPLE_SIGNAL_HISTORY: SignalEvent[] = [
+  {
+    schema_version: 1,
+    id: 'sig-001',
+    topic: 'user.input.text',
+    ts: 1741161600000,
+    source: 'ui:test',
+    origin_host_id: 'local-host',
+    hop: 0,
+    trace_id: 'trace-a',
+    payload: { text: 'hello from signal history' },
+  },
+  {
+    schema_version: 1,
+    id: 'sig-002',
+    topic: 'eventlog.appended',
+    ts: 1741161601000,
+    source: 'actor:eventlog',
+    origin_host_id: 'local-host',
+    hop: 1,
+    trace_id: 'trace-b',
+    payload: { text: 'saved to eventlog' },
+  },
+];
+
+describe('agents page signal history issue-444（信号历史独立交互）', () => {
+  beforeEach(() => {
+    window.history.pushState({}, '', '/agents');
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    runtimeControlMocks.getStatus.mockResolvedValue({
+      running: true,
+      host: '127.0.0.1',
+      port: 1949,
+    });
+
+    runtimeManagerMocks.refreshSnapshot.mockResolvedValue({
+      updatedAt: '2026-03-05T10:00:00.000Z',
+      agents: [],
+      hosts: [
+        {
+          host: {
+            id: 'host-a',
+            name: '127.0.0.1:1919',
+            host: '127.0.0.1',
+            port: 1919,
+            status: 'unknown',
+            createdAt: '2026-03-05T00:00:00.000Z',
+            updatedAt: '2026-03-05T00:00:00.000Z',
+          },
+          connectionState: 'online',
+          agents: [],
+          topology: null,
+        },
+      ],
+    });
+
+    serviceMocks.getDeviceView.mockResolvedValue([]);
+    serviceMocks.getAgentDetail.mockResolvedValue(null);
+    serviceMocks.getActorDetail.mockResolvedValue(null);
+    serviceMocks.getConversation.mockResolvedValue([]);
+    serviceMocks.streamConversation.mockImplementation(async function* () {});
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/signal-routes')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => SAMPLE_SIGNAL_ROUTES,
+        } as Response;
+      }
+      if (url.includes('/signals/history')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => SAMPLE_SIGNAL_HISTORY,
+        } as Response;
+      }
+
+      return {
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'not found' }),
+      } as Response;
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('filters history, expands payload, and opens signal detail（支持过滤、展开 payload、打开信号详情）', async () => {
+    render(<AgentsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-hub-page')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('agent-view-toggle-history'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-signal-history-view')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('signal-history-filter-all')).toBeInTheDocument();
+    expect(screen.getByTestId('signal-history-filter-user.input.text')).toBeInTheDocument();
+    expect(screen.getByTestId('signal-history-filter-eventlog.appended')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('signal-history-filter-user.input.text'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('signal-history-item-sig-001')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('signal-history-item-sig-002')).not.toBeInTheDocument();
+
+    const payloadPanel = screen.getByTestId('signal-history-payload-sig-001');
+    fireEvent.click(within(payloadPanel).getByText('展开 payload'));
+    expect(screen.getByText(/Payload:/)).toBeInTheDocument();
+    expect(within(payloadPanel).getByText(/hello from signal history/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('signal-history-open-sig-001'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-rightpanel-signal-detail')).toBeInTheDocument();
+    });
+
+    const detail = screen.getByTestId('agent-rightpanel-signal-detail');
+    expect(within(detail).getByText('sig-001')).toBeInTheDocument();
+    expect(within(detail).getByText('ui:test')).toBeInTheDocument();
+    expect(within(detail).getByText('local-host')).toBeInTheDocument();
+    expect(within(detail).getByText('0')).toBeInTheDocument();
+    expect(within(detail).getByText(/hello from signal history/)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/ui/agent-hub/agents-signal-topology.issue245f.test.ts
+++ b/tests/unit/ui/agent-hub/agents-signal-topology.issue245f.test.ts
@@ -81,6 +81,15 @@ const SAMPLE_AGENTS: RuntimeAggregatedAgent[] = [
     sourceHostId: 'host-a',
     sourceHostName: 'RT-A',
     sourceHostAddress: '127.0.0.1:1919',
+    energy: {
+      agent_id: 'classifier',
+      current: 180,
+      max: 200,
+      ratio: 0.9,
+      tick_cost: 5,
+      phase: 'normal',
+      is_dormant: false,
+    },
   },
   {
     id: 'reviewer',
@@ -90,6 +99,15 @@ const SAMPLE_AGENTS: RuntimeAggregatedAgent[] = [
     sourceHostId: 'host-a',
     sourceHostName: 'RT-A',
     sourceHostAddress: '127.0.0.1:1919',
+    energy: {
+      agent_id: 'reviewer',
+      current: 0,
+      max: 100,
+      ratio: 0,
+      tick_cost: 10,
+      phase: 'dormant',
+      is_dormant: true,
+    },
   },
 ];
 
@@ -151,6 +169,19 @@ describe('agents signal topology builder issue-245f（信号拓扑构建）', ()
       source: 'input:voice',
       target: 'topic:voice.input.transcript',
       topic: 'voice.input.transcript',
+    });
+  });
+
+  it('projects agent energy phase onto graph nodes（把 agent 能量阶段映射到拓扑节点）', () => {
+    const graph = buildSignalGraph(SAMPLE_ROUTES, SAMPLE_AGENTS);
+
+    expect(graph.nodes.find((node) => node.id === 'agent:classifier')).toMatchObject({
+      energyPhase: 'normal',
+      isDormant: false,
+    });
+    expect(graph.nodes.find((node) => node.id === 'agent:reviewer')).toMatchObject({
+      energyPhase: 'dormant',
+      isDormant: true,
     });
   });
 });


### PR DESCRIPTION
## Summary
- 添加运行时生命周期复活支持：`TickManager`、`POST /agents/:id/energy/refill`、`SignalDispatcherActor`
- 添加 Agent Hub 复活控件、信号历史增强、生命周期感知的拓扑样式
- 添加 Rust 和 Vitest 覆盖：复活、信号分发、runtime client、能量条、拓扑行为

## Test Plan
- `cargo test -p exomind-runtime tick_manager_restarts_finished_agent_tick_without_duplication -- --nocapture`
- `cargo test -p exomind-runtime routes::energy::tests::refill_revives_dormant_agent_and_restarts_tick -- --nocapture`
- `cargo test -p exomind-runtime signal_dispatcher_actor -- --nocapture`
- `bunx vitest run tests/unit/services/runtime-client.issue201.test.ts tests/unit/ui/agent-hub/agent-energy-bar.issue444.test.tsx tests/unit/ui/agent-hub/agents-signal-topology.issue245f.test.ts tests/unit/ui/agent-hub/agents-page.energy.test.tsx tests/unit/ui/agent-hub/agent-actor-detail.issue204.test.tsx tests/unit/ui/agent-hub/agents-page.issue204.test.tsx tests/unit/ui/agent-hub/agents-page.runtime.issue201.test.tsx tests/unit/ui/agent-hub/agents-page.history-chat.issue354.test.tsx tests/unit/ui/agent-hub/agents-page.topology-layout.issue382.test.tsx`
- `bunx tsc --noEmit` 目前因本次改动范围外的 PouchDB 类型问题仍会失败

Closes #444