### PR TITLE
feat(issue-136): 新增专注背景音播放器与运行时控制

### DIFF
--- a/docs/plans/2026-03-13-issue-136-focus-bgm-player-plan.md
+++ b/docs/plans/2026-03-13-issue-136-focus-bgm-player-plan.md
@@ -1,0 +1,199 @@
+# Issue 136 Focus BGM Player Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 为 `#136` 落地专注过程背景音乐 / 白噪音播放能力，支持预设噪音、自定义本地音频、多文件顺序播放、循环播放，以及与专注计时联动的自动开始/停止。
+
+**Architecture:** 新增 `focus-bgm-preferences` 作为本地设置真值（source of truth，真实来源），新增 `focus-bgm-player` 作为单例播放引擎（singleton player，单例播放器），通过设置页 `custom setting（自定义设置项）` 配置播放参数，再由 `FocusTimerWidget` 在专注开始 / 结束 / 暂停 / 恢复时驱动播放器。Tauri 端通过新增多音频文件选择命令返回绝对路径，前端按需读取二进制并生成 `blob:` URL 播放。
+
+**Tech Stack:** React 18, TypeScript, Vitest, Tauri v2, tauri-plugin-dialog, localStorage, HTMLAudioElement, Web Audio API
+
+---
+
+### Task 1: 定义 BGM 偏好与预设模型
+
+**Files:**
+- Create: `src/config/focus-bgm-preferences.ts`
+- Create: `src/lib/media/focus-bgm-presets.ts`
+- Test: `tests/unit/config/focus-bgm-preferences.test.ts`
+
+**Step 1: Write the failing test**
+
+- 覆盖默认值、非法值归一化、`subscribe` 触发、`multiple tracks（多轨）` 持久化。
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/config/focus-bgm-preferences.test.ts`
+
+Expected: FAIL because the module does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+- 定义：
+  - `enabled`
+  - `sourceType: 'preset' | 'custom'`
+  - `presetId`
+  - `customTracks: { path: string; name: string }[]`
+  - `playbackMode: 'loop' | 'sequence'`
+  - `stopBehavior: 'timer-end' | 'manual-end'`
+  - `volume`
+- 提供 `get/set/update/subscribe`。
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/config/focus-bgm-preferences.test.ts`
+
+Expected: PASS
+
+### Task 2: 补 Tauri 多音频文件选择能力
+
+**Files:**
+- Modify: `src-tauri/src/commands/file_commands.rs`
+- Modify: `src-tauri/src/lib.rs`
+- Create: `src/lib/media/focus-bgm-file-picker.ts`
+- Test: `tests/unit/media/focus-bgm-file-picker.test.ts`
+
+**Step 1: Write the failing test**
+
+- 覆盖：
+  - Web 下返回“不支持持久本地音频选择”
+  - Tauri 下调用 `pick_audio_files`
+  - 返回多文件时保留文件名与路径顺序
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/media/focus-bgm-file-picker.test.ts`
+
+Expected: FAIL because picker helpers do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+- Rust 新增 `pick_audio_files` 命令，过滤常见音频扩展名并支持 `blocking_pick_files()`
+- TS 新增文件选择封装与返回类型
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/media/focus-bgm-file-picker.test.ts`
+
+Expected: PASS
+
+### Task 3: 实现背景音播放器单例
+
+**Files:**
+- Create: `src/lib/media/focus-bgm-player.ts`
+- Test: `tests/unit/media/focus-bgm-player.test.ts`
+
+**Step 1: Write the failing test**
+
+- 覆盖：
+  - 预设噪音开始播放 / 停止
+  - 自定义多轨在 `sequence` 模式按顺序切换
+  - `loop` 模式循环当前曲目
+  - 修改音量后同步到当前播放实例
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/media/focus-bgm-player.test.ts`
+
+Expected: FAIL because the player does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+- 用单例管理当前 `Audio` / `AudioContext`
+- 自定义本地音频通过 `read_file_binary` + `Blob URL` 播放
+- 生成型噪音预设用 Web Audio API
+- 暴露 `startFromPreferences / pause / resume / stop / toggle / subscribe`
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/media/focus-bgm-player.test.ts`
+
+Expected: PASS
+
+### Task 4: 在设置页落地 BGM 配置入口
+
+**Files:**
+- Modify: `src/ui/app/components/settings/settings-custom-items.tsx`
+- Modify: `src/ui/app/config/settings/settings-registry.ts`
+- Modify: `tests/unit/components/settings/setup-settings-mocks.tsx`
+- Create: `tests/unit/settings/settings-focus-bgm.issue136.test.tsx`
+
+**Step 1: Write the failing test**
+
+- 覆盖：
+  - “专注背景音”行可见
+  - 打开配置面板
+  - 切换预设 / 本地音频来源
+  - 选择播放模式 / 停止策略 / 音量
+  - Tauri mock 下可选择多本地音频
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/settings/settings-focus-bgm.issue136.test.tsx`
+
+Expected: FAIL because the BGM setting UI does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+- 新增 `FocusBgmSetting`
+- 注册到 `timer` 分类
+- 行右侧显示当前摘要（例如 `白噪音 · 循环` / `3 首本地音频 · 顺序`）
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/settings/settings-focus-bgm.issue136.test.tsx`
+
+Expected: PASS
+
+### Task 5: 接入专注计时联动与运行中快捷控制
+
+**Files:**
+- Modify: `src/ui/app/components/FocusTimerWidget.tsx`
+- Create: `tests/unit/components/FocusTimerWidget.bgm.issue136.test.tsx`
+
+**Step 1: Write the failing test**
+
+- 覆盖：
+  - 专注开始时自动播放
+  - 暂停时暂停 BGM，恢复时继续
+  - 倒计时结束且 `stopBehavior='timer-end'` 时停止
+  - 手动结束时总是停止
+  - 运行态有 BGM 播放/暂停按钮
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/components/FocusTimerWidget.bgm.issue136.test.tsx`
+
+Expected: FAIL because the widget does not control BGM yet.
+
+**Step 3: Write minimal implementation**
+
+- 在 `handleStart / handlePauseOrResume / handleOpenEndDialog / countdown end branch / submit end` 中接入播放器
+- 增加运行态快捷按钮
+- 避免影响现有提示音逻辑
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/components/FocusTimerWidget.bgm.issue136.test.tsx`
+
+Expected: PASS
+
+### Task 6: 回归验证
+
+**Files:**
+- Test: `tests/unit/components/FocusTimerWidget.countdown-end-settings.issue182.test.tsx`
+- Test: `tests/unit/settings/settings-timer-card.issue182.test.tsx`
+- Test: `tests/unit/settings/settings-focus-bgm.issue136.test.tsx`
+- Test: `tests/unit/components/FocusTimerWidget.bgm.issue136.test.tsx`
+
+**Step 1: Run targeted verification**
+
+Run: `npx vitest run tests/unit/config/focus-bgm-preferences.test.ts tests/unit/media/focus-bgm-file-picker.test.ts tests/unit/media/focus-bgm-player.test.ts tests/unit/settings/settings-focus-bgm.issue136.test.tsx tests/unit/components/FocusTimerWidget.bgm.issue136.test.tsx tests/unit/components/FocusTimerWidget.countdown-end-settings.issue182.test.tsx tests/unit/settings/settings-timer-card.issue182.test.tsx`
+
+Expected: PASS
+
+**Step 2: Run typecheck**
+
+Run: `npx tsc --noEmit`
+
+Expected: PASS

--- a/src-tauri/src/commands/file_commands.rs
+++ b/src-tauri/src/commands/file_commands.rs
@@ -397,6 +397,37 @@ pub struct PickedJsonFile {
     content: String,
 }
 
+#[derive(Debug, Serialize)]
+pub struct PickedAudioFile {
+    path: String,
+    name: String,
+}
+
+fn resolve_selected_file_path(selected: &FilePath) -> String {
+    match selected {
+        FilePath::Path(path) => path.to_string_lossy().to_string(),
+        uri_like => uri_like.to_string(),
+    }
+}
+
+fn resolve_selected_file_name(selected: &FilePath) -> String {
+    match selected {
+        FilePath::Path(path) => path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| path.to_string_lossy().to_string()),
+        uri_like => {
+            let display = uri_like.to_string();
+            display
+                .split('/')
+                .next_back()
+                .map(|value| value.to_string())
+                .unwrap_or(display)
+        }
+    }
+}
+
 fn read_import_content_from_selected_file<PR, UR>(
     selected: FilePath,
     path_reader: PR,
@@ -579,6 +610,29 @@ pub fn pick_json_file(app: AppHandle) -> FileResult<Option<PickedJsonFile>> {
     )?;
 
     Ok(Some(picked))
+}
+
+#[tauri::command]
+pub fn pick_audio_files(app: AppHandle) -> FileResult<Option<Vec<PickedAudioFile>>> {
+    let selected = app
+        .dialog()
+        .file()
+        .add_filter("Audio", &["mp3", "wav", "ogg", "m4a", "flac"])
+        .blocking_pick_files();
+
+    let Some(selected) = selected else {
+        return Ok(None);
+    };
+
+    Ok(Some(
+        selected
+            .iter()
+            .map(|file| PickedAudioFile {
+                path: resolve_selected_file_path(file),
+                name: resolve_selected_file_name(file),
+            })
+            .collect(),
+    ))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,8 +15,8 @@ use commands::eventlog_commands::{
 };
 use commands::file_commands::{
     append_file, append_to_markdown, delete_file, export_messages_to_markdown, file_exists,
-    list_files, pick_json_file, read_file, read_file_binary, save_binary_file, save_json_file,
-    write_file,
+    list_files, pick_audio_files, pick_json_file, read_file, read_file_binary,
+    save_binary_file, save_json_file, write_file,
 };
 use commands::now_workbench_overlay_commands::{
     ensure_now_workbench_overlay_window, now_workbench_overlay_ensure,
@@ -154,6 +154,7 @@ pub fn run() {
             save_binary_file,
             save_json_file,
             pick_json_file,
+            pick_audio_files,
             get_device_id,
             eventlog_list,
             eventlog_append,
@@ -175,8 +176,8 @@ pub fn run() {
             voice_overlay_set_bottom_offset,
             now_workbench_overlay_ensure,
             now_workbench_overlay_show,
-            now_workbench_overlay_hide,
             now_workbench_overlay_restore,
+            now_workbench_overlay_hide,
             now_workbench_overlay_focus_main,
             now_workbench_overlay_set_position,
             voice_shortcut_set,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { ThemeController } from "@/components/ThemeController";
 import { Toaster } from "@/components/ui/toaster";
 import { TimeBlockSyncCoordinator } from "@/ui/app/components/TimeBlockSyncCoordinator";
 import { ReminderSyncCoordinator } from "@/ui/app/components/ReminderSyncCoordinator";
+import { FocusBgmCoordinator } from "@/ui/app/components/FocusBgmCoordinator";
 import {
   initUpdateChecker,
   destroyUpdateChecker,
@@ -37,6 +38,7 @@ function App() {
       <ThemeController />
       <TimeBlockSyncCoordinator />
       <ReminderSyncCoordinator />
+      <FocusBgmCoordinator />
       <RouterProvider router={appRouter} />
       <Toaster />
     </>

--- a/src/config/focus-bgm-preferences.ts
+++ b/src/config/focus-bgm-preferences.ts
@@ -1,0 +1,184 @@
+import {
+  DEFAULT_FOCUS_BGM_PRESET_ID,
+  getFocusBgmPresetById,
+  type FocusBgmPresetId,
+} from '@/lib/media/focus-bgm-presets';
+
+export const FOCUS_BGM_PREFERENCES_STORAGE_KEY = 'exomind:focusBgmPreferences';
+export const FOCUS_BGM_PREFERENCES_CHANGED_EVENT = 'exomind:focus-bgm-preferences-changed';
+
+export type FocusBgmSourceType = 'preset' | 'custom';
+export type FocusBgmPlaybackMode = 'loop' | 'sequence';
+export type FocusBgmStopBehavior = 'timer-end' | 'manual-end';
+
+export interface FocusBgmTrack {
+  path: string;
+  name: string;
+}
+
+export interface FocusBgmPreferences {
+  enabled: boolean;
+  sourceType: FocusBgmSourceType;
+  presetId: FocusBgmPresetId;
+  customTracks: FocusBgmTrack[];
+  playbackMode: FocusBgmPlaybackMode;
+  stopBehavior: FocusBgmStopBehavior;
+  volume: number;
+}
+
+const DEFAULT_FOCUS_BGM_PREFERENCES: FocusBgmPreferences = {
+  enabled: false,
+  sourceType: 'preset',
+  presetId: DEFAULT_FOCUS_BGM_PRESET_ID,
+  customTracks: [],
+  playbackMode: 'loop',
+  stopBehavior: 'manual-end',
+  volume: 60,
+};
+
+function isFocusBgmSourceType(value: unknown): value is FocusBgmSourceType {
+  return value === 'preset' || value === 'custom';
+}
+
+function isFocusBgmPlaybackMode(value: unknown): value is FocusBgmPlaybackMode {
+  return value === 'loop' || value === 'sequence';
+}
+
+function isFocusBgmStopBehavior(value: unknown): value is FocusBgmStopBehavior {
+  return value === 'timer-end' || value === 'manual-end';
+}
+
+function resolveTrackName(path: string, name: unknown): string {
+  if (typeof name === 'string' && name.trim().length > 0) {
+    return name.trim();
+  }
+
+  const normalizedPath = path.replace(/\\/g, '/');
+  const leaf = normalizedPath.split('/').pop()?.trim();
+  return leaf && leaf.length > 0 ? leaf : path.trim();
+}
+
+function normalizeTracks(value: unknown): FocusBgmTrack[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return null;
+      }
+
+      const record = entry as Partial<FocusBgmTrack>;
+      if (typeof record.path !== 'string' || record.path.trim().length === 0) {
+        return null;
+      }
+
+      const path = record.path.trim();
+      return {
+        path,
+        name: resolveTrackName(path, record.name),
+      } satisfies FocusBgmTrack;
+    })
+    .filter((entry): entry is FocusBgmTrack => entry !== null);
+}
+
+function clampVolume(value: unknown): number {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return DEFAULT_FOCUS_BGM_PREFERENCES.volume;
+  }
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function normalizeFocusBgmPreferences(value: unknown): FocusBgmPreferences {
+  if (!value || typeof value !== 'object') {
+    return DEFAULT_FOCUS_BGM_PREFERENCES;
+  }
+
+  const record = value as Partial<FocusBgmPreferences>;
+  return {
+    enabled: typeof record.enabled === 'boolean' ? record.enabled : DEFAULT_FOCUS_BGM_PREFERENCES.enabled,
+    sourceType: isFocusBgmSourceType(record.sourceType) ? record.sourceType : DEFAULT_FOCUS_BGM_PREFERENCES.sourceType,
+    presetId: getFocusBgmPresetById(record.presetId).id,
+    customTracks: normalizeTracks(record.customTracks),
+    playbackMode: isFocusBgmPlaybackMode(record.playbackMode) ? record.playbackMode : DEFAULT_FOCUS_BGM_PREFERENCES.playbackMode,
+    stopBehavior: isFocusBgmStopBehavior(record.stopBehavior) ? record.stopBehavior : DEFAULT_FOCUS_BGM_PREFERENCES.stopBehavior,
+    volume: clampVolume(record.volume),
+  };
+}
+
+export function getFocusBgmPreferences(): FocusBgmPreferences {
+  if (typeof window === 'undefined') {
+    return DEFAULT_FOCUS_BGM_PREFERENCES;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(FOCUS_BGM_PREFERENCES_STORAGE_KEY);
+    if (!raw) {
+      return DEFAULT_FOCUS_BGM_PREFERENCES;
+    }
+
+    return normalizeFocusBgmPreferences(JSON.parse(raw));
+  } catch {
+    return DEFAULT_FOCUS_BGM_PREFERENCES;
+  }
+}
+
+export function setFocusBgmPreferences(preferences: FocusBgmPreferences): FocusBgmPreferences {
+  if (typeof window === 'undefined') {
+    return normalizeFocusBgmPreferences(preferences);
+  }
+
+  const normalized = normalizeFocusBgmPreferences(preferences);
+  try {
+    window.localStorage.setItem(
+      FOCUS_BGM_PREFERENCES_STORAGE_KEY,
+      JSON.stringify(normalized),
+    );
+    window.dispatchEvent(new CustomEvent(FOCUS_BGM_PREFERENCES_CHANGED_EVENT, {
+      detail: { value: normalized },
+    }));
+  } catch {
+    // Ignore localStorage write failures（忽略本地存储失败）
+  }
+
+  return normalized;
+}
+
+export function updateFocusBgmPreferences(
+  patch: Partial<FocusBgmPreferences>,
+): FocusBgmPreferences {
+  return setFocusBgmPreferences({
+    ...getFocusBgmPreferences(),
+    ...patch,
+  });
+}
+
+export function subscribeFocusBgmPreferencesChanges(
+  listener: (preferences: FocusBgmPreferences) => void,
+): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key !== FOCUS_BGM_PREFERENCES_STORAGE_KEY) {
+      return;
+    }
+
+    listener(event.newValue ? normalizeFocusBgmPreferences(JSON.parse(event.newValue)) : DEFAULT_FOCUS_BGM_PREFERENCES);
+  };
+
+  const handleCustomEvent = (event: Event) => {
+    const detail = (event as CustomEvent<{ value?: unknown }>).detail;
+    listener(normalizeFocusBgmPreferences(detail?.value));
+  };
+
+  window.addEventListener('storage', handleStorage);
+  window.addEventListener(FOCUS_BGM_PREFERENCES_CHANGED_EVENT, handleCustomEvent);
+
+  return () => {
+    window.removeEventListener('storage', handleStorage);
+    window.removeEventListener(FOCUS_BGM_PREFERENCES_CHANGED_EVENT, handleCustomEvent);
+  };
+}

--- a/src/lib/media/focus-bgm-file-picker.ts
+++ b/src/lib/media/focus-bgm-file-picker.ts
@@ -1,0 +1,33 @@
+import { invoke, isTauri } from '@tauri-apps/api/core';
+import type { FocusBgmTrack } from '@/config/focus-bgm-preferences';
+
+function normalizePickedTrack(track: FocusBgmTrack): FocusBgmTrack {
+  return {
+    path: track.path.trim(),
+    name: track.name.trim() || track.path.trim().replace(/\\/g, '/').split('/').pop() || track.path.trim(),
+  };
+}
+
+export async function pickFocusBgmTracks(): Promise<FocusBgmTrack[]> {
+  if (!await isTauri()) {
+    throw new Error('仅桌面端支持选择本地背景音频');
+  }
+
+  const picked = await invoke<FocusBgmTrack[] | null>('pick_audio_files');
+  if (!Array.isArray(picked)) {
+    return [];
+  }
+
+  return picked
+    .filter((track): track is FocusBgmTrack => Boolean(track?.path && track?.name))
+    .map(normalizePickedTrack);
+}
+
+export async function readFocusBgmTrackBytes(path: string): Promise<Uint8Array> {
+  if (!await isTauri()) {
+    throw new Error('仅桌面端支持读取本地背景音频');
+  }
+
+  const bytes = await invoke<number[]>('read_file_binary', { path });
+  return new Uint8Array(bytes);
+}

--- a/src/lib/media/focus-bgm-player.ts
+++ b/src/lib/media/focus-bgm-player.ts
@@ -1,0 +1,406 @@
+import type {
+  FocusBgmPlaybackMode,
+  FocusBgmPreferences,
+} from '@/config/focus-bgm-preferences';
+import { getFocusBgmPresetById, type FocusBgmPreset } from '@/lib/media/focus-bgm-presets';
+import { readFocusBgmTrackBytes } from '@/lib/media/focus-bgm-file-picker';
+
+export interface FocusBgmPlayerState {
+  status: 'idle' | 'playing' | 'paused';
+  sourceType: FocusBgmPreferences['sourceType'] | null;
+  trackLabel: string | null;
+  currentIndex: number;
+  total: number;
+}
+
+interface NoiseRuntime {
+  context: AudioContext;
+  gainNode: GainNode;
+  sourceNode: AudioBufferSourceNode;
+}
+
+function guessAudioMimeType(path: string): string {
+  const lower = path.toLowerCase();
+  if (lower.endsWith('.mp3')) return 'audio/mpeg';
+  if (lower.endsWith('.wav')) return 'audio/wav';
+  if (lower.endsWith('.ogg')) return 'audio/ogg';
+  if (lower.endsWith('.m4a')) return 'audio/mp4';
+  if (lower.endsWith('.flac')) return 'audio/flac';
+  return 'audio/mpeg';
+}
+
+function createNoiseBuffer(
+  context: AudioContext,
+  preset: FocusBgmPreset,
+): AudioBuffer {
+  const sampleRate = 44_100;
+  const durationSeconds = 2;
+  const frameCount = sampleRate * durationSeconds;
+  const buffer = context.createBuffer(1, frameCount, sampleRate);
+  const channel = buffer.getChannelData(0);
+
+  let pinkB0 = 0;
+  let pinkB1 = 0;
+  let pinkB2 = 0;
+  let pinkB3 = 0;
+  let pinkB4 = 0;
+  let pinkB5 = 0;
+  let pinkB6 = 0;
+  let brownLast = 0;
+
+  for (let index = 0; index < frameCount; index += 1) {
+    const white = Math.random() * 2 - 1;
+    if (preset.noiseColor === 'white') {
+      channel[index] = white * 0.22;
+      continue;
+    }
+
+    if (preset.noiseColor === 'pink') {
+      pinkB0 = 0.99886 * pinkB0 + white * 0.0555179;
+      pinkB1 = 0.99332 * pinkB1 + white * 0.0750759;
+      pinkB2 = 0.96900 * pinkB2 + white * 0.1538520;
+      pinkB3 = 0.86650 * pinkB3 + white * 0.3104856;
+      pinkB4 = 0.55000 * pinkB4 + white * 0.5329522;
+      pinkB5 = -0.7616 * pinkB5 - white * 0.0168980;
+      const pink = pinkB0 + pinkB1 + pinkB2 + pinkB3 + pinkB4 + pinkB5 + pinkB6 + white * 0.5362;
+      pinkB6 = white * 0.115926;
+      channel[index] = pink * 0.11;
+      continue;
+    }
+
+    brownLast = (brownLast + 0.02 * white) / 1.02;
+    channel[index] = brownLast * 3.5 * 0.18;
+  }
+
+  return buffer;
+}
+
+export class FocusBgmPlayer {
+  private listeners = new Set<(state: FocusBgmPlayerState) => void>();
+  private state: FocusBgmPlayerState = {
+    status: 'idle',
+    sourceType: null,
+    trackLabel: null,
+    currentIndex: -1,
+    total: 0,
+  };
+  private lastPreferences: FocusBgmPreferences | null = null;
+  private activeAudio: HTMLAudioElement | null = null;
+  private activeObjectUrl: string | null = null;
+  private noiseRuntime: NoiseRuntime | null = null;
+  private disposed = false;
+
+  private hasPlayableRuntime(preferences: FocusBgmPreferences): boolean {
+    return preferences.enabled
+      && (preferences.sourceType === 'preset' || preferences.customTracks.length > 0);
+  }
+
+  private areTrackListsEqual(
+    left: FocusBgmPreferences['customTracks'],
+    right: FocusBgmPreferences['customTracks'],
+  ): boolean {
+    if (left.length !== right.length) {
+      return false;
+    }
+
+    return left.every((track, index) => {
+      const candidate = right[index];
+      return candidate?.path === track.path && candidate?.name === track.name;
+    });
+  }
+
+  private applyVolume(preferences: FocusBgmPreferences): void {
+    const volume = preferences.volume / 100;
+
+    if (this.activeAudio) {
+      this.activeAudio.volume = volume;
+    }
+
+    if (this.noiseRuntime) {
+      this.noiseRuntime.gainNode.gain.value = volume;
+    }
+  }
+
+  getState(): FocusBgmPlayerState {
+    return this.state;
+  }
+
+  subscribe(listener: (state: FocusBgmPlayerState) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private emit(): void {
+    this.listeners.forEach((listener) => listener(this.state));
+  }
+
+  private setState(next: FocusBgmPlayerState): void {
+    this.state = next;
+    this.emit();
+  }
+
+  private clearActiveObjectUrl(): void {
+    if (!this.activeObjectUrl) {
+      return;
+    }
+
+    URL.revokeObjectURL(this.activeObjectUrl);
+    this.activeObjectUrl = null;
+  }
+
+  private async teardownNoiseRuntime(): Promise<void> {
+    if (!this.noiseRuntime) {
+      return;
+    }
+
+    this.noiseRuntime.sourceNode.stop();
+    this.noiseRuntime.sourceNode.disconnect();
+    this.noiseRuntime.gainNode.disconnect();
+    await this.noiseRuntime.context.close();
+    this.noiseRuntime = null;
+  }
+
+  async stop(): Promise<void> {
+    this.lastPreferences = this.lastPreferences;
+    if (this.activeAudio) {
+      this.activeAudio.pause();
+      this.activeAudio.onended = null;
+      this.activeAudio = null;
+    }
+    await this.teardownNoiseRuntime();
+    this.clearActiveObjectUrl();
+    this.setState({
+      status: 'idle',
+      sourceType: null,
+      trackLabel: null,
+      currentIndex: -1,
+      total: 0,
+    });
+  }
+
+  async startFromPreferences(preferences: FocusBgmPreferences): Promise<void> {
+    this.lastPreferences = preferences;
+
+    if (!preferences.enabled) {
+      await this.stop();
+      return;
+    }
+
+    if (preferences.sourceType === 'preset') {
+      await this.startPreset(preferences);
+      return;
+    }
+
+    if (preferences.customTracks.length === 0) {
+      await this.stop();
+      return;
+    }
+
+    await this.startCustomTrack(preferences, 0);
+  }
+
+  async syncRuntimePreferences(preferences: FocusBgmPreferences): Promise<void> {
+    const previous = this.lastPreferences;
+    this.lastPreferences = preferences;
+
+    if (this.state.status === 'idle') {
+      return;
+    }
+
+    if (!this.hasPlayableRuntime(preferences)) {
+      await this.stop();
+      return;
+    }
+
+    if (!previous) {
+      this.applyVolume(preferences);
+      return;
+    }
+
+    const sourceChanged = previous.sourceType !== preferences.sourceType;
+    const presetChanged = preferences.sourceType === 'preset' && previous.presetId !== preferences.presetId;
+    const tracksChanged = preferences.sourceType === 'custom'
+      && !this.areTrackListsEqual(previous.customTracks, preferences.customTracks);
+
+    if (sourceChanged || presetChanged || tracksChanged) {
+      await this.startFromPreferences(preferences);
+      return;
+    }
+
+    this.applyVolume(preferences);
+  }
+
+  async pause(): Promise<void> {
+    if (this.state.status !== 'playing') {
+      return;
+    }
+
+    if (this.activeAudio) {
+      this.activeAudio.pause();
+    }
+    if (this.noiseRuntime) {
+      await this.noiseRuntime.context.suspend();
+    }
+
+    this.setState({
+      ...this.state,
+      status: 'paused',
+    });
+  }
+
+  async resume(): Promise<void> {
+    if (this.state.status !== 'paused') {
+      return;
+    }
+
+    if (this.activeAudio) {
+      await this.activeAudio.play();
+    }
+    if (this.noiseRuntime) {
+      await this.noiseRuntime.context.resume();
+    }
+
+    this.setState({
+      ...this.state,
+      status: 'playing',
+    });
+  }
+
+  async toggle(): Promise<void> {
+    if (this.state.status === 'playing') {
+      await this.pause();
+      return;
+    }
+
+    if (this.state.status === 'paused') {
+      await this.resume();
+      return;
+    }
+
+    if (this.lastPreferences?.enabled) {
+      await this.startFromPreferences(this.lastPreferences);
+    }
+  }
+
+  private async startPreset(preferences: FocusBgmPreferences): Promise<void> {
+    await this.stop();
+
+    const AudioContextCtor = globalThis.AudioContext;
+    if (!AudioContextCtor) {
+      throw new Error('AudioContext is unavailable in current runtime');
+    }
+
+    const preset = getFocusBgmPresetById(preferences.presetId);
+    const context = new AudioContextCtor();
+    const gainNode = context.createGain();
+    gainNode.gain.value = preferences.volume / 100;
+    const sourceNode = context.createBufferSource();
+    sourceNode.buffer = createNoiseBuffer(context, preset);
+    sourceNode.loop = true;
+    sourceNode.connect(gainNode);
+    gainNode.connect(context.destination);
+    sourceNode.start();
+
+    this.noiseRuntime = { context, gainNode, sourceNode };
+    this.setState({
+      status: 'playing',
+      sourceType: 'preset',
+      trackLabel: preset.label,
+      currentIndex: 0,
+      total: 1,
+    });
+  }
+
+  private async startCustomTrack(
+    preferences: FocusBgmPreferences,
+    index: number,
+  ): Promise<void> {
+    const track = preferences.customTracks[index];
+    if (!track) {
+      await this.stop();
+      return;
+    }
+
+    if (this.noiseRuntime) {
+      await this.teardownNoiseRuntime();
+    }
+    if (this.activeAudio) {
+      this.activeAudio.pause();
+      this.activeAudio.onended = null;
+      this.activeAudio = null;
+    }
+    this.clearActiveObjectUrl();
+
+    const bytes = await readFocusBgmTrackBytes(track.path);
+    const blob = new Blob([bytes], { type: guessAudioMimeType(track.path) });
+    const objectUrl = URL.createObjectURL(blob);
+    const audio = new Audio(objectUrl);
+    audio.loop = false;
+    audio.preload = 'auto';
+    audio.currentTime = 0;
+    audio.volume = preferences.volume / 100;
+    audio.onended = () => {
+      void this.handleTrackEnded(index);
+    };
+    await audio.play();
+
+    this.activeAudio = audio;
+    this.activeObjectUrl = objectUrl;
+    this.setState({
+      status: 'playing',
+      sourceType: 'custom',
+      trackLabel: track.name,
+      currentIndex: index,
+      total: preferences.customTracks.length,
+    });
+  }
+
+  private async handleTrackEnded(currentIndex: number): Promise<void> {
+    if (this.disposed) {
+      return;
+    }
+
+    const preferences = this.lastPreferences;
+    if (!preferences || !this.hasPlayableRuntime(preferences)) {
+      await this.stop();
+      return;
+    }
+
+    const mode: FocusBgmPlaybackMode = preferences.playbackMode;
+
+    const nextIndex = currentIndex + 1;
+    if (nextIndex < preferences.customTracks.length) {
+      await this.startCustomTrack(preferences, nextIndex);
+      return;
+    }
+
+    if (mode === 'loop' && preferences.customTracks.length > 0) {
+      await this.startCustomTrack(preferences, 0);
+      return;
+    }
+
+    await this.stop();
+  }
+
+  async destroy(): Promise<void> {
+    this.disposed = true;
+    await this.stop();
+    this.listeners.clear();
+  }
+}
+
+let focusBgmPlayerInstance: FocusBgmPlayer | null = null;
+
+export function createFocusBgmPlayer(): FocusBgmPlayer {
+  return new FocusBgmPlayer();
+}
+
+export function getFocusBgmPlayer(): FocusBgmPlayer {
+  if (!focusBgmPlayerInstance) {
+    focusBgmPlayerInstance = createFocusBgmPlayer();
+  }
+
+  return focusBgmPlayerInstance;
+}

--- a/src/lib/media/focus-bgm-presets.ts
+++ b/src/lib/media/focus-bgm-presets.ts
@@ -1,0 +1,42 @@
+export type FocusBgmPresetId = 'white-noise' | 'pink-noise' | 'brown-noise';
+
+export type FocusBgmPresetKind = 'noise';
+
+export interface FocusBgmPreset {
+  id: FocusBgmPresetId;
+  label: string;
+  kind: FocusBgmPresetKind;
+  noiseColor: 'white' | 'pink' | 'brown';
+}
+
+export const FOCUS_BGM_PRESETS: readonly FocusBgmPreset[] = [
+  {
+    id: 'white-noise',
+    label: 'White noise',
+    kind: 'noise',
+    noiseColor: 'white',
+  },
+  {
+    id: 'pink-noise',
+    label: 'Pink noise',
+    kind: 'noise',
+    noiseColor: 'pink',
+  },
+  {
+    id: 'brown-noise',
+    label: 'Brown noise',
+    kind: 'noise',
+    noiseColor: 'brown',
+  },
+] as const;
+
+export const DEFAULT_FOCUS_BGM_PRESET_ID: FocusBgmPresetId = 'white-noise';
+
+export function getFocusBgmPresetById(id: string | null | undefined): FocusBgmPreset {
+  const normalized = (id ?? '').trim() as FocusBgmPresetId;
+  return (
+    FOCUS_BGM_PRESETS.find((preset) => preset.id === normalized)
+    ?? FOCUS_BGM_PRESETS.find((preset) => preset.id === DEFAULT_FOCUS_BGM_PRESET_ID)
+    ?? FOCUS_BGM_PRESETS[0]
+  );
+}

--- a/src/ui/app/components/FocusBgmCoordinator.tsx
+++ b/src/ui/app/components/FocusBgmCoordinator.tsx
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { getTimeBlockService } from '@/lib/services';
+import {
+  getFocusBgmPreferences,
+  subscribeFocusBgmPreferencesChanges,
+  type FocusBgmPreferences,
+} from '@/config/focus-bgm-preferences';
+import { getFocusBgmPlayer } from '@/lib/media/focus-bgm-player';
+import { resolveCountdownOverrunMs } from '@/lib/timeblock/countdown-overrun';
+import type { ActiveBlockData } from '@/lib/types/event';
+
+function isFeedbackPhase(block: ActiveBlockData): boolean {
+  if (block.feedbackSubmittedAt) {
+    return true;
+  }
+
+  return block.phase === 'feedback_in_progress'
+    || block.phase === 'action_ended'
+    || Boolean(block.actionEndedAt || block.feedbackStartedAt);
+}
+
+function shouldStopForCountdownEnd(
+  block: ActiveBlockData,
+  preferences: FocusBgmPreferences,
+): boolean {
+  if (block.mode !== 'countdown' || preferences.stopBehavior !== 'timer-end') {
+    return false;
+  }
+
+  return resolveCountdownOverrunMs(block) > 0;
+}
+
+function hasPlayableBgm(preferences: FocusBgmPreferences): boolean {
+  return preferences.enabled
+    && (preferences.sourceType === 'preset' || preferences.customTracks.length > 0);
+}
+
+export function FocusBgmCoordinator(): null {
+  const timeBlockServiceRef = useRef(getTimeBlockService());
+  const playerRef = useRef(getFocusBgmPlayer());
+  const currentBlockRef = useRef<ActiveBlockData | null>(null);
+  const currentPreferencesRef = useRef(getFocusBgmPreferences());
+  const currentStartIdRef = useRef<string | null>(null);
+
+  const syncPlayback = useCallback(async (
+    block: ActiveBlockData | null,
+    preferences: FocusBgmPreferences,
+  ) => {
+    currentBlockRef.current = block;
+    currentPreferencesRef.current = preferences;
+
+    if (!hasPlayableBgm(preferences)) {
+      currentStartIdRef.current = null;
+      await playerRef.current.stop();
+      return;
+    }
+
+    if (!block) {
+      currentStartIdRef.current = null;
+      await playerRef.current.stop();
+      return;
+    }
+
+    if (isFeedbackPhase(block) || shouldStopForCountdownEnd(block, preferences)) {
+      currentStartIdRef.current = null;
+      await playerRef.current.stop();
+      return;
+    }
+
+    await playerRef.current.syncRuntimePreferences(preferences);
+
+    const shouldStartFresh = currentStartIdRef.current !== block.startId
+      || (currentStartIdRef.current === null && playerRef.current.getState().status === 'idle');
+
+    if (block.paused) {
+      if (shouldStartFresh) {
+        await playerRef.current.startFromPreferences(preferences);
+        currentStartIdRef.current = block.startId;
+      }
+      await playerRef.current.pause();
+      return;
+    }
+
+    if (shouldStartFresh) {
+      await playerRef.current.startFromPreferences(preferences);
+      currentStartIdRef.current = block.startId;
+      return;
+    }
+
+    if (playerRef.current.getState().status === 'paused') {
+      await playerRef.current.resume();
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const unsubscribeBlock = timeBlockServiceRef.current.onBlockChange((block) => {
+      if (cancelled) {
+        return;
+      }
+
+      void syncPlayback(block, currentPreferencesRef.current);
+    });
+
+    const unsubscribePreferences = subscribeFocusBgmPreferencesChanges((preferences) => {
+      if (cancelled) {
+        return;
+      }
+
+      void syncPlayback(currentBlockRef.current, preferences);
+    });
+
+    void timeBlockServiceRef.current.loadActiveBlock().then((block) => {
+      if (cancelled) {
+        return;
+      }
+
+      void syncPlayback(block, currentPreferencesRef.current);
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribeBlock();
+      unsubscribePreferences();
+      currentStartIdRef.current = null;
+      void playerRef.current.stop();
+    };
+  }, [syncPlayback]);
+
+  return null;
+}

--- a/src/ui/app/components/FocusTimerWidget.tsx
+++ b/src/ui/app/components/FocusTimerWidget.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { ChevronDown, ChevronRight, NotepadText, Pause, Play, Square, Target } from 'lucide-react';
+import { ChevronDown, ChevronRight, Music4, NotepadText, Pause, Play, Square, Target } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -24,12 +24,17 @@ import {
   getTimerPreferences,
   subscribeTimerPreferencesChanges,
 } from '@/config/timer-preferences';
+import {
+  getFocusBgmPreferences,
+  subscribeFocusBgmPreferencesChanges,
+} from '@/config/focus-bgm-preferences';
 import { getTimerEndSoundPresetById } from '@/lib/media/timer-end-sounds';
 import { getTaskService, getTaskTimerService, getTimeBlockService, type TimerConfig, type TimerMode } from '@/lib/services';
 import { resolveCountdownOverrunMs } from '@/lib/timeblock/countdown-overrun';
 import { resolveCountdownEndTimeDisplay } from '@/lib/timeblock/expected-end-time';
 import type { ActiveBlockData } from '@/lib/types/event';
 import type { TaskNode, TaskStatus } from '@/lib/types/task';
+import { FocusBgmPanel } from '@/ui/app/components/settings/settings-custom-items';
 
 type TaskStatusChoice = 'continue' | 'suspended' | 'completed' | 'abandoned';
 
@@ -122,6 +127,8 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
   const [elapsedMs, setElapsedMs] = useState(25 * 60 * 1000);
   const [countdownOvertimeMs, setCountdownOvertimeMs] = useState(0);
   const [timerPreferences, setTimerPreferences] = useState(() => getTimerPreferences());
+  const [focusBgmPreferences, setFocusBgmPreferences] = useState(() => getFocusBgmPreferences());
+  const [focusBgmDialogOpen, setFocusBgmDialogOpen] = useState(false);
 
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   const [feedback, setFeedback] = useState('');
@@ -214,6 +221,13 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
   useEffect(() => {
     const unsubscribe = subscribeTimerPreferencesChanges((preferences) => {
       setTimerPreferences(preferences);
+    });
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = subscribeFocusBgmPreferencesChanges((preferences) => {
+      setFocusBgmPreferences(preferences);
     });
     return unsubscribe;
   }, []);
@@ -520,6 +534,11 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
     });
     setFeedbackOpen(true);
   }, [enqueueServiceMutation, feedbackInProgress, isRunningUi]);
+
+  const hasFocusBgmConfigured = focusBgmPreferences.enabled
+    && (focusBgmPreferences.sourceType === 'preset' || focusBgmPreferences.customTracks.length > 0);
+  const focusBgmToggleAriaLabel = '背景音设置（Background audio settings）';
+  const focusBgmToggleIcon = <Music4 size={16} />;
 
   const handleSubmitEnd = useCallback(async (feedbackText?: string) => {
     if (feedbackSubmitting) return;
@@ -860,11 +879,27 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
               data-testid="new-focus-running-task-card"
               className={`absolute left-4 right-4 top-4 flex h-[169px] flex-col gap-3 rounded-[24px] border border-[#FFFFFF80] dark:border-[#FFFFFF15] bg-[linear-gradient(180deg,rgba(255,255,255,0.64)_0%,rgba(255,255,255,0.36)_100%)] dark:[background-color:rgba(28,25,23,0.5)] dark:bg-[linear-gradient(180deg,rgba(28,25,23,0.25)_0%,rgba(28,25,23,0)_100%)] px-5 py-4 backdrop-blur-[24px] ${glassCardShadowClass()}`}
             >
-              <div className="flex min-w-0 items-center gap-3">
-                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[#FEF0ED] dark:bg-[#2A1510] text-[#C75B3A] dark:text-[#E8734E]">
-                  <Target size={20} />
+              <div className="flex min-w-0 items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-3">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-[#FEF0ED] dark:bg-[#2A1510] text-[#C75B3A] dark:text-[#E8734E]">
+                    <Target size={20} />
+                  </div>
+                  <p className="truncate text-[20px] font-semibold leading-[1.4] text-[#1C1917] dark:text-[#FAFAF9]">{taskName || '未命名任务'}</p>
                 </div>
-                <p className="truncate text-[20px] font-semibold leading-[1.4] text-[#1C1917] dark:text-[#FAFAF9]">{taskName || '未命名任务'}</p>
+                {hasFocusBgmConfigured ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    data-testid="new-focus-bgm-toggle-button"
+                    aria-label={focusBgmToggleAriaLabel}
+                    className="h-9 w-9 rounded-[10px] border border-[#E7E5E4] bg-white/50 p-0 text-[#C75B3A] hover:bg-white/70 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF10] dark:text-[#E8734E]"
+                    onClick={() => {
+                      setFocusBgmDialogOpen(true);
+                    }}
+                  >
+                    {focusBgmToggleIcon}
+                  </Button>
+                ) : null}
               </div>
               <div className="h-px w-full bg-[#D4785F30] dark:bg-[#D4785F20]" />
               <div className="flex items-center justify-between px-1 pt-1">
@@ -986,6 +1021,16 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
               {feedbackConfirmLabel}
             </Button>
           </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={focusBgmDialogOpen} onOpenChange={setFocusBgmDialogOpen}>
+        <DialogContent className="rounded-2xl">
+          <DialogHeader>
+            <DialogTitle>专注背景音</DialogTitle>
+            <DialogDescription>在专注进行中调整背景音配置与音量</DialogDescription>
+          </DialogHeader>
+          <FocusBgmPanel ctx={{ isDesktop: !isOverlaySurface }} />
         </DialogContent>
       </Dialog>
     </div>

--- a/src/ui/app/components/settings/settings-custom-items.tsx
+++ b/src/ui/app/components/settings/settings-custom-items.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { Bell, Bot, Check, ChevronRight, Key, Mic, Timer, Upload, Wifi } from 'lucide-react';
+import { Bell, Bot, Check, ChevronRight, Key, Mic, Music4, Timer, Upload, Wifi } from 'lucide-react';
 import { useNavigate } from '@tanstack/react-router';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { getTaskBackupService } from '@/lib/services';
@@ -18,6 +18,20 @@ import {
   getTimerEndSoundPresetById,
   type TimerEndSoundPresetId,
 } from '@/lib/media/timer-end-sounds';
+import {
+  getFocusBgmPreferences,
+  subscribeFocusBgmPreferencesChanges,
+  updateFocusBgmPreferences,
+  type FocusBgmPlaybackMode,
+  type FocusBgmStopBehavior,
+  type FocusBgmSourceType,
+} from '@/config/focus-bgm-preferences';
+import {
+  FOCUS_BGM_PRESETS,
+  getFocusBgmPresetById,
+  type FocusBgmPresetId,
+} from '@/lib/media/focus-bgm-presets';
+import { pickFocusBgmTracks } from '@/lib/media/focus-bgm-file-picker';
 import {
   getLLMApiKey,
   getLLMBaseUrl,
@@ -83,6 +97,282 @@ function SecondaryValue({ value }: { value: string }) {
       <span>{value}</span>
       <ChevronRight className="h-4 w-4" />
     </div>
+  );
+}
+
+function FocusBgmChoiceButton({
+  label,
+  selected,
+  onClick,
+}: {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex w-full items-center justify-between rounded-xl border px-4 py-3 text-left text-sm transition-colors ${
+        selected
+          ? 'border-[#C75B3A] bg-[#FEF0ED] text-[#1C1917] dark:border-[#E8734E] dark:bg-[#2A1510] dark:text-[#FAFAF9]'
+          : 'border-[#F0ECE8] bg-white text-[#1C1917] dark:border-[#FFFFFF15] dark:bg-[#1C1917] dark:text-[#FAFAF9]'
+      }`}
+    >
+      <span>{label}</span>
+      {selected ? <Check className="h-4 w-4 text-[#C75B3A]" /> : null}
+    </button>
+  );
+}
+
+function hasFocusBgmSourceSelection(sourceType: FocusBgmSourceType, trackCount: number): boolean {
+  return sourceType === 'preset' || trackCount > 0;
+}
+
+function formatFocusBgmSummary(preferences: ReturnType<typeof getFocusBgmPreferences>): string {
+  if (!preferences.enabled) {
+    return '已关闭';
+  }
+
+  const modeLabel = preferences.playbackMode === 'loop' ? '循环' : '顺序';
+  if (preferences.sourceType === 'preset') {
+    return `${getFocusBgmPresetById(preferences.presetId).label} · ${modeLabel}`;
+  }
+
+  if (preferences.customTracks.length > 0) {
+    return `${preferences.customTracks.length} 首本地音频 · ${modeLabel}`;
+  }
+
+  return `未选择本地音频 · ${modeLabel}`;
+}
+
+export function FocusBgmPanel(_props: { ctx: SettingsContext }) {
+  const [notice, setNotice] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [preferences, setPreferences] = useSettingValue(
+    () => getFocusBgmPreferences(),
+    subscribeFocusBgmPreferencesChanges,
+  );
+
+  const applyPatch = (patch: Partial<typeof preferences>) => {
+    const next = {
+      ...preferences,
+      ...updateFocusBgmPreferences(patch),
+    };
+    setPreferences(next);
+    setError(null);
+    return next;
+  };
+
+  const handleToggleEnabled = (enabled: boolean) => {
+    applyPatch({ enabled });
+  };
+
+  const handleSelectSource = (sourceType: FocusBgmSourceType) => {
+    applyPatch({ sourceType });
+  };
+
+  const handleSelectPreset = (presetId: FocusBgmPresetId) => {
+    applyPatch({ sourceType: 'preset', presetId, enabled: true });
+  };
+
+  const handleSelectPlaybackMode = (playbackMode: FocusBgmPlaybackMode) => {
+    applyPatch({ playbackMode });
+  };
+
+  const handleSelectStopBehavior = (stopBehavior: FocusBgmStopBehavior) => {
+    applyPatch({ stopBehavior });
+  };
+
+  const handleSelectLocalTracks = async () => {
+    try {
+      const tracks = await pickFocusBgmTracks();
+      if (tracks.length === 0) {
+        setNotice('未选择新的本地音频');
+        setError(null);
+        return;
+      }
+
+      applyPatch({
+        enabled: true,
+        sourceType: 'custom',
+        customTracks: tracks,
+      });
+      setNotice(`已选择 ${tracks.length} 首本地音频`);
+    } catch (selectionError) {
+      setNotice(null);
+      setError(selectionError instanceof Error ? selectionError.message : '选择本地音频失败');
+    }
+  };
+
+  const handleClearLocalTracks = () => {
+    applyPatch({ customTracks: [] });
+    setNotice('已清空本地音频列表');
+    setError(null);
+  };
+
+  return (
+    <div className="space-y-4">
+      <NoticeBlock message={notice} tone="success" />
+      <NoticeBlock message={error} tone="error" />
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <p className="text-xs font-medium text-[#78716C]">播放开关</p>
+          <div className="grid grid-cols-2 gap-2">
+            <FocusBgmChoiceButton
+              label="关闭背景音"
+              selected={!preferences.enabled}
+              onClick={() => handleToggleEnabled(false)}
+            />
+            <FocusBgmChoiceButton
+              label="开启背景音"
+              selected={preferences.enabled}
+              onClick={() => handleToggleEnabled(true)}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs font-medium text-[#78716C]">音源类型</p>
+          <div className="grid grid-cols-2 gap-2">
+            <FocusBgmChoiceButton
+              label="预设白噪音"
+              selected={preferences.sourceType === 'preset'}
+              onClick={() => handleSelectSource('preset')}
+            />
+            <FocusBgmChoiceButton
+              label="本地音频"
+              selected={preferences.sourceType === 'custom'}
+              onClick={() => handleSelectSource('custom')}
+            />
+          </div>
+        </div>
+
+        {preferences.sourceType === 'preset' ? (
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-[#78716C]">预设选择</p>
+            {FOCUS_BGM_PRESETS.map((preset) => (
+              <FocusBgmChoiceButton
+                key={preset.id}
+                label={preset.label}
+                selected={preferences.presetId === preset.id}
+                onClick={() => handleSelectPreset(preset.id)}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-[#78716C]">本地音频</p>
+            <div className="grid grid-cols-2 gap-2">
+              <FocusBgmChoiceButton
+                label="选择本地音频"
+                selected={preferences.customTracks.length > 0}
+                onClick={() => {
+                  void handleSelectLocalTracks();
+                }}
+              />
+              <FocusBgmChoiceButton
+                label="清空本地列表"
+                selected={false}
+                onClick={handleClearLocalTracks}
+              />
+            </div>
+            <div className="rounded-xl border border-[#F0ECE8] bg-[#FAF7F5] px-4 py-3 text-xs text-[#57534E] dark:border-[#FFFFFF15] dark:bg-[#1C1917] dark:text-[#D6D3D1]">
+              {preferences.customTracks.length > 0 ? (
+                <ul className="space-y-1">
+                  {preferences.customTracks.map((track) => (
+                    <li key={track.path}>{track.name}</li>
+                  ))}
+                </ul>
+              ) : (
+                <span>当前未选择本地音频</span>
+              )}
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <p className="text-xs font-medium text-[#78716C]">播放模式</p>
+          <div className="grid grid-cols-2 gap-2">
+            <FocusBgmChoiceButton
+              label="循环播放"
+              selected={preferences.playbackMode === 'loop'}
+              onClick={() => handleSelectPlaybackMode('loop')}
+            />
+            <FocusBgmChoiceButton
+              label="顺序播放"
+              selected={preferences.playbackMode === 'sequence'}
+              onClick={() => handleSelectPlaybackMode('sequence')}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs font-medium text-[#78716C]">停止策略</p>
+          <div className="grid grid-cols-2 gap-2">
+            <FocusBgmChoiceButton
+              label="时间到即停"
+              selected={preferences.stopBehavior === 'timer-end'}
+              onClick={() => handleSelectStopBehavior('timer-end')}
+            />
+            <FocusBgmChoiceButton
+              label="手动结束才停"
+              selected={preferences.stopBehavior === 'manual-end'}
+              onClick={() => handleSelectStopBehavior('manual-end')}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-xs font-medium text-[#78716C]">
+            <span>音量</span>
+            <span>{preferences.volume}%</span>
+          </div>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            step={1}
+            value={preferences.volume}
+            onChange={(event) => applyPatch({ volume: Number(event.target.value) })}
+            className="w-full accent-[#C75B3A]"
+            aria-label="背景音音量（Background music volume）"
+          />
+        </div>
+
+        {!hasFocusBgmSourceSelection(preferences.sourceType, preferences.customTracks.length) ? (
+          <p className="text-xs text-[#A8A29E]">切换到本地音频后，请先选择至少一首音频文件。</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function FocusBgmSetting(_props: { ctx: SettingsContext }) {
+  const [open, setOpen] = useState(false);
+  const [preferences] = useSettingValue(
+    () => getFocusBgmPreferences(),
+    subscribeFocusBgmPreferencesChanges,
+  );
+
+  return (
+    <>
+      <SettingRow
+        icon={<Music4 className="h-[18px] w-[18px] text-[#78716C]" />}
+        label="专注背景音"
+        onClick={() => setOpen(true)}
+        right={<SecondaryValue value={formatFocusBgmSummary(preferences)} />}
+      />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="rounded-2xl">
+          <DialogHeader>
+            <DialogTitle>专注背景音</DialogTitle>
+            <DialogDescription>为专注过程配置白噪音或本地背景音乐</DialogDescription>
+          </DialogHeader>
+          <FocusBgmPanel ctx={_props.ctx} />
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 

--- a/src/ui/app/config/settings/settings-registry.ts
+++ b/src/ui/app/config/settings/settings-registry.ts
@@ -126,6 +126,7 @@ import {
 import {
   AiApiKeySetting,
   DevicePairingSetting,
+  FocusBgmSetting,
   MossVoiceTestSetting,
   TaskBackendStatusSetting,
   TaskImportActionSetting,
@@ -429,6 +430,13 @@ export const SETTINGS_REGISTRY: SettingsItem[] = [
     subscribe: (cb: (value: string) => void) => subscribeTimerPreferencesChanges((preferences) => {
       cb(preferences.countdownEndSoundEnabled ? preferences.countdownEndSoundPresetId : 'off');
     }),
+  },
+  {
+    id: 'focus-bgm',
+    label: '专注背景音',
+    category: 'timer',
+    type: 'custom',
+    component: FocusBgmSetting,
   },
   {
     id: 'feedback-content',

--- a/tests/unit/components/FocusBgmCoordinator.issue136.test.tsx
+++ b/tests/unit/components/FocusBgmCoordinator.issue136.test.tsx
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import type { ActiveBlockData } from '@/lib/types/event';
+
+type MockFocusBgmPreferences = {
+  enabled: boolean;
+  sourceType: 'preset' | 'custom';
+  presetId: 'white-noise' | 'pink-noise' | 'brown-noise';
+  customTracks: { path: string; name: string }[];
+  playbackMode: 'loop' | 'sequence';
+  stopBehavior: 'timer-end' | 'manual-end';
+  volume: number;
+};
+
+const loadActiveBlockMock = vi.hoisted(() => vi.fn());
+const onBlockChangeMock = vi.hoisted(() => vi.fn());
+const startFromPreferencesMock = vi.hoisted(() => vi.fn());
+const syncRuntimePreferencesMock = vi.hoisted(() => vi.fn());
+const pauseMock = vi.hoisted(() => vi.fn());
+const resumeMock = vi.hoisted(() => vi.fn());
+const stopMock = vi.hoisted(() => vi.fn());
+const resolveCountdownOverrunMsMock = vi.hoisted(() => vi.fn(() => 0));
+
+const bgmState = vi.hoisted(() => ({
+  value: {
+    enabled: true,
+    sourceType: 'preset' as const,
+    presetId: 'white-noise' as const,
+    customTracks: [] as { path: string; name: string }[],
+    playbackMode: 'loop' as const,
+    stopBehavior: 'manual-end' as const,
+    volume: 60,
+  } satisfies MockFocusBgmPreferences,
+  listeners: new Set<(value: MockFocusBgmPreferences) => void>(),
+}));
+
+vi.mock('@/lib/services', () => ({
+  getTimeBlockService: () => ({
+    loadActiveBlock: loadActiveBlockMock,
+    onBlockChange: onBlockChangeMock,
+  }),
+}));
+
+vi.mock('@/config/focus-bgm-preferences', () => ({
+  getFocusBgmPreferences: vi.fn(() => bgmState.value),
+  subscribeFocusBgmPreferencesChanges: vi.fn((listener: (value: MockFocusBgmPreferences) => void) => {
+    bgmState.listeners.add(listener);
+    return () => {
+      bgmState.listeners.delete(listener);
+    };
+  }),
+}));
+
+vi.mock('@/lib/media/focus-bgm-player', () => ({
+  getFocusBgmPlayer: () => ({
+    getState: () => ({ status: 'idle', sourceType: null, trackLabel: null, currentIndex: -1, total: 0 }),
+    startFromPreferences: startFromPreferencesMock,
+    syncRuntimePreferences: syncRuntimePreferencesMock,
+    pause: pauseMock,
+    resume: resumeMock,
+    stop: stopMock,
+  }),
+}));
+
+vi.mock('@/lib/timeblock/countdown-overrun', () => ({
+  resolveCountdownOverrunMs: resolveCountdownOverrunMsMock,
+}));
+
+import { FocusBgmCoordinator } from '@/ui/app/components/FocusBgmCoordinator';
+
+function runningBlock(overrides: Partial<ActiveBlockData> = {}): ActiveBlockData {
+  return {
+    startId: 'block-1',
+    name: '专注任务',
+    mode: 'countdown',
+    targetMinutes: 25,
+    elapsed: 1000,
+    startTime: 0,
+    paused: false,
+    phase: 'running',
+    ...overrides,
+  };
+}
+
+describe('issue-136 focus bgm coordinator（专注背景音全局协调器）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    bgmState.value = {
+      enabled: true,
+      sourceType: 'preset',
+      presetId: 'white-noise',
+      customTracks: [],
+      playbackMode: 'loop',
+      stopBehavior: 'manual-end',
+      volume: 60,
+    };
+    bgmState.listeners.clear();
+    loadActiveBlockMock.mockResolvedValue(null);
+    onBlockChangeMock.mockImplementation(() => () => {});
+    startFromPreferencesMock.mockResolvedValue(undefined);
+    syncRuntimePreferencesMock.mockResolvedValue(undefined);
+    pauseMock.mockResolvedValue(undefined);
+    resumeMock.mockResolvedValue(undefined);
+    stopMock.mockResolvedValue(undefined);
+    resolveCountdownOverrunMsMock.mockReturnValue(0);
+  });
+
+  it('starts bgm for an active running block（存在运行中的专注块时自动开始播放）', async () => {
+    loadActiveBlockMock.mockResolvedValue(runningBlock());
+
+    render(<FocusBgmCoordinator />);
+
+    await waitFor(() => expect(startFromPreferencesMock).toHaveBeenCalledWith(expect.objectContaining({
+      enabled: true,
+      presetId: 'white-noise',
+    })));
+  });
+
+  it('pauses and resumes based on block state（随专注暂停与恢复同步暂停/恢复）', async () => {
+    let listener: ((block: ActiveBlockData | null) => void) | null = null;
+    onBlockChangeMock.mockImplementation((cb: (block: ActiveBlockData | null) => void) => {
+      listener = cb;
+      return () => {};
+    });
+
+    render(<FocusBgmCoordinator />);
+
+    listener?.(runningBlock({ paused: true, phase: 'paused' }));
+    await waitFor(() => expect(pauseMock).toHaveBeenCalledTimes(1));
+
+    listener?.(runningBlock({ paused: false, phase: 'running' }));
+    await waitFor(() => expect(startFromPreferencesMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('stops when countdown overrun should end music（到达停止条件时停止播放）', async () => {
+    let listener: ((block: ActiveBlockData | null) => void) | null = null;
+    onBlockChangeMock.mockImplementation((cb: (block: ActiveBlockData | null) => void) => {
+      listener = cb;
+      return () => {};
+    });
+    bgmState.value = {
+      ...bgmState.value,
+      stopBehavior: 'timer-end',
+    };
+    resolveCountdownOverrunMsMock.mockReturnValue(3_000);
+
+    render(<FocusBgmCoordinator />);
+
+    listener?.(runningBlock());
+    await waitFor(() => expect(stopMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('pushes updated preferences into the active player（设置变更时应把新音量推给当前播放器）', async () => {
+    loadActiveBlockMock.mockResolvedValue(runningBlock());
+
+    render(<FocusBgmCoordinator />);
+
+    await waitFor(() => expect(startFromPreferencesMock).toHaveBeenCalledTimes(1));
+
+    bgmState.listeners.forEach((listener) => listener({
+      ...bgmState.value,
+      volume: 88,
+    }));
+
+    await waitFor(() => expect(syncRuntimePreferencesMock).toHaveBeenCalledWith(expect.objectContaining({
+      volume: 88,
+    })));
+  });
+});

--- a/tests/unit/components/FocusTimerWidget.bgm.issue136.test.tsx
+++ b/tests/unit/components/FocusTimerWidget.bgm.issue136.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FocusTimerWidget } from '@/ui/app/components/FocusTimerWidget';
+
+const loadActiveBlockMock = vi.hoisted(() => vi.fn());
+const onBlockChangeMock = vi.hoisted(() => vi.fn(() => () => {}));
+const pickFocusBgmTracksMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/services', () => ({
+  getTimeBlockService: () => ({
+    loadActiveBlock: loadActiveBlockMock,
+    startBlock: vi.fn(),
+    pauseBlock: vi.fn(),
+    resumeBlock: vi.fn(),
+    endBlock: vi.fn(),
+    markEnding: vi.fn(),
+    updateElapsed: vi.fn(),
+    onBlockChange: onBlockChangeMock,
+    startSync: vi.fn(),
+    stopSync: vi.fn(),
+  }),
+  getTaskService: () => ({
+    getTask: vi.fn().mockResolvedValue(null),
+  }),
+  getTaskTimerService: () => ({
+    startBlockForTask: vi.fn(),
+  }),
+}));
+
+vi.mock('@/config/timer-preferences', () => ({
+  getTimerPreferences: () => ({
+    countdownEndMode: 'soft',
+    countdownEndSoundEnabled: false,
+    countdownEndSoundPresetId: 'dang',
+  }),
+  subscribeTimerPreferencesChanges: () => () => {},
+}));
+
+vi.mock('@/config/focus-bgm-preferences', () => ({
+  getFocusBgmPreferences: () => ({
+    enabled: true,
+    sourceType: 'preset',
+    presetId: 'white-noise',
+    customTracks: [],
+    playbackMode: 'loop',
+    stopBehavior: 'manual-end',
+    volume: 60,
+  }),
+  subscribeFocusBgmPreferencesChanges: () => () => {},
+  updateFocusBgmPreferences: vi.fn((patch: Record<string, unknown>) => patch),
+}));
+
+vi.mock('@/lib/media/focus-bgm-file-picker', () => ({
+  pickFocusBgmTracks: pickFocusBgmTracksMock,
+}));
+
+describe('issue-136 FocusTimerWidget bgm control（专注计时器背景音快捷控制）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pickFocusBgmTracksMock.mockResolvedValue([]);
+    loadActiveBlockMock.mockResolvedValue({
+      startId: 'block-1',
+      name: '专注任务',
+      startTime: 0,
+      elapsed: 10_000,
+      mode: 'countdown',
+      paused: false,
+      targetMinutes: 25,
+      phase: 'running',
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('opens bgm settings dialog while running（运行态背景音按钮可打开设置弹窗）', async () => {
+    render(<FocusTimerWidget />);
+
+    await waitFor(() => expect(screen.getByTestId('new-focus-state-running')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('new-focus-bgm-toggle-button'));
+
+    expect(screen.getByText('专注背景音')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '开启背景音' })).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/settings/setup-settings-mocks.tsx
+++ b/tests/unit/components/settings/setup-settings-mocks.tsx
@@ -100,6 +100,24 @@ vi.mock('@/config/timer-preferences', () => ({
   updateTimerPreferences: vi.fn((p: any) => p),
 }));
 
+vi.mock('@/config/focus-bgm-preferences', () => ({
+  getFocusBgmPreferences: vi.fn(() => ({
+    enabled: false,
+    sourceType: 'preset',
+    presetId: 'white-noise',
+    customTracks: [],
+    playbackMode: 'loop',
+    stopBehavior: 'manual-end',
+    volume: 60,
+  })),
+  subscribeFocusBgmPreferencesChanges: vi.fn(() => () => {}),
+  updateFocusBgmPreferences: vi.fn((patch: any) => patch),
+}));
+
+vi.mock('@/lib/media/focus-bgm-file-picker', () => ({
+  pickFocusBgmTracks: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock('@/config/mock-data', () => ({
   getUseMockDataEnabled: vi.fn(() => false),
   setUseMockDataEnabled: vi.fn(),

--- a/tests/unit/config/focus-bgm-preferences.test.ts
+++ b/tests/unit/config/focus-bgm-preferences.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('focus bgm preferences（专注背景音偏好）', () => {
+  let storage: Record<string, string>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    storage = {};
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => (key in storage ? storage[key] : null),
+        setItem: (key: string, value: string) => {
+          storage[key] = value;
+        },
+        removeItem: (key: string) => {
+          delete storage[key];
+        },
+      },
+    });
+  });
+
+  it('defaults to disabled preset playback（默认关闭并使用预设源）', async () => {
+    const module = await import('@/config/focus-bgm-preferences');
+
+    expect(module.getFocusBgmPreferences()).toEqual({
+      enabled: false,
+      sourceType: 'preset',
+      presetId: 'white-noise',
+      customTracks: [],
+      playbackMode: 'loop',
+      stopBehavior: 'manual-end',
+      volume: 60,
+    });
+  });
+
+  it('normalizes invalid persisted data（能归一化非法持久化数据）', async () => {
+    storage['exomind:focusBgmPreferences'] = JSON.stringify({
+      enabled: 'yes',
+      sourceType: 'invalid',
+      presetId: 'unknown',
+      customTracks: [{ path: 'C:/music/a.mp3' }, { path: 1, name: 'bad' }],
+      playbackMode: 'invalid',
+      stopBehavior: 'invalid',
+      volume: 999,
+    });
+
+    const module = await import('@/config/focus-bgm-preferences');
+
+    expect(module.getFocusBgmPreferences()).toEqual({
+      enabled: false,
+      sourceType: 'preset',
+      presetId: 'white-noise',
+      customTracks: [{ path: 'C:/music/a.mp3', name: 'a.mp3' }],
+      playbackMode: 'loop',
+      stopBehavior: 'manual-end',
+      volume: 100,
+    });
+  });
+
+  it('persists updates and emits changes（持久化更新并广播变化）', async () => {
+    const module = await import('@/config/focus-bgm-preferences');
+    const listener = vi.fn();
+    const unsubscribe = module.subscribeFocusBgmPreferencesChanges(listener);
+
+    const next = module.updateFocusBgmPreferences({
+      enabled: true,
+      sourceType: 'custom',
+      customTracks: [
+        { path: 'D:/music/one.mp3', name: 'one.mp3' },
+        { path: 'D:/music/two.mp3', name: 'two.mp3' },
+      ],
+      playbackMode: 'sequence',
+      stopBehavior: 'timer-end',
+      volume: 78,
+    });
+
+    expect(next.enabled).toBe(true);
+    expect(next.sourceType).toBe('custom');
+    expect(next.customTracks).toHaveLength(2);
+    expect(next.playbackMode).toBe('sequence');
+    expect(next.stopBehavior).toBe('timer-end');
+    expect(next.volume).toBe(78);
+    expect(JSON.parse(storage['exomind:focusBgmPreferences'])).toEqual(next);
+    expect(listener).toHaveBeenCalledWith(next);
+
+    unsubscribe();
+  });
+
+  it('syncs through storage events（支持 storage 事件同步）', async () => {
+    const module = await import('@/config/focus-bgm-preferences');
+    const listener = vi.fn();
+    const unsubscribe = module.subscribeFocusBgmPreferencesChanges(listener);
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'exomind:focusBgmPreferences',
+      newValue: JSON.stringify({
+        enabled: true,
+        sourceType: 'preset',
+        presetId: 'brown-noise',
+        customTracks: [],
+        playbackMode: 'loop',
+        stopBehavior: 'manual-end',
+        volume: 42,
+      }),
+    }));
+
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({
+      enabled: true,
+      presetId: 'brown-noise',
+      volume: 42,
+    }));
+
+    unsubscribe();
+  });
+});

--- a/tests/unit/media/focus-bgm-file-picker.test.ts
+++ b/tests/unit/media/focus-bgm-file-picker.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  isTauri: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: mocks.isTauri,
+  invoke: mocks.invoke,
+}));
+
+describe('focus bgm file picker（专注背景音文件选择）', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.isTauri.mockResolvedValue(false);
+    mocks.invoke.mockResolvedValue(null);
+  });
+
+  it('rejects custom local track picking on web（Web 下拒绝本地持久音频选择）', async () => {
+    const module = await import('@/lib/media/focus-bgm-file-picker');
+
+    await expect(module.pickFocusBgmTracks()).rejects.toThrow('仅桌面端支持选择本地背景音频');
+  });
+
+  it('returns tauri-picked tracks in original order（Tauri 下按原顺序返回多音频）', async () => {
+    mocks.isTauri.mockResolvedValue(true);
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command === 'pick_audio_files') {
+        return [
+          { path: 'D:/music/rain.mp3', name: 'rain.mp3' },
+          { path: 'D:/music/cafe.flac', name: 'cafe.flac' },
+        ];
+      }
+      return null;
+    });
+
+    const module = await import('@/lib/media/focus-bgm-file-picker');
+
+    await expect(module.pickFocusBgmTracks()).resolves.toEqual([
+      { path: 'D:/music/rain.mp3', name: 'rain.mp3' },
+      { path: 'D:/music/cafe.flac', name: 'cafe.flac' },
+    ]);
+    expect(mocks.invoke).toHaveBeenCalledWith('pick_audio_files');
+  });
+
+  it('reads selected track bytes via tauri command（通过 Tauri 命令读取音频字节）', async () => {
+    mocks.isTauri.mockResolvedValue(true);
+    mocks.invoke.mockImplementation(async (command: string, payload?: Record<string, unknown>) => {
+      if (command === 'read_file_binary') {
+        expect(payload).toEqual({ path: 'D:/music/rain.mp3' });
+        return [1, 2, 3, 4];
+      }
+      return null;
+    });
+
+    const module = await import('@/lib/media/focus-bgm-file-picker');
+
+    await expect(module.readFocusBgmTrackBytes('D:/music/rain.mp3')).resolves.toEqual(new Uint8Array([1, 2, 3, 4]));
+  });
+});

--- a/tests/unit/media/focus-bgm-player.test.ts
+++ b/tests/unit/media/focus-bgm-player.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const filePickerMocks = vi.hoisted(() => ({
+  readFocusBgmTrackBytes: vi.fn(),
+}));
+
+vi.mock('@/lib/media/focus-bgm-file-picker', () => ({
+  readFocusBgmTrackBytes: filePickerMocks.readFocusBgmTrackBytes,
+}));
+
+describe('focus bgm player（专注背景音播放器）', () => {
+  let audioInstances: MockAudio[];
+  let gainNodes: MockGainNode[];
+
+  class MockAudio {
+    src: string;
+    loop = false;
+    volume = 1;
+    preload = '';
+    currentTime = 0;
+    onended: (() => void) | null = null;
+    play = vi.fn().mockResolvedValue(undefined);
+    pause = vi.fn();
+
+    constructor(src: string) {
+      this.src = src;
+      audioInstances.push(this);
+    }
+  }
+
+  class MockGainNode {
+    gain = { value: 1 };
+    connect = vi.fn();
+    disconnect = vi.fn();
+  }
+
+  class MockBufferSourceNode {
+    buffer: unknown = null;
+    loop = false;
+    onended: (() => void) | null = null;
+    connect = vi.fn();
+    start = vi.fn();
+    stop = vi.fn();
+    disconnect = vi.fn();
+  }
+
+  class MockAudioContext {
+    destination = {};
+    state: 'running' | 'suspended' | 'closed' = 'running';
+    createGain = vi.fn(() => {
+      const node = new MockGainNode();
+      gainNodes.push(node);
+      return node;
+    });
+    createBuffer = vi.fn((_channels: number, length: number, _sampleRate: number) => ({
+      getChannelData: (_channel: number) => new Float32Array(length),
+    }));
+    createBufferSource = vi.fn(() => new MockBufferSourceNode());
+    resume = vi.fn(async () => {
+      this.state = 'running';
+    });
+    suspend = vi.fn(async () => {
+      this.state = 'suspended';
+    });
+    close = vi.fn(async () => {
+      this.state = 'closed';
+    });
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    audioInstances = [];
+    gainNodes = [];
+
+    vi.stubGlobal('Audio', MockAudio as unknown as typeof Audio);
+    vi.stubGlobal('AudioContext', MockAudioContext as unknown as typeof AudioContext);
+    vi.stubGlobal('URL', class MockUrl extends URL {} as unknown as typeof URL);
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob://track-1');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    filePickerMocks.readFocusBgmTrackBytes.mockResolvedValue(new Uint8Array([1, 2, 3]));
+  });
+
+  it('plays generated noise preset and updates state（可播放生成型噪音预设）', async () => {
+    const module = await import('@/lib/media/focus-bgm-player');
+    const player = module.createFocusBgmPlayer();
+
+    const stateListener = vi.fn();
+    const unsubscribe = player.subscribe(stateListener);
+
+    await player.startFromPreferences({
+      enabled: true,
+      sourceType: 'preset',
+      presetId: 'pink-noise',
+      customTracks: [],
+      playbackMode: 'loop',
+      stopBehavior: 'manual-end',
+      volume: 55,
+    });
+
+    expect(player.getState()).toEqual(expect.objectContaining({
+      status: 'playing',
+      trackLabel: 'Pink noise',
+      sourceType: 'preset',
+    }));
+    expect(stateListener).toHaveBeenCalled();
+
+    unsubscribe();
+  });
+
+  it('plays custom tracks sequentially（本地多音频可顺序播放）', async () => {
+    const module = await import('@/lib/media/focus-bgm-player');
+    const player = module.createFocusBgmPlayer();
+
+    await player.startFromPreferences({
+      enabled: true,
+      sourceType: 'custom',
+      presetId: 'white-noise',
+      customTracks: [
+        { path: 'D:/music/one.mp3', name: 'one.mp3' },
+        { path: 'D:/music/two.mp3', name: 'two.mp3' },
+      ],
+      playbackMode: 'sequence',
+      stopBehavior: 'manual-end',
+      volume: 80,
+    });
+
+    expect(audioInstances).toHaveLength(1);
+    expect(audioInstances[0].play).toHaveBeenCalledTimes(1);
+
+    audioInstances[0].onended?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(audioInstances).toHaveLength(2);
+    expect(filePickerMocks.readFocusBgmTrackBytes).toHaveBeenCalledWith('D:/music/one.mp3');
+    expect(filePickerMocks.readFocusBgmTrackBytes).toHaveBeenCalledWith('D:/music/two.mp3');
+    expect(player.getState()).toEqual(expect.objectContaining({
+      status: 'playing',
+      trackLabel: 'two.mp3',
+      currentIndex: 1,
+    }));
+  });
+
+  it('restarts playlist in loop mode（循环模式会回到第一首）', async () => {
+    const module = await import('@/lib/media/focus-bgm-player');
+    const player = module.createFocusBgmPlayer();
+
+    await player.startFromPreferences({
+      enabled: true,
+      sourceType: 'custom',
+      presetId: 'white-noise',
+      customTracks: [
+        { path: 'D:/music/one.mp3', name: 'one.mp3' },
+        { path: 'D:/music/two.mp3', name: 'two.mp3' },
+      ],
+      playbackMode: 'loop',
+      stopBehavior: 'manual-end',
+      volume: 80,
+    });
+
+    audioInstances[0].onended?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    audioInstances[1].onended?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(audioInstances).toHaveLength(3);
+    expect(player.getState()).toEqual(expect.objectContaining({
+      status: 'playing',
+      currentIndex: 0,
+    }));
+  });
+
+  it('supports pause and resume（支持暂停与恢复）', async () => {
+    const module = await import('@/lib/media/focus-bgm-player');
+    const player = module.createFocusBgmPlayer();
+
+    await player.startFromPreferences({
+      enabled: true,
+      sourceType: 'custom',
+      presetId: 'white-noise',
+      customTracks: [{ path: 'D:/music/one.mp3', name: 'one.mp3' }],
+      playbackMode: 'loop',
+      stopBehavior: 'manual-end',
+      volume: 30,
+    });
+
+    await player.pause();
+    expect(audioInstances[0].pause).toHaveBeenCalledTimes(1);
+    expect(player.getState().status).toBe('paused');
+
+    await player.resume();
+    expect(audioInstances[0].play).toHaveBeenCalledTimes(2);
+    expect(player.getState().status).toBe('playing');
+  });
+
+  it('updates custom track volume without restarting playback（运行中调整本地音频音量应立即生效且不重播）', async () => {
+    const module = await import('@/lib/media/focus-bgm-player');
+    const player = module.createFocusBgmPlayer();
+
+    await player.startFromPreferences({
+      enabled: true,
+      sourceType: 'custom',
+      presetId: 'white-noise',
+      customTracks: [{ path: 'D:/music/one.mp3', name: 'one.mp3' }],
+      playbackMode: 'loop',
+      stopBehavior: 'manual-end',
+      volume: 20,
+    });
+
+    expect(audioInstances).toHaveLength(1);
+    expect(audioInstances[0].volume).toBe(0.2);
+
+    await player.syncRuntimePreferences({
+      enabled: true,
+      sourceType: 'custom',
+      presetId: 'white-noise',
+      customTracks: [{ path: 'D:/music/one.mp3', name: 'one.mp3' }],
+      playbackMode: 'loop',
+      stopBehavior: 'manual-end',
+      volume: 75,
+    });
+
+    expect(audioInstances).toHaveLength(1);
+    expect(audioInstances[0].play).toHaveBeenCalledTimes(1);
+    expect(audioInstances[0].volume).toBe(0.75);
+  });
+
+  it('updates preset gain without recreating noise runtime（运行中调整预设噪音音量应立即生效）', async () => {
+    const module = await import('@/lib/media/focus-bgm-player');
+    const player = module.createFocusBgmPlayer();
+
+    await player.startFromPreferences({
+      enabled: true,
+      sourceType: 'preset',
+      presetId: 'brown-noise',
+      customTracks: [],
+      playbackMode: 'loop',
+      stopBehavior: 'manual-end',
+      volume: 25,
+    });
+
+    expect(gainNodes).toHaveLength(1);
+    expect(gainNodes[0].gain.value).toBe(0.25);
+
+    await player.syncRuntimePreferences({
+      enabled: true,
+      sourceType: 'preset',
+      presetId: 'brown-noise',
+      customTracks: [],
+      playbackMode: 'loop',
+      stopBehavior: 'manual-end',
+      volume: 65,
+    });
+
+    expect(gainNodes).toHaveLength(1);
+    expect(gainNodes[0].gain.value).toBe(0.65);
+  });
+});

--- a/tests/unit/settings/settings-focus-bgm.issue136.test.tsx
+++ b/tests/unit/settings/settings-focus-bgm.issue136.test.tsx
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '../components/settings/setup-settings-mocks';
+
+type MockFocusBgmPreferences = {
+  enabled: boolean;
+  sourceType: 'preset' | 'custom';
+  presetId: 'white-noise' | 'pink-noise' | 'brown-noise';
+  customTracks: { path: string; name: string }[];
+  playbackMode: 'loop' | 'sequence';
+  stopBehavior: 'timer-end' | 'manual-end';
+  volume: number;
+};
+
+const bgmState = vi.hoisted(() => ({
+  value: {
+    enabled: false,
+    sourceType: 'preset' as const,
+    presetId: 'white-noise' as const,
+    customTracks: [] as { path: string; name: string }[],
+    playbackMode: 'loop' as const,
+    stopBehavior: 'manual-end' as const,
+    volume: 60,
+  } satisfies MockFocusBgmPreferences,
+  listeners: new Set<(value: MockFocusBgmPreferences) => void>(),
+}));
+
+vi.mock('@/config/focus-bgm-preferences', () => ({
+  getFocusBgmPreferences: vi.fn(() => bgmState.value),
+  updateFocusBgmPreferences: vi.fn((patch: Partial<MockFocusBgmPreferences>) => {
+    bgmState.value = {
+      ...bgmState.value,
+      ...patch,
+    };
+    bgmState.listeners.forEach((listener) => listener(bgmState.value));
+    return bgmState.value;
+  }),
+  subscribeFocusBgmPreferencesChanges: vi.fn((listener: (value: MockFocusBgmPreferences) => void) => {
+    bgmState.listeners.add(listener);
+    return () => {
+      bgmState.listeners.delete(listener);
+    };
+  }),
+}));
+
+import { pickFocusBgmTracks } from '@/lib/media/focus-bgm-file-picker';
+import { SettingsPage } from '@/ui/app/pages/SettingsPage';
+
+describe('issue-136 focus bgm setting（专注背景音设置项）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    bgmState.value = {
+      enabled: false,
+      sourceType: 'preset',
+      presetId: 'white-noise',
+      customTracks: [],
+      playbackMode: 'loop',
+      stopBehavior: 'manual-end',
+      volume: 60,
+    };
+    bgmState.listeners.clear();
+    vi.mocked(pickFocusBgmTracks).mockResolvedValue([
+      { path: 'D:/music/rain.mp3', name: 'rain.mp3' },
+      { path: 'D:/music/cafe.mp3', name: 'cafe.mp3' },
+    ]);
+  });
+
+  it('renders focus bgm row in timer settings（在计时设置中显示专注背景音入口）', () => {
+    render(<SettingsPage />);
+    fireEvent.click(screen.getByRole('button', { name: '专注设置' }));
+
+    expect(screen.getByRole('button', { name: '专注背景音 已关闭' })).toBeInTheDocument();
+  });
+
+  it('can switch to local tracks and sequence mode（可切换到本地多音频顺序播放）', async () => {
+    render(<SettingsPage />);
+    fireEvent.click(screen.getByRole('button', { name: '专注设置' }));
+
+    fireEvent.click(screen.getByRole('button', { name: '专注背景音 已关闭' }));
+
+    fireEvent.click(screen.getByRole('button', { name: '开启背景音' }));
+    fireEvent.click(screen.getByRole('button', { name: '本地音频' }));
+    fireEvent.click(screen.getByRole('button', { name: '选择本地音频' }));
+
+    await waitFor(() => expect(pickFocusBgmTracks).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: '顺序播放' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('rain.mp3')).toBeInTheDocument();
+      expect(screen.getByText('cafe.mp3')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '顺序播放' }).className).toContain('border-[#C75B3A]');
+    });
+  });
+
+  it('uses dark-mode friendly surfaces in the bgm panel（暗色模式下不应保留亮白面板块）', () => {
+    render(<SettingsPage />);
+    fireEvent.click(screen.getByRole('button', { name: '专注设置' }));
+    fireEvent.click(screen.getByRole('button', { name: '专注背景音 已关闭' }));
+    fireEvent.click(screen.getByRole('button', { name: '本地音频' }));
+
+    const enableButton = screen.getByRole('button', { name: '开启背景音' });
+    const localTracksPanel = screen.getByText('当前未选择本地音频').closest('div');
+
+    expect(enableButton.className).toContain('dark:bg-');
+    expect(enableButton.className).toContain('dark:text-');
+    expect(enableButton.className).toContain('dark:border-');
+    expect(localTracksPanel?.className ?? '').toContain('dark:bg-');
+    expect(localTracksPanel?.className ?? '').toContain('dark:border-');
+    expect(localTracksPanel?.className ?? '').toContain('dark:text-');
+  });
+});


### PR DESCRIPTION
## 摘要
- 为 #136 新增专注背景音乐 / 白噪音偏好、播放器运行时，以及 Tauri 多音频文件选择器
- 新增设置页与专注计时会话内控制，包括运行时音量同步与深色模式面板修复
- 为偏好、播放器运行时、协调器接线，以及运行中组件对话行为补充重点单测覆盖

## 测试计划
- `npx vitest run tests/unit/media/focus-bgm-player.test.ts tests/unit/components/FocusBgmCoordinator.issue136.test.tsx tests/unit/components/FocusTimerWidget.bgm.issue136.test.tsx tests/unit/settings/settings-focus-bgm.issue136.test.tsx tests/unit/components/FocusTimerWidget.countdown-end-settings.issue182.test.tsx tests/unit/settings/settings-timer-card.issue182.test.tsx`
- `& '.\\node_modules\\.bin\\tsc.exe' --noEmit`
- `cargo check --manifest-path src-tauri/Cargo.toml`

Closes #136
