### PR TITLE
fix(export): 统一备份文件名并合并事件+任务导出

### DIFF
--- a/src/lib/eventlog/transfer.ts
+++ b/src/lib/eventlog/transfer.ts
@@ -8,7 +8,7 @@ export interface EventLogTransferPayloadV1 {
   events: EventData[];
 }
 
-const TRANSFER_VERSION = 1;
+const SUPPORTED_VERSIONS = [1, 2];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -54,7 +54,7 @@ export function parseTransferPayload(raw: string): EventLogTransferPayloadV1 {
 
   const payload = parsed as Record<string, unknown>;
 
-  if (payload.version !== TRANSFER_VERSION) {
+  if (!SUPPORTED_VERSIONS.includes(payload.version as number)) {
     throw new Error('不支持的备份版本');
   }
 

--- a/src/ui/app/pages/SettingsPage.tsx
+++ b/src/ui/app/pages/SettingsPage.tsx
@@ -165,7 +165,7 @@ const MOSS_API_KEY_STORAGE_KEY = 'moss_api_key';
 
 function buildBackupFileName(): string {
   const date = new Date().toISOString().slice(0, 10);
-  return `exomind-eventlog-${date}.json`;
+  return `exomind-data-${date}.json`;
 }
 
 function normalizeMossApiKey(value: string): string {
@@ -384,27 +384,52 @@ export function SettingsPage() {
     setLoading(true);
     try {
       const service = getEventLogService();
-      const json = await service.exportEventsAsJson();
-      const payload = JSON.parse(json) as { events?: unknown[] };
-      const count = Array.isArray(payload.events) ? payload.events.length : 0;
+      const eventJson = await service.exportEventsAsJson();
+      const payload = JSON.parse(eventJson) as {
+        version?: number;
+        events?: unknown[];
+        tasks?: unknown[];
+      };
+      const eventCount = Array.isArray(payload.events) ? payload.events.length : 0;
+
+      // Try to include tasks (graceful degradation if RT server unavailable)
+      let taskCount = 0;
+      try {
+        const taskResult = await getTaskBackupService().exportTasksAsJson();
+        const taskPayload = JSON.parse(taskResult.content) as { tasks?: unknown[] };
+        if (Array.isArray(taskPayload.tasks)) {
+          payload.tasks = taskPayload.tasks;
+          payload.version = 2;
+          taskCount = taskPayload.tasks.length;
+        }
+      } catch {
+        // Task server unavailable, export events only
+      }
+
+      const combinedJson = JSON.stringify(payload, null, 2);
       const defaultName = buildBackupFileName();
+
+      const parts: string[] = [];
+      if (eventCount > 0) parts.push(`${eventCount} 条事件`);
+      if (taskCount > 0) parts.push(`${taskCount} 条任务`);
+      const summary = parts.length > 0 ? parts.join('、') : '0 条记录';
 
       const isRunningInTauri = await isTauri();
       if (isRunningInTauri) {
         const savedPath = await invoke<string | null>('save_json_file', {
-          content: json,
+          content: combinedJson,
           defaultName,
         });
         if (!savedPath) {
           setStatusMessage('已取消保存。');
           return;
         }
-        setStatusMessage(`导出成功，共 ${count} 条事件。保存路径：${savedPath}`);
+        setStatusMessage(`导出成功，共 ${summary}。保存路径：${savedPath}`);
         return;
       }
 
-      downloadFileFallback(json, 'application/json;charset=utf-8', defaultName);
-      setStatusMessage(`导出成功，共 ${count} 条事件。`);
+      downloadFileFallback(combinedJson, 'application/json;charset=utf-8', defaultName);
+      setStatusMessage(`导出成功，共 ${summary}。`);
     } catch (error) {
       const message = error instanceof Error ? error.message : '未知错误';
       setErrorMessage(`导出失败：${message}`);
@@ -467,8 +492,22 @@ export function SettingsPage() {
     try {
       const service = getEventLogService();
       const result = await service.importEventsFromJson(picked.content, importStrategy);
+
+      // Import tasks if present in v2 payload
+      let taskSummary = '';
+      try {
+        const parsed = JSON.parse(picked.content) as { tasks?: unknown[] };
+        if (Array.isArray(parsed.tasks) && parsed.tasks.length > 0) {
+          const taskJson = JSON.stringify({ version: 1, tasks: parsed.tasks });
+          const taskResult = await getTaskBackupService().importTasksFromJson(taskJson, importStrategy);
+          taskSummary = `；任务新增 ${taskResult.imported} 条，跳过 ${taskResult.skipped} 条`;
+        }
+      } catch {
+        // Task import failed or no task data, continue with event-only result
+      }
+
       setStatusMessage(
-        `导入成功：新增 ${result.imported} 条，跳过 ${result.skipped} 条，当前共 ${result.total} 条。来源：${picked.path}`
+        `导入成功：事件新增 ${result.imported} 条，跳过 ${result.skipped} 条，当前共 ${result.total} 条${taskSummary}。来源：${picked.path}`
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : '未知错误';

--- a/src/ui/app/pages/SettingsPage.tsx
+++ b/src/ui/app/pages/SettingsPage.tsx
@@ -503,7 +503,7 @@ export function SettingsPage() {
           taskSummary = `；任务新增 ${taskResult.imported} 条，跳过 ${taskResult.skipped} 条`;
         }
       } catch {
-        // Task import failed or no task data, continue with event-only result
+        taskSummary = '；任务恢复失败';
       }
 
       setStatusMessage(

--- a/tests/unit/settings/import-export.test.tsx
+++ b/tests/unit/settings/import-export.test.tsx
@@ -15,4 +15,9 @@ describe('SettingsPage import/export', () => {
     expect(source).toContain('同步服务器');
     expect(source).toContain('handleSaveSyncServerUrl');
   });
+
+  it('uses generic backup filename prefix', () => {
+    expect(source).toContain('exomind-data-');
+    expect(source).not.toContain('exomind-eventlog-');
+  });
 });

--- a/tests/unit/settings/settings-export-runtime.issue222.test.tsx
+++ b/tests/unit/settings/settings-export-runtime.issue222.test.tsx
@@ -144,7 +144,7 @@ describe('SettingsPage export/import runtime routing (issue-222)', () => {
 
   it('uses tauri native save command for export in tauri runtime', async () => {
     mocks.isTauri.mockResolvedValue(true);
-    mocks.invoke.mockResolvedValue('/storage/emulated/0/Download/exomind-eventlog-2026-02-24.json');
+    mocks.invoke.mockResolvedValue('/storage/emulated/0/Download/exomind-data-2026-02-24.json');
 
     render(<SettingsPage />);
     fireEvent.click(screen.getByRole('button', { name: '导出备份' }));
@@ -152,7 +152,7 @@ describe('SettingsPage export/import runtime routing (issue-222)', () => {
     await waitFor(() => {
       expect(mocks.invoke).toHaveBeenCalledWith('save_json_file', expect.objectContaining({
         content: expect.stringContaining('"events"'),
-        defaultName: expect.stringMatching(/^exomind-eventlog-\d{4}-\d{2}-\d{2}\.json$/),
+        defaultName: expect.stringMatching(/^exomind-data-\d{4}-\d{2}-\d{2}\.json$/),
       }));
     });
 
@@ -201,7 +201,7 @@ describe('SettingsPage export/import runtime routing (issue-222)', () => {
     });
 
     expect(mocks.importEventsFromJson).toHaveBeenCalledWith(expect.stringContaining('"version":1'), 'merge');
-    expect(screen.getByText(/导入成功：新增 1 条/)).toBeInTheDocument();
+    expect(screen.getByText(/导入成功：事件新增 1 条/)).toBeInTheDocument();
     expect(screen.getByText(/来源：content:\/\/downloads\/document\/eventlog\.json/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 概要

- 导出文件名从 `exomind-eventlog-*.json` 改为通用 `exomind-data-*.json`
- 「导出备份」现在同时导出事件和任务到同一个 v2 payload，任务服务不可用时优雅降级为仅事件
- 导入兼容 v1（纯事件）和 v2（事件+任务）两种格式
- 导出/导入消息分别展示事件和任务计数

Closes #428
Closes #489

## 改动

| 文件 | 变更 |
|------|------|
| `src/lib/eventlog/transfer.ts` | 接受 version 1 和 2 两种 payload |
| `src/ui/app/pages/SettingsPage.tsx` | 重命名文件名、合并导出/导入逻辑、更新提示消息 |
| `tests/unit/settings/import-export.test.tsx` | 新增文件名前缀断言 |

## 测试计划

- [x] `npx vitest run tests/unit/settings/import-export.test.tsx` — 3 个测试通过
- [x] `npx vitest run tests/unit/eventlog/transfer.test.ts` — 4 个测试通过
- [ ] 手动验证：Web 端导出生成 `exomind-data-YYYY-MM-DD.json`
- [ ] 手动验证：旧 `exomind-eventlog-*.json` 文件仍可正常导入
- [ ] 手动验证：RT 服务运行时，合并导出包含任务数据

🤖 Generated with [Claude Code](https://claude.com/claude-code)