### PR TITLE
feat: 一次性旧版数据迁移对话框

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { DevInstanceTitleSync } from "@/ui/app/components/DevInstanceTitleSync";
 import { TimeBlockSyncCoordinator } from "@/ui/app/components/TimeBlockSyncCoordinator";
 import { ReminderSyncCoordinator } from "@/ui/app/components/ReminderSyncCoordinator";
 import { FocusBgmCoordinator } from "@/ui/app/components/FocusBgmCoordinator";
+import { MigrationDialogController } from "@/ui/components/MigrationDialogController";
 import {
   initUpdateChecker,
   destroyUpdateChecker,
@@ -41,6 +42,7 @@ function App() {
       <TimeBlockSyncCoordinator />
       <ReminderSyncCoordinator />
       <FocusBgmCoordinator />
+      <MigrationDialogController />
       <RouterProvider router={appRouter} />
       <Toaster />
     </>

--- a/src/config/domain-backend-mode.ts
+++ b/src/config/domain-backend-mode.ts
@@ -55,3 +55,9 @@ export function getTimeblockBackendMode(): DomainBackendMode {
 export function setTimeblockBackendMode(mode: DomainBackendMode): DomainBackendMode {
   return setMode('timeblock', mode);
 }
+
+export function setAllBackendModes(mode: DomainBackendMode): void {
+  setMode('eventlog', mode);
+  setMode('task', mode);
+  setMode('timeblock', mode);
+}

--- a/src/lib/migration/legacy-migration-detector.ts
+++ b/src/lib/migration/legacy-migration-detector.ts
@@ -1,0 +1,105 @@
+/**
+ * Legacy Data Detection（旧数据检测）
+ *
+ * 使用依赖注入的 reader 函数检测是否存在需要迁移的旧数据，
+ * 以及 RT（Runtime）数据库是否为空（迁移目标是否干净）。
+ *
+ * 所有 reader 均为 async 函数，错误会被优雅捕获（返回 0，不抛出）。
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface LegacyDataSummary {
+  eventlogCount: number;
+  taskCount: number;
+  timeblockCount: number;
+  hasActiveBlock: boolean;
+  hasAnyData: boolean;
+}
+
+export interface LegacyDataReaders {
+  readLegacyEvents: () => Promise<unknown[]>;
+  readLegacyTasks: () => Promise<unknown[]>;
+  readLegacyCompletedBlocks: () => Promise<unknown[]>;
+  readLegacyActiveBlock: () => Promise<unknown | null>;
+}
+
+export interface RtDataReaders {
+  readRtEvents: () => Promise<unknown[]>;
+  readRtTasks: () => Promise<unknown[]>;
+  readRtCompletedBlocks: () => Promise<unknown[]>;
+  readRtActiveBlock: () => Promise<unknown | null>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Safely read an array; returns empty array on any error（安全读取数组，失败返回空数组）. */
+async function safeReadArray(fn: () => Promise<unknown[]>): Promise<unknown[]> {
+  try {
+    return await fn();
+  } catch {
+    return [];
+  }
+}
+
+/** Safely read a nullable value; returns null on any error（安全读取可空值，失败返回 null）. */
+async function safeReadNullable(fn: () => Promise<unknown | null>): Promise<unknown | null> {
+  try {
+    return await fn();
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * detectLegacyData — 读取所有旧数据源并汇总统计。
+ *
+ * - 所有读取并发执行（Promise.all）。
+ * - 单个 reader 失败不影响其他来源，失败项记为 0 / false。
+ */
+export async function detectLegacyData(readers: LegacyDataReaders): Promise<LegacyDataSummary> {
+  const [events, tasks, completedBlocks, activeBlock] = await Promise.all([
+    safeReadArray(readers.readLegacyEvents),
+    safeReadArray(readers.readLegacyTasks),
+    safeReadArray(readers.readLegacyCompletedBlocks),
+    safeReadNullable(readers.readLegacyActiveBlock),
+  ]);
+
+  const eventlogCount = events.length;
+  const taskCount = tasks.length;
+  const timeblockCount = completedBlocks.length;
+  const hasActiveBlock = activeBlock !== null;
+  const hasAnyData = eventlogCount > 0 || taskCount > 0 || timeblockCount > 0 || hasActiveBlock;
+
+  return { eventlogCount, taskCount, timeblockCount, hasActiveBlock, hasAnyData };
+}
+
+/**
+ * detectRtIsEmpty — 检测 RT 数据库是否完全为空。
+ *
+ * 当所有 RT 来源均无数据时返回 true（迁移目标干净，安全迁入）。
+ * Reader 失败视为空（保守策略：宁可误判为有数据，也不因读取错误误触发迁移）。
+ */
+export async function detectRtIsEmpty(readers: RtDataReaders): Promise<boolean> {
+  const [events, tasks, completedBlocks, activeBlock] = await Promise.all([
+    safeReadArray(readers.readRtEvents),
+    safeReadArray(readers.readRtTasks),
+    safeReadArray(readers.readRtCompletedBlocks),
+    safeReadNullable(readers.readRtActiveBlock),
+  ]);
+
+  return (
+    events.length === 0 &&
+    tasks.length === 0 &&
+    completedBlocks.length === 0 &&
+    activeBlock === null
+  );
+}

--- a/src/lib/migration/legacy-migration-detector.ts
+++ b/src/lib/migration/legacy-migration-detector.ts
@@ -83,23 +83,38 @@ export async function detectLegacyData(readers: LegacyDataReaders): Promise<Lega
 }
 
 /**
+ * RT reader 失败时视为"有数据"（返回 false），避免因 RT 不可达而误触发迁移。
+ * 与 legacy reader 的保守策略相反：legacy 失败 = 无数据；RT 失败 = 有数据。
+ */
+async function rtHasNoArrayData(fn: () => Promise<unknown[]>): Promise<boolean> {
+  try {
+    return (await fn()).length === 0;
+  } catch {
+    return false; // RT 不可达时假设有数据，不触发迁移
+  }
+}
+
+async function rtHasNoActiveBlock(fn: () => Promise<unknown | null>): Promise<boolean> {
+  try {
+    return (await fn()) === null;
+  } catch {
+    return false; // RT 不可达时假设有数据，不触发迁移
+  }
+}
+
+/**
  * detectRtIsEmpty — 检测 RT 数据库是否完全为空。
  *
  * 当所有 RT 来源均无数据时返回 true（迁移目标干净，安全迁入）。
- * Reader 失败视为空（保守策略：宁可误判为有数据，也不因读取错误误触发迁移）。
+ * RT reader 失败视为"有数据"（返回 false），避免因 RT 不可达而误触发迁移。
  */
 export async function detectRtIsEmpty(readers: RtDataReaders): Promise<boolean> {
-  const [events, tasks, completedBlocks, activeBlock] = await Promise.all([
-    safeReadArray(readers.readRtEvents),
-    safeReadArray(readers.readRtTasks),
-    safeReadArray(readers.readRtCompletedBlocks),
-    safeReadNullable(readers.readRtActiveBlock),
+  const [eventsEmpty, tasksEmpty, blocksEmpty, activeEmpty] = await Promise.all([
+    rtHasNoArrayData(readers.readRtEvents),
+    rtHasNoArrayData(readers.readRtTasks),
+    rtHasNoArrayData(readers.readRtCompletedBlocks),
+    rtHasNoActiveBlock(readers.readRtActiveBlock),
   ]);
 
-  return (
-    events.length === 0 &&
-    tasks.length === 0 &&
-    completedBlocks.length === 0 &&
-    activeBlock === null
-  );
+  return eventsEmpty && tasksEmpty && blocksEmpty && activeEmpty;
 }

--- a/src/lib/migration/legacy-migration-executor.ts
+++ b/src/lib/migration/legacy-migration-executor.ts
@@ -1,0 +1,73 @@
+export type MigrationDomain = 'eventlog' | 'task' | 'timeblock';
+
+export interface MigrationProgress {
+  domain: MigrationDomain;
+  step: number;
+  totalSteps: number;
+  label: string;
+}
+
+export interface MigrationResult {
+  success: boolean;
+  migratedDomains: MigrationDomain[];
+  error?: string;
+}
+
+export interface MigrationAdapters {
+  readLegacyEvents: () => Promise<unknown[]>;
+  readLegacyTasks: () => Promise<unknown[]>;
+  readLegacyCompletedBlocks: () => Promise<unknown[]>;
+  readLegacyActiveBlock: () => Promise<unknown | null>;
+  importEventsToRt: (events: unknown[]) => Promise<void>;
+  importTasksToRt: (tasks: unknown[]) => Promise<void>;
+  writeCompletedBlocksToRt: (blocks: unknown[]) => Promise<void>;
+  writeActiveBlockToRt: (block: unknown) => Promise<void>;
+}
+
+type ProgressCallback = (progress: MigrationProgress) => void;
+
+const TOTAL_STEPS = 3;
+
+export async function executeMigration(
+  adapters: MigrationAdapters,
+  onProgress?: ProgressCallback,
+): Promise<MigrationResult> {
+  const migratedDomains: MigrationDomain[] = [];
+
+  try {
+    // Step 1: eventlog
+    onProgress?.({ domain: 'eventlog', step: 1, totalSteps: TOTAL_STEPS, label: '迁移事件日志' });
+    const events = await adapters.readLegacyEvents();
+    if (events.length > 0) {
+      await adapters.importEventsToRt(events);
+      migratedDomains.push('eventlog');
+    }
+
+    // Step 2: task
+    onProgress?.({ domain: 'task', step: 2, totalSteps: TOTAL_STEPS, label: '迁移任务' });
+    const tasks = await adapters.readLegacyTasks();
+    if (tasks.length > 0) {
+      await adapters.importTasksToRt(tasks);
+      migratedDomains.push('task');
+    }
+
+    // Step 3: timeblock
+    onProgress?.({ domain: 'timeblock', step: 3, totalSteps: TOTAL_STEPS, label: '迁移时间块' });
+    const completedBlocks = await adapters.readLegacyCompletedBlocks();
+    const activeBlock = await adapters.readLegacyActiveBlock();
+    if (completedBlocks.length > 0 || activeBlock !== null) {
+      if (completedBlocks.length > 0) {
+        await adapters.writeCompletedBlocksToRt(completedBlocks);
+      }
+      if (activeBlock !== null) {
+        await adapters.writeActiveBlockToRt(activeBlock);
+      }
+      migratedDomains.push('timeblock');
+    }
+
+    return { success: true, migratedDomains };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { success: false, migratedDomains, error };
+  }
+}

--- a/src/lib/migration/legacy-migration-flags.ts
+++ b/src/lib/migration/legacy-migration-flags.ts
@@ -1,0 +1,44 @@
+const MIGRATION_COMPLETED_KEY = 'exomind:migrationCompleted';
+const MIGRATION_SKIPPED_KEY = 'exomind:migrationSkipped';
+
+function getStorage(): Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> | null {
+  if (typeof window === 'undefined') return null;
+  const localStorageLike = window.localStorage as Partial<Storage> | undefined;
+  if (!localStorageLike) return null;
+  if (typeof localStorageLike.getItem !== 'function') return null;
+  if (typeof localStorageLike.setItem !== 'function') return null;
+  if (typeof localStorageLike.removeItem !== 'function') return null;
+  return localStorageLike as Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+}
+
+export function isMigrationCompleted(): boolean {
+  const storage = getStorage();
+  if (!storage) return false;
+  return storage.getItem(MIGRATION_COMPLETED_KEY) === 'true';
+}
+
+export function markMigrationCompleted(): void {
+  const storage = getStorage();
+  if (!storage) return;
+  storage.setItem(MIGRATION_COMPLETED_KEY, 'true');
+  storage.removeItem(MIGRATION_SKIPPED_KEY);
+}
+
+export function isMigrationSkipped(): boolean {
+  const storage = getStorage();
+  if (!storage) return false;
+  return storage.getItem(MIGRATION_SKIPPED_KEY) === 'true';
+}
+
+export function markMigrationSkipped(): void {
+  const storage = getStorage();
+  if (!storage) return;
+  storage.setItem(MIGRATION_SKIPPED_KEY, 'true');
+}
+
+export function clearMigrationFlags(): void {
+  const storage = getStorage();
+  if (!storage) return;
+  storage.removeItem(MIGRATION_COMPLETED_KEY);
+  storage.removeItem(MIGRATION_SKIPPED_KEY);
+}

--- a/src/lib/services/timeblock.service.ts
+++ b/src/lib/services/timeblock.service.ts
@@ -730,27 +730,7 @@ export class TimeBlockServiceImpl implements TimeBlockService {
 
   private async readActiveBlock(): Promise<ActiveBlockData | null> {
     if (this.backendMode === 'rt-sqlite') {
-      const fromRtAdapter = await this.rtAdapter?.getActiveBlock() ?? null;
-      if (fromRtAdapter) {
-        return fromRtAdapter;
-      }
-
-      const legacyData = await this.env.storage.read<ActiveBlockData>(ACTIVE_BLOCK_KEY);
-      if (legacyData) {
-        await this.rtAdapter?.putActiveBlock(legacyData);
-        await this.env.storage.delete(ACTIVE_BLOCK_KEY);
-        return legacyData;
-      }
-
-      if (!this.useInjectedEnvStorage) {
-        const fromLegacyStorage = await getActiveBlockStorage().loadActiveBlock();
-        if (fromLegacyStorage) {
-          await this.rtAdapter?.putActiveBlock(fromLegacyStorage);
-          return fromLegacyStorage;
-        }
-      }
-
-      return null;
+      return await this.rtAdapter?.getActiveBlock() ?? null;
     }
 
     if (this.useInjectedEnvStorage) {
@@ -792,17 +772,7 @@ export class TimeBlockServiceImpl implements TimeBlockService {
 
   private async readCompletedBlockData(): Promise<TimeBlockData[]> {
     if (this.backendMode === 'rt-sqlite') {
-      const fromRt = await this.rtAdapter?.listCompletedBlocks() ?? [];
-      if (fromRt.length > 0) {
-        return fromRt;
-      }
-
-      const legacyData = await this.env.storage.read<TimeBlockData[]>(TIME_BLOCKS_KEY);
-      const nextBlocks = legacyData ?? [];
-      if (nextBlocks.length > 0) {
-        await this.rtAdapter?.replaceCompletedBlocks(nextBlocks);
-      }
-      return nextBlocks;
+      return await this.rtAdapter?.listCompletedBlocks() ?? [];
     }
 
     return await this.env.storage.read<TimeBlockData[]>(TIME_BLOCKS_KEY) || [];

--- a/src/ui/app/config/settings/settings-registry.ts
+++ b/src/ui/app/config/settings/settings-registry.ts
@@ -783,7 +783,8 @@ export const SETTINGS_REGISTRY: SettingsItem[] = [
     category: 'data',
     type: 'action',
     icon: DatabaseZap,
-    visible: () => {
+    visible: (ctx) => {
+      if (!ctx.isDesktop) return false;
       try {
         return !isMigrationCompleted();
       } catch {

--- a/src/ui/app/config/settings/settings-registry.ts
+++ b/src/ui/app/config/settings/settings-registry.ts
@@ -6,6 +6,7 @@ import {
   Bug,
   Code,
   Command,
+  DatabaseZap,
   GitCommit,
   Globe,
   Heart,
@@ -140,6 +141,7 @@ import {
   type CountdownEndMode,
 } from '@/config/timer-preferences';
 import { syncDevtoolsWithSettings } from '@/lib/debug/devtools-runtime';
+import { isMigrationCompleted, clearMigrationFlags } from '@/lib/migration/legacy-migration-flags';
 import {
   TIMER_END_SOUND_PRESETS,
   type TimerEndSoundPresetId,
@@ -773,6 +775,29 @@ export const SETTINGS_REGISTRY: SettingsItem[] = [
     category: 'data',
     type: 'custom',
     component: DataTransferSetting,
+  },
+  {
+    id: 'data-legacy-migration',
+    label: '迁移旧版数据',
+    description: '将旧版存储中的数据迁移到本地 SQLite',
+    category: 'data',
+    type: 'action',
+    icon: DatabaseZap,
+    visible: () => {
+      try {
+        return !isMigrationCompleted();
+      } catch {
+        return false;
+      }
+    },
+    onAction: () => {
+      try {
+        clearMigrationFlags();
+        window.location.reload();
+      } catch {
+        // ignore
+      }
+    },
   },
   {
     id: 'more-update',

--- a/src/ui/components/MigrationDialog.tsx
+++ b/src/ui/components/MigrationDialog.tsx
@@ -14,6 +14,7 @@ export interface MigrationDialogProps {
   summary: LegacyDataSummary;
   onMigrate: () => void;
   onSkip: () => void;
+  onErrorDismiss?: () => void;
   migrating?: boolean;
   progress?: MigrationProgress;
   error?: string;
@@ -24,6 +25,7 @@ export function MigrationDialog({
   summary,
   onMigrate,
   onSkip,
+  onErrorDismiss,
   migrating = false,
   progress,
   error,
@@ -58,7 +60,7 @@ export function MigrationDialog({
             <DialogFooter>
               <button
                 type="button"
-                onClick={onSkip}
+                onClick={onErrorDismiss ?? onSkip}
                 className="w-full rounded-xl border border-[#F0ECE8] px-4 py-2.5 text-sm font-medium text-[#78716C] hover:bg-[#FAF7F5] dark:border-[#292524] dark:text-[#A8A29E] dark:hover:bg-[#1C1917]"
               >
                 继续使用旧版存储
@@ -84,6 +86,11 @@ export function MigrationDialog({
 
               <div className="h-2 w-full overflow-hidden rounded-full bg-[#F0ECE8] dark:bg-[#292524]">
                 <div
+                  role="progressbar"
+                  aria-valuenow={progressPercent}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-label="迁移进度"
                   className="h-full rounded-full bg-blue-500 transition-all duration-300"
                   style={{ width: `${progressPercent}%` }}
                 />

--- a/src/ui/components/MigrationDialog.tsx
+++ b/src/ui/components/MigrationDialog.tsx
@@ -1,0 +1,151 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import type { LegacyDataSummary } from '@/lib/migration/legacy-migration-detector';
+import type { MigrationProgress } from '@/lib/migration/legacy-migration-executor';
+
+export interface MigrationDialogProps {
+  open: boolean;
+  summary: LegacyDataSummary;
+  onMigrate: () => void;
+  onSkip: () => void;
+  migrating?: boolean;
+  progress?: MigrationProgress;
+  error?: string;
+}
+
+export function MigrationDialog({
+  open,
+  summary,
+  onMigrate,
+  onSkip,
+  migrating = false,
+  progress,
+  error,
+}: MigrationDialogProps) {
+  const progressPercent =
+    progress && progress.totalSteps > 0
+      ? Math.round((progress.step / progress.totalSteps) * 100)
+      : 0;
+
+  return (
+    <Dialog open={open}>
+      <DialogContent
+        hideCloseButton
+        className="max-w-sm sm:max-w-md dark:border-[#FFFFFF15] dark:bg-[rgba(28,25,23,0.92)]"
+        onInteractOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => migrating && e.preventDefault()}
+      >
+        {/* ── Error State ── */}
+        {error ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>迁移失败</DialogTitle>
+              <DialogDescription>
+                迁移过程中遇到问题，将继续使用旧版存储。
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-400">
+              {error}
+            </div>
+
+            <DialogFooter>
+              <button
+                type="button"
+                onClick={onSkip}
+                className="w-full rounded-xl border border-[#F0ECE8] px-4 py-2.5 text-sm font-medium text-[#78716C] hover:bg-[#FAF7F5] dark:border-[#292524] dark:text-[#A8A29E] dark:hover:bg-[#1C1917]"
+              >
+                继续使用旧版存储
+              </button>
+            </DialogFooter>
+          </>
+        ) : migrating ? (
+          /* ── Migrating State ── */
+          <>
+            {/* Visually hidden title/description satisfies Radix Dialog accessibility requirement */}
+            <DialogTitle className="sr-only">正在迁移数据</DialogTitle>
+            <DialogDescription className="sr-only">数据迁移正在进行中，请稍候。</DialogDescription>
+
+            <div className="flex flex-col gap-4 py-2">
+              <p className="text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">
+                正在迁移...{' '}
+                {progress && (
+                  <span className="text-[#78716C] dark:text-[#A8A29E]">
+                    {progress.label}（{progress.step}/{progress.totalSteps}）
+                  </span>
+                )}
+              </p>
+
+              <div className="h-2 w-full overflow-hidden rounded-full bg-[#F0ECE8] dark:bg-[#292524]">
+                <div
+                  className="h-full rounded-full bg-blue-500 transition-all duration-300"
+                  style={{ width: `${progressPercent}%` }}
+                />
+              </div>
+            </div>
+          </>
+        ) : (
+          /* ── Default State ── */
+          <>
+            <DialogHeader>
+              <DialogTitle>检测到旧版数据</DialogTitle>
+              <DialogDescription>
+                系统检测到以下旧版数据可以迁移到新的本地存储格式：
+              </DialogDescription>
+            </DialogHeader>
+
+            <ul className="space-y-1.5 rounded-lg border border-[#F0ECE8] bg-[#FAF7F5] px-4 py-3 text-sm text-[#1C1917] dark:border-[#292524] dark:bg-[#1C1917]/40 dark:text-[#FAFAF9]">
+              {summary.eventlogCount > 0 && (
+                <li>
+                  事件日志 — <span className="font-medium">{summary.eventlogCount}</span> 条
+                </li>
+              )}
+              {summary.taskCount > 0 && (
+                <li>
+                  任务 — <span className="font-medium">{summary.taskCount}</span> 个
+                </li>
+              )}
+              {(summary.timeblockCount > 0 || summary.hasActiveBlock) && (
+                <li>
+                  时间块 — <span className="font-medium">{summary.timeblockCount}</span> 个
+                  {summary.hasActiveBlock && (
+                    <span className="ml-1 text-[#78716C] dark:text-[#A8A29E]">
+                      （含进行中 1）
+                    </span>
+                  )}
+                </li>
+              )}
+            </ul>
+
+            <p className="text-xs text-[#78716C] dark:text-[#A8A29E]">
+              迁移后，数据将统一存储在本地 SQLite 数据库中，原始数据将保留作为备份。
+            </p>
+
+            <DialogFooter className="flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
+              <button
+                type="button"
+                onClick={onSkip}
+                className="mt-2 w-full rounded-xl border border-[#F0ECE8] px-4 py-2.5 text-sm font-medium text-[#78716C] hover:bg-[#FAF7F5] sm:mt-0 sm:w-auto dark:border-[#292524] dark:text-[#A8A29E] dark:hover:bg-[#1C1917]"
+              >
+                暂不迁移
+              </button>
+              <button
+                type="button"
+                onClick={onMigrate}
+                className="w-full rounded-xl bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-700 sm:w-auto"
+              >
+                立即迁移
+              </button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/ui/components/MigrationDialogController.tsx
+++ b/src/ui/components/MigrationDialogController.tsx
@@ -86,7 +86,7 @@ export function MigrationDialogController() {
               method: 'GET',
               headers: { Accept: 'application/json' },
             });
-            if (!response.ok) return [];
+            if (!response.ok) throw new Error(`RT blocks unavailable: ${response.status}`);
             return response.json() as Promise<unknown[]>;
           },
           readRtActiveBlock: async () => {
@@ -97,7 +97,7 @@ export function MigrationDialogController() {
               headers: { Accept: 'application/json' },
             });
             if (response.status === 404) return null;
-            if (!response.ok) return null;
+            if (!response.ok) throw new Error(`RT active block unavailable: ${response.status}`);
             return response.json() as Promise<unknown>;
           },
         };

--- a/src/ui/components/MigrationDialogController.tsx
+++ b/src/ui/components/MigrationDialogController.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useState, useCallback } from 'react';
+import { MigrationDialog } from './MigrationDialog';
+import {
+  detectLegacyData,
+  detectRtIsEmpty,
+  type LegacyDataSummary,
+} from '@/lib/migration/legacy-migration-detector';
+import {
+  executeMigration,
+  type MigrationAdapters,
+  type MigrationProgress,
+} from '@/lib/migration/legacy-migration-executor';
+import {
+  isMigrationCompleted,
+  isMigrationSkipped,
+  markMigrationCompleted,
+  markMigrationSkipped,
+} from '@/lib/migration/legacy-migration-flags';
+import { setAllBackendModes } from '@/config/domain-backend-mode';
+import { detectRuntime } from '@/lib/environment/bootstrap';
+import { TauriEventLogStorageAdapter } from '@/lib/adapters/tauri-eventlog-storage';
+import { TaskPouchAdapter } from '@/lib/adapters/task-pouch-adapter';
+import { WebStorageAdapter } from '@/lib/adapters/web-storage';
+import { EventLogRtAdapter } from '@/lib/adapters/eventlog-rt-adapter';
+import { TaskRtAdapter } from '@/lib/adapters/task-rt-adapter';
+import { appendRuntimeProfileScope } from '@/lib/adapters/runtime-profile-scope';
+import { getSelectedRuntimeTarget } from '@/config/runtime-target';
+
+// Legacy localStorage keys used by TimeBlockService via WebStorageAdapter
+const TIME_BLOCKS_KEY = 'time_blocks';
+const ACTIVE_BLOCK_KEY = 'active_block';
+
+function buildRtBaseUrl(): string {
+  const target = getSelectedRuntimeTarget();
+  const host =
+    target.host.includes(':') && !target.host.startsWith('[')
+      ? `[${target.host}]`
+      : target.host;
+  return `http://${host}:${target.port}`;
+}
+
+export function MigrationDialogController() {
+  const [open, setOpen] = useState(false);
+  const [summary, setSummary] = useState<LegacyDataSummary | null>(null);
+  const [migrating, setMigrating] = useState(false);
+  const [progress, setProgress] = useState<MigrationProgress | undefined>();
+  const [error, setError] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (detectRuntime() !== 'tauri') {
+      return;
+    }
+    if (isMigrationCompleted() || isMigrationSkipped()) {
+      return;
+    }
+
+    void (async () => {
+      try {
+        const legacyEventLogAdapter = new TauriEventLogStorageAdapter();
+        const legacyTaskAdapter = new TaskPouchAdapter();
+        const legacyStorage = new WebStorageAdapter();
+
+        const legacyReaders = {
+          readLegacyEvents: () => legacyEventLogAdapter.listEvents(),
+          readLegacyTasks: () => legacyTaskAdapter.listTasks(true),
+          readLegacyCompletedBlocks: () =>
+            legacyStorage.read<unknown[]>(TIME_BLOCKS_KEY).then((v) => v ?? []),
+          readLegacyActiveBlock: () => legacyStorage.read<unknown>(ACTIVE_BLOCK_KEY),
+        };
+
+        const detectedSummary = await detectLegacyData(legacyReaders);
+        if (!detectedSummary.hasAnyData) {
+          return;
+        }
+
+        const rtEventLogAdapter = new EventLogRtAdapter();
+        const rtTaskAdapter = new TaskRtAdapter();
+
+        const rtReaders = {
+          readRtEvents: () => rtEventLogAdapter.listEvents(),
+          readRtTasks: () => rtTaskAdapter.listTasks(true),
+          readRtCompletedBlocks: async () => {
+            const baseUrl = buildRtBaseUrl();
+            const url = `${baseUrl}${appendRuntimeProfileScope('/timeblocks')}`;
+            const response = await fetch(url, {
+              method: 'GET',
+              headers: { Accept: 'application/json' },
+            });
+            if (!response.ok) return [];
+            return response.json() as Promise<unknown[]>;
+          },
+          readRtActiveBlock: async () => {
+            const baseUrl = buildRtBaseUrl();
+            const url = `${baseUrl}${appendRuntimeProfileScope('/timeblocks/active')}`;
+            const response = await fetch(url, {
+              method: 'GET',
+              headers: { Accept: 'application/json' },
+            });
+            if (response.status === 404) return null;
+            if (!response.ok) return null;
+            return response.json() as Promise<unknown>;
+          },
+        };
+
+        const rtIsEmpty = await detectRtIsEmpty(rtReaders);
+        if (!rtIsEmpty) {
+          return;
+        }
+
+        setSummary(detectedSummary);
+        setOpen(true);
+      } catch {
+        // Detection errors are silently ignored — don't block app startup
+      }
+    })();
+  }, []);
+
+  const handleMigrate = useCallback(async () => {
+    if (!summary) return;
+
+    setMigrating(true);
+    setError(undefined);
+
+    const legacyEventLogAdapter = new TauriEventLogStorageAdapter();
+    const legacyTaskAdapter = new TaskPouchAdapter();
+    const legacyStorage = new WebStorageAdapter();
+
+    const adapters: MigrationAdapters = {
+      readLegacyEvents: () => legacyEventLogAdapter.listEvents(),
+      readLegacyTasks: () => legacyTaskAdapter.listTasks(true),
+      readLegacyCompletedBlocks: () =>
+        legacyStorage.read<unknown[]>(TIME_BLOCKS_KEY).then((v) => v ?? []),
+      readLegacyActiveBlock: () => legacyStorage.read<unknown>(ACTIVE_BLOCK_KEY),
+
+      importEventsToRt: async (events) => {
+        const baseUrl = buildRtBaseUrl();
+        const url = `${baseUrl}${appendRuntimeProfileScope('/eventlog/import/json')}`;
+        const scopedUrl = new URL(url);
+        scopedUrl.searchParams.set('strategy', 'merge');
+        const response = await fetch(scopedUrl.toString(), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+          body: JSON.stringify(events),
+        });
+        if (!response.ok) {
+          throw new Error(`Import events failed: ${response.status}`);
+        }
+      },
+
+      importTasksToRt: async (tasks) => {
+        const baseUrl = buildRtBaseUrl();
+        const url = `${baseUrl}${appendRuntimeProfileScope('/tasks/import/json')}`;
+        const scopedUrl = new URL(url);
+        scopedUrl.searchParams.set('strategy', 'merge');
+        const response = await fetch(scopedUrl.toString(), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+          body: JSON.stringify(tasks),
+        });
+        if (!response.ok) {
+          throw new Error(`Import tasks failed: ${response.status}`);
+        }
+      },
+
+      writeCompletedBlocksToRt: async (blocks) => {
+        const baseUrl = buildRtBaseUrl();
+        const url = `${baseUrl}${appendRuntimeProfileScope('/timeblocks')}`;
+        const response = await fetch(url, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+          body: JSON.stringify(blocks),
+        });
+        if (!response.ok) {
+          throw new Error(`Write completed blocks failed: ${response.status}`);
+        }
+      },
+
+      writeActiveBlockToRt: async (block) => {
+        const baseUrl = buildRtBaseUrl();
+        const url = `${baseUrl}${appendRuntimeProfileScope('/timeblocks/active')}`;
+        const response = await fetch(url, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+          body: JSON.stringify(block),
+        });
+        if (!response.ok) {
+          throw new Error(`Write active block failed: ${response.status}`);
+        }
+      },
+    };
+
+    const result = await executeMigration(adapters, setProgress);
+
+    if (result.success) {
+      setAllBackendModes('rt-sqlite');
+      markMigrationCompleted();
+      setOpen(false);
+      window.location.reload();
+    } else {
+      setAllBackendModes('legacy');
+      setError(result.error);
+      setMigrating(false);
+    }
+  }, [summary]);
+
+  const handleSkip = useCallback(() => {
+    markMigrationSkipped();
+    setAllBackendModes('legacy');
+    setOpen(false);
+    window.location.reload();
+  }, []);
+
+  if (summary === null) {
+    return null;
+  }
+
+  return (
+    <MigrationDialog
+      open={open}
+      summary={summary}
+      onMigrate={() => void handleMigrate()}
+      onSkip={handleSkip}
+      migrating={migrating}
+      progress={progress}
+      error={error}
+    />
+  );
+}

--- a/src/ui/components/MigrationDialogController.tsx
+++ b/src/ui/components/MigrationDialogController.tsx
@@ -121,84 +121,92 @@ export function MigrationDialogController() {
     setMigrating(true);
     setError(undefined);
 
-    const legacyEventLogAdapter = new TauriEventLogStorageAdapter();
-    const legacyTaskAdapter = new TaskPouchAdapter();
-    const legacyStorage = new WebStorageAdapter();
+    try {
+      const legacyEventLogAdapter = new TauriEventLogStorageAdapter();
+      const legacyTaskAdapter = new TaskPouchAdapter();
+      const legacyStorage = new WebStorageAdapter();
 
-    const adapters: MigrationAdapters = {
-      readLegacyEvents: () => legacyEventLogAdapter.listEvents(),
-      readLegacyTasks: () => legacyTaskAdapter.listTasks(true),
-      readLegacyCompletedBlocks: () =>
-        legacyStorage.read<unknown[]>(TIME_BLOCKS_KEY).then((v) => v ?? []),
-      readLegacyActiveBlock: () => legacyStorage.read<unknown>(ACTIVE_BLOCK_KEY),
+      // Re-read legacy data at migration time to get the most up-to-date snapshot.
+      // Detection and execution are separate reads — this is intentional (TOCTOU acknowledged).
+      const adapters: MigrationAdapters = {
+        readLegacyEvents: () => legacyEventLogAdapter.listEvents(),
+        readLegacyTasks: () => legacyTaskAdapter.listTasks(true),
+        readLegacyCompletedBlocks: () =>
+          legacyStorage.read<unknown[]>(TIME_BLOCKS_KEY).then((v) => v ?? []),
+        readLegacyActiveBlock: () => legacyStorage.read<unknown>(ACTIVE_BLOCK_KEY),
 
-      importEventsToRt: async (events) => {
-        const baseUrl = buildRtBaseUrl();
-        const url = `${baseUrl}${appendRuntimeProfileScope('/eventlog/import/json')}`;
-        const scopedUrl = new URL(url);
-        scopedUrl.searchParams.set('strategy', 'merge');
-        const response = await fetch(scopedUrl.toString(), {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-          body: JSON.stringify(events),
-        });
-        if (!response.ok) {
-          throw new Error(`Import events failed: ${response.status}`);
-        }
-      },
+        importEventsToRt: async (events) => {
+          const baseUrl = buildRtBaseUrl();
+          const url = `${baseUrl}${appendRuntimeProfileScope('/eventlog/import/json')}`;
+          const scopedUrl = new URL(url);
+          scopedUrl.searchParams.set('strategy', 'merge');
+          const response = await fetch(scopedUrl.toString(), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+            body: JSON.stringify(events),
+          });
+          if (!response.ok) {
+            throw new Error(`Import events failed: ${response.status}`);
+          }
+        },
 
-      importTasksToRt: async (tasks) => {
-        const baseUrl = buildRtBaseUrl();
-        const url = `${baseUrl}${appendRuntimeProfileScope('/tasks/import/json')}`;
-        const scopedUrl = new URL(url);
-        scopedUrl.searchParams.set('strategy', 'merge');
-        const response = await fetch(scopedUrl.toString(), {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-          body: JSON.stringify(tasks),
-        });
-        if (!response.ok) {
-          throw new Error(`Import tasks failed: ${response.status}`);
-        }
-      },
+        importTasksToRt: async (tasks) => {
+          const baseUrl = buildRtBaseUrl();
+          const url = `${baseUrl}${appendRuntimeProfileScope('/tasks/import/json')}`;
+          const scopedUrl = new URL(url);
+          scopedUrl.searchParams.set('strategy', 'merge');
+          const response = await fetch(scopedUrl.toString(), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+            body: JSON.stringify(tasks),
+          });
+          if (!response.ok) {
+            throw new Error(`Import tasks failed: ${response.status}`);
+          }
+        },
 
-      writeCompletedBlocksToRt: async (blocks) => {
-        const baseUrl = buildRtBaseUrl();
-        const url = `${baseUrl}${appendRuntimeProfileScope('/timeblocks')}`;
-        const response = await fetch(url, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-          body: JSON.stringify(blocks),
-        });
-        if (!response.ok) {
-          throw new Error(`Write completed blocks failed: ${response.status}`);
-        }
-      },
+        writeCompletedBlocksToRt: async (blocks) => {
+          const baseUrl = buildRtBaseUrl();
+          const url = `${baseUrl}${appendRuntimeProfileScope('/timeblocks')}`;
+          const response = await fetch(url, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+            body: JSON.stringify(blocks),
+          });
+          if (!response.ok) {
+            throw new Error(`Write completed blocks failed: ${response.status}`);
+          }
+        },
 
-      writeActiveBlockToRt: async (block) => {
-        const baseUrl = buildRtBaseUrl();
-        const url = `${baseUrl}${appendRuntimeProfileScope('/timeblocks/active')}`;
-        const response = await fetch(url, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-          body: JSON.stringify(block),
-        });
-        if (!response.ok) {
-          throw new Error(`Write active block failed: ${response.status}`);
-        }
-      },
-    };
+        writeActiveBlockToRt: async (block) => {
+          const baseUrl = buildRtBaseUrl();
+          const url = `${baseUrl}${appendRuntimeProfileScope('/timeblocks/active')}`;
+          const response = await fetch(url, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+            body: JSON.stringify(block),
+          });
+          if (!response.ok) {
+            throw new Error(`Write active block failed: ${response.status}`);
+          }
+        },
+      };
 
-    const result = await executeMigration(adapters, setProgress);
+      const result = await executeMigration(adapters, setProgress);
 
-    if (result.success) {
-      setAllBackendModes('rt-sqlite');
-      markMigrationCompleted();
-      setOpen(false);
-      window.location.reload();
-    } else {
+      if (result.success) {
+        setAllBackendModes('rt-sqlite');
+        markMigrationCompleted();
+        setOpen(false);
+        window.location.reload();
+      } else {
+        setAllBackendModes('legacy');
+        setError(result.error ?? '迁移失败，请稍后重试');
+      }
+    } catch (err) {
       setAllBackendModes('legacy');
-      setError(result.error);
+      setError(err instanceof Error ? err.message : '迁移失败，请稍后重试');
+    } finally {
       setMigrating(false);
     }
   }, [summary]);
@@ -208,6 +216,13 @@ export function MigrationDialogController() {
     setAllBackendModes('legacy');
     setOpen(false);
     window.location.reload();
+  }, []);
+
+  // Error dismiss: don't mark as skipped (user didn't choose to skip, migration failed).
+  // Next launch will re-detect and offer migration again (retry on next startup).
+  const handleErrorDismiss = useCallback(() => {
+    setAllBackendModes('legacy');
+    setOpen(false);
   }, []);
 
   if (summary === null) {
@@ -220,6 +235,7 @@ export function MigrationDialogController() {
       summary={summary}
       onMigrate={() => void handleMigrate()}
       onSkip={handleSkip}
+      onErrorDismiss={handleErrorDismiss}
       migrating={migrating}
       progress={progress}
       error={error}

--- a/tests/unit/migration/legacy-migration-detector.test.ts
+++ b/tests/unit/migration/legacy-migration-detector.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectLegacyData,
+  detectRtIsEmpty,
+  type LegacyDataReaders,
+  type RtDataReaders,
+} from '@/lib/migration/legacy-migration-detector';
+
+// --- helpers ---
+
+function makeLegacyReaders(overrides: Partial<LegacyDataReaders> = {}): LegacyDataReaders {
+  return {
+    readLegacyEvents: async () => [],
+    readLegacyTasks: async () => [],
+    readLegacyCompletedBlocks: async () => [],
+    readLegacyActiveBlock: async () => null,
+    ...overrides,
+  };
+}
+
+function makeRtReaders(overrides: Partial<RtDataReaders> = {}): RtDataReaders {
+  return {
+    readRtEvents: async () => [],
+    readRtTasks: async () => [],
+    readRtCompletedBlocks: async () => [],
+    readRtActiveBlock: async () => null,
+    ...overrides,
+  };
+}
+
+// --- detectLegacyData ---
+
+describe('detectLegacyData（检测旧数据）', () => {
+  it('no legacy data → returns all zero counts and hasAnyData false（没有旧数据返回全零）', async () => {
+    const summary = await detectLegacyData(makeLegacyReaders());
+
+    expect(summary.eventlogCount).toBe(0);
+    expect(summary.taskCount).toBe(0);
+    expect(summary.timeblockCount).toBe(0);
+    expect(summary.hasActiveBlock).toBe(false);
+    expect(summary.hasAnyData).toBe(false);
+  });
+
+  it('legacy events present → correct eventlogCount（检测到旧事件日志）', async () => {
+    const readers = makeLegacyReaders({
+      readLegacyEvents: async () => [{ id: '1' }, { id: '2' }, { id: '3' }],
+    });
+
+    const summary = await detectLegacyData(readers);
+
+    expect(summary.eventlogCount).toBe(3);
+    expect(summary.hasAnyData).toBe(true);
+  });
+
+  it('legacy tasks present → correct taskCount（检测到旧任务）', async () => {
+    const readers = makeLegacyReaders({
+      readLegacyTasks: async () => [{ id: 'task-1' }, { id: 'task-2' }],
+    });
+
+    const summary = await detectLegacyData(readers);
+
+    expect(summary.taskCount).toBe(2);
+    expect(summary.hasAnyData).toBe(true);
+  });
+
+  it('legacy completed blocks present → correct timeblockCount（检测到已完成时间块）', async () => {
+    const readers = makeLegacyReaders({
+      readLegacyCompletedBlocks: async () => [{ id: 'block-1' }],
+    });
+
+    const summary = await detectLegacyData(readers);
+
+    expect(summary.timeblockCount).toBe(1);
+    expect(summary.hasAnyData).toBe(true);
+  });
+
+  it('active block present → hasActiveBlock true（检测到活跃时间块）', async () => {
+    const readers = makeLegacyReaders({
+      readLegacyActiveBlock: async () => ({ id: 'active-block' }),
+    });
+
+    const summary = await detectLegacyData(readers);
+
+    expect(summary.hasActiveBlock).toBe(true);
+    expect(summary.hasAnyData).toBe(true);
+  });
+
+  it('all legacy data present → all counts correct（全部旧数据都存在）', async () => {
+    const readers = makeLegacyReaders({
+      readLegacyEvents: async () => [{ id: 'e1' }, { id: 'e2' }],
+      readLegacyTasks: async () => [{ id: 't1' }],
+      readLegacyCompletedBlocks: async () => [{ id: 'b1' }, { id: 'b2' }, { id: 'b3' }],
+      readLegacyActiveBlock: async () => ({ id: 'active' }),
+    });
+
+    const summary = await detectLegacyData(readers);
+
+    expect(summary.eventlogCount).toBe(2);
+    expect(summary.taskCount).toBe(1);
+    expect(summary.timeblockCount).toBe(3);
+    expect(summary.hasActiveBlock).toBe(true);
+    expect(summary.hasAnyData).toBe(true);
+  });
+
+  it('reader throws error → returns 0 for that source, does not throw（读取失败优雅降级为0）', async () => {
+    const readers = makeLegacyReaders({
+      readLegacyEvents: async () => { throw new Error('IndexedDB unavailable'); },
+      readLegacyTasks: async () => [{ id: 't1' }],
+    });
+
+    const summary = await detectLegacyData(readers);
+
+    expect(summary.eventlogCount).toBe(0);
+    expect(summary.taskCount).toBe(1);
+    expect(summary.hasAnyData).toBe(true);
+  });
+
+  it('all readers throw → returns zero summary and hasAnyData false（所有读取失败返回全零）', async () => {
+    const fail = async (): Promise<unknown[]> => { throw new Error('storage error'); };
+    const readers = makeLegacyReaders({
+      readLegacyEvents: fail,
+      readLegacyTasks: fail,
+      readLegacyCompletedBlocks: fail,
+      readLegacyActiveBlock: async () => { throw new Error('storage error'); },
+    });
+
+    const summary = await detectLegacyData(readers);
+
+    expect(summary.eventlogCount).toBe(0);
+    expect(summary.taskCount).toBe(0);
+    expect(summary.timeblockCount).toBe(0);
+    expect(summary.hasActiveBlock).toBe(false);
+    expect(summary.hasAnyData).toBe(false);
+  });
+});
+
+// --- detectRtIsEmpty ---
+
+describe('detectRtIsEmpty（检测 RT 是否为空）', () => {
+  it('all RT sources empty → returns true（RT 全空返回 true）', async () => {
+    const isEmpty = await detectRtIsEmpty(makeRtReaders());
+    expect(isEmpty).toBe(true);
+  });
+
+  it('RT has events → returns false（RT 有事件返回 false）', async () => {
+    const readers = makeRtReaders({
+      readRtEvents: async () => [{ id: 'rt-event-1' }],
+    });
+
+    const isEmpty = await detectRtIsEmpty(readers);
+    expect(isEmpty).toBe(false);
+  });
+
+  it('RT has tasks → returns false（RT 有任务返回 false）', async () => {
+    const readers = makeRtReaders({
+      readRtTasks: async () => [{ id: 'rt-task-1' }],
+    });
+
+    const isEmpty = await detectRtIsEmpty(readers);
+    expect(isEmpty).toBe(false);
+  });
+
+  it('RT has completed blocks → returns false（RT 有已完成时间块返回 false）', async () => {
+    const readers = makeRtReaders({
+      readRtCompletedBlocks: async () => [{ id: 'rt-block-1' }],
+    });
+
+    const isEmpty = await detectRtIsEmpty(readers);
+    expect(isEmpty).toBe(false);
+  });
+
+  it('RT has active block → returns false（RT 有活跃时间块返回 false）', async () => {
+    const readers = makeRtReaders({
+      readRtActiveBlock: async () => ({ id: 'rt-active' }),
+    });
+
+    const isEmpty = await detectRtIsEmpty(readers);
+    expect(isEmpty).toBe(false);
+  });
+
+  it('RT has data in multiple sources → returns false（RT 多个数据源有数据返回 false）', async () => {
+    const readers = makeRtReaders({
+      readRtEvents: async () => [{ id: 'e1' }],
+      readRtTasks: async () => [{ id: 't1' }],
+    });
+
+    const isEmpty = await detectRtIsEmpty(readers);
+    expect(isEmpty).toBe(false);
+  });
+});

--- a/tests/unit/migration/legacy-migration-detector.test.ts
+++ b/tests/unit/migration/legacy-migration-detector.test.ts
@@ -188,16 +188,16 @@ describe('detectRtIsEmpty（检测 RT 是否为空）', () => {
     expect(isEmpty).toBe(false);
   });
 
-  it('RT reader throws → treats as empty (conservative failure)（RT 读取失败视为空）', async () => {
+  it('RT reader throws → assumes not empty to prevent false migration trigger（RT 读取失败视为有数据）', async () => {
     const readers = makeRtReaders({
       readRtEvents: async () => { throw new Error('network error'); },
     });
 
     const isEmpty = await detectRtIsEmpty(readers);
-    expect(isEmpty).toBe(true);
+    expect(isEmpty).toBe(false);
   });
 
-  it('all RT readers throw → returns true（RT 全部读取失败视为空）', async () => {
+  it('all RT readers throw → returns false to prevent migration（RT 全部读取失败视为有数据）', async () => {
     const fail = async (): Promise<unknown[]> => { throw new Error('RT unavailable'); };
     const readers = makeRtReaders({
       readRtEvents: fail,
@@ -207,6 +207,6 @@ describe('detectRtIsEmpty（检测 RT 是否为空）', () => {
     });
 
     const isEmpty = await detectRtIsEmpty(readers);
-    expect(isEmpty).toBe(true);
+    expect(isEmpty).toBe(false);
   });
 });

--- a/tests/unit/migration/legacy-migration-detector.test.ts
+++ b/tests/unit/migration/legacy-migration-detector.test.ts
@@ -187,4 +187,26 @@ describe('detectRtIsEmpty（检测 RT 是否为空）', () => {
     const isEmpty = await detectRtIsEmpty(readers);
     expect(isEmpty).toBe(false);
   });
+
+  it('RT reader throws → treats as empty (conservative failure)（RT 读取失败视为空）', async () => {
+    const readers = makeRtReaders({
+      readRtEvents: async () => { throw new Error('network error'); },
+    });
+
+    const isEmpty = await detectRtIsEmpty(readers);
+    expect(isEmpty).toBe(true);
+  });
+
+  it('all RT readers throw → returns true（RT 全部读取失败视为空）', async () => {
+    const fail = async (): Promise<unknown[]> => { throw new Error('RT unavailable'); };
+    const readers = makeRtReaders({
+      readRtEvents: fail,
+      readRtTasks: fail,
+      readRtCompletedBlocks: fail,
+      readRtActiveBlock: async () => { throw new Error('RT unavailable'); },
+    });
+
+    const isEmpty = await detectRtIsEmpty(readers);
+    expect(isEmpty).toBe(true);
+  });
 });

--- a/tests/unit/migration/legacy-migration-executor.test.ts
+++ b/tests/unit/migration/legacy-migration-executor.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  executeMigration,
+  type MigrationAdapters,
+  type MigrationProgress,
+} from '@/lib/migration/legacy-migration-executor';
+
+function makeAdapters(overrides: Partial<MigrationAdapters> = {}): MigrationAdapters {
+  return {
+    readLegacyEvents: vi.fn().mockResolvedValue([]),
+    readLegacyTasks: vi.fn().mockResolvedValue([]),
+    readLegacyCompletedBlocks: vi.fn().mockResolvedValue([]),
+    readLegacyActiveBlock: vi.fn().mockResolvedValue(null),
+    importEventsToRt: vi.fn().mockResolvedValue(undefined),
+    importTasksToRt: vi.fn().mockResolvedValue(undefined),
+    writeCompletedBlocksToRt: vi.fn().mockResolvedValue(undefined),
+    writeActiveBlockToRt: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('executeMigration（迁移执行引擎）', () => {
+  it('migrates all three domains successfully when legacy data exists（全三领域迁移成功）', async () => {
+    const adapters = makeAdapters({
+      readLegacyEvents: vi.fn().mockResolvedValue([{ id: 'e1' }]),
+      readLegacyTasks: vi.fn().mockResolvedValue([{ id: 't1' }]),
+      readLegacyCompletedBlocks: vi.fn().mockResolvedValue([{ id: 'b1' }]),
+    });
+
+    const result = await executeMigration(adapters);
+
+    expect(result.success).toBe(true);
+    expect(result.migratedDomains).toContain('eventlog');
+    expect(result.migratedDomains).toContain('task');
+    expect(result.migratedDomains).toContain('timeblock');
+    expect(adapters.importEventsToRt).toHaveBeenCalledWith([{ id: 'e1' }]);
+    expect(adapters.importTasksToRt).toHaveBeenCalledWith([{ id: 't1' }]);
+    expect(adapters.writeCompletedBlocksToRt).toHaveBeenCalledWith([{ id: 'b1' }]);
+  });
+
+  it('reports failure when eventlog import fails（事件日志导入失败时报告失败）', async () => {
+    const adapters = makeAdapters({
+      readLegacyEvents: vi.fn().mockResolvedValue([{ id: 'e1' }]),
+      importEventsToRt: vi.fn().mockRejectedValue(new Error('RT connection refused')),
+    });
+
+    const result = await executeMigration(adapters);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('RT connection refused');
+  });
+
+  it('skips domains with no legacy data（无旧数据时跳过对应领域）', async () => {
+    const adapters = makeAdapters({
+      readLegacyEvents: vi.fn().mockResolvedValue([]),
+      readLegacyTasks: vi.fn().mockResolvedValue([]),
+      readLegacyCompletedBlocks: vi.fn().mockResolvedValue([]),
+      readLegacyActiveBlock: vi.fn().mockResolvedValue(null),
+    });
+
+    const result = await executeMigration(adapters);
+
+    expect(result.success).toBe(true);
+    expect(result.migratedDomains).toHaveLength(0);
+    expect(adapters.importEventsToRt).not.toHaveBeenCalled();
+    expect(adapters.importTasksToRt).not.toHaveBeenCalled();
+    expect(adapters.writeCompletedBlocksToRt).not.toHaveBeenCalled();
+    expect(adapters.writeActiveBlockToRt).not.toHaveBeenCalled();
+  });
+
+  it('migrates active block when present（存在活跃时间块时执行迁移）', async () => {
+    const activeBlock = { id: 'active-1', startedAt: '2026-01-01T10:00:00Z' };
+    const adapters = makeAdapters({
+      readLegacyCompletedBlocks: vi.fn().mockResolvedValue([]),
+      readLegacyActiveBlock: vi.fn().mockResolvedValue(activeBlock),
+    });
+
+    const result = await executeMigration(adapters);
+
+    expect(result.success).toBe(true);
+    expect(result.migratedDomains).toContain('timeblock');
+    expect(adapters.writeActiveBlockToRt).toHaveBeenCalledWith(activeBlock);
+  });
+
+  it('calls onProgress for each domain step（每个领域步骤均触发进度回调）', async () => {
+    const adapters = makeAdapters({
+      readLegacyEvents: vi.fn().mockResolvedValue([{ id: 'e1' }]),
+      readLegacyTasks: vi.fn().mockResolvedValue([{ id: 't1' }]),
+      readLegacyCompletedBlocks: vi.fn().mockResolvedValue([{ id: 'b1' }]),
+    });
+    const progressCalls: MigrationProgress[] = [];
+    const onProgress = vi.fn((p: MigrationProgress) => progressCalls.push(p));
+
+    await executeMigration(adapters, onProgress);
+
+    expect(onProgress).toHaveBeenCalled();
+    const domains = progressCalls.map((p) => p.domain);
+    expect(domains).toContain('eventlog');
+    expect(domains).toContain('task');
+    expect(domains).toContain('timeblock');
+  });
+
+  it('returns partial migratedDomains on mid-flight failure（中途失败时返回已完成领域）', async () => {
+    const adapters = makeAdapters({
+      readLegacyEvents: vi.fn().mockResolvedValue([{ id: 'e1' }]),
+      readLegacyTasks: vi.fn().mockResolvedValue([{ id: 't1' }]),
+      importTasksToRt: vi.fn().mockRejectedValue(new Error('task import error')),
+    });
+
+    const result = await executeMigration(adapters);
+
+    expect(result.success).toBe(false);
+    // eventlog should have completed before task failed
+    expect(result.migratedDomains).toContain('eventlog');
+    expect(result.migratedDomains).not.toContain('task');
+  });
+});

--- a/tests/unit/migration/legacy-migration-flags.test.ts
+++ b/tests/unit/migration/legacy-migration-flags.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearMigrationFlags,
+  isMigrationCompleted,
+  isMigrationSkipped,
+  markMigrationCompleted,
+  markMigrationSkipped,
+} from '@/lib/migration/legacy-migration-flags';
+
+describe('legacy migration flags（历史数据迁移状态标志）', () => {
+  let storage: Record<string, string>;
+
+  beforeEach(() => {
+    storage = {};
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => (key in storage ? storage[key] : null),
+        setItem: (key: string, value: string) => {
+          storage[key] = value;
+        },
+        removeItem: (key: string) => {
+          delete storage[key];
+        },
+      },
+    });
+  });
+
+  it('returns false for completed when no flags set（未设置时 completed 返回 false）', () => {
+    expect(isMigrationCompleted()).toBe(false);
+  });
+
+  it('returns false for skipped when no flags set（未设置时 skipped 返回 false）', () => {
+    expect(isMigrationSkipped()).toBe(false);
+  });
+
+  it('markMigrationCompleted sets completed flag（标记完成后 completed 为 true）', () => {
+    markMigrationCompleted();
+    expect(isMigrationCompleted()).toBe(true);
+  });
+
+  it('markMigrationSkipped sets skipped flag（标记跳过后 skipped 为 true）', () => {
+    markMigrationSkipped();
+    expect(isMigrationSkipped()).toBe(true);
+  });
+
+  it('markMigrationCompleted clears skipped flag（标记完成同时清除跳过标志）', () => {
+    markMigrationSkipped();
+    expect(isMigrationSkipped()).toBe(true);
+
+    markMigrationCompleted();
+    expect(isMigrationCompleted()).toBe(true);
+    expect(isMigrationSkipped()).toBe(false);
+  });
+
+  it('clearMigrationFlags removes all flags（clearMigrationFlags 清除所有标志）', () => {
+    markMigrationCompleted();
+    markMigrationSkipped();
+
+    clearMigrationFlags();
+
+    expect(isMigrationCompleted()).toBe(false);
+    expect(isMigrationSkipped()).toBe(false);
+  });
+});

--- a/tests/unit/services/timeblock.service.rt-sqlite.test.ts
+++ b/tests/unit/services/timeblock.service.rt-sqlite.test.ts
@@ -109,7 +109,7 @@ describe('TimeBlockServiceImpl rt-sqlite backend', () => {
     });
   });
 
-  it('promotes legacy completed blocks into RT adapter on first load', async () => {
+  it('returns empty list when RT adapter has no completed blocks (no lazy migration)', async () => {
     const legacyBlocks: TimeBlockData[] = [
       {
         id: 'tb-legacy',
@@ -122,6 +122,7 @@ describe('TimeBlockServiceImpl rt-sqlite backend', () => {
         endTime: 1700000060000,
       },
     ];
+    // Legacy data exists in env.storage, but rt-sqlite backend should NOT read it
     const env = createMemoryEnv({ time_blocks: legacyBlocks });
     const rtAdapter = createRtAdapter();
 
@@ -132,16 +133,12 @@ describe('TimeBlockServiceImpl rt-sqlite backend', () => {
 
     const blocks = await service.loadTimeBlocks();
 
-    expect(rtAdapter.replaceCompletedBlocks).toHaveBeenCalledWith(legacyBlocks);
-    expect(blocks).toEqual([
-      {
-        ...legacyBlocks[0],
-        tags: new Set(['block_feedback']),
-      },
-    ]);
+    // Migration is now handled by MigrationDialog, not lazily by the service
+    expect(rtAdapter.replaceCompletedBlocks).not.toHaveBeenCalled();
+    expect(blocks).toEqual([]);
   });
 
-  it('promotes legacy active block into RT adapter on first load', async () => {
+  it('returns null when RT adapter has no active block (no lazy migration)', async () => {
     const legacyActive: ActiveBlockData = {
       startId: 'active-legacy',
       name: 'Legacy active',
@@ -151,6 +148,7 @@ describe('TimeBlockServiceImpl rt-sqlite backend', () => {
       paused: false,
       startTime: 1700000000000,
     };
+    // Legacy data exists in env.storage, but rt-sqlite backend should NOT read it
     const env = createMemoryEnv({ active_block: legacyActive });
     const rtAdapter = createRtAdapter();
 
@@ -161,8 +159,9 @@ describe('TimeBlockServiceImpl rt-sqlite backend', () => {
 
     const block = await service.loadActiveBlock();
 
-    expect(rtAdapter.putActiveBlock).toHaveBeenCalledWith(legacyActive);
-    expect(block).toEqual(expect.objectContaining(legacyActive));
+    // Migration is now handled by MigrationDialog, not lazily by the service
+    expect(rtAdapter.putActiveBlock).not.toHaveBeenCalled();
+    expect(block).toBeNull();
   });
 
   it('writes new active block and completed block to RT adapter when ending a block', async () => {

--- a/tests/unit/settings/settings-registry-coverage.test.ts
+++ b/tests/unit/settings/settings-registry-coverage.test.ts
@@ -40,6 +40,7 @@ const AUDITED_SETTINGS_IDS = [
   'task-backend-mode',
   'timeblock-backend-mode',
   'data-transfer',
+  'data-legacy-migration',
   'more-update',
   'more-help-center',
   'more-feedback',
@@ -97,6 +98,7 @@ const NUMBER_IDS = [
 ] as const;
 
 const ROW_ACTION_IDS = [
+  'data-legacy-migration',
   'more-update',
   'more-help-center',
   'more-feedback',

--- a/tests/unit/settings/settings-registry-coverage.test.ts
+++ b/tests/unit/settings/settings-registry-coverage.test.ts
@@ -292,6 +292,10 @@ describe('settings registry coverage audit', () => {
       getBaseCtx(),
       {
         ...getBaseCtx(),
+        isDesktop: true,
+      },
+      {
+        ...getBaseCtx(),
         developerMode: true,
       },
       {

--- a/tests/unit/ui/migration-dialog.test.tsx
+++ b/tests/unit/ui/migration-dialog.test.tsx
@@ -1,0 +1,197 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MigrationDialog } from '@/ui/components/MigrationDialog';
+import type { LegacyDataSummary } from '@/lib/migration/legacy-migration-detector';
+import type { MigrationProgress } from '@/lib/migration/legacy-migration-executor';
+
+function makeSummary(overrides: Partial<LegacyDataSummary> = {}): LegacyDataSummary {
+  return {
+    eventlogCount: 5,
+    taskCount: 3,
+    timeblockCount: 2,
+    hasActiveBlock: false,
+    hasAnyData: true,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('MigrationDialog（旧数据迁移弹窗）', () => {
+  it('renders data summary correctly when open（打开时正确渲染数据摘要）', () => {
+    render(
+      <MigrationDialog
+        open
+        summary={makeSummary()}
+        onMigrate={vi.fn()}
+        onSkip={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('检测到旧版数据')).toBeInTheDocument();
+    // Each list item spans multiple DOM elements (count is in a nested <span>).
+    // Use getByText with an exact=false option, which matches nodes whose full
+    // text content contains the substring.
+    expect(screen.getByText(/事件日志/, { exact: false })).toBeInTheDocument();
+    expect(screen.getByText(/任务/, { exact: false })).toBeInTheDocument();
+    expect(screen.getByText(/时间块/, { exact: false })).toBeInTheDocument();
+    // Counts appear in <span> elements
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('calls onMigrate when migrate button clicked（点击立即迁移时调用 onMigrate）', () => {
+    const onMigrate = vi.fn();
+    render(
+      <MigrationDialog
+        open
+        summary={makeSummary()}
+        onMigrate={onMigrate}
+        onSkip={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '立即迁移' }));
+    expect(onMigrate).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onSkip when skip button clicked（点击暂不迁移时调用 onSkip）', () => {
+    const onSkip = vi.fn();
+    render(
+      <MigrationDialog
+        open
+        summary={makeSummary()}
+        onMigrate={vi.fn()}
+        onSkip={onSkip}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '暂不迁移' }));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows progress during migration（迁移中显示进度信息）', () => {
+    const progress: MigrationProgress = {
+      domain: 'eventlog',
+      step: 1,
+      totalSteps: 3,
+      label: '迁移事件日志',
+    };
+
+    render(
+      <MigrationDialog
+        open
+        summary={makeSummary()}
+        onMigrate={vi.fn()}
+        onSkip={vi.fn()}
+        migrating
+        progress={progress}
+      />,
+    );
+
+    // Multiple elements can match /正在迁移/ (visible <p> + hidden sr-only title)
+    expect(screen.getAllByText(/正在迁移/).length).toBeGreaterThan(0);
+    // The progress label and step info are rendered inside a single <span>;
+    // use getAllByText with a regex so the full text content of the <span> matches.
+    expect(screen.getAllByText(/迁移事件日志/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/1.*3/).length).toBeGreaterThan(0);
+  });
+
+  it('hides skip and migrate buttons during migration（迁移中隐藏跳过和迁移按钮）', () => {
+    const progress: MigrationProgress = {
+      domain: 'task',
+      step: 2,
+      totalSteps: 3,
+      label: '迁移任务',
+    };
+
+    render(
+      <MigrationDialog
+        open
+        summary={makeSummary()}
+        onMigrate={vi.fn()}
+        onSkip={vi.fn()}
+        migrating
+        progress={progress}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: '立即迁移' })).toBeNull();
+    expect(screen.queryByRole('button', { name: '暂不迁移' })).toBeNull();
+  });
+
+  it('does not render content when open is false（关闭时不渲染内容）', () => {
+    render(
+      <MigrationDialog
+        open={false}
+        summary={makeSummary()}
+        onMigrate={vi.fn()}
+        onSkip={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText('检测到旧版数据')).toBeNull();
+    expect(screen.queryByRole('button', { name: '立即迁移' })).toBeNull();
+  });
+
+  it('shows error state with fallback button（错误状态显示错误信息和后备按钮）', () => {
+    render(
+      <MigrationDialog
+        open
+        summary={makeSummary()}
+        onMigrate={vi.fn()}
+        onSkip={vi.fn()}
+        error="RT connection refused"
+      />,
+    );
+
+    expect(screen.getByText('迁移失败')).toBeInTheDocument();
+    expect(screen.getByText(/RT connection refused/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '继续使用旧版存储' })).toBeInTheDocument();
+  });
+
+  it('calls onSkip when fallback button clicked in error state（错误状态点击后备按钮时调用 onSkip）', () => {
+    const onSkip = vi.fn();
+    render(
+      <MigrationDialog
+        open
+        summary={makeSummary()}
+        onMigrate={vi.fn()}
+        onSkip={onSkip}
+        error="something went wrong"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '继续使用旧版存储' }));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows hasActiveBlock annotation in timeblock line（有活跃时间块时显示注记）', () => {
+    render(
+      <MigrationDialog
+        open
+        summary={makeSummary({ timeblockCount: 1, hasActiveBlock: true })}
+        onMigrate={vi.fn()}
+        onSkip={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/含进行中/)).toBeInTheDocument();
+  });
+
+  it('hides zero-count rows from summary（计数为零的数据行不显示）', () => {
+    render(
+      <MigrationDialog
+        open
+        summary={makeSummary({ taskCount: 0 })}
+        onMigrate={vi.fn()}
+        onSkip={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(/任务/)).toBeNull();
+  });
+});


### PR DESCRIPTION
## 摘要

- 提交 `9bb5916` 将三个数据域（EventLog、Task、TimeBlock）的默认存储后端从 legacy（PouchDB/IndexedDB/JSON）切换到 RT SQLite，但缺少数据迁移逻辑，导致已有用户看到空数据
- 本 PR 实现**一次性迁移对话框**：启动时检测旧数据 -> 用户确认 -> 批量导入到 RT SQLite
- 同时清理了 TimeBlock 的 lazy migration fallback，统一由迁移对话框处理

### 核心变更

- **迁移标记管理**（`legacy-migration-flags.ts`）- 使用 localStorage 标记控制迁移流程
- **旧数据检测**（`legacy-migration-detector.ts`）- 并行检测三个域的旧数据量和 RT 空状态
- **迁移执行器**（`legacy-migration-executor.ts`）- 顺序迁移 EventLog -> Task -> TimeBlock，并提供进度回调
- **MigrationDialog** - 展示数据统计、进度条，适配桌面端 / 移动端
- **MigrationDialogController** - 启动时检测，连接 Dialog 与执行器，处理成功 / 失败 / 跳过
- **设置页入口** - 在「数据」分类下新增「迁移旧版数据」，跳过后可手动触发
- **TimeBlock 清理** - 移除 `readActiveBlock()` 和 `readCompletedBlockData()` 中的 lazy migration fallback

### 迁移策略

- 使用 RT 现有的 `POST /eventlog/import/json?strategy=merge` 和 `POST /tasks/import/json?strategy=merge` API
- TimeBlock 使用 `PUT /timeblocks` 与 `PUT /timeblocks/active`
- 旧数据保留不删除（作为备份）
- 失败时自动回退 legacy 模式，下次启动重新提示

## 测试计划

- [x] `npx vitest run tests/unit/migration/` - 28 个测试通过（flags + detector + executor）
- [x] `npx vitest run tests/unit/ui/migration-dialog.test.tsx` - 10 个测试通过
- [x] `npx vitest run tests/unit/settings/settings-registry-coverage.test.ts` - 6 个测试通过
- [x] `npx vitest run tests/unit/services/timeblock.service.rt-sqlite.test.ts` - 3 个测试通过
- [x] `bunx tsc --noEmit` - 类型检查通过
- [x] 全量测试无新增失败

由 [Claude Code](https://claude.ai/code) 生成
通过 [Happy](https://happy.engineering)
