### PR TITLE
feat(log): tauri-plugin-log + 设置页实时日志面板

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,17 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -42,6 +53,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
+]
+
+[[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -79,6 +107,12 @@ dependencies = [
  "wl-clipboard-rs",
  "x11rb",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-broadcast"
@@ -366,6 +400,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +452,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +500,40 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byte-unit"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+dependencies = [
+ "rust_decimal",
+ "schemars 1.2.1",
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -1103,6 +1206,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,6 +1280,7 @@ dependencies = [
  "flate2",
  "futures",
  "futures-util",
+ "log",
  "parking_lot",
  "rand 0.8.5",
  "reqwest 0.12.28",
@@ -1178,6 +1292,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-global-shortcut",
+ "tauri-plugin-log",
  "tauri-plugin-mcp-bridge",
  "tauri-plugin-opener",
  "thiserror 1.0.69",
@@ -1266,6 +1381,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1375,6 +1499,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futf"
@@ -1848,6 +1978,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1855,7 +1988,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -2489,6 +2622,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru-slab"
@@ -2772,6 +2908,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3649,6 +3794,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3753,6 +3918,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3951,6 +4122,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4064,6 +4244,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4075,6 +4284,22 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4273,6 +4498,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -4646,6 +4877,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4943,6 +5180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5147,6 +5390,28 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-log"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7545bd67f070a4500432c826e2e0682146a1d6712aee22a2786490156b574d93"
+dependencies = [
+ "android_logger",
+ "byte-unit",
+ "fern",
+ "log",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
@@ -5404,7 +5669,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -5960,6 +6227,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5982,6 +6255,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -7160,6 +7439,15 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@radix-ui/react-toast": "^1.2.15",
     "@tanstack/react-router": "^1.158.0",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-log": "^2.8.0",
     "@tauri-apps/plugin-opener": "^2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,3 +50,5 @@ exomind-runtime = { path = "../crates/exomind-runtime" }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tauri-plugin-global-shortcut = "2"
 enigo = { version = "0.3", features = ["serde"] }
+log = "0.4"
+tauri-plugin-log = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,6 +12,7 @@
     "mcp-bridge:default",
     "global-shortcut:allow-register",
     "global-shortcut:allow-unregister",
-    "global-shortcut:allow-is-registered"
+    "global-shortcut:allow-is-registered",
+    "log:default"
   ]
 }

--- a/src-tauri/src/commands/asr_commands.rs
+++ b/src-tauri/src/commands/asr_commands.rs
@@ -805,10 +805,13 @@ async fn run_volcano_stream_session(
 
     let _ = write.close().await;
     stream_state.remove_session(&session_id).await;
-    eprintln!(
-        "{}",
-        format_stream_finish_log_line(&session_id, &endpoint, &outcome)
-    );
+    match &outcome {
+        Ok(_) => log::info!("{}", format_stream_finish_log_line(&session_id, &endpoint, &outcome)),
+        Err(error) if error == VOLCANO_STREAM_CANCELLED_MESSAGE => {
+            log::debug!("{}", format_stream_finish_log_line(&session_id, &endpoint, &outcome))
+        }
+        Err(_) => log::warn!("{}", format_stream_finish_log_line(&session_id, &endpoint, &outcome)),
+    }
 
     if let Err(error) = &outcome {
         if error != VOLCANO_STREAM_CANCELLED_MESSAGE {
@@ -835,10 +838,7 @@ pub async fn volcano_asr_recognize(
     let (ws_stream, endpoint) = open_configured_ws(&config).await?;
     let (mut write, mut read): (VolcanoWriteHalf, VolcanoReadHalf) = ws_stream.split();
 
-    eprintln!(
-        "[ASR-Rust] 开始识别: endpoint={endpoint}, audio={} bytes",
-        audio_data.len()
-    );
+    log::debug!("[ASR] 开始识别: endpoint={endpoint}, audio={} bytes", audio_data.len());
 
     let chunk_size = 6400usize;
     let total_chunks = audio_data.chunks(chunk_size).len();
@@ -901,7 +901,10 @@ pub async fn volcano_asr_recognize(
     .and_then(|result| result);
 
     let _ = write.close().await;
-    eprintln!("{}", format_recognize_finish_log_line(&endpoint, &result));
+    match &result {
+        Ok(_) => log::info!("{}", format_recognize_finish_log_line(&endpoint, &result)),
+        Err(_) => log::warn!("{}", format_recognize_finish_log_line(&endpoint, &result)),
+    }
     result
 }
 
@@ -925,7 +928,7 @@ pub async fn volcano_asr_stream_start(
         .insert_session(session_id.clone(), Arc::clone(&session))
         .await;
 
-    eprintln!("{}", format_stream_start_log_line(&session_id, &endpoint));
+    log::debug!("{}", format_stream_start_log_line(&session_id, &endpoint));
 
     tokio::spawn(run_volcano_stream_session(
         app,

--- a/src-tauri/src/commands/runtime_commands.rs
+++ b/src-tauri/src/commands/runtime_commands.rs
@@ -300,10 +300,7 @@ pub async fn ensure_runtime_started(
                 return mark_external_runtime_running(&state, &options.bind_host, options.port);
             }
             if i == 0 {
-                eprintln!(
-                    "[tauri/setup] port {} busy, waiting for release...",
-                    options.port
-                );
+                log::info!("port {} busy, waiting for release...", options.port);
             }
             sleep(Duration::from_millis(100)).await;
         }

--- a/src-tauri/src/commands/shortcut_commands.rs
+++ b/src-tauri/src/commands/shortcut_commands.rs
@@ -72,7 +72,7 @@ impl VoiceShortcutState {
 pub fn register_voice_shortcut(app: &AppHandle, state: &VoiceShortcutState) {
     let shortcut = state.get();
     if let Err(error) = register_shortcut_listener(app, &shortcut) {
-        eprintln!("[shortcut] failed to register voice shortcut {shortcut}: {error}");
+        log::warn!("failed to register voice shortcut {shortcut}: {error}");
     }
 }
 
@@ -402,8 +402,8 @@ fn resolve_overlay_monitor(app: &AppHandle) -> Result<Option<tauri::Monitor>, St
         }
         // Cursor is in a gap between monitors (non-contiguous layout) or
         // available_monitors() returned an empty list — fall through to main window.
-        eprintln!(
-            "[voice-overlay] cursor ({cx},{cy}) not within any monitor rect, falling back to main window monitor"
+        log::debug!(
+            "cursor ({cx},{cy}) not within any monitor rect, falling back to main window monitor"
         );
     }
 

--- a/src-tauri/src/commands/ws_commands.rs
+++ b/src-tauri/src/commands/ws_commands.rs
@@ -63,7 +63,7 @@ pub async fn ws_connect<R: Runtime>(
         .await
         .map_err(|e| format!("Connection failed: {}", e))?;
 
-    println!("Connected to {}, response: {:?}", url, response.status());
+    log::info!("Connected to {}, response: {:?}", url, response.status());
 
     // 保存流
     let mut stream_guard = client_state.stream.lock().await;
@@ -159,7 +159,7 @@ async fn receive_messages<R: Runtime>(app: AppHandle<R>, client_state: Arc<WsCli
     while let Some(msg_result) = ws_stream.next().await {
         match msg_result {
             Ok(Message::Text(text)) => {
-                println!("Received message: {}", text);
+                log::trace!("Received message: {}", text);
                 app.emit("ws-message", &text).ok();
 
                 if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
@@ -194,23 +194,23 @@ async fn receive_messages<R: Runtime>(app: AppHandle<R>, client_state: Arc<WsCli
                 }
             }
             Ok(Message::Binary(data)) => {
-                println!("Received binary data: {} bytes", data.len());
+                log::trace!("Received binary data: {} bytes", data.len());
             }
             Ok(Message::Ping(ping)) => {
-                println!("Received ping: {:?}", ping);
+                log::trace!("Received ping: {:?}", ping);
             }
             Ok(Message::Pong(pong)) => {
-                println!("Received pong: {:?}", pong);
+                log::trace!("Received pong: {:?}", pong);
             }
             Ok(Message::Close(close_frame)) => {
-                println!("Connection closed: {:?}", close_frame);
+                log::info!("Connection closed: {:?}", close_frame);
                 break;
             }
             Ok(Message::Frame(_)) => {
                 // 内部帧类型，通常不需要处理
             }
             Err(e) => {
-                println!("WebSocket error: {}", e);
+                log::warn!("WebSocket error: {}", e);
                 break;
             }
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ use commands::workspace_commands::{
 };
 use commands::ws_commands::{ws_connect, ws_disconnect, ws_get_state, ws_send, WsClientState};
 use tauri::Manager;
+use tauri_plugin_log::{Target, TargetKind, RotationStrategy, TimezoneStrategy};
 
 #[tauri::command]
 fn greet(name: &str) -> String {
@@ -64,6 +65,23 @@ pub fn run() {
     let volcano_asr_stream_state = std::sync::Arc::new(VolcanoAsrStreamState::default());
 
     let mut builder = tauri::Builder::default()
+        .plugin(
+            tauri_plugin_log::Builder::new()
+                .targets([
+                    Target::new(TargetKind::Stdout),
+                    Target::new(TargetKind::Webview),
+                    Target::new(TargetKind::LogDir { file_name: Some("exomind.log".into()) }),
+                ])
+                .level(log::LevelFilter::Info)
+                .level_for("tungstenite", log::LevelFilter::Warn)
+                .level_for("tokio_tungstenite", log::LevelFilter::Warn)
+                .level_for("reqwest", log::LevelFilter::Warn)
+                .level_for("hyper", log::LevelFilter::Warn)
+                .max_file_size(5_000_000) // 5MB per file
+                .rotation_strategy(RotationStrategy::KeepSome(5))
+                .timezone_strategy(TimezoneStrategy::UseLocal)
+                .build(),
+        )
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -95,10 +95,10 @@ pub fn run() {
             let voice_shortcut_state = app.state::<VoiceShortcutState>();
             register_voice_shortcut(app.handle(), &voice_shortcut_state);
             if let Err(error) = ensure_voice_overlay_window(app.handle()) {
-                eprintln!("[tauri/setup] failed to prewarm voice overlay window: {error}");
+                log::warn!("failed to prewarm voice overlay window: {error}");
             }
             if let Err(error) = ensure_now_workbench_overlay_window(app.handle()) {
-                eprintln!("[tauri/setup] failed to prewarm now overlay window: {error}");
+                log::warn!("failed to prewarm now overlay window: {error}");
             }
 
             if std::env::var_os("EXOMIND_RT_SIGNAL_SQLITE_PATH").is_none()
@@ -110,8 +110,8 @@ pub fn run() {
                     Ok(app_data_dir) => {
                         let runtime_dir = app_data_dir.join("runtime");
                         if let Err(error) = std::fs::create_dir_all(&runtime_dir) {
-                            eprintln!(
-                                "[tauri/setup] failed to create runtime data dir for signal sqlite: {error}"
+                            log::error!(
+                                "failed to create runtime data dir for signal sqlite: {error}"
                             );
                         } else {
                             if std::env::var_os("EXOMIND_RT_SIGNAL_SQLITE_PATH").is_none() {
@@ -151,8 +151,8 @@ pub fn run() {
                         }
                     }
                     Err(error) => {
-                        eprintln!(
-                            "[tauri/setup] failed to resolve app data dir for runtime sqlite files: {error}"
+                        log::error!(
+                            "failed to resolve app data dir for runtime sqlite files: {error}"
                         );
                     }
                 }
@@ -165,9 +165,8 @@ pub fn run() {
                 if let Err(error) =
                     ensure_runtime_started(runtime_state, None, Some(runtime_port)).await
                 {
-                    eprintln!(
-                        "[tauri/setup] failed to auto-start embedded runtime on {}: {error}",
-                        runtime_port
+                    log::error!(
+                        "failed to auto-start embedded runtime on {runtime_port}: {error}"
                     );
                 }
             });

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,54 @@
+import { info, warn, error, debug, trace, attachLogger } from '@tauri-apps/plugin-log'
+
+export type LogLevel = 'TRACE' | 'DEBUG' | 'INFO' | 'WARN' | 'ERROR'
+
+export interface LogEntry {
+  level: LogLevel
+  message: string
+  timestamp: Date
+}
+
+export type LogListener = (entry: LogEntry) => void
+
+const LOG_LEVEL_MAP: Record<number, LogLevel> = {
+  1: 'TRACE',
+  2: 'DEBUG',
+  3: 'INFO',
+  4: 'WARN',
+  5: 'ERROR',
+}
+
+let detachFn: (() => void) | null = null
+const listeners = new Set<LogListener>()
+
+export async function startLogStream(): Promise<() => void> {
+  if (detachFn) return detachFn
+
+  detachFn = await attachLogger(({ level, message }) => {
+    const entry: LogEntry = {
+      level: LOG_LEVEL_MAP[level] ?? 'INFO',
+      message,
+      timestamp: new Date(),
+    }
+    for (const listener of listeners) {
+      listener(entry)
+    }
+  })
+
+  return detachFn
+}
+
+export function stopLogStream() {
+  if (detachFn) {
+    detachFn()
+    detachFn = null
+  }
+}
+
+export function addLogListener(listener: LogListener): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+// Re-export for frontend code to send logs to the unified log file
+export { info, warn, error, debug, trace }

--- a/src/ui/app/components/settings/LogPanel.tsx
+++ b/src/ui/app/components/settings/LogPanel.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { Button } from '@/components/ui/button'
+import { addLogListener, startLogStream, stopLogStream, type LogEntry, type LogLevel } from '@/lib/logger'
+
+const LEVELS: LogLevel[] = ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR']
+const LEVEL_ORDER: Record<LogLevel, number> = { TRACE: 0, DEBUG: 1, INFO: 2, WARN: 3, ERROR: 4 }
+const LEVEL_COLORS: Record<LogLevel, string> = {
+  TRACE: 'text-muted-foreground',
+  DEBUG: 'text-blue-500',
+  INFO: 'text-green-500',
+  WARN: 'text-yellow-500',
+  ERROR: 'text-red-500',
+}
+const MAX_ENTRIES = 500
+
+export function LogPanel() {
+  const [entries, setEntries] = useState<LogEntry[]>([])
+  const [minLevel, setMinLevel] = useState<LogLevel>('INFO')
+  const bottomRef = useRef<HTMLDivElement>(null)
+  const autoScroll = useRef(true)
+
+  useEffect(() => {
+    startLogStream()
+    const removeListener = addLogListener((entry) => {
+      setEntries((prev) => {
+        const next = [...prev, entry]
+        return next.length > MAX_ENTRIES ? next.slice(-MAX_ENTRIES) : next
+      })
+    })
+    return () => {
+      removeListener()
+      stopLogStream()
+    }
+  }, [])
+
+  useEffect(() => {
+    if (autoScroll.current) {
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+    }
+  }, [entries])
+
+  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget
+    autoScroll.current = el.scrollHeight - el.scrollTop - el.clientHeight < 40
+  }, [])
+
+  const filtered = entries.filter((e) => LEVEL_ORDER[e.level] >= LEVEL_ORDER[minLevel])
+
+  return (
+    <div className="flex flex-col h-[60vh] gap-2">
+      <div className="flex items-center gap-1 flex-shrink-0">
+        {LEVELS.map((level) => (
+          <Button
+            key={level}
+            variant={minLevel === level ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setMinLevel(level)}
+            aria-label={level}
+            aria-pressed={minLevel === level}
+          >
+            {level.toLowerCase()}
+          </Button>
+        ))}
+        <div className="flex-1" />
+        <Button variant="ghost" size="sm" onClick={() => setEntries([])} aria-label="清除">
+          清除
+        </Button>
+      </div>
+      <div
+        className="flex-1 overflow-y-auto font-mono text-xs bg-muted/50 rounded-md p-2 space-y-0.5"
+        onScroll={handleScroll}
+      >
+        {filtered.length === 0 ? (
+          <div className="text-muted-foreground text-center py-8">暂无日志</div>
+        ) : (
+          filtered.map((entry, i) => (
+            <div key={i} className="flex gap-2 leading-5">
+              <span className="text-muted-foreground whitespace-nowrap">
+                {entry.timestamp.toLocaleTimeString()}
+              </span>
+              <span className={`font-semibold w-12 text-right ${LEVEL_COLORS[entry.level]}`}>
+                {entry.level}
+              </span>
+              <span className="break-all">{entry.message}</span>
+            </div>
+          ))
+        )}
+        <div ref={bottomRef} />
+      </div>
+    </div>
+  )
+}

--- a/src/ui/app/components/settings/LogPanel.tsx
+++ b/src/ui/app/components/settings/LogPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { Button } from '@/components/ui/button'
-import { addLogListener, startLogStream, stopLogStream, type LogEntry, type LogLevel } from '@/lib/logger'
+import { addLogListener, startLogStream, type LogEntry, type LogLevel } from '@/lib/logger'
 
 const LEVELS: LogLevel[] = ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR']
 const LEVEL_ORDER: Record<LogLevel, number> = { TRACE: 0, DEBUG: 1, INFO: 2, WARN: 3, ERROR: 4 }
@@ -29,7 +29,6 @@ export function LogPanel() {
     })
     return () => {
       removeListener()
-      stopLogStream()
     }
   }, [])
 

--- a/src/ui/app/components/settings/__tests__/LogPanel.test.tsx
+++ b/src/ui/app/components/settings/__tests__/LogPanel.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { LogPanel } from '../LogPanel'
+import * as logger from '@/lib/logger'
+
+vi.mock('@/lib/logger', () => ({
+  startLogStream: vi.fn().mockResolvedValue(vi.fn()),
+  stopLogStream: vi.fn(),
+  addLogListener: vi.fn().mockReturnValue(vi.fn()),
+}))
+
+function emitLog(level: logger.LogLevel, message: string) {
+  const listener = vi.mocked(logger.addLogListener).mock.calls[0]?.[0]
+  if (listener) {
+    act(() => {
+      listener({ level, message, timestamp: new Date('2026-03-14T10:00:00') })
+    })
+  }
+}
+
+describe('LogPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders empty state', () => {
+    render(<LogPanel />)
+    expect(screen.getByText('暂无日志')).toBeInTheDocument()
+  })
+
+  it('displays log entries from stream', () => {
+    render(<LogPanel />)
+    emitLog('INFO', 'application started')
+    expect(screen.getByText(/application started/)).toBeInTheDocument()
+  })
+
+  it('shows level badge for each entry', () => {
+    render(<LogPanel />)
+    emitLog('WARN', 'low memory')
+    expect(screen.getByText('WARN')).toBeInTheDocument()
+  })
+
+  it('filters by log level — hides lower levels', () => {
+    render(<LogPanel />)
+    emitLog('DEBUG', 'debug message')
+    emitLog('ERROR', 'error message')
+
+    // Default level is INFO, so DEBUG should be hidden
+    expect(screen.queryByText(/debug message/)).not.toBeInTheDocument()
+    expect(screen.getByText(/error message/)).toBeInTheDocument()
+  })
+
+  it('changes filter level via buttons', () => {
+    render(<LogPanel />)
+
+    // Click DEBUG filter button to lower threshold
+    fireEvent.click(screen.getByRole('button', { name: /DEBUG/ }))
+    emitLog('DEBUG', 'now visible debug')
+    expect(screen.getByText(/now visible debug/)).toBeInTheDocument()
+  })
+
+  it('clears log entries', () => {
+    render(<LogPanel />)
+    emitLog('INFO', 'some log')
+    expect(screen.getByText(/some log/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /清除/ }))
+    expect(screen.queryByText(/some log/)).not.toBeInTheDocument()
+  })
+
+  it('cleans up listener on unmount', () => {
+    const removeFn = vi.fn()
+    vi.mocked(logger.addLogListener).mockReturnValue(removeFn)
+
+    const { unmount } = render(<LogPanel />)
+    unmount()
+    expect(removeFn).toHaveBeenCalled()
+  })
+})

--- a/src/ui/app/components/settings/__tests__/LogPanel.test.tsx
+++ b/src/ui/app/components/settings/__tests__/LogPanel.test.tsx
@@ -1,3 +1,4 @@
+/// <reference types="@testing-library/jest-dom" />
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import { LogPanel } from '../LogPanel'

--- a/src/ui/app/components/settings/__tests__/LogPanel.test.tsx
+++ b/src/ui/app/components/settings/__tests__/LogPanel.test.tsx
@@ -6,7 +6,6 @@ import * as logger from '@/lib/logger'
 
 vi.mock('@/lib/logger', () => ({
   startLogStream: vi.fn().mockResolvedValue(vi.fn()),
-  stopLogStream: vi.fn(),
   addLogListener: vi.fn().mockReturnValue(vi.fn()),
 }))
 

--- a/src/ui/app/config/settings/LogPanelDialog.tsx
+++ b/src/ui/app/config/settings/LogPanelDialog.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { LogPanel } from '@/ui/app/components/settings/LogPanel'
+
+export function LogPanelDialog() {
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    const handler = () => setOpen(true)
+    window.addEventListener('open-log-panel', handler)
+    return () => window.removeEventListener('open-log-panel', handler)
+  }, [])
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>调试日志</DialogTitle>
+        </DialogHeader>
+        <LogPanel />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/ui/app/config/settings/settings-registry.ts
+++ b/src/ui/app/config/settings/settings-registry.ts
@@ -850,7 +850,10 @@ export const SETTINGS_REGISTRY: SettingsItem[] = [
     icon: ScrollText,
     category: 'more',
     type: 'action',
-    onAction: () => '敬请期待',
+    onAction: () => {
+      window.dispatchEvent(new CustomEvent('open-log-panel'))
+      return undefined
+    },
   },
   {
     id: 'about-website',

--- a/src/ui/app/pages/SettingsPage.tsx
+++ b/src/ui/app/pages/SettingsPage.tsx
@@ -7,6 +7,7 @@ import { DesktopSettingsLayout } from '@/ui/app/layouts/DesktopSettingsLayout';
 import { MobileSettingsLayout } from '@/ui/app/layouts/MobileSettingsLayout';
 import { getVisibleSettings } from '@/ui/app/config/settings/settings-registry';
 import type { SettingsContext } from '@/ui/app/config/settings/settings-types';
+import { LogPanelDialog } from '@/ui/app/config/settings/LogPanelDialog';
 import { useIsDesktop } from '@/ui/app/hooks/useIsDesktop';
 
 /*
@@ -48,26 +49,32 @@ export function SettingsPage() {
 
   if (isDesktopVcLayout) {
     return (
-      <div className="h-full min-h-full bg-[#FAF7F5] dark:bg-[#0C0A09]">
-        <div className="mx-auto max-w-3xl px-8 py-8">
-          <UserCard />
-          <div className="mt-6">
-            <DesktopSettingsLayout items={items} ctx={ctx} />
+      <>
+        <div className="h-full min-h-full bg-[#FAF7F5] dark:bg-[#0C0A09]">
+          <div className="mx-auto max-w-3xl px-8 py-8">
+            <UserCard />
+            <div className="mt-6">
+              <DesktopSettingsLayout items={items} ctx={ctx} />
+            </div>
           </div>
         </div>
-      </div>
+        <LogPanelDialog />
+      </>
     );
   }
 
   return (
-    <div className="min-h-full bg-[#FAF7F5] dark:bg-[#0C0A09]">
-      <header className="flex items-center justify-center px-6 py-3">
-        <h1 className="text-lg font-semibold leading-[1.5] text-[#1C1917] dark:text-[#FAFAF9]">设置</h1>
-      </header>
-      <div className="space-y-5 px-5 pb-[calc(env(safe-area-inset-bottom,0px)+108px)] pt-2">
-        <UserCard />
-        <MobileSettingsLayout items={items} ctx={ctx} />
+    <>
+      <div className="min-h-full bg-[#FAF7F5] dark:bg-[#0C0A09]">
+        <header className="flex items-center justify-center px-6 py-3">
+          <h1 className="text-lg font-semibold leading-[1.5] text-[#1C1917] dark:text-[#FAFAF9]">设置</h1>
+        </header>
+        <div className="space-y-5 px-5 pb-[calc(env(safe-area-inset-bottom,0px)+108px)] pt-2">
+          <UserCard />
+          <MobileSettingsLayout items={items} ctx={ctx} />
+        </div>
       </div>
-    </div>
+      <LogPanelDialog />
+    </>
   );
 }


### PR DESCRIPTION
## 摘要

- 引入 `tauri-plugin-log`（Stdout + Webview + LogDir 三目标，5MB 轮转，保留 5 份）
- 迁移全部 19 个 `eprintln!/println!` 到 `log` 宏，按语义分级
- 前端 `@tauri-apps/plugin-log` 桥接 + `src/lib/logger.ts` 工具封装
- 设置页「调试日志」按钮打开实时日志流 Dialog（LogPanel 组件，支持 5 级过滤）

### 日志级别映射

| 原始调用 | 新级别 | 效果 |
|---------|--------|------|
| ASR 开始流式识别 | `debug` | 默认不显示 |
| ASR cancelled | `debug` | 默认不显示 |
| ASR 识别成功 | `info` | 正常显示 |
| ASR 识别错误 | `warn` | 高亮显示 |
| WebSocket ping/pong/data | `trace` | 最安静 |
| 启动失败 | `error` | 最醒目 |

## 测试计划

- [x] `vitest run LogPanel.test.tsx` - 7 个测试通过
- [x] `tsc --noEmit` - 零错误
- [ ] `cargo test` - 需要在构建前端产物后验证
- [ ] 启动应用 -> 设置 -> 调试日志 -> 看到实时日志流
- [ ] ASR 语音输入 -> 确认 cancelled 日志不再刷屏

Closes #525

由 [Claude Code](https://claude.ai/code) 生成
通过 [Happy](https://happy.engineering)
