### PR TITLE
fix(mesh): IPv6 配对、地址解析与发起方反馈修复

### DIFF
--- a/src/lib/services/runtime-mesh-sync.service.ts
+++ b/src/lib/services/runtime-mesh-sync.service.ts
@@ -236,6 +236,24 @@ export class RuntimeMeshSyncService {
     return (await response.json()) as Array<{ host_id: string; host: string; port: number }>;
   }
 
+  /** List registered mesh peers (calls local runtime, requires auth). */
+  async listMeshPeers(
+    runtimeBaseUrl: string,
+    localAuthToken?: string,
+  ): Promise<Array<{ id: string; base_url: string; enabled: boolean }>> {
+    const url = `${runtimeBaseUrl}/mesh/peers`;
+    const response = await this.fetchImpl(url, {
+      method: 'GET',
+      headers: authHeaders('application/json', localAuthToken),
+    });
+    if (!response.ok) {
+      throw await buildHttpError('listMeshPeers', 'GET', url, response as Response, {
+        authState: localAuthToken ? 'present' : 'missing',
+      });
+    }
+    return (await response.json()) as Array<{ id: string; base_url: string; enabled: boolean }>;
+  }
+
   // ── Peer Upsert ────────────────────────────────────────────────
 
   private async upsertPeer(

--- a/src/ui/app/components/PeerPairingDialog.tsx
+++ b/src/ui/app/components/PeerPairingDialog.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/components/ui/dialog';
 import { getRuntimeMeshSyncService } from '@/lib/services/runtime-mesh-sync.service';
 import { formatHostForUrl } from '@/config/runtime-target';
+import { getRuntimeControlService } from '@/lib/services/runtime-control.service';
 import { Loader2, RefreshCw, Check, X, ChevronLeft } from 'lucide-react';
 
 // ── Types ──────────────────────────────────────────────────────
@@ -114,6 +115,30 @@ export function PeerPairingDialog({
       setSessionId(result.session_id);
       setPin(result.pin);
       setStatus('waiting');
+
+      // Start polling for pairing completion
+      const initialPeers = await meshService.listMeshPeers(runtimeBaseUrl, localAuthToken).catch(() => []);
+      const initialPeerIds = new Set(initialPeers.map((p: { id: string }) => p.id));
+
+      if (pollTimerRef.current) {
+        clearInterval(pollTimerRef.current);
+      }
+      pollTimerRef.current = setInterval(async () => {
+        try {
+          const currentPeers = await meshService.listMeshPeers(runtimeBaseUrl, localAuthToken);
+          const newPeer = currentPeers.find((p: { id: string }) => !initialPeerIds.has(p.id));
+          if (newPeer) {
+            if (pollTimerRef.current) {
+              clearInterval(pollTimerRef.current);
+              pollTimerRef.current = null;
+            }
+            setPeerToken('paired-via-initiator');
+            setStatus('success');
+          }
+        } catch {
+          // Silently retry
+        }
+      }, 2000);
     } catch (err) {
       setErrorMessage(
         buildInitiatorDiagnosticMessage(runtimeBaseUrl, localHostId, localAuthToken, err),
@@ -184,12 +209,27 @@ export function PeerPairingDialog({
       const responderInboundToken = crypto.randomUUID();
 
       const initiatorBaseUrl = `http://${formatHostForUrl(selectedPeer.host)}:${selectedPeer.port}`;
+
+      // Determine our externally-reachable address (what the initiator should use to call us)
+      let responderBaseUrl = runtimeBaseUrl;
+      try {
+        const reachable = await getRuntimeControlService().getReachableAddress(
+          selectedPeer.host,
+          selectedPeer.port,
+        );
+        if (reachable.host) {
+          responderBaseUrl = `http://${formatHostForUrl(reachable.host)}:${reachable.port}`;
+        }
+      } catch {
+        // Fall back to runtimeBaseUrl if reachable address resolution fails
+      }
+
       const result = await meshService.respondToPairing(
         initiatorBaseUrl,
         '', // session_id will be looked up server-side by host_id
         pinInput,
         localHostId,
-        runtimeBaseUrl,
+        responderBaseUrl,
         responderInboundToken,
       );
       if (result.paired) {
@@ -436,8 +476,8 @@ export function PeerPairingDialog({
           </div>
         )}
 
-        {/* ── Responder: Success ── */}
-        {mode === 'responder' && status === 'success' && (
+        {/* ── Success (both modes) ── */}
+        {status === 'success' && (
           <div className="flex flex-col items-center gap-4 py-4">
             <Check className="h-10 w-10 text-green-500" />
             <p className="text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">配对成功</p>

--- a/src/ui/app/components/PeerPairingDialog.tsx
+++ b/src/ui/app/components/PeerPairingDialog.tsx
@@ -132,7 +132,6 @@ export function PeerPairingDialog({
               clearInterval(pollTimerRef.current);
               pollTimerRef.current = null;
             }
-            setPeerToken('paired-via-initiator');
             setStatus('success');
           }
         } catch {


### PR DESCRIPTION
## 摘要
- 为 `RuntimeMeshSyncService` 新增 `listMeshPeers`，用于查询已注册 peer
- 为发起方新增 peer 轮询逻辑，“等待对方连接...” UI 现在可以检测配对完成
- 修复 `responder_base_url` 错误发送回环地址 `127.0.0.1` 的问题，改为使用 `getReachableAddress` 做 UDP 探测
- 为发起方与响应方统一展示成功视图
- 移除发起方的假 token 展示（真实 token 只存在于响应方）

## 变更文件
- `src/lib/services/runtime-mesh-sync.service.ts` - 新增 `listMeshPeers()` 方法
- `src/ui/app/components/PeerPairingDialog.tsx` - 发起方轮询、可达地址解析、统一成功视图

## 根因
当发起方开始配对后，“等待对方连接...” 对话框一直不会切到成功状态，因为前端没有机制检测响应方何时完成配对。此外，响应方还会把 `127.0.0.1` 当作自己的 base URL 发送出去，导致发起方在跨设备网络中根本无法访问。

## 测试计划
- [ ] 在同一局域网启动两个 ExoMind 实例（桌面端 + Android 模拟器）
- [ ] 一端发起配对，另一端响应
- [ ] 验证双方都能成功完成 PIN 输入
- [ ] 验证两个实例的 peer 列表都出现 mesh peer
- [ ] 验证响应方提交 PIN 后，发起方对话框会显示“配对成功”
- [ ] 验证发起方成功视图**不会**再显示 token 行
