### PR TITLE
feat(issue-514): 新增开发态实例诊断与标题同步

### DIFF
--- a/docs/plans/2026-03-13-issue-514-instance-diagnostics-plan.md
+++ b/docs/plans/2026-03-13-issue-514-instance-diagnostics-plan.md
@@ -1,0 +1,172 @@
+# Issue 514 Instance Diagnostics Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 为开发态多实例提供“窗口标题快速辨认 + 设置内详细实例诊断信息”，支持显示 branch、Web/RT/MCP 端口、worktree 名、PID，以及关键环境变量是否已配置。
+
+**Architecture:** 前端新增一个 `dev-instance-diagnostics` 配置模块，统一组装 branch、worktree、端口、环境变量状态等实例元数据；Tauri 端补一个只返回安全白名单诊断信息的命令用于 PID 和运行时环境变量存在性；App 层新增开发态标题同步，设置页开发者分组新增一个自定义条目，点击后用桌面对话框 / 移动端抽屉展示详细诊断信息。
+
+**Tech Stack:** React 18, TypeScript, Vitest, Vite, Tauri v2, Rust commands, localStorage-backed developer mode
+
+---
+
+### Task 1: 建立开发态实例诊断模型
+
+**Files:**
+- Create: `src/config/dev-instance-diagnostics.ts`
+- Modify: `src/vite-env.d.ts`
+- Modify: `vite.config.ts`
+- Test: `tests/unit/config/dev-instance-diagnostics.test.ts`
+
+**Step 1: Write the failing test**
+
+- 覆盖：
+  - branch / worktree / Web / RT / MCP 端口的组合与默认值
+  - 敏感环境变量只输出 `configured / missing`
+  - 标题格式为 `ExoMind [branch] [Web:x RT:y]`
+
+**Step 2: Run test to verify it fails**
+
+Run: `& '..\\..\\node_modules\\.bin\\vitest.exe' run tests/unit/config/dev-instance-diagnostics.test.ts`
+
+Expected: FAIL because the diagnostics module does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+- 在 `vite.config.ts` 注入开发态实例元数据：
+  - 当前 branch
+  - worktree 名 / 目录名
+  - Web / HMR / RT / MCP 端口
+  - 非敏感环境变量值
+  - 敏感 key 的存在性布尔值
+
+**Step 4: Run test to verify it passes**
+
+Run: `& '..\\..\\node_modules\\.bin\\vitest.exe' run tests/unit/config/dev-instance-diagnostics.test.ts`
+
+Expected: PASS
+
+### Task 2: 增加 Tauri 运行时实例诊断命令
+
+**Files:**
+- Create: `src-tauri/src/commands/dev_commands.rs`
+- Modify: `src-tauri/src/commands/mod.rs`
+- Modify: `src-tauri/src/lib.rs`
+- Test: `tests/unit/tauri/dev-instance-diagnostics-command.test.ts`
+
+**Step 1: Write the failing test**
+
+- 覆盖：
+  - 前端通过 `invoke` 读取运行时诊断
+  - 只返回白名单字段，不返回敏感值
+  - 可读到 `PID`
+
+**Step 2: Run test to verify it fails**
+
+Run: `& '..\\..\\node_modules\\.bin\\vitest.exe' run tests/unit/tauri/dev-instance-diagnostics-command.test.ts`
+
+Expected: FAIL because the command does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+- Rust 命令返回：
+  - `pid`
+  - 运行时 secrets / config env 的 `configured` 布尔值
+
+**Step 4: Run test to verify it passes**
+
+Run: `& '..\\..\\node_modules\\.bin\\vitest.exe' run tests/unit/tauri/dev-instance-diagnostics-command.test.ts`
+
+Expected: PASS
+
+### Task 3: 开发态窗口标题快速辨认
+
+**Files:**
+- Create: `src/ui/app/components/DevInstanceTitleSync.tsx`
+- Modify: `src/App.tsx`
+- Test: `tests/unit/app/dev-instance-title-sync.test.tsx`
+
+**Step 1: Write the failing test**
+
+- 覆盖：
+  - dev 模式下生成 `ExoMind [branch] [Web:x RT:y]`
+  - Tauri 下调用当前窗口 `setTitle`
+  - Web 下同步 `document.title`
+  - production 下不污染普通用户标题
+
+**Step 2: Run test to verify it fails**
+
+Run: `& '..\\..\\node_modules\\.bin\\vitest.exe' run tests/unit/app/dev-instance-title-sync.test.tsx`
+
+Expected: FAIL because title sync component does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+- App 挂载标题同步组件
+- 仅在开发态启用
+
+**Step 4: Run test to verify it passes**
+
+Run: `& '..\\..\\node_modules\\.bin\\vitest.exe' run tests/unit/app/dev-instance-title-sync.test.tsx`
+
+Expected: PASS
+
+### Task 4: 设置页开发者分组新增实例诊断入口
+
+**Files:**
+- Modify: `src/ui/app/components/settings/settings-custom-items.tsx`
+- Modify: `src/ui/app/config/settings/settings-registry.ts`
+- Modify: `tests/unit/components/settings/setup-settings-mocks.tsx`
+- Create: `tests/unit/settings/settings-instance-diagnostics.issue514.test.tsx`
+
+**Step 1: Write the failing test**
+
+- 覆盖：
+  - 开发者模式下出现 `实例诊断信息` 条目
+  - 点击后打开桌面 `Dialog` / 移动 `Drawer`
+  - 可见 `branch / Web / RT / MCP / worktree / PID`
+  - 环境变量只显示“已配置 / 未配置”
+
+**Step 2: Run test to verify it fails**
+
+Run: `& '..\\..\\node_modules\\.bin\\vitest.exe' run tests/unit/settings/settings-instance-diagnostics.issue514.test.tsx`
+
+Expected: FAIL because the diagnostics entry does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+- 新增 `DevInstanceDiagnosticsSetting`
+- 归入 `developer` 分类
+- 桌面大弹窗 / 移动抽屉展示详细信息
+
+**Step 4: Run test to verify it passes**
+
+Run: `& '..\\..\\node_modules\\.bin\\vitest.exe' run tests/unit/settings/settings-instance-diagnostics.issue514.test.tsx`
+
+Expected: PASS
+
+### Task 5: 回归验证
+
+**Files:**
+- Test: `tests/unit/config/dev-instance-diagnostics.test.ts`
+- Test: `tests/unit/tauri/dev-instance-diagnostics-command.test.ts`
+- Test: `tests/unit/app/dev-instance-title-sync.test.tsx`
+- Test: `tests/unit/settings/settings-instance-diagnostics.issue514.test.tsx`
+
+**Step 1: Run targeted verification**
+
+Run: `& '..\\..\\node_modules\\.bin\\vitest.exe' run tests/unit/config/dev-instance-diagnostics.test.ts tests/unit/tauri/dev-instance-diagnostics-command.test.ts tests/unit/app/dev-instance-title-sync.test.tsx tests/unit/settings/settings-instance-diagnostics.issue514.test.tsx`
+
+Expected: PASS
+
+**Step 2: Run typecheck**
+
+Run: `& '..\\..\\node_modules\\.bin\\tsc.exe' --noEmit`
+
+Expected: PASS
+
+**Step 3: Run Rust check**
+
+Run: `cargo check --manifest-path src-tauri/Cargo.toml`
+
+Expected: PASS

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
     "opener:default",
     "clipboard-manager:allow-read-text",
     "clipboard-manager:allow-write-text",
+    "core:window:allow-set-title",
     "mcp-bridge:default",
     "global-shortcut:allow-register",
     "global-shortcut:allow-unregister",

--- a/src-tauri/src/commands/dev_commands.rs
+++ b/src-tauri/src/commands/dev_commands.rs
@@ -1,0 +1,13 @@
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct DevInstanceRuntimeInfo {
+    pid: u32,
+}
+
+#[tauri::command]
+pub fn dev_instance_runtime_info() -> DevInstanceRuntimeInfo {
+    DevInstanceRuntimeInfo {
+        pid: std::process::id(),
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,6 +2,7 @@
 //! 导出所有 Tauri 命令
 
 pub mod asr_commands;
+pub mod dev_commands;
 pub mod device_commands;
 pub mod eventlog_commands;
 pub mod file_commands;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ use commands::asr_commands::{
     volcano_asr_stream_start,
     VolcanoAsrStreamState,
 };
+use commands::dev_commands::dev_instance_runtime_info;
 use commands::device_commands::get_device_id;
 use commands::eventlog_commands::{
     eventlog_append, eventlog_clear, eventlog_get, eventlog_list, eventlog_mirror_status,
@@ -155,6 +156,7 @@ pub fn run() {
             save_json_file,
             pick_json_file,
             pick_audio_files,
+            dev_instance_runtime_info,
             get_device_id,
             eventlog_list,
             eventlog_append,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { RouterProvider } from "@tanstack/react-router";
 import { appRouter } from "@/routes";
 import { ThemeController } from "@/components/ThemeController";
 import { Toaster } from "@/components/ui/toaster";
+import { DevInstanceTitleSync } from "@/ui/app/components/DevInstanceTitleSync";
 import { TimeBlockSyncCoordinator } from "@/ui/app/components/TimeBlockSyncCoordinator";
 import { ReminderSyncCoordinator } from "@/ui/app/components/ReminderSyncCoordinator";
 import { FocusBgmCoordinator } from "@/ui/app/components/FocusBgmCoordinator";
@@ -35,6 +36,7 @@ function App() {
 
   return (
     <>
+      <DevInstanceTitleSync />
       <ThemeController />
       <TimeBlockSyncCoordinator />
       <ReminderSyncCoordinator />

--- a/src/config/dev-instance-diagnostics.ts
+++ b/src/config/dev-instance-diagnostics.ts
@@ -1,0 +1,105 @@
+export type DevInstanceEnvStatus = {
+  sensitive: boolean;
+  configured: boolean;
+  value?: string;
+};
+
+export type DevInstanceMeta = {
+  branch: string;
+  worktreeName: string;
+  webPort: number;
+  hmrPort: number;
+  rtPort: number;
+  mcpPort: number;
+  syncServerUrl: string;
+  asrServerUrl: string;
+  envStatus: Record<string, DevInstanceEnvStatus>;
+};
+
+export type DevInstanceDiagnosticsSnapshot = DevInstanceMeta & {
+  pid: number | null;
+};
+
+const DEFAULT_DEV_INSTANCE_META: DevInstanceMeta = {
+  branch: 'dev',
+  worktreeName: 'default',
+  webPort: 1420,
+  hmrPort: 1421,
+  rtPort: 9124,
+  mcpPort: 9223,
+  syncServerUrl: 'http://localhost:6984',
+  asrServerUrl: 'http://localhost:1949',
+  envStatus: {},
+};
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' ? value as Record<string, unknown> : null;
+}
+
+function normalizeEnvStatus(value: unknown): Record<string, DevInstanceEnvStatus> {
+  const record = toRecord(value);
+  if (!record) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(record).map(([key, raw]) => {
+      const item = toRecord(raw);
+      return [key, {
+        sensitive: Boolean(item?.sensitive),
+        configured: Boolean(item?.configured),
+        ...(typeof item?.value === 'string' && item.value.trim().length > 0
+          ? { value: item.value.trim() }
+          : {}),
+      } satisfies DevInstanceEnvStatus];
+    }),
+  );
+}
+
+function normalizeString(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : fallback;
+}
+
+function normalizeNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function readInjectedMeta(): DevInstanceMeta {
+  const raw = (globalThis as typeof globalThis & {
+    __EXOMIND_DEV_INSTANCE_META__?: unknown;
+  }).__EXOMIND_DEV_INSTANCE_META__;
+  const record = toRecord(raw);
+  if (!record) {
+    return DEFAULT_DEV_INSTANCE_META;
+  }
+
+  return {
+    branch: normalizeString(record.branch, DEFAULT_DEV_INSTANCE_META.branch),
+    worktreeName: normalizeString(record.worktreeName, DEFAULT_DEV_INSTANCE_META.worktreeName),
+    webPort: normalizeNumber(record.webPort, DEFAULT_DEV_INSTANCE_META.webPort),
+    hmrPort: normalizeNumber(record.hmrPort, DEFAULT_DEV_INSTANCE_META.hmrPort),
+    rtPort: normalizeNumber(record.rtPort, DEFAULT_DEV_INSTANCE_META.rtPort),
+    mcpPort: normalizeNumber(record.mcpPort, DEFAULT_DEV_INSTANCE_META.mcpPort),
+    syncServerUrl: normalizeString(record.syncServerUrl, DEFAULT_DEV_INSTANCE_META.syncServerUrl),
+    asrServerUrl: normalizeString(record.asrServerUrl, DEFAULT_DEV_INSTANCE_META.asrServerUrl),
+    envStatus: normalizeEnvStatus(record.envStatus),
+  };
+}
+
+export function isDevInstanceDiagnosticsEnabled(): boolean {
+  return Boolean(import.meta.env.DEV);
+}
+
+export function getDevInstanceDiagnosticsSnapshot(
+  runtime: { pid?: number | null } = {},
+): DevInstanceDiagnosticsSnapshot {
+  return {
+    ...readInjectedMeta(),
+    pid: typeof runtime.pid === 'number' ? runtime.pid : null,
+  };
+}
+
+export function formatDevInstanceWindowTitle(): string {
+  const snapshot = getDevInstanceDiagnosticsSnapshot();
+  return `ExoMind [${snapshot.branch}] [Web:${snapshot.webPort} RT:${snapshot.rtPort}]`;
+}

--- a/src/config/dev-instance-diagnostics.ts
+++ b/src/config/dev-instance-diagnostics.ts
@@ -1,3 +1,5 @@
+import { resolveAsrServerUrl, resolveSyncServerUrl } from '@/config/port-env';
+
 export type DevInstanceEnvStatus = {
   sensitive: boolean;
   configured: boolean;
@@ -11,12 +13,16 @@ export type DevInstanceMeta = {
   hmrPort: number;
   rtPort: number;
   mcpPort: number;
-  syncServerUrl: string;
-  asrServerUrl: string;
+  pouchdbPort: number;
+  asrPort: number;
+  syncServerEnvUrl?: string;
+  asrServerEnvUrl?: string;
   envStatus: Record<string, DevInstanceEnvStatus>;
 };
 
 export type DevInstanceDiagnosticsSnapshot = DevInstanceMeta & {
+  syncServerUrl: string;
+  asrServerUrl: string;
   pid: number | null;
 };
 
@@ -27,8 +33,10 @@ const DEFAULT_DEV_INSTANCE_META: DevInstanceMeta = {
   hmrPort: 1421,
   rtPort: 9124,
   mcpPort: 9223,
-  syncServerUrl: 'http://localhost:6984',
-  asrServerUrl: 'http://localhost:1949',
+  pouchdbPort: 6984,
+  asrPort: 1949,
+  syncServerEnvUrl: undefined,
+  asrServerEnvUrl: undefined,
   envStatus: {},
 };
 
@@ -80,10 +88,20 @@ function readInjectedMeta(): DevInstanceMeta {
     hmrPort: normalizeNumber(record.hmrPort, DEFAULT_DEV_INSTANCE_META.hmrPort),
     rtPort: normalizeNumber(record.rtPort, DEFAULT_DEV_INSTANCE_META.rtPort),
     mcpPort: normalizeNumber(record.mcpPort, DEFAULT_DEV_INSTANCE_META.mcpPort),
-    syncServerUrl: normalizeString(record.syncServerUrl, DEFAULT_DEV_INSTANCE_META.syncServerUrl),
-    asrServerUrl: normalizeString(record.asrServerUrl, DEFAULT_DEV_INSTANCE_META.asrServerUrl),
+    pouchdbPort: normalizeNumber(record.pouchdbPort, DEFAULT_DEV_INSTANCE_META.pouchdbPort),
+    asrPort: normalizeNumber(record.asrPort, DEFAULT_DEV_INSTANCE_META.asrPort),
+    syncServerEnvUrl: normalizeString(record.syncServerEnvUrl, ''),
+    asrServerEnvUrl: normalizeString(record.asrServerEnvUrl, ''),
     envStatus: normalizeEnvStatus(record.envStatus),
   };
+}
+
+function resolveRuntimeHostname(): string | undefined {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  return window.location?.hostname;
 }
 
 export function isDevInstanceDiagnosticsEnabled(): boolean {
@@ -93,8 +111,27 @@ export function isDevInstanceDiagnosticsEnabled(): boolean {
 export function getDevInstanceDiagnosticsSnapshot(
   runtime: { pid?: number | null } = {},
 ): DevInstanceDiagnosticsSnapshot {
+  const meta = readInjectedMeta();
+  const hostname = resolveRuntimeHostname();
+  const syncServerUrl = resolveSyncServerUrl(
+    {
+      VITE_SYNC_SERVER_URL: meta.syncServerEnvUrl,
+      EXOMIND_POUCHDB_PORT: String(meta.pouchdbPort),
+    },
+    { hostname },
+  );
+  const asrServerUrl = resolveAsrServerUrl(
+    {
+      VITE_ASR_SERVER_URL: meta.asrServerEnvUrl,
+      EXOMIND_ASR_PORT: String(meta.asrPort),
+    },
+    { hostname },
+  );
+
   return {
-    ...readInjectedMeta(),
+    ...meta,
+    syncServerUrl,
+    asrServerUrl,
     pid: typeof runtime.pid === 'number' ? runtime.pid : null,
   };
 }

--- a/src/config/dev-instance-diagnostics.ts
+++ b/src/config/dev-instance-diagnostics.ts
@@ -32,7 +32,7 @@ const DEFAULT_DEV_INSTANCE_META: DevInstanceMeta = {
   webPort: 1420,
   hmrPort: 1421,
   rtPort: 9124,
-  mcpPort: 9223,
+  mcpPort: 9232,
   pouchdbPort: 6984,
   asrPort: 1949,
   syncServerEnvUrl: undefined,

--- a/src/lib/dev-instance-runtime.ts
+++ b/src/lib/dev-instance-runtime.ts
@@ -1,0 +1,13 @@
+import { invoke, isTauri } from '@tauri-apps/api/core';
+
+export type DevInstanceRuntimeInfo = {
+  pid: number | null;
+};
+
+export async function loadTauriRuntimeInstanceDiagnostics(): Promise<DevInstanceRuntimeInfo> {
+  if (!await isTauri()) {
+    return { pid: null };
+  }
+
+  return invoke<DevInstanceRuntimeInfo>('dev_instance_runtime_info');
+}

--- a/src/ui/app/components/DevInstanceTitleSync.tsx
+++ b/src/ui/app/components/DevInstanceTitleSync.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { isTauri } from '@tauri-apps/api/core';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import {
+  formatDevInstanceWindowTitle,
+  isDevInstanceDiagnosticsEnabled,
+} from '@/config/dev-instance-diagnostics';
+
+export function DevInstanceTitleSync(): null {
+  useEffect(() => {
+    if (!isDevInstanceDiagnosticsEnabled()) {
+      return;
+    }
+
+    const title = formatDevInstanceWindowTitle();
+    document.title = title;
+
+    void (async () => {
+      if (!await isTauri()) {
+        return;
+      }
+
+      try {
+        await getCurrentWindow().setTitle(title);
+      } catch {
+        // Ignore dev-only title sync failures（忽略开发态标题同步失败）
+      }
+    })();
+  }, []);
+
+  return null;
+}

--- a/src/ui/app/components/settings/settings-custom-items.tsx
+++ b/src/ui/app/components/settings/settings-custom-items.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { Bell, Bot, Check, ChevronRight, Key, Mic, Music4, Timer, Upload, Wifi } from 'lucide-react';
+import { Bell, Bot, Check, ChevronRight, Code, Key, Mic, Music4, Timer, Upload, Wifi } from 'lucide-react';
 import { useNavigate } from '@tanstack/react-router';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
 import { getTaskBackupService } from '@/lib/services';
 import { SettingRow } from '@/ui/app/components/settings-shared';
 import { PeerPairingDialog } from '@/ui/app/components/PeerPairingDialog';
@@ -48,6 +49,11 @@ import {
   getSelectedRuntimeTarget,
   toRuntimeBaseUrl,
 } from '@/config/runtime-target';
+import {
+  getDevInstanceDiagnosticsSnapshot,
+  type DevInstanceEnvStatus,
+} from '@/config/dev-instance-diagnostics';
+import { loadTauriRuntimeInstanceDiagnostics } from '@/lib/dev-instance-runtime';
 
 function useSettingValue<T>(
   getValue: () => T,
@@ -98,6 +104,33 @@ function SecondaryValue({ value }: { value: string }) {
       <ChevronRight className="h-4 w-4" />
     </div>
   );
+}
+
+function DiagnosticsValue({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-3 rounded-xl border border-[#F0ECE8] bg-[#FAF7F5] px-4 py-3 dark:border-[#FFFFFF15] dark:bg-[#1C1917]">
+      <span className="text-xs font-medium text-[#78716C] dark:text-[#A8A29E]">{label}</span>
+      <span className="text-right text-sm text-[#1C1917] dark:text-[#FAFAF9]">{value}</span>
+    </div>
+  );
+}
+
+function renderEnvStatusText(status: DevInstanceEnvStatus): string {
+  if (!status.configured) {
+    return '未配置';
+  }
+
+  if (status.sensitive) {
+    return '已配置';
+  }
+
+  return status.value?.trim() || '已配置';
 }
 
 function FocusBgmChoiceButton({
@@ -704,6 +737,106 @@ export function TaskBackendStatusSetting(_props: { ctx: SettingsContext }) {
       <p className="text-sm text-[#1C1917] dark:text-[#FAFAF9]">任务后端：{status.backend}</p>
       <p className="mt-1 text-xs text-[#A8A29E]">任务备份：{backupLabel}</p>
     </div>
+  );
+}
+
+export function DevInstanceDiagnosticsSetting(props: { ctx: SettingsContext }) {
+  const [open, setOpen] = useState(false);
+  const [runtimeInfo, setRuntimeInfo] = useState<{ pid: number | null } | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const diagnostics = getDevInstanceDiagnosticsSnapshot(runtimeInfo ?? undefined);
+  const shouldUseDialog = props.ctx.isDesktop || Boolean(props.ctx.isLandscape);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    let cancelled = false;
+    void loadTauriRuntimeInstanceDiagnostics()
+      .then((nextInfo) => {
+        if (cancelled) {
+          return;
+        }
+        setRuntimeInfo(nextInfo);
+        setLoadError(null);
+      })
+      .catch((error) => {
+        if (cancelled) {
+          return;
+        }
+        setLoadError(error instanceof Error ? error.message : '加载实例诊断失败');
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const detailContent = (
+    <div className="space-y-3">
+      <DiagnosticsValue label="Branch" value={diagnostics.branch} />
+      <DiagnosticsValue label="Web Port" value={String(diagnostics.webPort)} />
+      <DiagnosticsValue label="RT Port" value={String(diagnostics.rtPort)} />
+      <DiagnosticsValue label="MCP Port" value={String(diagnostics.mcpPort)} />
+      <DiagnosticsValue label="Worktree" value={diagnostics.worktreeName} />
+      <DiagnosticsValue label="PID" value={diagnostics.pid ? String(diagnostics.pid) : 'N/A'} />
+      <DiagnosticsValue label="Sync URL" value={diagnostics.syncServerUrl} />
+      <DiagnosticsValue label="ASR URL" value={diagnostics.asrServerUrl} />
+
+      <div className="space-y-2 pt-2">
+        <p className="text-xs font-medium text-[#78716C] dark:text-[#A8A29E]">环境变量 / 配置状态</p>
+        {Object.entries(diagnostics.envStatus).map(([key, status]) => (
+          <DiagnosticsValue
+            key={key}
+            label={key}
+            value={renderEnvStatusText(status)}
+          />
+        ))}
+      </div>
+
+      {loadError ? (
+        <p className="text-xs text-red-600">{loadError}</p>
+      ) : null}
+    </div>
+  );
+
+  return (
+    <>
+      <SettingRow
+        icon={<Code className="h-[18px] w-[18px] text-[#78716C]" />}
+        label="实例诊断信息"
+        onClick={() => setOpen(true)}
+        right={<SecondaryValue value={`${diagnostics.branch} · Web:${diagnostics.webPort}`} />}
+      />
+      {shouldUseDialog ? (
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogContent className="max-w-2xl rounded-2xl">
+            <DialogHeader>
+              <DialogTitle>实例诊断信息</DialogTitle>
+              <DialogDescription>查看当前开发实例的标题辨认与环境诊断信息</DialogDescription>
+            </DialogHeader>
+            {detailContent}
+          </DialogContent>
+        </Dialog>
+      ) : (
+        <Drawer open={open} onOpenChange={setOpen}>
+          <DrawerContent className="dark:bg-[#1C1917]">
+            <DrawerHeader className="pb-0 text-center">
+              <DrawerTitle className="text-center text-base font-semibold text-[#1C1917] dark:text-[#FAFAF9]">
+                实例诊断信息
+              </DrawerTitle>
+              <DrawerDescription className="text-xs text-[#A8A29E]">
+                查看当前开发实例的标题辨认与环境诊断信息
+              </DrawerDescription>
+            </DrawerHeader>
+            <div className="px-5 pb-8 pt-2">
+              {detailContent}
+            </div>
+          </DrawerContent>
+        </Drawer>
+      )}
+    </>
   );
 }
 

--- a/src/ui/app/config/settings/settings-registry.ts
+++ b/src/ui/app/config/settings/settings-registry.ts
@@ -125,6 +125,7 @@ import {
 } from '@/services/impl/settings-data-service';
 import {
   AiApiKeySetting,
+  DevInstanceDiagnosticsSetting,
   DevicePairingSetting,
   FocusBgmSetting,
   MossVoiceTestSetting,
@@ -809,6 +810,14 @@ export const SETTINGS_REGISTRY: SettingsItem[] = [
       set: setting.set,
       subscribe: setting.subscribe,
     })),
+  },
+  {
+    id: 'instance-diagnostics',
+    label: '实例诊断信息',
+    category: 'developer',
+    type: 'custom',
+    visible: devOnly,
+    component: DevInstanceDiagnosticsSetting,
   },
   {
     id: 'device-pairing',

--- a/tests/config/vite-env-prefix.test.ts
+++ b/tests/config/vite-env-prefix.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest';
 import viteConfig from '../../vite.config';
 
 describe('vite env prefix config', () => {
-  async function resolveConfig() {
+  async function resolveConfig(mode = 'test') {
     return typeof viteConfig === 'function'
-      ? viteConfig({ command: 'serve', mode: 'test', isSsrBuild: false, isPreview: false })
+      ? viteConfig({ command: 'serve', mode, isSsrBuild: false, isPreview: false })
       : viteConfig;
   }
 
@@ -58,6 +58,13 @@ describe('vite env prefix config', () => {
       '**/website/**',
       '**/packages/ts-agent-cli/**',
     ]));
+  });
+
+  it('should not inject dev instance metadata outside development mode（非 development 模式不应注入实例诊断元数据）', async () => {
+    const resolved = await resolveConfig('production');
+    const define = typeof resolved.define === 'object' && resolved.define ? resolved.define : {};
+
+    expect(Object.prototype.hasOwnProperty.call(define, 'globalThis.__EXOMIND_DEV_INSTANCE_META__')).toBe(false);
   });
 });
 

--- a/tests/unit/app/dev-instance-title-sync.test.tsx
+++ b/tests/unit/app/dev-instance-title-sync.test.tsx
@@ -1,0 +1,47 @@
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  isTauri: vi.fn(),
+  setTitle: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: mocks.isTauri,
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    setTitle: mocks.setTitle,
+  }),
+}));
+
+vi.mock('@/config/dev-instance-diagnostics', () => ({
+  formatDevInstanceWindowTitle: () => 'ExoMind [dev] [Web:5173 RT:6984]',
+  isDevInstanceDiagnosticsEnabled: () => true,
+}));
+
+describe('DevInstanceTitleSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.title = 'ExoMind';
+  });
+
+  it('updates tauri window title in dev mode（开发态同步 Tauri 窗口标题）', async () => {
+    mocks.isTauri.mockResolvedValue(true);
+    const { DevInstanceTitleSync } = await import('@/ui/app/components/DevInstanceTitleSync');
+
+    render(<DevInstanceTitleSync />);
+
+    await waitFor(() => expect(mocks.setTitle).toHaveBeenCalledWith('ExoMind [dev] [Web:5173 RT:6984]'));
+  });
+
+  it('updates document title for web preview（开发态同步浏览器标题）', async () => {
+    mocks.isTauri.mockResolvedValue(false);
+    const { DevInstanceTitleSync } = await import('@/ui/app/components/DevInstanceTitleSync');
+
+    render(<DevInstanceTitleSync />);
+
+    await waitFor(() => expect(document.title).toBe('ExoMind [dev] [Web:5173 RT:6984]'));
+  });
+});

--- a/tests/unit/components/settings/setup-settings-mocks.tsx
+++ b/tests/unit/components/settings/setup-settings-mocks.tsx
@@ -46,6 +46,7 @@ vi.mock('@/lib/services', () => ({
 vi.mock('@/config/port-env', () => ({
   getSyncServerUrlOverride: vi.fn(() => null),
   resolveSyncServerUrl: vi.fn(() => 'http://localhost:5984'),
+  resolveAsrServerUrl: vi.fn(() => 'http://localhost:1949'),
   setSyncServerUrlOverride: vi.fn(),
 }));
 

--- a/tests/unit/config/dev-instance-diagnostics.test.ts
+++ b/tests/unit/config/dev-instance-diagnostics.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('dev instance diagnostics（开发态实例诊断）', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    (globalThis as typeof globalThis & {
+      __EXOMIND_DEV_INSTANCE_META__?: unknown;
+    }).__EXOMIND_DEV_INSTANCE_META__ = {
+      branch: 'feature/issue-514-instance-diagnostics',
+      worktreeName: 'issue-514-instance-diagnostics',
+      webPort: 5173,
+      hmrPort: 5174,
+      rtPort: 6984,
+      mcpPort: 9223,
+      syncServerUrl: 'http://localhost:6984',
+      asrServerUrl: 'http://localhost:1949',
+      envStatus: {
+        VITE_MOSS_API_KEY: { sensitive: true, configured: false },
+        VITE_VOLCANO_APP_KEY: { sensitive: true, configured: true },
+        EXOMIND_RT_SECRET: { sensitive: true, configured: true },
+        VITE_SYNC_SERVER_URL: { sensitive: false, configured: true, value: 'http://localhost:6984' },
+      },
+    };
+  });
+
+  afterEach(() => {
+    delete (globalThis as typeof globalThis & {
+      __EXOMIND_DEV_INSTANCE_META__?: unknown;
+    }).__EXOMIND_DEV_INSTANCE_META__;
+  });
+
+  it('formats a concise dev window title（生成简短开发态窗口标题）', async () => {
+    const module = await import('@/config/dev-instance-diagnostics');
+
+    expect(module.formatDevInstanceWindowTitle()).toBe(
+      'ExoMind [feature/issue-514-instance-diagnostics] [Web:5173 RT:6984]',
+    );
+  });
+
+  it('builds a diagnostics snapshot with env status（生成包含环境变量状态的诊断快照）', async () => {
+    const module = await import('@/config/dev-instance-diagnostics');
+
+    expect(module.getDevInstanceDiagnosticsSnapshot()).toEqual(expect.objectContaining({
+      branch: 'feature/issue-514-instance-diagnostics',
+      worktreeName: 'issue-514-instance-diagnostics',
+      webPort: 5173,
+      rtPort: 6984,
+      mcpPort: 9223,
+      envStatus: expect.objectContaining({
+        VITE_VOLCANO_APP_KEY: expect.objectContaining({ configured: true, sensitive: true }),
+        EXOMIND_RT_SECRET: expect.objectContaining({ configured: true, sensitive: true }),
+      }),
+    }));
+  });
+});

--- a/tests/unit/config/dev-instance-diagnostics.test.ts
+++ b/tests/unit/config/dev-instance-diagnostics.test.ts
@@ -11,9 +11,9 @@ describe('dev instance diagnostics（开发态实例诊断）', () => {
       webPort: 5173,
       hmrPort: 5174,
       rtPort: 6984,
-      mcpPort: 9223,
-      syncServerUrl: 'http://localhost:6984',
-      asrServerUrl: 'http://localhost:1949',
+      mcpPort: 9232,
+      syncServerEnvUrl: 'http://localhost:6984',
+      asrServerEnvUrl: 'http://localhost:1949',
       envStatus: {
         VITE_MOSS_API_KEY: { sensitive: true, configured: false },
         VITE_VOLCANO_APP_KEY: { sensitive: true, configured: true },
@@ -45,7 +45,7 @@ describe('dev instance diagnostics（开发态实例诊断）', () => {
       worktreeName: 'issue-514-instance-diagnostics',
       webPort: 5173,
       rtPort: 6984,
-      mcpPort: 9223,
+      mcpPort: 9232,
       envStatus: expect.objectContaining({
         VITE_VOLCANO_APP_KEY: expect.objectContaining({ configured: true, sensitive: true }),
         EXOMIND_RT_SECRET: expect.objectContaining({ configured: true, sensitive: true }),
@@ -69,7 +69,7 @@ describe('dev instance diagnostics（开发态实例诊断）', () => {
       webPort: 5173,
       hmrPort: 5174,
       rtPort: 6984,
-      mcpPort: 9223,
+      mcpPort: 9232,
       pouchdbPort: 6984,
       asrPort: 1949,
       syncServerEnvUrl: '',
@@ -82,5 +82,27 @@ describe('dev instance diagnostics（开发态实例诊断）', () => {
 
     expect(snapshot.syncServerUrl).toBe('http://192.168.1.88:6984');
     expect(snapshot.asrServerUrl).toBe('http://192.168.1.88:1949');
+  });
+
+  it('defaults MCP port to 9232 when no explicit MCP env is provided（未显式配置时 MCP 默认端口应为 9232）', async () => {
+    (globalThis as typeof globalThis & {
+      __EXOMIND_DEV_INSTANCE_META__?: unknown;
+    }).__EXOMIND_DEV_INSTANCE_META__ = {
+      branch: 'feature/issue-514-instance-diagnostics',
+      worktreeName: 'issue-514-instance-diagnostics',
+      webPort: 5173,
+      hmrPort: 5174,
+      rtPort: 6984,
+      pouchdbPort: 6984,
+      asrPort: 1949,
+      syncServerEnvUrl: '',
+      asrServerEnvUrl: '',
+      envStatus: {},
+    };
+
+    const module = await import('@/config/dev-instance-diagnostics');
+    const snapshot = module.getDevInstanceDiagnosticsSnapshot();
+
+    expect(snapshot.mcpPort).toBe(9232);
   });
 });

--- a/tests/unit/config/dev-instance-diagnostics.test.ts
+++ b/tests/unit/config/dev-instance-diagnostics.test.ts
@@ -52,4 +52,35 @@ describe('dev instance diagnostics（开发态实例诊断）', () => {
       }),
     }));
   });
+
+  it('derives sync and asr urls from the runtime hostname when no explicit url is configured（未显式配置时应按运行时 hostname 推导服务地址）', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        hostname: '192.168.1.88',
+      },
+    });
+
+    (globalThis as typeof globalThis & {
+      __EXOMIND_DEV_INSTANCE_META__?: unknown;
+    }).__EXOMIND_DEV_INSTANCE_META__ = {
+      branch: 'feature/issue-514-instance-diagnostics',
+      worktreeName: 'issue-514-instance-diagnostics',
+      webPort: 5173,
+      hmrPort: 5174,
+      rtPort: 6984,
+      mcpPort: 9223,
+      pouchdbPort: 6984,
+      asrPort: 1949,
+      syncServerEnvUrl: '',
+      asrServerEnvUrl: '',
+      envStatus: {},
+    };
+
+    const module = await import('@/config/dev-instance-diagnostics');
+    const snapshot = module.getDevInstanceDiagnosticsSnapshot();
+
+    expect(snapshot.syncServerUrl).toBe('http://192.168.1.88:6984');
+    expect(snapshot.asrServerUrl).toBe('http://192.168.1.88:1949');
+  });
 });

--- a/tests/unit/settings/settings-export-runtime.issue222.test.tsx
+++ b/tests/unit/settings/settings-export-runtime.issue222.test.tsx
@@ -46,6 +46,7 @@ vi.mock('@/lib/services', () => ({
 vi.mock('@/config/port-env', () => ({
   getSyncServerUrlOverride: () => null,
   resolveSyncServerUrl: () => 'http://127.0.0.1:6984',
+  resolveAsrServerUrl: () => 'http://127.0.0.1:1949',
   setSyncServerUrlOverride: vi.fn(),
 }));
 

--- a/tests/unit/settings/settings-instance-diagnostics.issue514.test.tsx
+++ b/tests/unit/settings/settings-instance-diagnostics.issue514.test.tsx
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const developerModeState = {
+  enabled: true,
+};
+
+const mocks = vi.hoisted(() => ({
+  isTauri: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: mocks.isTauri,
+  invoke: mocks.invoke,
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/config/dev-instance-diagnostics', () => ({
+  getDevInstanceDiagnosticsSnapshot: (runtime?: { pid?: number | null }) => ({
+    branch: 'feature/issue-514-instance-diagnostics',
+    worktreeName: 'issue-514-instance-diagnostics',
+    webPort: 5173,
+    rtPort: 6984,
+    mcpPort: 9223,
+    syncServerUrl: 'http://localhost:6984',
+    asrServerUrl: 'http://localhost:1949',
+    pid: runtime?.pid ?? null,
+    envStatus: {
+      VITE_MOSS_API_KEY: { sensitive: true, configured: false },
+      VITE_VOLCANO_APP_KEY: { sensitive: true, configured: true },
+      EXOMIND_RT_SECRET: { sensitive: true, configured: true },
+      VITE_SYNC_SERVER_URL: { sensitive: false, configured: true, value: 'http://localhost:6984' },
+    },
+  }),
+  isDevInstanceDiagnosticsEnabled: () => true,
+}));
+
+vi.mock('@/lib/dev-instance-runtime', () => ({
+  loadTauriRuntimeInstanceDiagnostics: vi.fn(async () => ({
+    pid: 43120,
+  })),
+}));
+
+vi.mock('@/lib/services', () => ({
+  getEventLogService: () => ({
+    exportEventsAsJson: vi.fn().mockResolvedValue('[]'),
+    importEventsFromJson: vi.fn().mockResolvedValue({ imported: 0, skipped: 0 }),
+  }),
+  getTaskBackupService: () => ({
+    exportTasksAsJson: vi.fn().mockResolvedValue({
+      fileName: 'exomind-tasks.json',
+      content: '{"version":1,"tasks":[]}',
+      taskCount: 0,
+    }),
+    exportTasksAsSqliteSnapshot: vi.fn().mockResolvedValue({
+      fileName: 'exomind-tasks.sqlite',
+      bytes: new Uint8Array(),
+      taskCount: 0,
+    }),
+    importTasksFromJson: vi.fn().mockResolvedValue({ imported: 0, skipped: 0, total: 0 }),
+    importTasksFromSqliteSnapshot: vi.fn().mockResolvedValue({ imported: 0, skipped: 0, total: 0 }),
+    getBackendStatus: vi.fn().mockResolvedValue({
+      backend: 'rt-sqlite',
+      supportsJsonBackup: true,
+      supportsSqliteSnapshot: true,
+    }),
+  }),
+}));
+
+vi.mock('@/config/port-env', () => ({
+  getSyncServerUrlOverride: () => null,
+  resolveSyncServerUrl: () => 'http://127.0.0.1:6984',
+  setSyncServerUrlOverride: vi.fn(),
+}));
+
+vi.mock('@/config/theme', () => ({
+  getThemePreference: () => 'system',
+  setThemePreference: vi.fn(),
+  subscribeThemePreferenceChanges: () => () => {},
+}));
+
+vi.mock('@/config/developer-mode', () => ({
+  getDeveloperModeEnabled: () => developerModeState.enabled,
+  setDeveloperModeEnabled: vi.fn(),
+  subscribeDeveloperModeChanges: () => () => {},
+}));
+
+vi.mock('@/config/agent-page-enabled', () => ({
+  getAgentPageEnabled: () => false,
+  setAgentPageEnabled: vi.fn(),
+  subscribeAgentPageEnabledChanges: () => () => {},
+}));
+
+vi.mock('@/config/desktop-adaptive', () => ({
+  getDesktopAdaptiveEnabled: () => true,
+  setDesktopAdaptiveEnabled: vi.fn(),
+  subscribeDesktopAdaptiveChanges: () => () => {},
+}));
+
+vi.mock('@/config/mock-data', () => ({
+  getUseMockDataEnabled: () => false,
+  setUseMockDataEnabled: vi.fn(),
+  subscribeUseMockDataChanges: () => () => {},
+}));
+
+vi.mock('@/config/timer-preferences', () => ({
+  getTimerPreferences: () => ({
+    countdownEndMode: 'soft',
+    countdownEndSoundEnabled: false,
+    countdownEndSoundPresetId: 'ring-10',
+  }),
+  subscribeTimerPreferencesChanges: () => () => {},
+  updateTimerPreferences: vi.fn((patch: Record<string, unknown>) => patch),
+}));
+
+vi.mock('@/config/focus-bgm-preferences', () => ({
+  getFocusBgmPreferences: () => ({
+    enabled: false,
+    sourceType: 'preset',
+    presetId: 'white-noise',
+    customTracks: [],
+    playbackMode: 'loop',
+    stopBehavior: 'manual-end',
+    volume: 60,
+  }),
+  subscribeFocusBgmPreferencesChanges: () => () => {},
+  updateFocusBgmPreferences: vi.fn((patch: Record<string, unknown>) => patch),
+}));
+
+vi.mock('@/lib/media/focus-bgm-file-picker', () => ({
+  pickFocusBgmTracks: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/config/devtools-mode', () => ({
+  getDevtoolsEnabled: () => false,
+  setDevtoolsEnabled: vi.fn(),
+  subscribeDevtoolsChanges: () => () => {},
+}));
+
+vi.mock('@/config/command-palette-enabled', () => ({
+  getCommandPaletteEnabled: () => false,
+  setCommandPaletteEnabled: vi.fn(),
+  subscribeCommandPaletteEnabledChanges: () => () => {},
+}));
+
+vi.mock('@/config/voice-transcript-send-mode', () => ({
+  getVoiceTranscriptSendMode: () => 'insert',
+  setVoiceTranscriptSendMode: vi.fn(),
+  subscribeVoiceTranscriptSendModeChanges: () => () => {},
+}));
+
+vi.mock('@/config/voice-shortcut-hotkey', () => ({
+  VOICE_SHORTCUT_HOTKEY_VALUES: ['Alt+Q', 'Alt+W'],
+  getVoiceShortcutHotkey: () => 'Alt+Q',
+  setVoiceShortcutHotkey: vi.fn(),
+  subscribeVoiceShortcutHotkeyChanges: () => () => {},
+}));
+
+vi.mock('@/config/voice-shortcut-send-mode', () => ({
+  getVoiceShortcutSendMode: () => 'insert-only',
+  setVoiceShortcutSendMode: vi.fn(),
+  subscribeVoiceShortcutSendModeChanges: () => () => {},
+}));
+
+vi.mock('@/config/voice-shortcut-mic-prewarm', () => ({
+  getVoiceShortcutMicPrewarmEnabled: () => true,
+  setVoiceShortcutMicPrewarmEnabled: vi.fn(),
+  subscribeVoiceShortcutMicPrewarmChanges: () => () => {},
+}));
+
+vi.mock('@/config/voice-overlay-preferences', () => ({
+  DEFAULT_VOICE_OVERLAY_BOTTOM_OFFSET: 56,
+  getVoiceOverlayOpacity: () => 62,
+  getVoiceOverlayShowDiagnostics: () => false,
+  getVoiceOverlayTranscriptLines: () => 3,
+  getVoiceOverlayBottomOffset: () => 56,
+  MAX_VOICE_OVERLAY_OPACITY: 92,
+  MIN_VOICE_OVERLAY_OPACITY: 32,
+  MAX_VOICE_OVERLAY_BOTTOM_OFFSET: 160,
+  subscribeVoiceOverlayOpacityChanges: () => () => {},
+  subscribeVoiceOverlayBottomOffsetChanges: () => () => {},
+  subscribeVoiceOverlayShowDiagnosticsChanges: () => () => {},
+  subscribeVoiceOverlayTranscriptLinesChanges: () => () => {},
+  setVoiceOverlayOpacity: vi.fn(),
+  setVoiceOverlayShowDiagnostics: vi.fn(),
+  setVoiceOverlayTranscriptLines: vi.fn(),
+  setVoiceOverlayBottomOffset: vi.fn(),
+  MAX_VOICE_OVERLAY_TRANSCRIPT_LINES: 5,
+  MIN_VOICE_OVERLAY_BOTTOM_OFFSET: 24,
+  MIN_VOICE_OVERLAY_TRANSCRIPT_LINES: 1,
+}));
+
+vi.mock('@/config/voice-shortcut-asr-provider', () => ({
+  getVoiceShortcutAsrProvider: () => 'volcano',
+  getVoiceShortcutAsrProviderLabel: () => 'Volcano',
+  setVoiceShortcutAsrProvider: vi.fn(),
+  subscribeVoiceShortcutAsrProviderChanges: () => () => {},
+}));
+
+vi.mock('@/lib/asr/volcano-config', () => ({
+  DEFAULT_VOLCANO_RESOURCE_ID: 'volc.default',
+  VOLCANO_RESOURCE_PRESETS: [{ value: 'volc.default', label: 'Volcano Default' }],
+  getVolcanoResourceId: () => 'volc.default',
+  setVolcanoResourceId: vi.fn((value: string) => value),
+}));
+
+vi.mock('@/config/feedback-preferences', () => ({
+  getFeedbackPreferences: () => ({
+    timingInfoEnabled: false,
+    statisticsEnabled: false,
+    quickFeedbackEnabled: true,
+  }),
+  setFeedbackPreferences: vi.fn(),
+  subscribeFeedbackPreferencesChanges: () => () => {},
+}));
+
+vi.mock('@/config/version-build-info', () => ({
+  resolveVersionBuildInfo: () => ({
+    appVersion: '0.3.6',
+    buildHash: 'issue514',
+  }),
+}));
+
+vi.mock('@/lib/debug/devtools-runtime', () => ({
+  syncDevtoolsWithSettings: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/media/timer-end-sounds', () => ({
+  TIMER_END_SOUND_PRESETS: [],
+  getTimerEndSoundPresetById: vi.fn(() => ({ label: 'Bell' })),
+}));
+
+vi.mock('@/ui/app/components/UserCard', () => ({
+  UserCard: () => null,
+}));
+
+vi.mock('@/ui/app/components/MoreSection', () => ({
+  MoreSection: () => null,
+}));
+
+vi.mock('@/ui/app/components/AboutSection', () => ({
+  AboutSection: () => null,
+}));
+
+import { SettingsPage } from '@/ui/app/pages/SettingsPage';
+
+describe('issue-514 instance diagnostics setting（实例诊断设置项）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    developerModeState.enabled = true;
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes('min-width: 768px'),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    mocks.isTauri.mockResolvedValue(true);
+    mocks.invoke.mockResolvedValue({ pid: 43120 });
+  });
+
+  it('shows the diagnostics entry in developer section and opens details（开发者分组展示实例诊断条目并可打开详情）', async () => {
+    render(<SettingsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: '开发者' }));
+    fireEvent.click(screen.getByRole('button', { name: /实例诊断信息/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText('feature/issue-514-instance-diagnostics')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('5173')).toBeInTheDocument();
+    expect(screen.getByText('6984')).toBeInTheDocument();
+    expect(screen.getByText('9223')).toBeInTheDocument();
+    expect(screen.getByText('issue-514-instance-diagnostics')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('43120')).toBeInTheDocument());
+    expect(screen.getAllByText('已配置').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('未配置').length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/settings/settings-instance-diagnostics.issue514.test.tsx
+++ b/tests/unit/settings/settings-instance-diagnostics.issue514.test.tsx
@@ -25,7 +25,7 @@ vi.mock('@/config/dev-instance-diagnostics', () => ({
     worktreeName: 'issue-514-instance-diagnostics',
     webPort: 5173,
     rtPort: 6984,
-    mcpPort: 9223,
+    mcpPort: 9232,
     syncServerUrl: 'http://localhost:6984',
     asrServerUrl: 'http://localhost:1949',
     pid: runtime?.pid ?? null,
@@ -278,7 +278,7 @@ describe('issue-514 instance diagnostics setting（实例诊断设置项）', ()
 
     expect(screen.getByText('5173')).toBeInTheDocument();
     expect(screen.getByText('6984')).toBeInTheDocument();
-    expect(screen.getByText('9223')).toBeInTheDocument();
+    expect(screen.getByText('9232')).toBeInTheDocument();
     expect(screen.getByText('issue-514-instance-diagnostics')).toBeInTheDocument();
     await waitFor(() => expect(screen.getByText('43120')).toBeInTheDocument());
     expect(screen.getAllByText('已配置').length).toBeGreaterThan(0);

--- a/tests/unit/settings/settings-mock-data-toggle.issue213.test.tsx
+++ b/tests/unit/settings/settings-mock-data-toggle.issue213.test.tsx
@@ -39,6 +39,7 @@ vi.mock('@/lib/services', () => ({
 vi.mock('@/config/port-env', () => ({
   getSyncServerUrlOverride: () => null,
   resolveSyncServerUrl: () => 'http://127.0.0.1:6984',
+  resolveAsrServerUrl: () => 'http://127.0.0.1:1949',
   setSyncServerUrlOverride: vi.fn(),
 }));
 

--- a/tests/unit/settings/settings-registry-coverage.test.ts
+++ b/tests/unit/settings/settings-registry-coverage.test.ts
@@ -18,6 +18,7 @@ const AUDITED_SETTINGS_IDS = [
   'theme',
   'countdown-end-mode',
   'sound-preset',
+  'focus-bgm',
   'feedback-content',
   'voice-transcript-send-mode',
   'voice-shortcut-send-mode',
@@ -44,6 +45,7 @@ const AUDITED_SETTINGS_IDS = [
   'use-mock-data',
   'devtools',
   'feature-toggles',
+  'instance-diagnostics',
   'device-pairing',
   'task-backend-status',
   'clear-local-cache',
@@ -98,10 +100,12 @@ const BUTTON_ACTION_IDS = [
 ] as const;
 
 const CUSTOM_ITEM_IDS = [
+  'focus-bgm',
   'moss-voice-test',
   'volcano-asr-test',
   'ai-api-key',
   'import-tasks',
+  'instance-diagnostics',
   'device-pairing',
   'task-backend-status',
 ] as const;
@@ -115,6 +119,7 @@ const DEV_ONLY_IDS = [
   'use-mock-data',
   'devtools',
   'feature-toggles',
+  'instance-diagnostics',
   'device-pairing',
   'task-backend-status',
 ] as const;

--- a/tests/unit/settings/settings-timer-card.issue182.test.tsx
+++ b/tests/unit/settings/settings-timer-card.issue182.test.tsx
@@ -41,6 +41,7 @@ vi.mock('@/lib/services', () => ({
 vi.mock('@/config/port-env', () => ({
   getSyncServerUrlOverride: () => null,
   resolveSyncServerUrl: () => 'http://127.0.0.1:6984',
+  resolveAsrServerUrl: () => 'http://127.0.0.1:1949',
   setSyncServerUrlOverride: vi.fn(),
 }));
 

--- a/tests/unit/settings/task-backend-diagnostics.issue481.test.tsx
+++ b/tests/unit/settings/task-backend-diagnostics.issue481.test.tsx
@@ -43,6 +43,7 @@ vi.mock('@/lib/services', () => ({
 vi.mock('@/config/port-env', () => ({
   getSyncServerUrlOverride: () => null,
   resolveSyncServerUrl: () => 'http://127.0.0.1:6984',
+  resolveAsrServerUrl: () => 'http://127.0.0.1:1949',
   setSyncServerUrlOverride: vi.fn(),
 }));
 

--- a/tests/unit/settings/task-import-export.issue481.test.tsx
+++ b/tests/unit/settings/task-import-export.issue481.test.tsx
@@ -43,6 +43,7 @@ vi.mock('@/lib/services', () => ({
 vi.mock('@/config/port-env', () => ({
   getSyncServerUrlOverride: () => null,
   resolveSyncServerUrl: () => 'http://127.0.0.1:6984',
+  resolveAsrServerUrl: () => 'http://127.0.0.1:1949',
   setSyncServerUrlOverride: vi.fn(),
 }));
 

--- a/tests/unit/tauri/dev-instance-title-capability.test.ts
+++ b/tests/unit/tauri/dev-instance-title-capability.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('dev instance title capability（开发态窗口标题权限）', () => {
+  it('allows the main window to update its native title（主窗口允许更新原生标题）', () => {
+    const filePath = resolve(process.cwd(), 'src-tauri/capabilities/default.json');
+    const capability = JSON.parse(readFileSync(filePath, 'utf8')) as {
+      permissions: string[];
+    };
+
+    expect(capability.permissions).toContain('core:window:allow-set-title');
+  });
+});

--- a/tests/unit/ui/legacy-sync-coordinators.issue381.test.tsx
+++ b/tests/unit/ui/legacy-sync-coordinators.issue381.test.tsx
@@ -53,6 +53,7 @@ vi.mock('@/lib/services/reminder.service', () => ({
 vi.mock('@/config/port-env', () => ({
   SYNC_SERVER_URL_CHANGED_EVENT: 'exomind:test-sync-server-url-changed',
   resolveSyncServerUrl: vi.fn(() => 'http://127.0.0.1:6984'),
+  resolveAsrServerUrl: vi.fn(() => 'http://127.0.0.1:1949'),
 }));
 
 describe('legacy sync coordinators issue-381（旧同步协调器门控）', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,7 +52,7 @@ export default defineConfig(({ mode }) => {
       readEnvValue(envMap, 'EXOMIND_MCP_PORT')
       ?? readEnvValue(envMap, 'EXOMIND_MCP_BRIDGE_PORT')
       ?? readEnvValue(envMap, 'TAURI_MCP_BRIDGE_PORT'),
-      9223,
+      9232,
     ),
     pouchdbPort: parsePort(readEnvValue(envMap, 'EXOMIND_POUCHDB_PORT'), 6984),
     asrPort: parsePort(readEnvValue(envMap, 'EXOMIND_ASR_PORT'), 1949),
@@ -79,9 +79,13 @@ export default defineConfig(({ mode }) => {
 
   return {
     plugins: [react()],
-    define: {
-      "globalThis.__EXOMIND_DEV_INSTANCE_META__": JSON.stringify(devInstanceMeta),
-    },
+    ...(mode === 'development'
+      ? {
+          define: {
+            "globalThis.__EXOMIND_DEV_INSTANCE_META__": JSON.stringify(devInstanceMeta),
+          },
+        }
+      : {}),
 
     envDir: ".",
     envPrefix: ["VITE_", "EXOMIND_"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import { execSync } from "node:child_process";
-import { parsePort, resolveAsrServerUrl, resolveDevPorts, resolveSyncServerUrl } from "./src/config/port-env";
+import { parsePort, resolveDevPorts } from "./src/config/port-env";
 
 function readCurrentBranch(projectRoot: string): string {
   try {
@@ -45,8 +45,10 @@ export default defineConfig(({ mode }) => {
       ?? readEnvValue(envMap, 'TAURI_MCP_BRIDGE_PORT'),
       9223,
     ),
-    syncServerUrl: resolveSyncServerUrl(envMap),
-    asrServerUrl: resolveAsrServerUrl(envMap),
+    pouchdbPort: parsePort(readEnvValue(envMap, 'EXOMIND_POUCHDB_PORT'), 6984),
+    asrPort: parsePort(readEnvValue(envMap, 'EXOMIND_ASR_PORT'), 1949),
+    syncServerEnvUrl: readEnvValue(envMap, 'VITE_SYNC_SERVER_URL') ?? '',
+    asrServerEnvUrl: readEnvValue(envMap, 'VITE_ASR_SERVER_URL') ?? '',
     envStatus: {
       VITE_MOSS_API_KEY: { sensitive: true, configured: hasEnvValue(envMap, 'VITE_MOSS_API_KEY') },
       VITE_VOLCANO_APP_KEY: { sensitive: true, configured: hasEnvValue(envMap, 'VITE_VOLCANO_APP_KEY') },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,76 @@
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
-import { resolveDevPorts } from "./src/config/port-env";
+import { execSync } from "node:child_process";
+import { parsePort, resolveAsrServerUrl, resolveDevPorts, resolveSyncServerUrl } from "./src/config/port-env";
+
+function readCurrentBranch(projectRoot: string): string {
+  try {
+    return execSync('git branch --show-current', {
+      cwd: projectRoot,
+      encoding: 'utf8',
+    }).trim() || 'dev';
+  } catch {
+    return 'dev';
+  }
+}
+
+function readEnvValue(env: Record<string, string | undefined>, key: string): string | undefined {
+  return env[key]?.trim() || process.env[key]?.trim();
+}
+
+function hasEnvValue(env: Record<string, string | undefined>, key: string): boolean {
+  return Boolean(readEnvValue(env, key));
+}
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const devPorts = resolveDevPorts(env);
   const tauriDevHost = env.TAURI_DEV_HOST?.trim() || process.env.TAURI_DEV_HOST?.trim();
+  const projectRoot = process.cwd();
+  const envMap = {
+    ...Object.fromEntries(Object.entries(process.env).map(([key, value]) => [key, value ?? undefined])),
+    ...env,
+  } as Record<string, string | undefined>;
+  const devInstanceMeta = {
+    branch: readCurrentBranch(projectRoot),
+    worktreeName: path.basename(projectRoot),
+    webPort: devPorts.web,
+    hmrPort: devPorts.hmr,
+    rtPort: parsePort(readEnvValue(envMap, 'EXOMIND_RT_PORT'), 9124),
+    mcpPort: parsePort(
+      readEnvValue(envMap, 'EXOMIND_MCP_PORT')
+      ?? readEnvValue(envMap, 'EXOMIND_MCP_BRIDGE_PORT')
+      ?? readEnvValue(envMap, 'TAURI_MCP_BRIDGE_PORT'),
+      9223,
+    ),
+    syncServerUrl: resolveSyncServerUrl(envMap),
+    asrServerUrl: resolveAsrServerUrl(envMap),
+    envStatus: {
+      VITE_MOSS_API_KEY: { sensitive: true, configured: hasEnvValue(envMap, 'VITE_MOSS_API_KEY') },
+      VITE_VOLCANO_APP_KEY: { sensitive: true, configured: hasEnvValue(envMap, 'VITE_VOLCANO_APP_KEY') },
+      VITE_VOLCANO_ACCESS_KEY: { sensitive: true, configured: hasEnvValue(envMap, 'VITE_VOLCANO_ACCESS_KEY') },
+      EXOMIND_ASR_AUTH_TOKEN: { sensitive: true, configured: hasEnvValue(envMap, 'EXOMIND_ASR_AUTH_TOKEN') },
+      EXOMIND_RT_SECRET: { sensitive: true, configured: hasEnvValue(envMap, 'EXOMIND_RT_SECRET') },
+      VITE_SYNC_SERVER_URL: {
+        sensitive: false,
+        configured: hasEnvValue(envMap, 'VITE_SYNC_SERVER_URL'),
+        value: readEnvValue(envMap, 'VITE_SYNC_SERVER_URL'),
+      },
+      VITE_ASR_SERVER_URL: {
+        sensitive: false,
+        configured: hasEnvValue(envMap, 'VITE_ASR_SERVER_URL'),
+        value: readEnvValue(envMap, 'VITE_ASR_SERVER_URL'),
+      },
+    },
+  };
 
   return {
     plugins: [react()],
+    define: {
+      "globalThis.__EXOMIND_DEV_INSTANCE_META__": JSON.stringify(devInstanceMeta),
+    },
 
     envDir: ".",
     envPrefix: ["VITE_", "EXOMIND_"],


### PR DESCRIPTION
## 摘要
- 新增仅开发态可见的实例诊断元数据模型，以及用于多实例辨认的运行时 PID 桥接
- 将开发环境窗口标题同步为 `ExoMind [branch] [Web:x RT:y]`
- 在设置页新增开发者入口，用于查看详细实例诊断信息，并安全展示环境状态

## 测试计划
- `& '..\\..\\node_modules\\.bin\\vitest.exe' run tests/unit/config/dev-instance-diagnostics.test.ts tests/unit/app/dev-instance-title-sync.test.tsx tests/unit/settings/settings-instance-diagnostics.issue514.test.tsx tests/unit/settings/settings-registry-coverage.test.ts tests/unit/settings/settings-layouts.test.tsx tests/unit/settings/task-backend-diagnostics.issue481.test.tsx`
- `& '..\\..\\node_modules\\.bin\\tsc.exe' --noEmit`
- `cargo check --manifest-path src-tauri/Cargo.toml`

Closes #514
