### PR TITLE
feat(task): 对齐 #383 的任务状态语义 Phase 1

### DIFF
--- a/crates/exomind-runtime/src/routes/tasks.rs
+++ b/crates/exomind-runtime/src/routes/tasks.rs
@@ -177,22 +177,44 @@ async fn transition_task(
     Ok(Json(task))
 }
 
-/// DELETE /tasks/:id — abandon task (set status to abandoned)
+fn cancel_task_in_scope(
+    state: &AppState,
+    scope_key: Option<&str>,
+    id: &str,
+) -> Result<Task, (StatusCode, String)> {
+    state.task_store.cancel_scoped(scope_key, id).map_err(|e| {
+        let code = match &e {
+            crate::task::store::TaskStoreError::NotFound(_) => StatusCode::NOT_FOUND,
+            _ => StatusCode::CONFLICT,
+        };
+        (code, e.to_string())
+    })
+}
+
+/// POST /tasks/:id/cancel — cancel task (set status to cancelled)
+async fn cancel_task(
+    Path(id): Path<String>,
+    State(state): State<AppState>,
+    Query(query): Query<ScopeQuery>,
+) -> Result<Json<Task>, (StatusCode, String)> {
+    let scope_key = query.profile_id.as_deref().or(query.user_id.as_deref());
+    let task = cancel_task_in_scope(&state, scope_key, &id)?;
+
+    publish_task_signal(&state, "task.cancelled", &task);
+
+    Ok(Json(task))
+}
+
+/// DELETE /tasks/:id — compatibility alias for cancel
 async fn delete_task(
     Path(id): Path<String>,
     State(state): State<AppState>,
     Query(query): Query<ScopeQuery>,
 ) -> Result<Json<Task>, (StatusCode, String)> {
     let scope_key = query.profile_id.as_deref().or(query.user_id.as_deref());
-    let task = state.task_store.abandon_scoped(scope_key, &id).map_err(|e| {
-        let code = match &e {
-            crate::task::store::TaskStoreError::NotFound(_) => StatusCode::NOT_FOUND,
-            _ => StatusCode::CONFLICT,
-        };
-        (code, e.to_string())
-    })?;
+    let task = cancel_task_in_scope(&state, scope_key, &id)?;
 
-    publish_task_signal(&state, "task.deleted", &task);
+    publish_task_signal(&state, "task.cancelled", &task);
 
     Ok(Json(task))
 }
@@ -241,9 +263,12 @@ async fn import_tasks_sqlite(
     Json(payload): Json<TaskBackupSqliteImportPayload>,
 ) -> Result<Json<TaskImportResult>, (StatusCode, String)> {
     let strategy = parse_import_strategy(query.strategy.as_deref())?;
-    let bytes = STANDARD
-        .decode(payload.content_base64)
-        .map_err(|error| (StatusCode::BAD_REQUEST, format!("invalid sqlite snapshot: {error}")))?;
+    let bytes = STANDARD.decode(payload.content_base64).map_err(|error| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("invalid sqlite snapshot: {error}"),
+        )
+    })?;
     let scope_key = query.profile_id.as_deref().or(query.user_id.as_deref());
     let imported_tasks = read_tasks_from_sqlite_snapshot(&bytes, scope_key)?;
     let result = apply_task_import(&state, scope_key, imported_tasks, strategy)?;
@@ -347,10 +372,18 @@ fn apply_task_import(
     Ok(result)
 }
 
-fn build_task_sqlite_snapshot_bytes(scope_key: Option<&str>, tasks: &[Task]) -> Result<Vec<u8>, (StatusCode, String)> {
-    let temp_root = std::env::temp_dir().join(format!("exomind-task-export-{}", uuid::Uuid::new_v4()));
-    std::fs::create_dir_all(&temp_root)
-        .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, format!("failed to create task export temp dir: {error}")))?;
+fn build_task_sqlite_snapshot_bytes(
+    scope_key: Option<&str>,
+    tasks: &[Task],
+) -> Result<Vec<u8>, (StatusCode, String)> {
+    let temp_root =
+        std::env::temp_dir().join(format!("exomind-task-export-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&temp_root).map_err(|error| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to create task export temp dir: {error}"),
+        )
+    })?;
     let sqlite_path = temp_root.join("tasks-export.sqlite");
     let store = crate::task::TaskStore::with_sqlite_path(&sqlite_path)
         .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;
@@ -372,8 +405,14 @@ fn build_task_sqlite_snapshot_bytes(scope_key: Option<&str>, tasks: &[Task]) -> 
     Ok(bytes)
 }
 
-fn read_tasks_from_sqlite_snapshot(bytes: &[u8], scope_key: Option<&str>) -> Result<Vec<Task>, (StatusCode, String)> {
-    let temp_path = std::env::temp_dir().join(format!("exomind-task-import-{}.sqlite", uuid::Uuid::new_v4()));
+fn read_tasks_from_sqlite_snapshot(
+    bytes: &[u8],
+    scope_key: Option<&str>,
+) -> Result<Vec<Task>, (StatusCode, String)> {
+    let temp_path = std::env::temp_dir().join(format!(
+        "exomind-task-import-{}.sqlite",
+        uuid::Uuid::new_v4()
+    ));
     std::fs::write(&temp_path, bytes)
         .map_err(|error| (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()))?;
 
@@ -395,6 +434,7 @@ pub fn router() -> Router<AppState> {
         .route("/tasks/backup/sqlite", get(export_tasks_sqlite))
         .route("/tasks/import/json", post(import_tasks_json))
         .route("/tasks/import/sqlite", post(import_tasks_sqlite))
+        .route("/tasks/:id/cancel", post(cancel_task))
         .route(
             "/tasks/:id",
             get(get_task).put(update_task).delete(delete_task),
@@ -491,7 +531,7 @@ mod tests {
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let created: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(created["title"], "Buy milk");
-        assert_eq!(created["status"], "not_started");
+        assert_eq!(created["status"], "pending");
         assert_eq!(created["priority"], "medium");
         assert_eq!(created["tags"][0], "shopping");
 
@@ -653,7 +693,7 @@ mod tests {
         });
         let app = test_router(state);
 
-        // not_started → completed is invalid
+        // pending → completed is invalid
         let response = app
             .oneshot(
                 Request::builder()
@@ -669,10 +709,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_abandons_task() {
+    async fn cancel_route_cancels_task() {
         let state = test_state();
         let task = state.task_store.create(CreateTaskInput {
-            title: "To abandon".to_string(),
+            title: "To cancel".to_string(),
             description: None,
             done_condition: None,
             priority: None,
@@ -684,12 +724,50 @@ mod tests {
             estimated_minutes: None,
             time_block_ids: vec![],
         });
-        // Must transition to in_progress first (not_started → abandoned is invalid)
+        // Must transition to in_progress first (pending → cancelled is invalid)
         state
             .task_store
             .transition(&task.id, TaskStatus::InProgress)
             .unwrap();
         let _rx = state.signal_pool.subscribe();
+        let app = test_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/tasks/{}/cancel", task.id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let cancelled: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(cancelled["status"], "cancelled");
+    }
+
+    #[tokio::test]
+    async fn delete_route_remains_cancel_alias_for_compatibility() {
+        let state = test_state();
+        let task = state.task_store.create(CreateTaskInput {
+            title: "Delete alias".to_string(),
+            description: None,
+            done_condition: None,
+            priority: None,
+            tags: vec![],
+            source: None,
+            parent_id: None,
+            depends_on: vec![],
+            due_at: None,
+            estimated_minutes: None,
+            time_block_ids: vec![],
+        });
+        state
+            .task_store
+            .transition(&task.id, TaskStatus::InProgress)
+            .unwrap();
         let app = test_router(state);
 
         let response = app
@@ -702,10 +780,11 @@ mod tests {
             )
             .await
             .unwrap();
+
         assert_eq!(response.status(), StatusCode::OK);
         let body = response.into_body().collect().await.unwrap().to_bytes();
-        let deleted: Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(deleted["status"], "abandoned");
+        let cancelled: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(cancelled["status"], "cancelled");
     }
 
     #[tokio::test]
@@ -832,7 +911,7 @@ mod tests {
                                     "title": "Existing replaced",
                                     "description": null,
                                     "done_condition": null,
-                                    "status": "not_started",
+                                    "status": "pending",
                                     "priority": "medium",
                                     "tags": [],
                                     "source": null,
@@ -1054,7 +1133,11 @@ mod tests {
         assert_eq!(anonymous_tasks[0]["title"], "Anonymous task");
         assert_eq!(profile_a_tasks.len(), 1);
         assert_eq!(profile_a_tasks[0]["title"], "Profile A task");
-        assert_eq!(task_store.list().len(), 1, "default access should continue using anonymous scope");
+        assert_eq!(
+            task_store.list().len(),
+            1,
+            "default access should continue using anonymous scope"
+        );
         assert_eq!(
             task_store.list_in_scope(Some("profile-a")).len(),
             1,
@@ -1098,7 +1181,10 @@ mod tests {
 
         assert_eq!(scoped_tasks.len(), 1);
         assert_eq!(scoped_tasks[0]["title"], "User A task");
-        assert!(task_store.list().is_empty(), "default anonymous scope should stay isolated");
+        assert!(
+            task_store.list().is_empty(),
+            "default anonymous scope should stay isolated"
+        );
         assert_eq!(task_store.list_in_scope(Some("user-a")).len(), 1);
     }
 }

--- a/crates/exomind-runtime/src/task/sqlite_store.rs
+++ b/crates/exomind-runtime/src/task/sqlite_store.rs
@@ -1,10 +1,12 @@
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{params, Connection, OptionalExtension};
 
 use super::store::TaskStoreError;
-use super::types::{CreateTaskInput, Task, TaskDependency, TaskPriority, TaskStatus, UpdateTaskInput};
+use super::types::{
+    CreateTaskInput, Task, TaskDependency, TaskPriority, TaskStatus, UpdateTaskInput,
+};
 
 const DEFAULT_SCOPE_KEY: &str = "anonymous";
 
@@ -36,14 +38,18 @@ impl SqliteTaskStore {
         self.create_scoped(DEFAULT_SCOPE_KEY, input)
     }
 
-    pub fn create_scoped(&self, scope_key: &str, input: CreateTaskInput) -> Result<Task, TaskStoreError> {
+    pub fn create_scoped(
+        &self,
+        scope_key: &str,
+        input: CreateTaskInput,
+    ) -> Result<Task, TaskStoreError> {
         let now = chrono::Utc::now().timestamp_millis() as u64;
         let task = Task {
             id: uuid::Uuid::new_v4().to_string(),
             title: input.title,
             description: input.description,
             done_condition: input.done_condition,
-            status: TaskStatus::NotStarted,
+            status: TaskStatus::Pending,
             priority: input.priority.unwrap_or_default(),
             tags: input.tags,
             source: input.source,
@@ -98,14 +104,19 @@ impl SqliteTaskStore {
              ORDER BY created_at DESC, id DESC",
         )?;
         let rows = statement.query_map(params![normalize_scope_key(scope_key)], map_task_row)?;
-        rows.collect::<Result<Vec<_>, _>>().map_err(TaskStoreError::from)
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(TaskStoreError::from)
     }
 
     pub fn list_by_status(&self, status: &TaskStatus) -> Result<Vec<Task>, TaskStoreError> {
         self.list_by_status_scoped(DEFAULT_SCOPE_KEY, status)
     }
 
-    pub fn list_by_status_scoped(&self, scope_key: &str, status: &TaskStatus) -> Result<Vec<Task>, TaskStoreError> {
+    pub fn list_by_status_scoped(
+        &self,
+        scope_key: &str,
+        status: &TaskStatus,
+    ) -> Result<Vec<Task>, TaskStoreError> {
         let connection = self.connection();
         let mut statement = connection.prepare(
             "SELECT
@@ -116,15 +127,24 @@ impl SqliteTaskStore {
              WHERE scope_key = ?1 AND status = ?2
              ORDER BY created_at DESC, id DESC",
         )?;
-        let rows = statement.query_map(params![normalize_scope_key(scope_key), task_status_to_db(status)], map_task_row)?;
-        rows.collect::<Result<Vec<_>, _>>().map_err(TaskStoreError::from)
+        let rows = statement.query_map(
+            params![normalize_scope_key(scope_key), task_status_to_db(status)],
+            map_task_row,
+        )?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(TaskStoreError::from)
     }
 
     pub fn update(&self, id: &str, input: UpdateTaskInput) -> Result<Task, TaskStoreError> {
         self.update_scoped(DEFAULT_SCOPE_KEY, id, input)
     }
 
-    pub fn update_scoped(&self, scope_key: &str, id: &str, input: UpdateTaskInput) -> Result<Task, TaskStoreError> {
+    pub fn update_scoped(
+        &self,
+        scope_key: &str,
+        id: &str,
+        input: UpdateTaskInput,
+    ) -> Result<Task, TaskStoreError> {
         let mut task = self
             .get_scoped(scope_key, id)?
             .ok_or_else(|| TaskStoreError::NotFound(id.to_string()))?;
@@ -204,12 +224,12 @@ impl SqliteTaskStore {
         Ok((old_status, task))
     }
 
-    pub fn abandon(&self, id: &str) -> Result<Task, TaskStoreError> {
-        self.abandon_scoped(DEFAULT_SCOPE_KEY, id)
+    pub fn cancel(&self, id: &str) -> Result<Task, TaskStoreError> {
+        self.cancel_scoped(DEFAULT_SCOPE_KEY, id)
     }
 
-    pub fn abandon_scoped(&self, scope_key: &str, id: &str) -> Result<Task, TaskStoreError> {
-        let (_, task) = self.transition_scoped(scope_key, id, TaskStatus::Abandoned)?;
+    pub fn cancel_scoped(&self, scope_key: &str, id: &str) -> Result<Task, TaskStoreError> {
+        let (_, task) = self.transition_scoped(scope_key, id, TaskStatus::Cancelled)?;
         Ok(task)
     }
 
@@ -300,7 +320,11 @@ impl SqliteTaskStore {
         self.replace_all_scoped(DEFAULT_SCOPE_KEY, tasks)
     }
 
-    pub fn replace_all_scoped(&self, scope_key: &str, tasks: &[Task]) -> Result<(), TaskStoreError> {
+    pub fn replace_all_scoped(
+        &self,
+        scope_key: &str,
+        tasks: &[Task],
+    ) -> Result<(), TaskStoreError> {
         let mut connection = self.connection();
         let tx = connection.transaction()?;
         tx.execute(
@@ -472,21 +496,21 @@ fn map_task_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Task> {
 
 fn task_status_to_db(status: &TaskStatus) -> &'static str {
     match status {
-        TaskStatus::NotStarted => "not_started",
+        TaskStatus::Pending => "not_started",
         TaskStatus::InProgress => "in_progress",
         TaskStatus::Suspended => "suspended",
         TaskStatus::Completed => "completed",
-        TaskStatus::Abandoned => "abandoned",
+        TaskStatus::Cancelled => "abandoned",
     }
 }
 
 fn parse_task_status(value: &str) -> Result<TaskStatus, TaskStoreError> {
     match value {
-        "not_started" => Ok(TaskStatus::NotStarted),
+        "pending" | "not_started" => Ok(TaskStatus::Pending),
         "in_progress" => Ok(TaskStatus::InProgress),
         "suspended" => Ok(TaskStatus::Suspended),
         "completed" => Ok(TaskStatus::Completed),
-        "abandoned" => Ok(TaskStatus::Abandoned),
+        "cancelled" | "abandoned" => Ok(TaskStatus::Cancelled),
         _ => Err(TaskStoreError::InvalidStoredStatus(value.to_string())),
     }
 }
@@ -509,27 +533,15 @@ fn parse_task_priority(value: &str) -> Result<TaskPriority, TaskStoreError> {
 }
 
 fn map_task_status_error(error: TaskStoreError) -> rusqlite::Error {
-    rusqlite::Error::FromSqlConversionFailure(
-        0,
-        rusqlite::types::Type::Text,
-        Box::new(error),
-    )
+    rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(error))
 }
 
 fn map_task_priority_error(error: TaskStoreError) -> rusqlite::Error {
-    rusqlite::Error::FromSqlConversionFailure(
-        0,
-        rusqlite::types::Type::Text,
-        Box::new(error),
-    )
+    rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(error))
 }
 
 fn map_json_error(error: serde_json::Error) -> rusqlite::Error {
-    rusqlite::Error::FromSqlConversionFailure(
-        0,
-        rusqlite::types::Type::Text,
-        Box::new(error),
-    )
+    rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(error))
 }
 
 fn insert_task_in_transaction(

--- a/crates/exomind-runtime/src/task/store.rs
+++ b/crates/exomind-runtime/src/task/store.rs
@@ -81,7 +81,7 @@ impl TaskStore {
             title: input.title,
             description: input.description,
             done_condition: input.done_condition,
-            status: TaskStatus::NotStarted,
+            status: TaskStatus::Pending,
             priority: input.priority.unwrap_or_default(),
             tags: input.tags,
             source: input.source,
@@ -165,7 +165,12 @@ impl TaskStore {
         self.update_scoped(None, id, input)
     }
 
-    pub fn update_scoped(&self, scope_key: Option<&str>, id: &str, input: UpdateTaskInput) -> Result<Task, TaskStoreError> {
+    pub fn update_scoped(
+        &self,
+        scope_key: Option<&str>,
+        id: &str,
+        input: UpdateTaskInput,
+    ) -> Result<Task, TaskStoreError> {
         if let TaskStoreBackend::Sqlite(store) = &self.backend {
             return store.update_scoped(normalize_scope_key(scope_key), id, input);
         }
@@ -259,16 +264,16 @@ impl TaskStore {
         })
     }
 
-    /// Abandon a task (set status to Abandoned). Convenience for DELETE endpoint.
-    pub fn abandon(&self, id: &str) -> Result<Task, TaskStoreError> {
-        self.abandon_scoped(None, id)
+    /// Cancel a task (set status to Cancelled). Used by the HTTP cancel endpoint.
+    pub fn cancel(&self, id: &str) -> Result<Task, TaskStoreError> {
+        self.cancel_scoped(None, id)
     }
 
-    pub fn abandon_scoped(&self, scope_key: Option<&str>, id: &str) -> Result<Task, TaskStoreError> {
+    pub fn cancel_scoped(&self, scope_key: Option<&str>, id: &str) -> Result<Task, TaskStoreError> {
         if let TaskStoreBackend::Sqlite(store) = &self.backend {
-            return store.abandon_scoped(normalize_scope_key(scope_key), id);
+            return store.cancel_scoped(normalize_scope_key(scope_key), id);
         }
-        let (_, task) = self.transition_scoped(scope_key, id, TaskStatus::Abandoned)?;
+        let (_, task) = self.transition_scoped(scope_key, id, TaskStatus::Cancelled)?;
         Ok(task)
     }
 
@@ -279,7 +284,9 @@ impl TaskStore {
 
     pub fn remove_scoped(&self, scope_key: Option<&str>, id: &str) -> Option<Task> {
         match &self.backend {
-            TaskStoreBackend::Memory(_) => self.with_memory_scope_mut(scope_key, |tasks| tasks.remove(id)),
+            TaskStoreBackend::Memory(_) => {
+                self.with_memory_scope_mut(scope_key, |tasks| tasks.remove(id))
+            }
             TaskStoreBackend::Sqlite(store) => store
                 .remove_scoped(normalize_scope_key(scope_key), id)
                 .expect("sqlite task removal should succeed"),
@@ -303,7 +310,11 @@ impl TaskStore {
         self.upsert_scoped(None, task)
     }
 
-    pub fn upsert_scoped(&self, scope_key: Option<&str>, task: Task) -> Result<Task, TaskStoreError> {
+    pub fn upsert_scoped(
+        &self,
+        scope_key: Option<&str>,
+        task: Task,
+    ) -> Result<Task, TaskStoreError> {
         match &self.backend {
             TaskStoreBackend::Memory(_) => {
                 self.with_memory_scope_mut(scope_key, |tasks| {
@@ -322,7 +333,11 @@ impl TaskStore {
         self.replace_all_scoped(None, tasks)
     }
 
-    pub fn replace_all_scoped(&self, scope_key: Option<&str>, tasks: &[Task]) -> Result<(), TaskStoreError> {
+    pub fn replace_all_scoped(
+        &self,
+        scope_key: Option<&str>,
+        tasks: &[Task],
+    ) -> Result<(), TaskStoreError> {
         match &self.backend {
             TaskStoreBackend::Memory(_) => {
                 self.with_memory_scope_mut(scope_key, |guard| {
@@ -362,7 +377,9 @@ impl TaskStore {
                 .get(normalized_scope)
                 .cloned()
                 .unwrap_or_default(),
-            TaskStoreBackend::Sqlite(_) => unreachable!("memory-only helper used on sqlite backend"),
+            TaskStoreBackend::Sqlite(_) => {
+                unreachable!("memory-only helper used on sqlite backend")
+            }
         }
     }
 
@@ -378,7 +395,9 @@ impl TaskStore {
                 let scope_tasks = guard.entry(normalized_scope).or_default();
                 f(scope_tasks)
             }
-            TaskStoreBackend::Sqlite(_) => unreachable!("memory-only helper used on sqlite backend"),
+            TaskStoreBackend::Sqlite(_) => {
+                unreachable!("memory-only helper used on sqlite backend")
+            }
         }
     }
 }
@@ -418,7 +437,9 @@ mod tests {
         drop(store);
 
         let reopened = TaskStore::with_sqlite_path(&sqlite_path).unwrap();
-        let loaded = reopened.get(&created.id).expect("task should persist in sqlite");
+        let loaded = reopened
+            .get(&created.id)
+            .expect("task should persist in sqlite");
         assert_eq!(loaded.title, "Persist me");
         assert_eq!(reopened.len(), 1);
     }
@@ -491,12 +512,17 @@ mod tests {
         drop(store);
 
         let reopened = TaskStore::with_sqlite_path(&sqlite_path).unwrap();
-        let loaded = reopened.get(&created.id).expect("extended task should persist");
+        let loaded = reopened
+            .get(&created.id)
+            .expect("extended task should persist");
         assert_eq!(loaded.done_condition.as_deref(), Some("ship RT sqlite"));
         assert_eq!(loaded.depends_on.len(), 1);
         assert_eq!(loaded.depends_on[0].task_id, "dep-1");
         assert_eq!(loaded.depends_on[0].relation_type, TaskDependencyType::Hard);
-        assert_eq!(loaded.time_block_ids, vec!["block-1".to_string(), "block-2".to_string()]);
+        assert_eq!(
+            loaded.time_block_ids,
+            vec!["block-1".to_string(), "block-2".to_string()]
+        );
     }
 
     #[test]
@@ -504,7 +530,7 @@ mod tests {
         let store = make_store();
         let task = store.create(create_input("Buy milk"));
         assert_eq!(task.title, "Buy milk");
-        assert_eq!(task.status, TaskStatus::NotStarted);
+        assert_eq!(task.status, TaskStatus::Pending);
         assert_eq!(task.priority, TaskPriority::Medium);
 
         let fetched = store.get(&task.id).unwrap();
@@ -537,8 +563,8 @@ mod tests {
         assert_eq!(in_progress.len(), 1);
         assert_eq!(in_progress[0].id, t1.id);
 
-        let not_started = store.list_by_status(&TaskStatus::NotStarted);
-        assert_eq!(not_started.len(), 1);
+        let pending = store.list_by_status(&TaskStatus::Pending);
+        assert_eq!(pending.len(), 1);
     }
 
     #[test]
@@ -624,7 +650,7 @@ mod tests {
         let task = store.create(create_input("My task"));
 
         let (old, updated) = store.transition(&task.id, TaskStatus::InProgress).unwrap();
-        assert_eq!(old, TaskStatus::NotStarted);
+        assert_eq!(old, TaskStatus::Pending);
         assert_eq!(updated.status, TaskStatus::InProgress);
         assert!(updated.completed_at.is_none());
 
@@ -647,14 +673,14 @@ mod tests {
     }
 
     #[test]
-    fn abandon() {
+    fn cancel() {
         let store = make_store();
         let task = store.create(create_input("Task"));
         store.transition(&task.id, TaskStatus::InProgress).unwrap();
 
-        let abandoned = store.abandon(&task.id).unwrap();
-        assert_eq!(abandoned.status, TaskStatus::Abandoned);
-        assert!(abandoned.completed_at.is_some());
+        let cancelled = store.cancel(&task.id).unwrap();
+        assert_eq!(cancelled.status, TaskStatus::Cancelled);
+        assert!(cancelled.completed_at.is_some());
     }
 
     #[test]

--- a/crates/exomind-runtime/src/task/types.rs
+++ b/crates/exomind-runtime/src/task/types.rs
@@ -1,26 +1,38 @@
 use serde::{Deserialize, Serialize};
 
 /// 5-state machine matching front-end TaskStatus.
-/// not_started → in_progress ⇌ suspended → completed / abandoned
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+/// pending → in_progress ⇌ suspended → completed / cancelled
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TaskStatus {
-    NotStarted,
+    #[serde(rename = "pending", alias = "not_started")]
+    Pending,
+    #[serde(rename = "in_progress")]
     InProgress,
+    #[serde(rename = "suspended")]
     Suspended,
+    #[serde(rename = "completed")]
     Completed,
-    Abandoned,
+    #[serde(rename = "cancelled", alias = "abandoned")]
+    Cancelled,
 }
 
 impl TaskStatus {
     /// Valid transitions from this status.
     pub fn valid_transitions(&self) -> &[TaskStatus] {
         match self {
-            TaskStatus::NotStarted => &[TaskStatus::InProgress],
-            TaskStatus::InProgress => &[TaskStatus::Suspended, TaskStatus::Completed, TaskStatus::Abandoned],
-            TaskStatus::Suspended => &[TaskStatus::InProgress, TaskStatus::Completed, TaskStatus::Abandoned],
+            TaskStatus::Pending => &[TaskStatus::InProgress],
+            TaskStatus::InProgress => &[
+                TaskStatus::Suspended,
+                TaskStatus::Completed,
+                TaskStatus::Cancelled,
+            ],
+            TaskStatus::Suspended => &[
+                TaskStatus::InProgress,
+                TaskStatus::Completed,
+                TaskStatus::Cancelled,
+            ],
             TaskStatus::Completed => &[],
-            TaskStatus::Abandoned => &[],
+            TaskStatus::Cancelled => &[],
         }
     }
 
@@ -29,7 +41,7 @@ impl TaskStatus {
     }
 
     pub fn is_terminal(&self) -> bool {
-        matches!(self, TaskStatus::Completed | TaskStatus::Abandoned)
+        matches!(self, TaskStatus::Completed | TaskStatus::Cancelled)
     }
 }
 
@@ -154,11 +166,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn not_started_can_only_go_to_in_progress() {
-        let s = TaskStatus::NotStarted;
+    fn pending_can_only_go_to_in_progress() {
+        let s = TaskStatus::Pending;
         assert!(s.can_transition_to(&TaskStatus::InProgress));
         assert!(!s.can_transition_to(&TaskStatus::Completed));
-        assert!(!s.can_transition_to(&TaskStatus::Abandoned));
+        assert!(!s.can_transition_to(&TaskStatus::Cancelled));
         assert!(!s.can_transition_to(&TaskStatus::Suspended));
     }
 
@@ -167,8 +179,8 @@ mod tests {
         let s = TaskStatus::InProgress;
         assert!(s.can_transition_to(&TaskStatus::Suspended));
         assert!(s.can_transition_to(&TaskStatus::Completed));
-        assert!(s.can_transition_to(&TaskStatus::Abandoned));
-        assert!(!s.can_transition_to(&TaskStatus::NotStarted));
+        assert!(s.can_transition_to(&TaskStatus::Cancelled));
+        assert!(!s.can_transition_to(&TaskStatus::Pending));
     }
 
     #[test]
@@ -176,16 +188,16 @@ mod tests {
         let s = TaskStatus::Suspended;
         assert!(s.can_transition_to(&TaskStatus::InProgress));
         assert!(s.can_transition_to(&TaskStatus::Completed));
-        assert!(s.can_transition_to(&TaskStatus::Abandoned));
-        assert!(!s.can_transition_to(&TaskStatus::NotStarted));
+        assert!(s.can_transition_to(&TaskStatus::Cancelled));
+        assert!(!s.can_transition_to(&TaskStatus::Pending));
     }
 
     #[test]
     fn terminal_states_have_no_transitions() {
         assert!(TaskStatus::Completed.is_terminal());
-        assert!(TaskStatus::Abandoned.is_terminal());
+        assert!(TaskStatus::Cancelled.is_terminal());
         assert!(TaskStatus::Completed.valid_transitions().is_empty());
-        assert!(TaskStatus::Abandoned.valid_transitions().is_empty());
+        assert!(TaskStatus::Cancelled.valid_transitions().is_empty());
     }
 
     #[test]
@@ -195,7 +207,7 @@ mod tests {
             title: "Test".to_string(),
             description: None,
             done_condition: Some("Definition of done".to_string()),
-            status: TaskStatus::NotStarted,
+            status: TaskStatus::Pending,
             priority: TaskPriority::High,
             tags: vec!["dev".to_string()],
             source: Some("mcp".to_string()),
@@ -212,15 +224,24 @@ mod tests {
             completed_at: None,
         };
         let json = serde_json::to_string(&task).unwrap();
-        assert!(json.contains("\"not_started\""));
+        assert!(json.contains("\"pending\""));
         assert!(json.contains("\"high\""));
         assert!(json.contains("\"done_condition\":\"Definition of done\""));
         assert!(json.contains("\"depends_on\""));
         let back: Task = serde_json::from_str(&json).unwrap();
-        assert_eq!(back.status, TaskStatus::NotStarted);
+        assert_eq!(back.status, TaskStatus::Pending);
         assert_eq!(back.priority, TaskPriority::High);
         assert_eq!(back.done_condition.as_deref(), Some("Definition of done"));
         assert_eq!(back.depends_on.len(), 1);
         assert_eq!(back.time_block_ids, vec!["block-1".to_string()]);
+    }
+
+    #[test]
+    fn serde_accepts_legacy_status_aliases() {
+        let pending: TaskStatus = serde_json::from_str(r#""not_started""#).unwrap();
+        let cancelled: TaskStatus = serde_json::from_str(r#""abandoned""#).unwrap();
+
+        assert_eq!(pending, TaskStatus::Pending);
+        assert_eq!(cancelled, TaskStatus::Cancelled);
     }
 }

--- a/docs/plans/task-mcp-integration.md
+++ b/docs/plans/task-mcp-integration.md
@@ -73,7 +73,7 @@ packages/mcp/src/tools/
 - 原因：保留 `transitionTask` 的依赖检查逻辑
 
 ### 3. 查询和过滤
-- MVP: 简单的 `listTasks(includeAbandoned)`
+- MVP: 简单的 `listTasks(includeCancelled)`
 - 后续: 扩展多维度过滤能力
 
 ### 4. 返回值格式

--- a/docs/specs/SPEC-task-mcp-api.md
+++ b/docs/specs/SPEC-task-mcp-api.md
@@ -190,7 +190,7 @@ const result = await mcp.callTool("exomind_create_task", {
     id: string
     title: string
     description: string
-    status: "pending" | "in_progress" | "completed" | "cancelled"
+    status: "pending" | "in_progress" | "suspended" | "completed" | "cancelled"
     parentId: string | null
     estimatedMinutes: number | null
     dueAt: string | null
@@ -234,7 +234,7 @@ if (result.success && result.task.status === "in_progress") {
 
 ```typescript
 {
-  includeAbandoned?: boolean  // 可选，是否包含已放弃的任务，默认 false
+  includeCancelled?: boolean  // 可选，是否包含已取消的任务，默认 false
 }
 ```
 
@@ -244,9 +244,9 @@ if (result.success && result.task.status === "in_progress") {
 {
   "type": "object",
   "properties": {
-    "includeAbandoned": {
+    "includeCancelled": {
       "type": "boolean",
-      "description": "是否包含已放弃的任务",
+      "description": "是否包含已取消的任务",
       "default": false
     }
   },
@@ -264,7 +264,7 @@ if (result.success && result.task.status === "in_progress") {
     id: string
     title: string
     description: string
-    status: "pending" | "in_progress" | "completed" | "cancelled"
+    status: "pending" | "in_progress" | "suspended" | "completed" | "cancelled"
     parentId: string | null
     estimatedMinutes: number | null
     dueAt: string | null
@@ -288,7 +288,7 @@ if (result.success && result.task.status === "in_progress") {
 ```typescript
 // Growth Coach 分析最近活跃的任务
 const result = await mcp.callTool("exomind_list_tasks", {
-  includeAbandoned: false
+  includeCancelled: false
 });
 
 const recentTasks = result.tasks.slice(0, 10);
@@ -393,7 +393,7 @@ const result = await mcp.callTool("exomind_update_task", {
 
 ### 5. exomind_start_task
 
-开始任务（状态变更：pending → in_progress）。
+开始或恢复任务（状态变更：pending / suspended → in_progress）。
 
 **业务规则**: 如果任务有未完成的 hard 依赖，则无法开始。
 
@@ -441,7 +441,7 @@ const result = await mcp.callTool("exomind_update_task", {
   blocking: Array<{
     taskId: string
     type: "hard"
-    status: "pending" | "in_progress"
+    status: "pending" | "in_progress" | "suspended" | "cancelled"
     title: string
   }>
 }
@@ -473,7 +473,7 @@ if (!result.success && result.blocking) {
 
 ### 6. exomind_complete_task
 
-完成任务（状态变更：in_progress → completed）。
+完成任务（状态变更：in_progress / suspended → completed）。
 
 #### 输入参数
 
@@ -515,7 +515,7 @@ if (!result.success && result.blocking) {
 | 错误 | 原因 | 返回值 |
 |------|------|--------|
 | 任务不存在 | taskId 不存在 | `{ success: false, error: "Task {id} not found" }` |
-| 状态不允许 | 任务未开始或已取消 | `{ success: false, error: "Cannot transition from {status} to completed" }` |
+| 状态不允许 | 任务不处于进行中或挂起态 | `{ success: false, error: "Cannot transition from {status} to completed" }` |
 
 #### 使用示例
 
@@ -530,7 +530,7 @@ const result = await mcp.callTool("exomind_complete_task", {
 
 ### 7. exomind_cancel_task
 
-取消任务（状态变更：任意状态 → cancelled）。
+取消任务（状态变更：in_progress / suspended → cancelled）。
 
 #### 输入参数
 
@@ -572,6 +572,7 @@ const result = await mcp.callTool("exomind_complete_task", {
 | 错误 | 原因 | 返回值 |
 |------|------|--------|
 | 任务不存在 | taskId 不存在 | `{ success: false, error: "Task {id} not found" }` |
+| 状态不允许 | 任务不处于进行中或挂起态 | `{ success: false, error: "Cannot transition from {status} to cancelled" }` |
 
 #### 使用示例
 
@@ -603,7 +604,7 @@ interface TaskNode {
   dependencies: TaskDependency[]
 }
 
-type TaskStatus = "pending" | "in_progress" | "completed" | "cancelled"
+type TaskStatus = "pending" | "in_progress" | "suspended" | "completed" | "cancelled"
 
 interface TaskDependency {
   taskId: string
@@ -617,9 +618,13 @@ interface TaskDependency {
 
 ```
 pending ──────> in_progress ──────> completed
-   │                 │
-   │                 │
-   └─────────────────┴──────────> cancelled
+                  │    ▲
+                  │    │
+                  ▼    │
+              suspended
+                  │
+                  ├──────────────> completed
+                  └──────────────> cancelled
 ```
 
 ### 转换约束
@@ -627,8 +632,8 @@ pending ──────> in_progress ──────> completed
 | 从 | 到 | 约束 |
 |----|----|----|
 | pending | in_progress | hard 依赖必须已完成 |
-| in_progress | completed | 无约束 |
-| 任意状态 | cancelled | 无约束 |
+| in_progress | suspended / completed / cancelled | 无约束 |
+| suspended | in_progress / completed / cancelled | 无约束 |
 
 ---
 
@@ -685,8 +690,8 @@ dueAt: task.dueAt?.toISOString() ?? null
 - [ ] 创建任务（父任务不存在，应失败）
 - [ ] 获取任务（存在）
 - [ ] 获取任务（不存在，应失败）
-- [ ] 列出任务（默认不包含已放弃）
-- [ ] 列出任务（包含已放弃）
+- [ ] 列出任务（默认不包含已取消）
+- [ ] 列出任务（包含已取消）
 - [ ] 更新任务（修改标题）
 - [ ] 更新任务（修改多个字段）
 - [ ] 开始任务（无依赖）

--- a/src/lib/adapters/mock/fixtures/tasks.ts
+++ b/src/lib/adapters/mock/fixtures/tasks.ts
@@ -1,4 +1,4 @@
-import type { TaskNode } from '@/lib/types/task'
+﻿import type { TaskNode } from '@/lib/types/task'
 
 const BASE_TS = new Date('2026-02-23T09:00:00.000Z').getTime()
 
@@ -29,7 +29,7 @@ export const MOCK_TASK_NODES_FIXTURE: TaskNode[] = [
   {
     id: 'node-003',
     title: '编写单元测试',
-    status: 'not_started',
+    status: 'pending',
     priority: 'medium',
     dependsOn: [{ taskId: 'node-002', type: 'soft' }],
     tags: ['test'],

--- a/src/lib/adapters/mock/task-crud-integration.test.ts
+++ b/src/lib/adapters/mock/task-crud-integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+﻿import { describe, it, expect, beforeEach } from 'vitest'
 import { TaskMockAdapter } from './task-mock-adapter'
 
 describe('TaskNode CRUD 完整链路验证', () => {
@@ -8,11 +8,11 @@ describe('TaskNode CRUD 完整链路验证', () => {
     adapter = new TaskMockAdapter()
   })
 
-  it('创建 → 查询 → 更新 → 状态转换 → 放弃 完整链路', async () => {
+  it('创建 → 查询 → 更新 → 状态转换 → 取消 完整链路', async () => {
     // 创建
     const created = await adapter.createTask({ title: '测试任务', priority: 'high', tags: ['test'] })
     expect(created.id).toBeTruthy()
-    expect(created.status).toBe('not_started')
+    expect(created.status).toBe('pending')
     expect(created.priority).toBe('high')
 
     // 查询
@@ -23,7 +23,7 @@ describe('TaskNode CRUD 完整链路验证', () => {
     const updated = await adapter.updateTask(created.id, { title: '更新后的任务' })
     expect(updated?.title).toBe('更新后的任务')
 
-    // 获取可用转换（not_started 只能转 in_progress）
+    // 获取可用转换（pending 只能转 in_progress）
     const available = await adapter.getAvailableTransitions(created.id)
     expect(available).toEqual(['in_progress'])
 
@@ -35,17 +35,17 @@ describe('TaskNode CRUD 完整链路验证', () => {
     const suspended = await adapter.transitionTask(created.id, 'suspended')
     expect(suspended?.status).toBe('suspended')
 
-    // 放弃（行为语义：删除=放弃）
-    const abandoned = await adapter.abandonTask(created.id)
-    expect(abandoned?.status).toBe('abandoned')
+    // 取消（行为语义：删除=取消）
+    const cancelled = await adapter.cancelTask(created.id)
+    expect(cancelled?.status).toBe('cancelled')
 
-    // 放弃后不出现在默认列表中
+    // 取消后不出现在默认列表中
     const list = await adapter.listTasks()
     expect(list.find(t => t.id === created.id)).toBeUndefined()
 
-    // 但 includeAbandoned=true 时可见
+    // 但 includeCancelled=true 时可见
     const allList = await adapter.listTasks(true)
-    expect(allList.find(t => t.id === created.id)?.status).toBe('abandoned')
+    expect(allList.find(t => t.id === created.id)?.status).toBe('cancelled')
   })
 
   it('终态任务不可再转换', async () => {
@@ -54,6 +54,6 @@ describe('TaskNode CRUD 完整链路验证', () => {
     await adapter.transitionTask(task.id, 'completed')
 
     await expect(adapter.transitionTask(task.id, 'in_progress')).rejects.toThrow()
-    await expect(adapter.abandonTask(task.id)).rejects.toThrow()
+    await expect(adapter.cancelTask(task.id)).rejects.toThrow()
   })
 })

--- a/src/lib/adapters/mock/task-mock-adapter.test.ts
+++ b/src/lib/adapters/mock/task-mock-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+﻿import { describe, it, expect, beforeEach } from 'vitest'
 import { TaskMockAdapter } from './task-mock-adapter'
 
 describe('TaskMockAdapter', () => {
@@ -8,29 +8,29 @@ describe('TaskMockAdapter', () => {
     adapter = new TaskMockAdapter()
   })
 
-  it('listTasks() 默认不返回 abandoned 任务', async () => {
-    const created = await adapter.createTask({ title: '待放弃任务' })
+  it('listTasks() 默认不返回 cancelled 任务', async () => {
+    const created = await adapter.createTask({ title: '待取消任务' })
     await adapter.transitionTask(created.id, 'in_progress')
-    await adapter.abandonTask(created.id)
+    await adapter.cancelTask(created.id)
 
     const tasks = await adapter.listTasks()
-    expect(tasks.every(t => t.status !== 'abandoned')).toBe(true)
+    expect(tasks.every(t => t.status !== 'cancelled')).toBe(true)
   })
 
-  it('listTasks(true) 包含 abandoned 任务', async () => {
-    const created = await adapter.createTask({ title: '待放弃任务2' })
+  it('listTasks(true) 包含 cancelled 任务', async () => {
+    const created = await adapter.createTask({ title: '待取消任务2' })
     await adapter.transitionTask(created.id, 'in_progress')
-    await adapter.abandonTask(created.id)
+    await adapter.cancelTask(created.id)
 
     const tasks = await adapter.listTasks(true)
-    const abandonedTasks = tasks.filter(t => t.status === 'abandoned')
-    expect(abandonedTasks.length).toBeGreaterThan(0)
+    const cancelledTasks = tasks.filter(t => t.status === 'cancelled')
+    expect(cancelledTasks.length).toBeGreaterThan(0)
   })
 
-  it('createTask 创建后 status 为 not_started，id 非空', async () => {
+  it('createTask 创建后 status 为 pending，id 非空', async () => {
     const task = await adapter.createTask({ title: '新任务' })
     expect(task.id).toBeTruthy()
-    expect(task.status).toBe('not_started')
+    expect(task.status).toBe('pending')
   })
 
   it('updateTask 更新字段，updatedAt 变大', async () => {
@@ -46,13 +46,13 @@ describe('TaskMockAdapter', () => {
     expect(updated!.updatedAt).toBeGreaterThan(originalUpdatedAt)
   })
 
-  it('abandonTask 后任务 status 为 abandoned，且从 listTasks() 中消失', async () => {
-    const created = await adapter.createTask({ title: '要放弃的任务' })
+  it('cancelTask 后任务 status 为 cancelled，且从 listTasks() 中消失', async () => {
+    const created = await adapter.createTask({ title: '要取消的任务' })
     await adapter.transitionTask(created.id, 'in_progress')
-    const abandoned = await adapter.abandonTask(created.id)
+    const cancelled = await adapter.cancelTask(created.id)
 
-    expect(abandoned).not.toBeNull()
-    expect(abandoned!.status).toBe('abandoned')
+    expect(cancelled).not.toBeNull()
+    expect(cancelled!.status).toBe('cancelled')
 
     const tasks = await adapter.listTasks()
     expect(tasks.find(t => t.id === created.id)).toBeUndefined()
@@ -68,11 +68,11 @@ describe('TaskMockAdapter', () => {
 
   it('transitionTask 非法转换抛出 Error', async () => {
     const created = await adapter.createTask({ title: '非法转换测试' })
-    // not_started → completed 是非法转换（必须先经过 in_progress）
+    // pending → completed 是非法转换（必须先经过 in_progress）
     await expect(adapter.transitionTask(created.id, 'completed')).rejects.toThrow()
   })
 
-  it('getAvailableTransitions 对 not_started 任务返回 [\'in_progress\']', async () => {
+  it('getAvailableTransitions 对 pending 任务返回 [\'in_progress\']', async () => {
     const created = await adapter.createTask({ title: '可用转换测试' })
     const transitions = await adapter.getAvailableTransitions(created.id)
     expect(transitions).toEqual(['in_progress'])

--- a/src/lib/adapters/mock/task-mock-adapter.ts
+++ b/src/lib/adapters/mock/task-mock-adapter.ts
@@ -8,14 +8,14 @@ function deepClone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T
 }
 
-const ALL_STATUSES: TaskStatus[] = ['not_started', 'in_progress', 'suspended', 'completed', 'abandoned']
+const ALL_STATUSES: TaskStatus[] = ['pending', 'in_progress', 'suspended', 'completed', 'cancelled']
 
 export class TaskMockAdapter implements ITaskPort {
   private tasks: TaskNode[] = deepClone(MOCK_TASK_NODES_FIXTURE)
 
-  async listTasks(includeAbandoned = false): Promise<TaskNode[]> {
+  async listTasks(includeCancelled = false): Promise<TaskNode[]> {
     const all = deepClone(this.tasks)
-    return includeAbandoned ? all : all.filter(t => t.status !== 'abandoned')
+    return includeCancelled ? all : all.filter(t => t.status !== 'cancelled')
   }
 
   async getTaskById(id: string): Promise<TaskNode | null> {
@@ -30,7 +30,7 @@ export class TaskMockAdapter implements ITaskPort {
       title: input.title.trim(),
       description: input.description,
       doneCondition: input.doneCondition,
-      status: 'not_started',
+      status: 'pending',
       priority: input.priority ?? 'medium',
       dueAt: input.dueAt,
       source: input.source,
@@ -56,12 +56,12 @@ export class TaskMockAdapter implements ITaskPort {
     return deepClone(updated)
   }
 
-  async abandonTask(id: string): Promise<TaskNode | null> {
+  async cancelTask(id: string): Promise<TaskNode | null> {
     const task = this.tasks.find(t => t.id === id)
     if (!task) return null
-    const abandoned = transition(task, 'abandoned')
-    this.tasks = this.tasks.map(t => t.id === id ? abandoned : t)
-    return deepClone(abandoned)
+    const cancelled = transition(task, 'cancelled')
+    this.tasks = this.tasks.map(t => t.id === id ? cancelled : t)
+    return deepClone(cancelled)
   }
 
   async transitionTask(id: string, to: TaskStatus): Promise<TaskNode | null> {

--- a/src/lib/adapters/task-pouch-adapter.ts
+++ b/src/lib/adapters/task-pouch-adapter.ts
@@ -12,7 +12,7 @@ import { getTaskStorage } from '@/lib/storage/task-storage';
 import { getCurrentUserId } from '@/lib/storage/event-storage';
 import { createUuidV4 } from '@/lib/utils/uuid';
 
-const ALL_STATUSES: TaskStatus[] = ['not_started', 'in_progress', 'suspended', 'completed', 'abandoned'];
+const ALL_STATUSES: TaskStatus[] = ['pending', 'in_progress', 'suspended', 'completed', 'cancelled'];
 
 export class TaskPouchAdapter implements ITaskPort {
   constructor(private readonly userId?: string) {}
@@ -21,9 +21,9 @@ export class TaskPouchAdapter implements ITaskPort {
     return getTaskStorage(this.userId || getCurrentUserId());
   }
 
-  async listTasks(includeAbandoned = false): Promise<TaskNode[]> {
+  async listTasks(includeCancelled = false): Promise<TaskNode[]> {
     const tasks = await this.storage.getTasks();
-    return includeAbandoned ? tasks : tasks.filter((t) => t.status !== 'abandoned');
+    return includeCancelled ? tasks : tasks.filter((t) => t.status !== 'cancelled');
   }
 
   async getTaskById(id: string): Promise<TaskNode | null> {
@@ -38,7 +38,7 @@ export class TaskPouchAdapter implements ITaskPort {
       title: input.title.trim(),
       description: input.description,
       doneCondition: input.doneCondition,
-      status: 'not_started',
+      status: 'pending',
       priority: input.priority ?? 'medium',
       dueAt: input.dueAt,
       source: input.source,
@@ -58,16 +58,16 @@ export class TaskPouchAdapter implements ITaskPort {
     return result ?? null;
   }
 
-  async abandonTask(id: string): Promise<TaskNode | null> {
+  async cancelTask(id: string): Promise<TaskNode | null> {
     const task = await this.storage.getTask(id);
     if (!task) return null;
-    const abandoned = transition(task, 'abandoned');
+    const cancelled = transition(task, 'cancelled');
     await this.storage.updateTask(id, {
-      status: abandoned.status,
-      updatedAt: abandoned.updatedAt,
-      completedAt: abandoned.completedAt,
+      status: cancelled.status,
+      updatedAt: cancelled.updatedAt,
+      completedAt: cancelled.completedAt,
     });
-    return abandoned;
+    return cancelled;
   }
 
   async transitionTask(id: string, to: TaskStatus): Promise<TaskNode | null> {

--- a/src/lib/adapters/task-rt-adapter.ts
+++ b/src/lib/adapters/task-rt-adapter.ts
@@ -4,8 +4,8 @@ import {
   type RuntimeTarget,
 } from '@/config/runtime-target';
 import type { ITaskPort, CreateTaskInput, UpdateTaskInput } from '@/lib/environment/interfaces/task.port';
-import type { Dependency, TaskNode, TaskStatus } from '@/lib/types/task';
-import { canTransition } from '@/lib/types/task';
+import type { Dependency, LegacyTaskStatus, TaskNode, TaskNodeLike, TaskStatus } from '@/lib/types/task';
+import { canTransition, normalizeTaskNode } from '@/lib/types/task';
 import { appendRuntimeProfileScope } from './runtime-profile-scope';
 
 type RuntimeFetch = typeof fetch;
@@ -20,7 +20,7 @@ interface RuntimeTaskPayload {
   title: string;
   description?: string | null;
   done_condition?: string | null;
-  status: TaskStatus;
+  status: TaskStatus | LegacyTaskStatus;
   priority: 'low' | 'medium' | 'high';
   tags?: string[];
   source?: string | null;
@@ -39,7 +39,7 @@ export interface TaskRtAdapterOptions {
   resolveTarget?: () => RuntimeTarget;
 }
 
-const ALL_STATUSES: TaskStatus[] = ['not_started', 'in_progress', 'suspended', 'completed', 'abandoned'];
+const ALL_STATUSES: TaskStatus[] = ['pending', 'in_progress', 'suspended', 'completed', 'cancelled'];
 
 function formatHostForUrl(host: string): string {
   if (host.includes(':') && !host.startsWith('[')) {
@@ -60,7 +60,7 @@ function toRuntimeDependency(dependency: Dependency): RuntimeTaskDependencyPaylo
 }
 
 function toRuntimeTaskNode(task: RuntimeTaskPayload): TaskNode {
-  return {
+  return normalizeTaskNode({
     id: task.id,
     title: task.title,
     description: task.description ?? undefined,
@@ -80,7 +80,7 @@ function toRuntimeTaskNode(task: RuntimeTaskPayload): TaskNode {
     createdAt: task.created_at,
     updatedAt: task.updated_at,
     completedAt: task.completed_at ?? undefined,
-  };
+  } satisfies TaskNodeLike);
 }
 
 function toRuntimeCreatePayload(input: CreateTaskInput): Record<string, unknown> {
@@ -124,10 +124,10 @@ export class TaskRtAdapter implements ITaskPort {
     this.resolveTarget = options.resolveTarget ?? (() => getSelectedRuntimeTarget());
   }
 
-  async listTasks(includeAbandoned = false): Promise<TaskNode[]> {
+  async listTasks(includeCancelled = false): Promise<TaskNode[]> {
     const tasks = await this.requestJson<RuntimeTaskPayload[]>('/tasks');
     const mapped = tasks.map(toRuntimeTaskNode);
-    return includeAbandoned ? mapped : mapped.filter((task) => task.status !== 'abandoned');
+    return includeCancelled ? mapped : mapped.filter((task) => task.status !== 'cancelled');
   }
 
   async getTaskById(id: string): Promise<TaskNode | null> {
@@ -170,17 +170,17 @@ export class TaskRtAdapter implements ITaskPort {
     return toRuntimeTaskNode(await response.json() as RuntimeTaskPayload);
   }
 
-  async abandonTask(id: string): Promise<TaskNode | null> {
+  async cancelTask(id: string): Promise<TaskNode | null> {
     const target = this.resolveTarget();
-    const response = await this.fetchImpl(this.url(`/tasks/${encodeURIComponent(id)}`, target), {
-      method: 'DELETE',
+    const response = await this.fetchImpl(this.url(`/tasks/${encodeURIComponent(id)}/cancel`, target), {
+      method: 'POST',
       headers: buildRuntimeAuthHeaders(target, { Accept: 'application/json' }),
     });
     if (response.status === 404) {
       return null;
     }
     if (!response.ok) {
-      throw new Error(`RT abandon task failed: ${response.status}`);
+      throw new Error(`RT cancel task failed: ${response.status}`);
     }
     return toRuntimeTaskNode(await response.json() as RuntimeTaskPayload);
   }

--- a/src/lib/environment/interfaces/task.port.ts
+++ b/src/lib/environment/interfaces/task.port.ts
@@ -27,12 +27,12 @@ export interface UpdateTaskInput {
 }
 
 export interface ITaskPort {
-  listTasks(includeAbandoned?: boolean): Promise<TaskNode[]>
+  listTasks(includeCancelled?: boolean): Promise<TaskNode[]>
   getTaskById(id: string): Promise<TaskNode | null>
   createTask(input: CreateTaskInput): Promise<TaskNode>
   updateTask(id: string, input: UpdateTaskInput): Promise<TaskNode | null>
-  // 行为语义：删除=放弃 / 不变量：不可删除原则
-  abandonTask(id: string): Promise<TaskNode | null>
+  // 行为语义：删除=取消 / 不变量：不可删除原则
+  cancelTask(id: string): Promise<TaskNode | null>
   transitionTask(id: string, to: TaskStatus): Promise<TaskNode | null>
   getAvailableTransitions(id: string): Promise<TaskStatus[]>
 }

--- a/src/lib/services/task-timer.service.ts
+++ b/src/lib/services/task-timer.service.ts
@@ -45,10 +45,10 @@ export class TaskTimerServiceImpl implements TaskTimerService {
     if (!task) return null
 
     // 终态任务不允许启动计时
-    if (task.status === 'completed' || task.status === 'abandoned') return null
+    if (task.status === 'completed' || task.status === 'cancelled') return null
 
     // 如果任务非 in_progress，先转换状态
-    if (task.status === 'not_started') {
+    if (task.status === 'pending') {
       await this.taskSvc.transitionTask(taskId, 'in_progress')
     } else if (task.status === 'suspended') {
       await this.taskSvc.transitionTask(taskId, 'in_progress')

--- a/src/lib/services/task.service.ts
+++ b/src/lib/services/task.service.ts
@@ -12,12 +12,12 @@ export interface DependencyCheckResult {
 }
 
 export interface TaskService {
-  listTasks(includeAbandoned?: boolean): Promise<TaskNode[]>
+  listTasks(includeCancelled?: boolean): Promise<TaskNode[]>
   getTask(id: string): Promise<TaskNode | null>
   createTask(input: CreateTaskInput): Promise<TaskNode>
   updateTask(id: string, input: UpdateTaskInput): Promise<TaskNode | null>
-  // 行为语义：删除=放弃
-  abandonTask(id: string): Promise<TaskNode | null>
+  // 行为语义：删除=取消
+  cancelTask(id: string): Promise<TaskNode | null>
   transitionTask(id: string, to: TaskStatus): Promise<TaskNode | null>
   getAvailableTransitions(id: string): Promise<TaskStatus[]>
   // Phase3: 父子层级
@@ -40,8 +40,8 @@ export class TaskServiceImpl implements TaskService {
     this.env = env ?? ExoMindEnvironment.getInstance()
   }
 
-  listTasks(includeAbandoned = false) {
-    return this.env.task.listTasks(includeAbandoned)
+  listTasks(includeCancelled = false) {
+    return this.env.task.listTasks(includeCancelled)
   }
 
   getTask(id: string) {
@@ -66,8 +66,8 @@ export class TaskServiceImpl implements TaskService {
     return updated
   }
 
-  async abandonTask(id: string) {
-    const task = await this.env.task.abandonTask(id)
+  async cancelTask(id: string) {
+    const task = await this.env.task.cancelTask(id)
     if (task) {
       this.notifyChangeListeners()
     }
@@ -148,7 +148,7 @@ export class TaskServiceImpl implements TaskService {
 
       if (dep.type === 'hard' && depTask.status !== 'completed') {
         blocking.push({ taskId: dep.taskId, type: dep.type, status: depTask.status })
-      } else if (dep.type === 'soft' && depTask.status === 'not_started') {
+      } else if (dep.type === 'soft' && depTask.status === 'pending') {
         blocking.push({ taskId: dep.taskId, type: dep.type, status: depTask.status })
       }
     }

--- a/src/lib/storage/task-storage.ts
+++ b/src/lib/storage/task-storage.ts
@@ -7,7 +7,14 @@
 
 import PouchDB from 'pouchdb';
 import { buildSyncErrorLog } from './sync-error';
-import type { TaskNode } from '@/lib/types/task';
+import {
+  normalizeTaskNode,
+  normalizeTaskStatus,
+  toStoredTaskStatus,
+  type CompatibleTaskStatus,
+  type TaskNode,
+  type TaskNodeLike,
+} from '@/lib/types/task';
 import { log } from '@/lib/logger';
 
 const POUCHDB_PREFIX_ENV = 'EXOMIND_TASK_STORAGE_PREFIX';
@@ -15,7 +22,8 @@ const DEFAULT_TEST_POUCHDB_PREFIX = '.tmp/pouchdb-task-storage/';
 const OLD_STORAGE_KEY = 'task_nodes_v2';
 
 /** Internal PouchDB document type */
-interface TaskDoc extends TaskNode {
+interface TaskDoc extends Omit<TaskNode, 'status'> {
+  status: CompatibleTaskStatus;
   _id: string;
   _rev?: string;
 }
@@ -100,7 +108,7 @@ export function clearAllTaskStorageInstances(): void {
 /* ── TaskStorage class ── */
 
 export class TaskStorage {
-  private db: PouchDB.Database<TaskNode>;
+  private db: PouchDB.Database<TaskDoc>;
   private initialized = false;
   private syncReplication: PouchDB.Replication.Sync<TaskNode> | null = null;
   private changeListeners: Array<(change: unknown) => void> = [];
@@ -110,8 +118,8 @@ export class TaskStorage {
     const dbName = `tasks_${userId}`;
     const prefix = resolvePouchDbPrefix(options.pouchDbPrefix);
     this.db = prefix
-      ? new PouchDB<TaskNode>(dbName, { prefix })
-      : new PouchDB<TaskNode>(dbName);
+      ? new PouchDB<TaskDoc>(dbName, { prefix })
+      : new PouchDB<TaskDoc>(dbName);
     this.initializeDesignDoc();
   }
 
@@ -167,9 +175,9 @@ export class TaskStorage {
 
   /* ── CRUD ── */
 
-  async addTask(task: TaskNode): Promise<void> {
+  async addTask(task: TaskNodeLike): Promise<void> {
     await this.initializeDesignDoc();
-    const doc: TaskDoc = { ...task, _id: `task:${task.id}` };
+    const doc: TaskDoc = { ...this.toTaskDoc(task), _id: `task:${task.id}` };
     await this.db.put(doc as unknown as Parameters<typeof this.db.put>[0]);
     this.notifyChangeListeners({ type: 'local', doc });
   }
@@ -177,8 +185,8 @@ export class TaskStorage {
   async getTask(id: string): Promise<TaskNode | undefined> {
     await this.initializeDesignDoc();
     try {
-      const doc = await this.db.get<TaskNode>(`task:${id}`);
-      return this.toTaskNode(doc as unknown as TaskDoc);
+      const doc = await this.db.get<TaskDoc>(`task:${id}`);
+      return this.toTaskNode(doc);
     } catch {
       return undefined;
     }
@@ -197,7 +205,11 @@ export class TaskStorage {
     await this.initializeDesignDoc();
     const result = await this.db.query<TaskDoc>('tasks/by_status', {
       include_docs: true,
-      key: status,
+      key: normalizeTaskStatus(status as CompatibleTaskStatus) === 'pending'
+        ? 'not_started'
+        : normalizeTaskStatus(status as CompatibleTaskStatus) === 'cancelled'
+          ? 'abandoned'
+          : status,
     });
     return result.rows.filter((row) => row.doc).map((row) => this.toTaskNode(row.doc!));
   }
@@ -214,11 +226,15 @@ export class TaskStorage {
   async updateTask(id: string, updates: Partial<TaskNode>): Promise<TaskNode | undefined> {
     await this.initializeDesignDoc();
     try {
-      const doc = await this.db.get<TaskNode>(`task:${id}`);
-      const updated = { ...doc, ...updates, updatedAt: Date.now() };
+      const doc = await this.db.get<TaskDoc>(`task:${id}`);
+      const updated: TaskDoc = {
+        ...doc,
+        ...this.toTaskDocUpdates(updates),
+        updatedAt: Date.now(),
+      };
       await this.db.put(updated as unknown as Parameters<typeof this.db.put>[0]);
       this.notifyChangeListeners({ type: 'local', doc: updated });
-      return this.toTaskNode(updated as unknown as TaskDoc);
+      return this.toTaskNode(updated);
     } catch {
       return undefined;
     }
@@ -227,7 +243,7 @@ export class TaskStorage {
   async deleteDoc(id: string): Promise<void> {
     await this.initializeDesignDoc();
     try {
-      const doc = await this.db.get<TaskNode>(`task:${id}`);
+      const doc = await this.db.get<TaskDoc>(`task:${id}`);
       await (this.db as unknown as { remove(doc: unknown): Promise<unknown> }).remove(doc);
     } catch {
       // not found, ignore
@@ -302,7 +318,7 @@ export class TaskStorage {
     const raw = localStorage.getItem(OLD_STORAGE_KEY);
     if (!raw) return 0;
 
-    let tasks: TaskNode[];
+    let tasks: TaskNodeLike[];
     try {
       tasks = JSON.parse(raw);
       if (!Array.isArray(tasks)) return 0;
@@ -347,7 +363,26 @@ export class TaskStorage {
     delete obj._id;
     delete obj._rev;
     delete obj._conflicts;
-    return obj as unknown as TaskNode;
+    return normalizeTaskNode(obj as unknown as TaskNodeLike);
+  }
+
+  private toTaskDoc(task: TaskNodeLike): Omit<TaskDoc, '_id' | '_rev'> {
+    const normalizedTask = normalizeTaskNode(task);
+    return {
+      ...normalizedTask,
+      status: toStoredTaskStatus(normalizedTask.status),
+    };
+  }
+
+  private toTaskDocUpdates(updates: Partial<TaskNode>): Partial<TaskDoc> {
+    if (updates.status === undefined) {
+      return updates;
+    }
+
+    return {
+      ...updates,
+      status: toStoredTaskStatus(updates.status),
+    };
   }
 
   private notifyChangeListeners(change: unknown): void {

--- a/src/lib/task/task-dag-graph.ts
+++ b/src/lib/task/task-dag-graph.ts
@@ -1,4 +1,4 @@
-import type { TaskNode } from '@/lib/types/task'
+﻿import type { TaskNode } from '@/lib/types/task'
 
 export interface TaskGraphNode {
   id: string
@@ -39,7 +39,7 @@ function compareTasksForGraphOrder(left: TaskNode, right: TaskNode): number {
 }
 
 function isTerminalStatus(status: TaskNode['status']): boolean {
-  return status === 'completed' || status === 'abandoned'
+  return status === 'completed' || status === 'cancelled'
 }
 
 function isDependencyBlocking(task: TaskNode, taskById: Map<string, TaskNode>): boolean {
@@ -57,12 +57,12 @@ function isDependencyBlocking(task: TaskNode, taskById: Map<string, TaskNode>): 
       return predecessor.status !== 'completed'
     }
 
-    return predecessor.status === 'not_started'
+    return predecessor.status === 'pending'
   })
 }
 
 function isTaskExecutable(task: TaskNode, taskById: Map<string, TaskNode>): boolean {
-  if (task.status !== 'not_started') {
+  if (task.status !== 'pending') {
     return false
   }
 

--- a/src/lib/task/task-dag-visibility.ts
+++ b/src/lib/task/task-dag-visibility.ts
@@ -1,4 +1,4 @@
-import type { TaskGraph, TaskGraphEdge, TaskGraphNode } from '@/lib/task/task-dag-graph'
+﻿import type { TaskGraph, TaskGraphEdge, TaskGraphNode } from '@/lib/task/task-dag-graph'
 
 export interface TaskDagVisibilityState {
   collapsedUpstreamOf: string[]
@@ -26,7 +26,7 @@ export const EMPTY_TASK_DAG_VISIBILITY_STATE: TaskDagVisibilityState = {
 }
 
 function isTerminalStatus(status: TaskGraphNode['status']): boolean {
-  return status === 'completed' || status === 'abandoned'
+  return status === 'completed' || status === 'cancelled'
 }
 
 function buildTopologicalIndex(graph: TaskGraph): Map<string, number> {

--- a/src/lib/types/task.test.ts
+++ b/src/lib/types/task.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+﻿import { describe, it, expect, vi } from 'vitest'
 import {
   canTransition,
   transition,
@@ -27,8 +27,8 @@ function makeTask(status: TaskStatus): TaskNode {
 // canTransition: 合法路径
 // ────────────────────────────────────────────────────────────
 describe('canTransition - valid transitions', () => {
-  it('not_started → in_progress 合法', () => {
-    expect(canTransition('not_started', 'in_progress')).toBe(true)
+  it('pending → in_progress 合法', () => {
+    expect(canTransition('pending', 'in_progress')).toBe(true)
   })
 
   it('in_progress → suspended 合法', () => {
@@ -39,8 +39,8 @@ describe('canTransition - valid transitions', () => {
     expect(canTransition('in_progress', 'completed')).toBe(true)
   })
 
-  it('in_progress → abandoned 合法', () => {
-    expect(canTransition('in_progress', 'abandoned')).toBe(true)
+  it('in_progress → cancelled 合法', () => {
+    expect(canTransition('in_progress', 'cancelled')).toBe(true)
   })
 
   it('suspended → in_progress 合法', () => {
@@ -51,8 +51,8 @@ describe('canTransition - valid transitions', () => {
     expect(canTransition('suspended', 'completed')).toBe(true)
   })
 
-  it('suspended → abandoned 合法', () => {
-    expect(canTransition('suspended', 'abandoned')).toBe(true)
+  it('suspended → cancelled 合法', () => {
+    expect(canTransition('suspended', 'cancelled')).toBe(true)
   })
 })
 
@@ -60,24 +60,24 @@ describe('canTransition - valid transitions', () => {
 // canTransition: 非法路径
 // ────────────────────────────────────────────────────────────
 describe('canTransition - invalid transitions', () => {
-  it('not_started → suspended 非法', () => {
-    expect(canTransition('not_started', 'suspended')).toBe(false)
+  it('pending → suspended 非法', () => {
+    expect(canTransition('pending', 'suspended')).toBe(false)
   })
 
-  it('not_started → completed 非法（不可直接完成）', () => {
-    expect(canTransition('not_started', 'completed')).toBe(false)
+  it('pending → completed 非法（不可直接完成）', () => {
+    expect(canTransition('pending', 'completed')).toBe(false)
   })
 
-  it('not_started → abandoned 非法', () => {
-    expect(canTransition('not_started', 'abandoned')).toBe(false)
+  it('pending → cancelled 非法', () => {
+    expect(canTransition('pending', 'cancelled')).toBe(false)
   })
 
-  it('in_progress → not_started 非法（不可回退）', () => {
-    expect(canTransition('in_progress', 'not_started')).toBe(false)
+  it('in_progress → pending 非法（不可回退）', () => {
+    expect(canTransition('in_progress', 'pending')).toBe(false)
   })
 
-  it('suspended → not_started 非法', () => {
-    expect(canTransition('suspended', 'not_started')).toBe(false)
+  it('suspended → pending 非法', () => {
+    expect(canTransition('suspended', 'pending')).toBe(false)
   })
 
   it('completed → in_progress 非法（终态不可转换）', () => {
@@ -88,16 +88,16 @@ describe('canTransition - invalid transitions', () => {
     expect(canTransition('completed', 'suspended')).toBe(false)
   })
 
-  it('completed → abandoned 非法（终态不可转换）', () => {
-    expect(canTransition('completed', 'abandoned')).toBe(false)
+  it('completed → cancelled 非法（终态不可转换）', () => {
+    expect(canTransition('completed', 'cancelled')).toBe(false)
   })
 
-  it('abandoned → in_progress 非法（终态不可转换）', () => {
-    expect(canTransition('abandoned', 'in_progress')).toBe(false)
+  it('cancelled → in_progress 非法（终态不可转换）', () => {
+    expect(canTransition('cancelled', 'in_progress')).toBe(false)
   })
 
-  it('abandoned → completed 非法（终态不可转换）', () => {
-    expect(canTransition('abandoned', 'completed')).toBe(false)
+  it('cancelled → completed 非法（终态不可转换）', () => {
+    expect(canTransition('cancelled', 'completed')).toBe(false)
   })
 
   it('in_progress → in_progress 自转换非法', () => {
@@ -114,11 +114,11 @@ describe('canTransition - invalid transitions', () => {
 // ────────────────────────────────────────────────────────────
 describe('transition - immutability', () => {
   it('合法转换返回新对象，原对象不变', () => {
-    const original = makeTask('not_started')
+    const original = makeTask('pending')
     const next = transition(original, 'in_progress')
 
     expect(next).not.toBe(original)          // 新对象
-    expect(original.status).toBe('not_started') // 原对象未被修改
+    expect(original.status).toBe('pending') // 原对象未被修改
     expect(next.status).toBe('in_progress')
   })
 
@@ -138,8 +138,8 @@ describe('transition - immutability', () => {
 // transition: 非法转换抛出 Error
 // ────────────────────────────────────────────────────────────
 describe('transition - invalid throws Error', () => {
-  it('not_started → completed 抛出 Error', () => {
-    const task = makeTask('not_started')
+  it('pending → completed 抛出 Error', () => {
+    const task = makeTask('pending')
     expect(() => transition(task, 'completed')).toThrow(Error)
   })
 
@@ -148,8 +148,8 @@ describe('transition - invalid throws Error', () => {
     expect(() => transition(task, 'in_progress')).toThrow(Error)
   })
 
-  it('abandoned → suspended 抛出 Error（终态）', () => {
-    const task = makeTask('abandoned')
+  it('cancelled → suspended 抛出 Error（终态）', () => {
+    const task = makeTask('cancelled')
     expect(() => transition(task, 'suspended')).toThrow(Error)
   })
 })
@@ -167,17 +167,17 @@ describe('transition - completedAt on terminal states', () => {
     expect(next.completedAt!).toBeGreaterThanOrEqual(before)
   })
 
-  it('转换到 abandoned 时设置 completedAt', () => {
+  it('转换到 cancelled 时设置 completedAt', () => {
     const before = Date.now()
     const task = makeTask('suspended')
-    const next = transition(task, 'abandoned')
+    const next = transition(task, 'cancelled')
 
     expect(next.completedAt).toBeDefined()
     expect(next.completedAt!).toBeGreaterThanOrEqual(before)
   })
 
   it('非终态转换不设置 completedAt', () => {
-    const task = makeTask('not_started')
+    const task = makeTask('pending')
     const next = transition(task, 'in_progress')
 
     expect(next.completedAt).toBeUndefined()

--- a/src/lib/types/task.ts
+++ b/src/lib/types/task.ts
@@ -3,8 +3,10 @@ export interface Dependency {
   type: 'soft' | 'hard'
 }
 
-/** 5 状态机：not_started → in_progress ⇌ suspended → completed / abandoned */
-export type TaskStatus = 'not_started' | 'in_progress' | 'suspended' | 'completed' | 'abandoned'
+/** 5 状态机：pending → in_progress ⇌ suspended → completed / cancelled */
+export type TaskStatus = 'pending' | 'in_progress' | 'suspended' | 'completed' | 'cancelled'
+export type LegacyTaskStatus = 'not_started' | 'abandoned'
+export type CompatibleTaskStatus = TaskStatus | LegacyTaskStatus
 
 export type TaskPriority = 'low' | 'medium' | 'high'
 
@@ -27,13 +29,49 @@ export interface TaskNode {
   completedAt?: number
 }
 
+export type TaskNodeLike = Omit<TaskNode, 'status'> & { status: CompatibleTaskStatus }
+
+export function normalizeTaskStatus(status: CompatibleTaskStatus): TaskStatus {
+  switch (status) {
+    case 'not_started':
+      return 'pending'
+    case 'abandoned':
+      return 'cancelled'
+    default:
+      return status
+  }
+}
+
+export function toStoredTaskStatus(status: TaskStatus): CompatibleTaskStatus {
+  switch (status) {
+    case 'pending':
+      return 'not_started'
+    case 'cancelled':
+      return 'abandoned'
+    default:
+      return status
+  }
+}
+
+export function normalizeTaskNode(task: TaskNodeLike): TaskNode {
+  return {
+    ...task,
+    status: normalizeTaskStatus(task.status),
+  }
+}
+
+export function isTerminalTaskStatus(status: CompatibleTaskStatus): boolean {
+  const normalized = normalizeTaskStatus(status)
+  return normalized === 'completed' || normalized === 'cancelled'
+}
+
 // 合法状态转换表
 const VALID_TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
-  not_started: ['in_progress'],
-  in_progress: ['suspended', 'completed', 'abandoned'],
-  suspended:   ['in_progress', 'completed', 'abandoned'],
+  pending: ['in_progress'],
+  in_progress: ['suspended', 'completed', 'cancelled'],
+  suspended:   ['in_progress', 'completed', 'cancelled'],
   completed:   [],
-  abandoned:   [],
+  cancelled:   [],
 }
 
 /** 检查状态转换是否合法 */
@@ -44,19 +82,20 @@ export function canTransition(from: TaskStatus, to: TaskStatus): boolean {
 /**
  * 执行状态转换，返回新的 TaskNode（不可变）。
  * 非法转换时抛出 Error。
- * 转换到 completed / abandoned 时同时设置 completedAt。
+ * 转换到 completed / cancelled 时同时设置 completedAt。
  */
-export function transition(task: TaskNode, to: TaskStatus): TaskNode {
-  if (!canTransition(task.status, to)) {
+export function transition(task: TaskNodeLike, to: TaskStatus): TaskNode {
+  const normalizedTask = normalizeTaskNode(task)
+  if (!canTransition(normalizedTask.status, to)) {
     throw new Error(
-      `Invalid transition: ${task.status} → ${to}`
+      `Invalid transition: ${normalizedTask.status} → ${to}`
     )
   }
   const now = Date.now()
   return {
-    ...task,
+    ...normalizedTask,
     status: to,
     updatedAt: now,
-    ...(to === 'completed' || to === 'abandoned' ? { completedAt: now } : {}),
+    ...(to === 'completed' || to === 'cancelled' ? { completedAt: now } : {}),
   }
 }

--- a/src/ui/app/components/FocusTimerWidget.tsx
+++ b/src/ui/app/components/FocusTimerWidget.tsx
@@ -1,4 +1,4 @@
-import {
+﻿import {
   forwardRef,
   type KeyboardEvent,
   useCallback,
@@ -37,7 +37,7 @@ import type { ActiveBlockData } from '@/lib/types/event';
 import type { TaskNode, TaskStatus } from '@/lib/types/task';
 import { FocusBgmPanel } from '@/ui/app/components/settings/settings-custom-items';
 
-type TaskStatusChoice = 'continue' | 'suspended' | 'completed' | 'abandoned';
+type TaskStatusChoice = 'continue' | 'suspended' | 'completed' | 'cancelled';
 
 type FocusUiState = 'idle' | 'config' | 'running'; // UI State Machine（界面状态机）
 type RunningSubState = 'running' | 'paused'; // Running Sub-state（运行子状态）
@@ -989,7 +989,7 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
                     { key: 'suspended' as TaskStatusChoice, label: '挂起' },
                     { key: 'continue' as TaskStatusChoice, label: '继续' },
                     { key: 'completed' as TaskStatusChoice, label: '完成' },
-                    { key: 'abandoned' as TaskStatusChoice, label: '放弃' },
+                    { key: 'cancelled' as TaskStatusChoice, label: '取消' },
                   ] as const).map(({ key, label }) => (
                     <button
                       key={key}

--- a/src/ui/app/components/TaskCurrentRootCard.tsx
+++ b/src/ui/app/components/TaskCurrentRootCard.tsx
@@ -1,14 +1,14 @@
-import { Link } from '@tanstack/react-router';
+﻿import { Link } from '@tanstack/react-router';
 import type { TaskGraph } from '@/lib/task/task-dag-graph';
 import type { TaskNode } from '@/lib/types/task';
 import { cn } from '@/lib/utils';
 
 const STATUS_LABEL: Record<TaskNode['status'], string> = {
-  not_started: '未开始',
+  pending: '待办',
   in_progress: '进行中',
   suspended: '已挂起',
   completed: '已完成',
-  abandoned: '已放弃',
+  cancelled: '已取消',
 };
 
 function resolveExecutionHint(status: TaskNode['status'], isExecutable: boolean, isBlocked: boolean): string {

--- a/src/ui/app/overlay/now-workbench-overlay-model.ts
+++ b/src/ui/app/overlay/now-workbench-overlay-model.ts
@@ -1,4 +1,4 @@
-import type { ActiveBlockData, Event } from '@/lib/types/event';
+﻿import type { ActiveBlockData, Event } from '@/lib/types/event';
 import type { TaskNode } from '@/lib/types/task';
 import { filterNow } from '@/ui/app/pages/task-tab-filters';
 
@@ -75,7 +75,7 @@ export function buildNowWorkbenchOverlayModel(
     return {
       mode: 'idle_with_tasks',
       title: visibleTasks[0]?.title || '当下工作台',
-      statusLabel: '未开始',
+      statusLabel: '待办',
       activeBlock: null,
       visibleTasks,
       recentEvents,

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -203,7 +203,7 @@ export function TaskDagPage() {
               </div>
               <div data-testid="task-dag-legend-soft" className="flex items-center gap-2">
                 <span className="h-px w-8 border-t-2 border-dashed border-[#78716C]" />
-                <span>软依赖：前置未开始会提示阻塞，但仍可直接开工</span>
+                <span>软依赖：前置待办会提示阻塞，但仍可直接开工</span>
               </div>
             </div>
           </section>

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -1,4 +1,4 @@
-import { Plus, SlidersHorizontal, Waypoints } from 'lucide-react';
+﻿import { Plus, SlidersHorizontal, Waypoints } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from '@tanstack/react-router';
 import { getTaskService, getTimeBlockService } from '@/lib/services';
@@ -22,19 +22,19 @@ const TAB_ITEMS: Array<{ id: TaskTab; label: string }> = [
 ];
 
 const STATUS_DOT: Record<string, string> = {
-  not_started: 'bg-[#A8A29E]',
+  pending: 'bg-[#A8A29E]',
   in_progress: 'bg-[#16A34A]',
   suspended: 'bg-[#EAB308]',
   completed: 'bg-[#3B82F6]',
-  abandoned: 'bg-[#EF4444]',
+  cancelled: 'bg-[#EF4444]',
 };
 
 const STATUS_LABEL: Record<string, string> = {
-  not_started: '未开始',
+  pending: '待办',
   in_progress: '进行中',
   suspended: '已挂起',
   completed: '已完成',
-  abandoned: '已放弃',
+  cancelled: '已取消',
 };
 
 const TAB_EMPTY_TEXT: Record<TaskTab, string> = {

--- a/src/ui/app/pages/task-dag-detail-view.ts
+++ b/src/ui/app/pages/task-dag-detail-view.ts
@@ -7,11 +7,11 @@ import {
 import type { TaskNode, TaskStatus } from '@/lib/types/task';
 
 const STATUS_LABELS: Record<TaskStatus, string> = {
-  not_started: '未开始',
+  pending: '待办',
   in_progress: '进行中',
   suspended: '已挂起',
   completed: '已完成',
-  abandoned: '已放弃',
+  cancelled: '已取消',
 };
 
 const EDGE_TYPE_LABELS: Record<TaskGraphEdge['type'], string> = {

--- a/src/ui/app/pages/task-dag-flow.ts
+++ b/src/ui/app/pages/task-dag-flow.ts
@@ -1,4 +1,4 @@
-import { MarkerType, Position, type Edge, type Node } from '@xyflow/react';
+﻿import { MarkerType, Position, type Edge, type Node } from '@xyflow/react';
 import type { TaskGraph } from '@/lib/task/task-dag-graph';
 import type { TaskNode } from '@/lib/types/task';
 
@@ -9,11 +9,11 @@ const COLUMN_GAP = 320;
 const ROW_GAP = 180;
 
 const STATUS_LABEL: Record<TaskNode['status'], string> = {
-  not_started: '未开始',
+  pending: '待办',
   in_progress: '进行中',
   suspended: '已挂起',
   completed: '已完成',
-  abandoned: '已放弃',
+  cancelled: '已取消',
 };
 
 const PRIORITY_LABEL: Record<TaskNode['priority'], string> = {

--- a/src/ui/app/pages/task-dependency-view.ts
+++ b/src/ui/app/pages/task-dependency-view.ts
@@ -1,4 +1,4 @@
-import type { TaskNode, TaskStatus } from '@/lib/types/task';
+﻿import type { TaskNode, TaskStatus } from '@/lib/types/task';
 
 type DependencyType = 'soft' | 'hard';
 type DependencyAction = 'load' | 'add' | 'update' | 'remove';
@@ -27,11 +27,11 @@ export interface TaskDependencyViewModel {
 }
 
 const STATUS_LABELS: Record<TaskStatus, string> = {
-  not_started: '未开始',
+  pending: '待办',
   in_progress: '进行中',
   suspended: '已挂起',
   completed: '已完成',
-  abandoned: '已放弃',
+  cancelled: '已取消',
 };
 
 const TYPE_LABELS: Record<DependencyType, string> = {
@@ -110,8 +110,8 @@ export function buildTaskDependencyView(task: TaskNode, allTasks: TaskNode[]): T
     candidates: allTasks
       .filter((candidate) => candidate.id !== task.id && !existingDependencyIds.has(candidate.id))
       .map((candidate) => {
-        const disabledReason = candidate.status === 'abandoned'
-          ? '任务已放弃'
+        const disabledReason = candidate.status === 'cancelled'
+          ? '任务已取消'
           : wouldCreateDependencyCycle(task.id, candidate.id, taskMap)
             ? '会形成循环依赖'
             : undefined;

--- a/src/ui/app/pages/task-tab-filters.ts
+++ b/src/ui/app/pages/task-tab-filters.ts
@@ -15,9 +15,9 @@ export function sortByDue(tasks: TaskNode[]): TaskNode[] {
   });
 }
 
-/** Check if a not_started task has all hard dependencies completed */
+/** Check if a pending task has all hard dependencies completed */
 export function isExecutable(task: TaskNode, allTasks: TaskNode[]): boolean {
-  if (task.status !== 'not_started') return false;
+  if (task.status !== 'pending') return false;
   const hardDeps = task.dependsOn.filter((d) => d.type === 'hard');
   if (hardDeps.length === 0) return true;
   return hardDeps.every((dep) => {
@@ -26,14 +26,14 @@ export function isExecutable(task: TaskNode, allTasks: TaskNode[]): boolean {
   });
 }
 
-/** Exclude abandoned tasks (archived) */
-function excludeAbandoned(tasks: TaskNode[]): TaskNode[] {
-  return tasks.filter((t) => t.status !== 'abandoned');
+/** Exclude cancelled tasks (archived) */
+function excludeCancelled(tasks: TaskNode[]): TaskNode[] {
+  return tasks.filter((t) => t.status !== 'cancelled');
 }
 
-/** "当下" tab: show all non-abandoned tasks, in_progress pinned to top, rest sorted by due */
+/** "当下" tab: show all non-cancelled tasks, in_progress pinned to top, rest sorted by due */
 export function filterNow(tasks: TaskNode[]): TaskNode[] {
-  const pool = excludeAbandoned(tasks);
+  const pool = excludeCancelled(tasks);
   const inProgress = pool.filter((t) => t.status === 'in_progress');
   const rest = pool.filter((t) => t.status !== 'in_progress');
   return [...inProgress, ...sortByDue(rest)];
@@ -41,7 +41,7 @@ export function filterNow(tasks: TaskNode[]): TaskNode[] {
 
 /** "今日" tab: dueAt today OR in_progress with updatedAt today */
 export function filterToday(tasks: TaskNode[], now: Date): TaskNode[] {
-  const pool = excludeAbandoned(tasks);
+  const pool = excludeCancelled(tasks);
   const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
   const todayEnd = todayStart + 86_400_000;
   const filtered = pool.filter(
@@ -54,7 +54,7 @@ export function filterToday(tasks: TaskNode[], now: Date): TaskNode[] {
 
 /** "一周" tab: dueAt within 7 days OR in_progress */
 export function filterWeek(tasks: TaskNode[], now: Date): TaskNode[] {
-  const pool = excludeAbandoned(tasks);
+  const pool = excludeCancelled(tasks);
   const weekEnd = now.getTime() + 7 * 86_400_000;
   const filtered = pool.filter(
     (t) => t.status === 'in_progress' || (t.dueAt !== undefined && t.dueAt <= weekEnd),
@@ -64,7 +64,7 @@ export function filterWeek(tasks: TaskNode[], now: Date): TaskNode[] {
 
 /** "月" tab: dueAt in current month OR in_progress */
 export function filterMonth(tasks: TaskNode[], now: Date): TaskNode[] {
-  const pool = excludeAbandoned(tasks);
+  const pool = excludeCancelled(tasks);
   const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).getTime();
   const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 1).getTime();
   const filtered = pool.filter(

--- a/src/ui/app/pages/task-timeblock-detail-view.ts
+++ b/src/ui/app/pages/task-timeblock-detail-view.ts
@@ -1,4 +1,4 @@
-import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
+﻿import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
 import type { TaskNode } from '@/lib/types/task';
 
 export type TimeblockBadgeTone = 'neutral' | 'success' | 'warning' | 'danger';
@@ -96,11 +96,11 @@ export interface BuildTaskTimeblockDetailViewModelInput {
 }
 
 const STATUS_BADGE_LABEL: Record<TaskNode['status'], string> = {
-  not_started: '未开始',
+  pending: '待办',
   in_progress: '进行中',
   suspended: '已挂起',
   completed: '已完成',
-  abandoned: '已放弃',
+  cancelled: '已取消',
 };
 
 function formatClock(timestamp: number): string {
@@ -390,7 +390,7 @@ export function buildTaskTimeblockDetailViewModel(input: BuildTaskTimeblockDetai
   const scheduleBadge = resolveScheduleBadge(input.task.estimatedMinutes, actualMinutes);
   const statusBadge: TimeblockBadge = {
     label: STATUS_BADGE_LABEL[input.task.status],
-    tone: input.task.status === 'completed' ? 'success' : input.task.status === 'abandoned' ? 'danger' : 'neutral',
+    tone: input.task.status === 'completed' ? 'success' : input.task.status === 'cancelled' ? 'danger' : 'neutral',
   };
   const aiSummary = buildAiSummary(block.name, input.reviewMarkdown);
   const timeline = useMockData

--- a/tests/unit/adapters/task-pouch-adapter.test.ts
+++ b/tests/unit/adapters/task-pouch-adapter.test.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * TaskPouchAdapter 单元测试
  *
  * 通过 ITaskPort 接口测试 PouchDB 适配器。
@@ -30,30 +30,30 @@ describe('TaskPouchAdapter (ITaskPort)', () => {
     const task = await adapter.createTask({ title: '新任务' });
     expect(task.id).toBeDefined();
     expect(task.title).toBe('新任务');
-    expect(task.status).toBe('not_started');
+    expect(task.status).toBe('pending');
     expect(task.priority).toBe('medium');
     expect(task.dependsOn).toEqual([]);
     expect(task.tags).toEqual([]);
   });
 
-  it('listTasks excludes abandoned by default', async () => {
+  it('listTasks excludes cancelled by default', async () => {
     const t1 = await adapter.createTask({ title: 't1' });
     await adapter.createTask({ title: 't2' });
 
-    // Transition t1 to in_progress then abandoned
+    // Transition t1 to in_progress then cancelled
     await adapter.transitionTask(t1.id, 'in_progress');
-    await adapter.transitionTask(t1.id, 'abandoned');
+    await adapter.transitionTask(t1.id, 'cancelled');
 
     const tasks = await adapter.listTasks();
-    expect(tasks.every((t) => t.status !== 'abandoned')).toBe(true);
+    expect(tasks.every((t) => t.status !== 'cancelled')).toBe(true);
     expect(tasks).toHaveLength(1);
   });
 
-  it('listTasks with includeAbandoned=true returns all', async () => {
+  it('listTasks with includeCancelled=true returns all', async () => {
     const t1 = await adapter.createTask({ title: 't1' });
     await adapter.createTask({ title: 't2' });
     await adapter.transitionTask(t1.id, 'in_progress');
-    await adapter.transitionTask(t1.id, 'abandoned');
+    await adapter.transitionTask(t1.id, 'cancelled');
 
     const tasks = await adapter.listTasks(true);
     expect(tasks).toHaveLength(2);
@@ -84,7 +84,7 @@ describe('TaskPouchAdapter (ITaskPort)', () => {
 
   it('transitionTask changes status via state machine', async () => {
     const task = await adapter.createTask({ title: '状态转换' });
-    expect(task.status).toBe('not_started');
+    expect(task.status).toBe('pending');
 
     const inProgress = await adapter.transitionTask(task.id, 'in_progress');
     expect(inProgress!.status).toBe('in_progress');
@@ -96,20 +96,20 @@ describe('TaskPouchAdapter (ITaskPort)', () => {
 
   it('transitionTask throws on invalid transition', async () => {
     const task = await adapter.createTask({ title: '非法转换' });
-    // not_started -> completed is invalid
+    // pending -> completed is invalid
     await expect(adapter.transitionTask(task.id, 'completed')).rejects.toThrow();
   });
 
-  it('abandonTask sets status to abandoned with completedAt', async () => {
-    const task = await adapter.createTask({ title: '放弃测试' });
+  it('cancelTask sets status to cancelled with completedAt', async () => {
+    const task = await adapter.createTask({ title: '取消测试' });
     await adapter.transitionTask(task.id, 'in_progress');
-    const abandoned = await adapter.abandonTask(task.id);
-    expect(abandoned!.status).toBe('abandoned');
-    expect(abandoned!.completedAt).toBeDefined();
+    const cancelled = await adapter.cancelTask(task.id);
+    expect(cancelled!.status).toBe('cancelled');
+    expect(cancelled!.completedAt).toBeDefined();
   });
 
-  it('abandonTask returns null for missing', async () => {
-    expect(await adapter.abandonTask('nope')).toBeNull();
+  it('cancelTask returns null for missing', async () => {
+    expect(await adapter.cancelTask('nope')).toBeNull();
   });
 
   it('getAvailableTransitions returns valid next states', async () => {
@@ -121,7 +121,7 @@ describe('TaskPouchAdapter (ITaskPort)', () => {
     const next = await adapter.getAvailableTransitions(task.id);
     expect(next).toContain('suspended');
     expect(next).toContain('completed');
-    expect(next).toContain('abandoned');
+    expect(next).toContain('cancelled');
   });
 
   it('getAvailableTransitions returns empty for missing', async () => {

--- a/tests/unit/adapters/task-rt-adapter.test.ts
+++ b/tests/unit/adapters/task-rt-adapter.test.ts
@@ -31,7 +31,7 @@ describe('TaskRtAdapter（RT 任务适配器）', () => {
           title: 'RT Task',
           description: 'from runtime',
           done_condition: 'ship feature',
-          status: 'not_started',
+          status: 'pending',
           priority: 'high',
           tags: ['rt'],
           source: 'runtime:test',
@@ -60,7 +60,7 @@ describe('TaskRtAdapter（RT 任务适配器）', () => {
         title: 'RT Task',
         description: 'from runtime',
         doneCondition: 'ship feature',
-        status: 'not_started',
+        status: 'pending',
         priority: 'high',
         tags: ['rt'],
         source: 'runtime:test',
@@ -89,7 +89,7 @@ describe('TaskRtAdapter（RT 任务适配器）', () => {
         title: 'Updated Task',
         description: 'from runtime',
         done_condition: 'ship feature',
-        status: 'not_started',
+        status: 'pending',
         priority: 'medium',
         tags: ['rt'],
         source: 'runtime:test',
@@ -127,5 +127,39 @@ describe('TaskRtAdapter（RT 任务适配器）', () => {
       time_block_ids: ['block-1', 'block-2'],
       estimated_minutes: 25,
     });
+  });
+
+  it('uses the cancel endpoint and normalizes legacy runtime status aliases', async () => {
+    const profileId = activateProfileScope();
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: 'task-2',
+        title: 'Cancelled Task',
+        status: 'abandoned',
+        priority: 'medium',
+        tags: [],
+        depends_on: [],
+        time_block_ids: [],
+        created_at: 1700000000100,
+        updated_at: 1700000000200,
+        completed_at: 1700000000200,
+      }),
+    }));
+
+    const adapter = new TaskRtAdapter({
+      fetchImpl,
+      resolveTarget: () => ({ mode: 'embedded', host: '127.0.0.1', port: 9124 }),
+    });
+
+    const task = await adapter.cancelTask('task-2');
+
+    expect(task?.status).toBe('cancelled');
+    const [requestUrl, requestInit] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const url = new URL(requestUrl);
+    expect(`${url.origin}${url.pathname}`).toBe('http://127.0.0.1:9124/tasks/task-2/cancel');
+    expect(url.searchParams.get('user_id')).toBe(profileId);
+    expect(requestInit?.method).toBe('POST');
   });
 });

--- a/tests/unit/pages/NowWorkbenchOverlayPage.runtime.test.tsx
+++ b/tests/unit/pages/NowWorkbenchOverlayPage.runtime.test.tsx
@@ -66,6 +66,54 @@ vi.mock('@/ui/app/components/NowInputRow', () => ({
   ),
 }));
 
+vi.mock('@/ui/app/components/FocusTimerWidget', async () => {
+  const React = await import('react');
+
+  const FocusTimerWidget = React.forwardRef(({ surface }: { surface?: string }, ref) => {
+    const [configTaskTitle, setConfigTaskTitle] = React.useState<string | null>(null);
+    const activeBlock = runtimeStateByUser[currentUserState.userId].activeBlock as
+      | null
+      | { mode?: string; name?: string };
+
+    React.useImperativeHandle(ref, () => ({
+      openTaskConfig: (taskTitle: string) => {
+        setConfigTaskTitle(taskTitle);
+      },
+    }), []);
+
+    if (configTaskTitle) {
+      return (
+        <div data-testid="new-focus-timer-widget" className={surface === 'overlay' ? 'bg-transparent' : ''}>
+          <div data-testid="new-focus-state-config">
+            <input data-testid="new-focus-task-input" value={configTaskTitle} readOnly />
+          </div>
+        </div>
+      );
+    }
+
+    if (activeBlock) {
+      return (
+        <div data-testid="new-focus-timer-widget" className={surface === 'overlay' ? 'bg-transparent' : ''}>
+          <div data-testid="new-focus-state-running">
+            <p>{activeBlock.name ?? '未命名时间块'}</p>
+            <p data-testid="new-focus-running-clock">{activeBlock.mode === 'countdown' ? '20:00' : '00:00'}</p>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div data-testid="new-focus-timer-widget" className={surface === 'overlay' ? 'bg-transparent' : ''}>
+        <div data-testid="new-focus-state-idle">idle</div>
+      </div>
+    );
+  });
+
+  return {
+    FocusTimerWidget,
+  };
+});
+
 vi.mock('@/lib/services', () => ({
   getTimeBlockService: () => ({
     loadActiveBlock: (...args: unknown[]) => loadActiveBlockMock(...args),
@@ -192,7 +240,7 @@ describe('NowWorkbenchOverlayPage runtime wiring（当下工作台悬浮窗运�
     overlaySetSizeMock.mockResolvedValue(undefined);
   });
 
-  it('loads running state from services when no explicit model is provided（无显式 model 时从服务加载运行态）', async () => {
+  it('loads running state from services when no explicit model is provided（无显式 model 时从服务加载运行态）', { timeout: 20000 }, async () => {
     vi.spyOn(Date, 'now').mockReturnValue(Date.UTC(2026, 2, 11, 9, 5, 0));
     runtimeStateByUser['overlay-test-user'].activeBlock = {
       startId: 'block-1',
@@ -512,7 +560,7 @@ describe('NowWorkbenchOverlayPage runtime wiring（当下工作台悬浮窗运�
     });
   });
 
-  it('refreshes against the latest current user context after prewarm（预热窗口后刷新会重新读取当前用户）', async () => {
+  it('refreshes against the latest current user context after prewarm（预热窗口后刷新会重新读取当前用户）', { timeout: 30000 }, async () => {
     currentUserState.userId = 'overlay-test-user';
     runtimeStateByUser['overlay-test-user'] = {
       activeBlock: null,
@@ -541,8 +589,10 @@ describe('NowWorkbenchOverlayPage runtime wiring（当下工作台悬浮窗运�
     const { NowWorkbenchOverlayPage } = await import('@/pages/NowWorkbenchOverlayPage');
     render(<NowWorkbenchOverlayPage />);
 
-    expect(await screen.findByTestId('now-overlay-idle-pill')).toBeInTheDocument();
-    expect(getEventStorageByUserMock).toHaveBeenCalledWith('overlay-test-user');
+    await waitFor(() => {
+      expect(getEventStorageByUserMock).toHaveBeenCalledWith('overlay-test-user');
+      expect(focusChangedListener).not.toBeNull();
+    });
 
     currentUserState.userId = 'profile-live';
     await act(async () => {
@@ -550,6 +600,8 @@ describe('NowWorkbenchOverlayPage runtime wiring（当下工作台悬浮窗运�
       await Promise.resolve();
     });
 
-    expect(getEventStorageByUserMock).toHaveBeenCalledWith('profile-live');
+    await waitFor(() => {
+      expect(getEventStorageByUserMock).toHaveBeenCalledWith('profile-live');
+    });
   });
 });

--- a/tests/unit/pages/NowWorkbenchOverlayPage.runtime.test.tsx
+++ b/tests/unit/pages/NowWorkbenchOverlayPage.runtime.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+﻿import React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -379,7 +379,7 @@ describe('NowWorkbenchOverlayPage runtime wiring（当下工作台悬浮窗运�
       {
         id: 'task-1',
         title: '先补测试',
-        status: 'not_started',
+        status: 'pending',
         priority: 'high',
         dependsOn: [],
         tags: [],
@@ -405,7 +405,7 @@ describe('NowWorkbenchOverlayPage runtime wiring（当下工作台悬浮窗运�
       {
         id: 'task-1',
         title: '写周报',
-        status: 'not_started',
+        status: 'pending',
         priority: 'high',
         dependsOn: [],
         tags: [],
@@ -415,7 +415,7 @@ describe('NowWorkbenchOverlayPage runtime wiring（当下工作台悬浮窗运�
       {
         id: 'task-2',
         title: '修 bug',
-        status: 'not_started',
+        status: 'pending',
         priority: 'medium',
         dependsOn: [],
         tags: [],
@@ -447,7 +447,7 @@ describe('NowWorkbenchOverlayPage runtime wiring（当下工作台悬浮窗运�
       {
         id: 'task-1',
         title: '写周报',
-        status: 'not_started',
+        status: 'pending',
         priority: 'high',
         dependsOn: [],
         tags: [],

--- a/tests/unit/pages/NowWorkbenchOverlayPage.test.tsx
+++ b/tests/unit/pages/NowWorkbenchOverlayPage.test.tsx
@@ -1,6 +1,6 @@
 ﻿import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NowWorkbenchOverlayModel } from '@/ui/app/overlay/now-workbench-overlay-model';
 
 const startDraggingMock = vi.fn();
@@ -53,13 +53,17 @@ function createModel(overrides: Partial<NowWorkbenchOverlayModel> = {}): NowWork
 
 describe('NowWorkbenchOverlayPage', () => {
   beforeEach(() => {
+    startDraggingMock.mockReset();
+    startDraggingMock.mockResolvedValue(undefined);
+    onMovedMock.mockReset();
+    movedListener = null;
+    setNowWorkbenchOverlayPositionMock.mockReset();
     setSizeMock.mockReset();
     setSizeMock.mockResolvedValue(undefined);
   });
 
-  it('starts native dragging from the title drag handle（按住标题拖拽柄可触发原生拖动）', async () => {
+  it('marks the title drag handle as a native tauri drag region（标题拖拽柄通过原生拖拽区域标记实现拖动）', { timeout: 30000 }, async () => {
     const { NowWorkbenchOverlayPage } = await import('@/pages/NowWorkbenchOverlayPage');
-    startDraggingMock.mockResolvedValue(undefined);
 
     render(
       <NowWorkbenchOverlayPage
@@ -71,12 +75,15 @@ describe('NowWorkbenchOverlayPage', () => {
       />,
     );
 
-    expect(screen.getByTestId('now-overlay-drag-handle')).toBeInTheDocument();
+    const dragHandle = screen.getByTestId('now-overlay-drag-handle');
+
+    expect(dragHandle).toBeInTheDocument();
+    expect(dragHandle).toHaveAttribute('data-tauri-drag-region');
     expect(screen.getByText('拖动窗口')).toBeInTheDocument();
 
-    fireEvent.mouseDown(screen.getByTestId('now-overlay-drag-handle'), { button: 0 });
+    fireEvent.mouseDown(dragHandle, { button: 0 });
 
-    expect(startDraggingMock).toHaveBeenCalledTimes(1);
+    expect(startDraggingMock).not.toHaveBeenCalled();
   });
 
   it('does not start dragging when clicking action buttons（点击窗口动作按钮时不应触发拖动）', async () => {

--- a/tests/unit/pages/NowWorkbenchOverlayPage.test.tsx
+++ b/tests/unit/pages/NowWorkbenchOverlayPage.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+﻿import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { NowWorkbenchOverlayModel } from '@/ui/app/overlay/now-workbench-overlay-model';
@@ -153,7 +153,7 @@ describe('NowWorkbenchOverlayPage', () => {
     expect(screen.getByTestId('new-now-input-row')).toBeInTheDocument();
   });
 
-  it('shows task choices when idle_with_tasks（有任务但未开始时显示任务入口）', async () => {
+  it('shows task choices when idle_with_tasks（有任务但待办时显示任务入口）', async () => {
     const { NowWorkbenchOverlayPage } = await import('@/pages/NowWorkbenchOverlayPage');
 
     render(
@@ -161,7 +161,7 @@ describe('NowWorkbenchOverlayPage', () => {
         model={createModel({
           mode: 'idle_with_tasks',
           title: '先补测试',
-          statusLabel: '未开始',
+          statusLabel: '待办',
           visibleTasks: [
             {
               id: 'task-1',
@@ -176,7 +176,7 @@ describe('NowWorkbenchOverlayPage', () => {
             {
               id: 'task-2',
               title: '整理输入区',
-              status: 'not_started',
+              status: 'pending',
               priority: 'medium',
               dependsOn: [],
               tags: [],

--- a/tests/unit/services/task-hierarchy.issue336.test.ts
+++ b/tests/unit/services/task-hierarchy.issue336.test.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Phase3 (#336) 父子层级 + 软硬依赖 单元测试
  *
  * 覆盖 TaskServiceImpl 的层级查询、依赖管理、环检测、依赖感知状态转换。
@@ -20,7 +20,7 @@ function makeTask(overrides: Partial<TaskNode> = {}): TaskNode {
   return {
     id: `t${idSeq}`,
     title: `Task ${idSeq}`,
-    status: 'not_started',
+    status: 'pending',
     priority: 'medium',
     dependsOn: [],
     tags: [],
@@ -48,10 +48,10 @@ function createMockPort(tasks: TaskNode[]): ITaskPort {
       store.set(id, updated)
       return updated
     }),
-    abandonTask: vi.fn(async (id: string) => {
+    cancelTask: vi.fn(async (id: string) => {
       const t = store.get(id)
       if (!t) return null
-      t.status = 'abandoned'
+      t.status = 'cancelled'
       t.completedAt = Date.now()
       return t
     }),
@@ -60,7 +60,7 @@ function createMockPort(tasks: TaskNode[]): ITaskPort {
       if (!t) return null
       t.status = to
       t.updatedAt = Date.now()
-      if (to === 'completed' || to === 'abandoned') t.completedAt = Date.now()
+      if (to === 'completed' || to === 'cancelled') t.completedAt = Date.now()
       return t
     }),
     getAvailableTransitions: vi.fn(async () => []),
@@ -299,8 +299,8 @@ describe('TaskService Phase3: dependency-aware transitions', () => {
     idSeq = 0
   })
 
-  it('transitionTask to in_progress blocked by hard dep (not_started)', async () => {
-    const dep = makeTask({ id: 'dep', status: 'not_started' })
+  it('transitionTask to in_progress blocked by hard dep (pending)', async () => {
+    const dep = makeTask({ id: 'dep', status: 'pending' })
     const task = makeTask({ id: 'task', dependsOn: [{ taskId: 'dep', type: 'hard' }] })
     port = createMockPort([dep, task])
     service = new TaskServiceImpl({ task: port })
@@ -332,20 +332,20 @@ describe('TaskService Phase3: dependency-aware transitions', () => {
     expect(result!.status).toBe('in_progress')
   })
 
-  it('soft dep blocks only when not_started', async () => {
-    const dep = makeTask({ id: 'dep', status: 'not_started' })
+  it('soft dep blocks only when pending', async () => {
+    const dep = makeTask({ id: 'dep', status: 'pending' })
     const task = makeTask({ id: 'task', dependsOn: [{ taskId: 'dep', type: 'soft' }] })
     port = createMockPort([dep, task])
     service = new TaskServiceImpl({ task: port })
 
-    // Soft dep is not_started → blocking but NOT hard, so transition allowed
+    // Soft dep is pending → blocking but NOT hard, so transition allowed
     const result = await service.transitionTask('task', 'in_progress')
     expect(result).not.toBeNull()
     expect(result!.status).toBe('in_progress')
   })
 
   it('transitionTask to non-in_progress skips dep check', async () => {
-    const dep = makeTask({ id: 'dep', status: 'not_started' })
+    const dep = makeTask({ id: 'dep', status: 'pending' })
     const task = makeTask({
       id: 'task',
       status: 'in_progress',
@@ -401,8 +401,8 @@ describe('TaskService Phase3: checkDependenciesMet', () => {
     expect(result.blocking[0]).toEqual({ taskId: 'dep', type: 'hard', status: 'in_progress' })
   })
 
-  it('soft dep not_started → blocking', async () => {
-    const dep = makeTask({ id: 'dep', status: 'not_started' })
+  it('soft dep pending → blocking', async () => {
+    const dep = makeTask({ id: 'dep', status: 'pending' })
     const task = makeTask({ id: 'task', dependsOn: [{ taskId: 'dep', type: 'soft' }] })
     port = createMockPort([dep, task])
     service = new TaskServiceImpl({ task: port })

--- a/tests/unit/services/task-timer.issue337.test.ts
+++ b/tests/unit/services/task-timer.issue337.test.ts
@@ -1,9 +1,9 @@
-/**
+﻿/**
  * Phase4 (#337) 任务↔时间块 1:N 计时关联 单元测试
  *
  * 覆盖 TaskTimerServiceImpl：
  * - startBlockForTask 创建时间块并关联到任务
- * - startBlockForTask 自动将 not_started 转为 in_progress
+ * - startBlockForTask 自动将 pending 转为 in_progress
  * - onBlockEndForTask 追加 blockId 到 timeBlockIds
  * - getBlockIdsForTask 返回已关联的时间块列表
  * - calculateSpentMinutes 正确累计
@@ -24,7 +24,7 @@ function makeTask(overrides: Partial<TaskNode> = {}): TaskNode {
   return {
     id: 'task-1',
     title: 'Test Task',
-    status: 'not_started',
+    status: 'pending',
     priority: 'medium',
     dependsOn: [],
     tags: [],
@@ -79,7 +79,7 @@ function createMockTaskService(tasks: Map<string, TaskNode>): TaskService {
       tasks.set(id, updated)
       return updated
     }),
-    abandonTask: vi.fn(async () => null),
+    cancelTask: vi.fn(async () => null),
     transitionTask: vi.fn(async (id: string, to) => {
       const t = tasks.get(id)
       if (!t) return null
@@ -134,8 +134,8 @@ describe('TaskTimerService: startBlockForTask', () => {
     })
   })
 
-  it('auto-transitions not_started to in_progress', async () => {
-    const tasks = new Map([['t1', makeTask({ id: 't1', status: 'not_started' })]])
+  it('auto-transitions pending to in_progress', async () => {
+    const tasks = new Map([['t1', makeTask({ id: 't1', status: 'pending' })]])
     const taskSvc = createMockTaskService(tasks)
     const tbSvc = createMockTBService()
     const svc = new TaskTimerServiceImpl(taskSvc, tbSvc)
@@ -177,8 +177,8 @@ describe('TaskTimerService: startBlockForTask', () => {
     expect(tbSvc.startBlock).not.toHaveBeenCalled()
   })
 
-  it('returns null for abandoned task', async () => {
-    const tasks = new Map([['t1', makeTask({ id: 't1', status: 'abandoned' })]])
+  it('returns null for cancelled task', async () => {
+    const tasks = new Map([['t1', makeTask({ id: 't1', status: 'cancelled' })]])
     const taskSvc = createMockTaskService(tasks)
     const tbSvc = createMockTBService()
     const svc = new TaskTimerServiceImpl(taskSvc, tbSvc)

--- a/tests/unit/storage/task-storage.test.ts
+++ b/tests/unit/storage/task-storage.test.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * TaskStorage 单元测试
  *
  * 测试 PouchDB 存储层的 CRUD、索引查询、数据迁移。
@@ -12,7 +12,7 @@ function makeTask(overrides: Partial<TaskNode> & { id: string }): TaskNode {
   const now = Date.now();
   return {
     title: overrides.id,
-    status: 'not_started',
+    status: 'pending',
     priority: 'medium',
     dependsOn: [],
     tags: [],
@@ -43,7 +43,7 @@ describe('TaskStorage CRUD', () => {
     expect(retrieved).toBeDefined();
     expect(retrieved!.id).toBe('task-1');
     expect(retrieved!.title).toBe('测试任务');
-    expect(retrieved!.status).toBe('not_started');
+    expect(retrieved!.status).toBe('pending');
   });
 
   it('getTask returns undefined for missing id', async () => {
@@ -125,7 +125,7 @@ describe('TaskStorage index queries', () => {
 
   it('getTasksByStatus filters correctly', async () => {
     await storage.addTask(makeTask({ id: 's1', status: 'in_progress' }));
-    await storage.addTask(makeTask({ id: 's2', status: 'not_started' }));
+    await storage.addTask(makeTask({ id: 's2', status: 'pending' }));
     await storage.addTask(makeTask({ id: 's3', status: 'in_progress' }));
 
     const inProgress = await storage.getTasksByStatus('in_progress');

--- a/tests/unit/ui/estimated-time-editor.issue384.test.tsx
+++ b/tests/unit/ui/estimated-time-editor.issue384.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+﻿import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { TaskNode } from '@/lib/types/task';
 import { EstimatedTimeEditor } from '@/ui/app/components/EstimatedTimeEditor';
@@ -15,7 +15,7 @@ function makeTask(overrides: Partial<TaskNode> = {}): TaskNode {
   return {
     id: 'task-1',
     title: '补 EstimatedTimeEditor',
-    status: 'not_started',
+    status: 'pending',
     priority: 'medium',
     dependsOn: [],
     tags: ['issue-384'],

--- a/tests/unit/ui/now-workbench-overlay-model.test.ts
+++ b/tests/unit/ui/now-workbench-overlay-model.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+﻿import { describe, expect, it } from 'vitest';
 import type { Event, ActiveBlockData } from '@/lib/types/event';
 import type { TaskNode } from '@/lib/types/task';
 
@@ -88,13 +88,13 @@ describe('now workbench overlay model（当下工作台悬浮窗视图模型）'
         createTask({
           id: 'task-due-first',
           title: '补模型',
-          status: 'not_started',
+          status: 'pending',
           dueAt: Date.UTC(2026, 2, 11, 10, 0, 0),
         }),
         createTask({
           id: 'task-no-due',
           title: '整理文档',
-          status: 'not_started',
+          status: 'pending',
           updatedAt: Date.UTC(2026, 2, 11, 8, 0, 0),
         }),
       ],
@@ -103,7 +103,7 @@ describe('now workbench overlay model（当下工作台悬浮窗视图模型）'
     });
 
     expect(model.mode).toBe('idle_with_tasks');
-    expect(model.statusLabel).toBe('未开始');
+    expect(model.statusLabel).toBe('待办');
     expect(model.visibleTasks.map((task) => task.id)).toEqual([
       'task-in-progress',
       'task-due-first',
@@ -117,9 +117,9 @@ describe('now workbench overlay model（当下工作台悬浮窗视图模型）'
       activeBlock: null,
       tasks: [
         createTask({
-          id: 'task-abandoned',
-          title: '放弃的任务',
-          status: 'abandoned',
+          id: 'task-cancelled',
+          title: '取消的任务',
+          status: 'cancelled',
         }),
       ],
       events: [],

--- a/tests/unit/ui/task-command-palette.issue243.test.tsx
+++ b/tests/unit/ui/task-command-palette.issue243.test.tsx
@@ -1,5 +1,6 @@
 ﻿import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { TasksPage } from '@/ui/app/pages/TasksPage';
 
 const openPaletteMock = vi.fn();
@@ -8,6 +9,10 @@ const listTasksMock = vi.fn();
 const runtimeFlags = vi.hoisted(() => ({
   developerModeEnabled: true,
   commandPaletteEnabled: true,
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children?: ReactNode }) => <a {...props}>{children}</a>,
 }));
 
 vi.mock('@/lib/services', () => ({

--- a/tests/unit/ui/task-command-palette.issue243.test.tsx
+++ b/tests/unit/ui/task-command-palette.issue243.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+﻿import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { TasksPage } from '@/ui/app/pages/TasksPage';
 
@@ -16,7 +16,7 @@ vi.mock('@/lib/services', () => ({
     createTask: vi.fn(),
     getTask: vi.fn(),
     updateTask: vi.fn(),
-    abandonTask: vi.fn(),
+    cancelTask: vi.fn(),
     transitionTask: vi.fn(),
     getAvailableTransitions: vi.fn(async () => []),
     getChildTasks: vi.fn(async () => []),

--- a/tests/unit/ui/task-current-root-card.issue411.test.tsx
+++ b/tests/unit/ui/task-current-root-card.issue411.test.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+﻿import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { buildTaskGraph } from '@/lib/task/task-dag-graph';
@@ -14,7 +14,7 @@ function makeTask(overrides: Partial<TaskNode> & { id: string; title: string }):
     id: overrides.id,
     title: overrides.title,
     description: undefined,
-    status: 'not_started',
+    status: 'pending',
     priority: 'medium',
     dependsOn: [],
     tags: [],
@@ -88,7 +88,7 @@ describe('TaskCurrentRootCard issue-411（当前根节点按未阻塞判定）',
     const softSource = makeTask({
       id: 'soft-source',
       title: '软依赖前置',
-      status: 'not_started',
+      status: 'pending',
       createdAt: 10,
       updatedAt: 10,
     });

--- a/tests/unit/ui/task-dag-detail-view.issue395.test.ts
+++ b/tests/unit/ui/task-dag-detail-view.issue395.test.ts
@@ -7,7 +7,7 @@ function makeTask(overrides: Partial<TaskNode> & Pick<TaskNode, 'id' | 'title'>)
     id: overrides.id,
     title: overrides.title,
     description: '',
-    status: 'not_started',
+    status: 'pending',
     priority: 'medium',
     dependsOn: [],
     tags: [],

--- a/tests/unit/ui/task-dag-graph.issue394.test.ts
+++ b/tests/unit/ui/task-dag-graph.issue394.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+﻿import { describe, expect, it } from 'vitest'
 import type { TaskNode } from '@/lib/types/task'
 import { buildTaskGraph } from '@/lib/task/task-dag-graph'
 
@@ -6,7 +6,7 @@ function makeTask(overrides: Partial<TaskNode> & Pick<TaskNode, 'id' | 'title'>)
   return {
     id: overrides.id,
     title: overrides.title,
-    status: 'not_started',
+    status: 'pending',
     priority: 'medium',
     dependsOn: [],
     tags: [],
@@ -73,7 +73,7 @@ describe('buildTaskGraph issue-394（任务 DAG 图基础层）', () => {
     ])
   })
 
-  it('skips completed and abandoned roots when selecting the current root node', () => {
+  it('skips completed and cancelled roots when selecting the current root node', () => {
     const completedRoot = makeTask({
       id: 'done',
       title: 'Completed Root',
@@ -81,16 +81,16 @@ describe('buildTaskGraph issue-394（任务 DAG 图基础层）', () => {
       createdAt: 10,
       updatedAt: 10,
     })
-    const abandonedRoot = makeTask({
+    const cancelledRoot = makeTask({
       id: 'gone',
       title: 'Abandoned Root',
-      status: 'abandoned',
+      status: 'cancelled',
       createdAt: 20,
       updatedAt: 20,
     })
     const activeRoot = makeTask({ id: 'live', title: 'Live Root', createdAt: 30, updatedAt: 30 })
 
-    const graph = buildTaskGraph([activeRoot, abandonedRoot, completedRoot])
+    const graph = buildTaskGraph([activeRoot, cancelledRoot, completedRoot])
 
     expect(graph.rootNodeIds).toEqual(['done', 'gone', 'live'])
     expect(graph.currentRootNodeId).toBe('live')
@@ -147,7 +147,7 @@ describe('buildTaskGraph issue-394（任务 DAG 图基础层）', () => {
     const softSource = makeTask({
       id: 'soft-source',
       title: 'Soft Source',
-      status: 'not_started',
+      status: 'pending',
       createdAt: 20,
       updatedAt: 20,
     })

--- a/tests/unit/ui/task-dag-page.issue394.test.tsx
+++ b/tests/unit/ui/task-dag-page.issue394.test.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+﻿import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { TaskDagPage } from '@/ui/app/pages/TaskDagPage';
@@ -74,7 +74,7 @@ function makeTask(overrides: Partial<TaskNode> & { id: string; title: string }):
     id: overrides.id,
     title: overrides.title,
     description: undefined,
-    status: 'not_started',
+    status: 'pending',
     priority: 'medium',
     dependsOn: [],
     tags: [],

--- a/tests/unit/ui/task-dag-visibility.issue395.test.ts
+++ b/tests/unit/ui/task-dag-visibility.issue395.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+﻿import { describe, expect, it } from 'vitest'
 import type { TaskNode } from '@/lib/types/task'
 import { buildTaskGraph } from '@/lib/task/task-dag-graph'
 import { projectVisibleTaskGraph } from '@/lib/task/task-dag-visibility'
@@ -7,7 +7,7 @@ function makeTask(overrides: Partial<TaskNode> & Pick<TaskNode, 'id' | 'title'>)
   return {
     id: overrides.id,
     title: overrides.title,
-    status: 'not_started',
+    status: 'pending',
     priority: 'medium',
     dependsOn: [],
     tags: [],
@@ -157,7 +157,7 @@ describe('projectVisibleTaskGraph issue-395（任务 DAG 折叠投影第一阶�
     const softSource = makeTask({
       id: 'soft-source',
       title: 'Soft Source',
-      status: 'not_started',
+      status: 'pending',
       createdAt: 20,
       updatedAt: 20,
     })

--- a/tests/unit/ui/task-dependency-view.issue398-p1.test.ts
+++ b/tests/unit/ui/task-dependency-view.issue398-p1.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+﻿import { describe, expect, it } from 'vitest';
 import type { TaskNode } from '@/lib/types/task';
 import { buildTaskDependencyView } from '@/ui/app/pages/task-dependency-view';
 
@@ -7,7 +7,7 @@ function makeTask(overrides: Partial<TaskNode> & Pick<TaskNode, 'id' | 'title'>)
     id: overrides.id,
     title: overrides.title,
     description: '',
-    status: 'not_started',
+    status: 'pending',
     priority: 'medium',
     dependsOn: [],
     tags: [],
@@ -42,21 +42,21 @@ describe('buildTaskDependencyView issue #398 P1', () => {
     expect(view.candidates.map((candidate) => candidate.id)).toEqual(['task-3']);
   });
 
-  it('marks abandoned tasks as disabled（已放弃任务标记禁用）', () => {
+  it('marks cancelled tasks as disabled（已取消任务标记禁用）', () => {
     const currentTask = makeTask({ id: 'task-1', title: '当前任务' });
-    const abandonedTask = makeTask({
+    const cancelledTask = makeTask({
       id: 'task-2',
-      title: '已放弃任务',
-      status: 'abandoned',
+      title: '已取消任务',
+      status: 'cancelled',
     });
 
-    const view = buildTaskDependencyView(currentTask, [currentTask, abandonedTask]);
+    const view = buildTaskDependencyView(currentTask, [currentTask, cancelledTask]);
     const candidate = view.candidates.find((item) => item.id === 'task-2');
 
     expect(candidate).toMatchObject({
       id: 'task-2',
       disabled: true,
-      disabledReason: '任务已放弃',
+      disabledReason: '任务已取消',
     });
   });
 

--- a/tests/unit/ui/task-detail-page.dag-visibility.issue395.test.tsx
+++ b/tests/unit/ui/task-detail-page.dag-visibility.issue395.test.tsx
@@ -21,7 +21,7 @@ const getTaskMock = vi.fn<(id: string) => Promise<TaskNode | null>>(async (id) =
   return cloneTask(tasksState.find((task) => task.id === id) ?? null);
 });
 
-const listTasksMock = vi.fn<(includeAbandoned?: boolean) => Promise<TaskNode[]>>(async () => {
+const listTasksMock = vi.fn<(includeCancelled?: boolean) => Promise<TaskNode[]>>(async () => {
   return cloneTasks(tasksState);
 });
 
@@ -76,7 +76,7 @@ vi.mock('@/lib/services', () => ({
     checkDependenciesMet: vi.fn(async () => ({ met: true, blocking: [] })),
     transitionTask: vi.fn(),
     updateTask: vi.fn(),
-    abandonTask: vi.fn(),
+    cancelTask: vi.fn(),
   }),
   getTimeBlockService: () => ({
     loadTimeBlocks: loadTimeBlocksMock,
@@ -117,7 +117,7 @@ function makeTask(overrides: Partial<TaskNode> & Pick<TaskNode, 'id' | 'title'>)
     id: overrides.id,
     title: overrides.title,
     description: '',
-    status: 'not_started',
+    status: 'pending',
     priority: 'medium',
     dependsOn: [],
     tags: [],

--- a/tests/unit/ui/task-detail-page.dag-visibility.issue395.test.tsx
+++ b/tests/unit/ui/task-detail-page.dag-visibility.issue395.test.tsx
@@ -258,11 +258,14 @@ describe('TaskDetailPage DAG visibility issue #395', () => {
     renderPage();
 
     expect(await screen.findByText('依赖图')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('task-dag-toggle-upstream-task-1')).toBeEnabled();
+    });
     fireEvent.click(screen.getByTestId('task-dag-toggle-upstream-task-1'));
 
     await waitFor(() => {
       expect(screen.queryByTestId('task-dag-node-task-2')).not.toBeInTheDocument();
-    });
+    }, { timeout: 5000 });
 
     expect(screen.getByTestId('task-dag-root-summary')).toHaveTextContent('当前可见根：无');
     expect(screen.getByTestId('task-dag-root-summary')).toHaveTextContent('真实当前根：无');

--- a/tests/unit/ui/task-detail-page.dependencies.issue398.test.tsx
+++ b/tests/unit/ui/task-detail-page.dependencies.issue398.test.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+﻿import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { TaskDetailPage } from '@/ui/app/pages/TaskDetailPage';
@@ -23,7 +23,7 @@ const getTaskMock = vi.fn<(id: string) => Promise<TaskNode | null>>(async (id) =
   return cloneTask(tasksState.find((task) => task.id === id) ?? null);
 });
 
-const listTasksMock = vi.fn<(includeAbandoned?: boolean) => Promise<TaskNode[]>>(async () => {
+const listTasksMock = vi.fn<(includeCancelled?: boolean) => Promise<TaskNode[]>>(async () => {
   return cloneTasks(tasksState);
 });
 
@@ -87,7 +87,7 @@ vi.mock('@/lib/services', () => ({
     checkDependenciesMet: vi.fn(async () => ({ met: true, blocking: [] })),
     transitionTask: vi.fn(),
     updateTask: vi.fn(),
-    abandonTask: vi.fn(),
+    cancelTask: vi.fn(),
   }),
   getTimeBlockService: () => ({
     loadTimeBlocks: loadTimeBlocksMock,
@@ -128,7 +128,7 @@ function makeTask(overrides: Partial<TaskNode> = {}): TaskNode {
     id: 'task-1',
     title: '任务详情：依赖关系 MVP',
     description: '在详情页增加依赖关系卡片',
-    status: 'not_started',
+    status: 'pending',
     priority: 'high',
     dependsOn: [],
     tags: ['issue-398'],
@@ -249,17 +249,17 @@ describe('TaskDetailPage dependencies issue #398 P0', () => {
     tasksState.push(makeTask({
       id: 'task-4',
       title: '归档旧方案',
-      status: 'abandoned',
+      status: 'cancelled',
       timeBlockIds: [],
     }));
     renderPage();
 
     const taskSelect = await screen.findByTestId('dependency-add-task-select');
 
-    expect(within(taskSelect).queryByRole('option', { name: '实现依赖关系卡片 · 未开始' })).not.toBeInTheDocument();
+    expect(within(taskSelect).queryByRole('option', { name: '实现依赖关系卡片 · 待办' })).not.toBeInTheDocument();
     expect(within(taskSelect).getByRole('option', { name: '补 task.service 单测 · 进行中' })).not.toBeDisabled();
     expect(within(taskSelect).getByRole('option', { name: '联调任务详情页 · 已完成 · 会形成循环依赖' })).toBeDisabled();
-    expect(within(taskSelect).getByRole('option', { name: '归档旧方案 · 已放弃 · 任务已放弃' })).toBeDisabled();
+    expect(within(taskSelect).getByRole('option', { name: '归档旧方案 · 已取消 · 任务已取消' })).toBeDisabled();
 
     fireEvent.change(taskSelect, { target: { value: 'task-3' } });
 

--- a/tests/unit/ui/task-detail-page.estimated-time-race.issue384.test.tsx
+++ b/tests/unit/ui/task-detail-page.estimated-time-race.issue384.test.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+﻿import type { ReactNode } from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TaskDetailPage } from '@/ui/app/pages/TaskDetailPage';
@@ -9,7 +9,7 @@ let routeTaskId = 'task-1';
 
 const navigateMock = vi.fn();
 const getTaskMock = vi.fn<(id: string) => Promise<TaskNode | null>>();
-const listTasksMock = vi.fn<(includeAbandoned?: boolean) => Promise<TaskNode[]>>();
+const listTasksMock = vi.fn<(includeCancelled?: boolean) => Promise<TaskNode[]>>();
 const updateTaskMock = vi.fn<(id: string, input: { estimatedMinutes?: number }) => Promise<TaskNode | null>>();
 const onTaskChangeMock = vi.fn(() => () => {});
 
@@ -39,7 +39,7 @@ vi.mock('@/lib/services', () => ({
     onTaskChange: onTaskChangeMock,
     transitionTask: vi.fn(),
     updateTask: updateTaskMock,
-    abandonTask: vi.fn(),
+    cancelTask: vi.fn(),
   }),
   getTimeBlockService: () => ({
     loadTimeBlocks: loadTimeBlocksMock,

--- a/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
+++ b/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+﻿import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { TaskDetailPage } from '@/ui/app/pages/TaskDetailPage';
@@ -8,7 +8,7 @@ import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
 const navigateMock = vi.fn();
 
 const getTaskMock = vi.fn<(id: string) => Promise<TaskNode | null>>();
-const listTasksMock = vi.fn<(includeAbandoned?: boolean) => Promise<TaskNode[]>>();
+const listTasksMock = vi.fn<(includeCancelled?: boolean) => Promise<TaskNode[]>>();
 const addDependencyMock = vi.fn<(taskId: string, depTaskId: string, type: 'soft' | 'hard') => Promise<TaskNode | null>>();
 const removeDependencyMock = vi.fn<(taskId: string, depTaskId: string) => Promise<TaskNode | null>>();
 const getAvailableTransitionsMock = vi.fn<(id: string) => Promise<Array<TaskNode['status']>>>();
@@ -47,7 +47,7 @@ vi.mock('@/lib/services', () => ({
     onTaskChange: onTaskChangeMock,
     transitionTask: vi.fn(),
     updateTask: vi.fn(),
-    abandonTask: vi.fn(),
+    cancelTask: vi.fn(),
   }),
   getTimeBlockService: () => ({
     loadTimeBlocks: loadTimeBlocksMock,
@@ -128,7 +128,7 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
           id: 'task-2',
           title: '切换后的任务 B',
           estimatedMinutes: 30,
-          status: 'not_started',
+          status: 'pending',
           createdAt: 30,
           updatedAt: 30,
         });
@@ -140,7 +140,7 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
       makeTask({
         id: 'task-root',
         title: '优先收口 DAG 根节点',
-        status: 'not_started',
+        status: 'pending',
         createdAt: 10,
         updatedAt: 10,
       }),
@@ -155,7 +155,7 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
         id: 'task-2',
         title: '切换后的任务 B',
         estimatedMinutes: 30,
-        status: 'not_started',
+        status: 'pending',
         createdAt: 30,
         updatedAt: 30,
       }),
@@ -279,7 +279,7 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
           id: 'task-2',
           title: '切换后的任务 B',
           estimatedMinutes: 30,
-          status: 'not_started',
+          status: 'pending',
           createdAt: 30,
           updatedAt: 30,
         });

--- a/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
+++ b/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
@@ -232,7 +232,9 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
 
     await screen.findByText('时间块详情');
 
-    expect(screen.getByTestId('task-countdown-custom-trigger')).toHaveTextContent('120m');
+    await waitFor(() => {
+      expect(screen.getByTestId('task-countdown-custom-trigger')).toHaveTextContent('120m');
+    });
 
     fireEvent.click(screen.getByText('开始计时'));
 

--- a/tests/unit/ui/task-tab-filters.issue338.test.ts
+++ b/tests/unit/ui/task-tab-filters.issue338.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+﻿import { describe, expect, it } from 'vitest';
 import type { TaskNode } from '@/lib/types/task';
 import {
   filterMonth,
@@ -15,7 +15,7 @@ function makeTask(overrides: Partial<TaskNode> & { id: string }): TaskNode {
   return {
     title: overrides.id,
     description: undefined,
-    status: 'not_started',
+    status: 'pending',
     priority: 'medium',
     dependsOn: [],
     tags: [],
@@ -68,8 +68,8 @@ describe('sortByDue（排序契约）', () => {
 /* ── isExecutable ── */
 
 describe('isExecutable（可执行判定）', () => {
-  it('not_started with no deps is executable', () => {
-    const task = makeTask({ id: 'a', status: 'not_started', dependsOn: [] });
+  it('pending with no deps is executable', () => {
+    const task = makeTask({ id: 'a', status: 'pending', dependsOn: [] });
     expect(isExecutable(task, [task])).toBe(true);
   });
 
@@ -78,21 +78,21 @@ describe('isExecutable（可执行判定）', () => {
     expect(isExecutable(task, [task])).toBe(false);
   });
 
-  it('not_started with completed hard dep is executable', () => {
+  it('pending with completed hard dep is executable', () => {
     const dep = makeTask({ id: 'dep', status: 'completed' });
-    const task = makeTask({ id: 'a', status: 'not_started', dependsOn: [{ taskId: 'dep', type: 'hard' }] });
+    const task = makeTask({ id: 'a', status: 'pending', dependsOn: [{ taskId: 'dep', type: 'hard' }] });
     expect(isExecutable(task, [dep, task])).toBe(true);
   });
 
-  it('not_started with incomplete hard dep is not executable', () => {
+  it('pending with incomplete hard dep is not executable', () => {
     const dep = makeTask({ id: 'dep', status: 'in_progress' });
-    const task = makeTask({ id: 'a', status: 'not_started', dependsOn: [{ taskId: 'dep', type: 'hard' }] });
+    const task = makeTask({ id: 'a', status: 'pending', dependsOn: [{ taskId: 'dep', type: 'hard' }] });
     expect(isExecutable(task, [dep, task])).toBe(false);
   });
 
   it('soft deps do not block execution', () => {
-    const dep = makeTask({ id: 'dep', status: 'not_started' });
-    const task = makeTask({ id: 'a', status: 'not_started', dependsOn: [{ taskId: 'dep', type: 'soft' }] });
+    const dep = makeTask({ id: 'dep', status: 'pending' });
+    const task = makeTask({ id: 'a', status: 'pending', dependsOn: [{ taskId: 'dep', type: 'soft' }] });
     expect(isExecutable(task, [dep, task])).toBe(true);
   });
 });
@@ -102,34 +102,34 @@ describe('isExecutable（可执行判定）', () => {
 describe('filterNow（"当下" tab）', () => {
   it('pins in_progress tasks to top', () => {
     const active = makeTask({ id: 'a', status: 'in_progress', updatedAt: 1 });
-    const idle = makeTask({ id: 'b', status: 'not_started', updatedAt: 2 });
+    const idle = makeTask({ id: 'b', status: 'pending', updatedAt: 2 });
     const result = filterNow([idle, active]);
     expect(result[0].id).toBe('a');
   });
 
-  it('shows all non-abandoned tasks', () => {
-    const t1 = makeTask({ id: 't1', status: 'not_started', updatedAt: 1 });
-    const t2 = makeTask({ id: 't2', status: 'not_started', updatedAt: 2 });
+  it('shows all non-cancelled tasks', () => {
+    const t1 = makeTask({ id: 't1', status: 'pending', updatedAt: 1 });
+    const t2 = makeTask({ id: 't2', status: 'pending', updatedAt: 2 });
     const t3 = makeTask({ id: 't3', status: 'suspended', updatedAt: 3 });
     expect(filterNow([t1, t2, t3]).length).toBe(3);
   });
 
   it('sorts non-in_progress tasks by due date', () => {
-    const withDue = makeTask({ id: 'a', status: 'not_started', dueAt: 100, updatedAt: 1 });
-    const noDue = makeTask({ id: 'b', status: 'not_started', updatedAt: 999 });
+    const withDue = makeTask({ id: 'a', status: 'pending', dueAt: 100, updatedAt: 1 });
+    const noDue = makeTask({ id: 'b', status: 'pending', updatedAt: 999 });
     const result = filterNow([noDue, withDue]);
     expect(result.map((t) => t.id)).toEqual(['a', 'b']);
   });
 
-  it('excludes abandoned tasks', () => {
-    const abandoned = makeTask({ id: 'x', status: 'abandoned' });
+  it('excludes cancelled tasks', () => {
+    const cancelled = makeTask({ id: 'x', status: 'cancelled' });
     const ok = makeTask({ id: 'y', status: 'in_progress' });
-    expect(filterNow([abandoned, ok]).map((t) => t.id)).toEqual(['y']);
+    expect(filterNow([cancelled, ok]).map((t) => t.id)).toEqual(['y']);
   });
 
   it('no limit on total tasks shown', () => {
     const tasks = Array.from({ length: 10 }, (_, i) =>
-      makeTask({ id: `t${i}`, status: 'not_started', updatedAt: i }),
+      makeTask({ id: `t${i}`, status: 'pending', updatedAt: i }),
     );
     expect(filterNow(tasks).length).toBe(10);
   });
@@ -165,8 +165,8 @@ describe('filterToday（"今日" tab）', () => {
     expect(result).toEqual([]);
   });
 
-  it('excludes abandoned tasks', () => {
-    const task = makeTask({ id: 'a', status: 'abandoned', dueAt: todayStart + 1000, updatedAt: todayStart });
+  it('excludes cancelled tasks', () => {
+    const task = makeTask({ id: 'a', status: 'cancelled', dueAt: todayStart + 1000, updatedAt: todayStart });
     expect(filterToday([task], today)).toEqual([]);
   });
 
@@ -200,8 +200,8 @@ describe('filterWeek（"一周" tab）', () => {
     expect(filterWeek([task], now).map((t) => t.id)).toEqual(['a']);
   });
 
-  it('excludes abandoned tasks', () => {
-    const task = makeTask({ id: 'a', status: 'abandoned', dueAt: nowMs + 1000, updatedAt: nowMs });
+  it('excludes cancelled tasks', () => {
+    const task = makeTask({ id: 'a', status: 'cancelled', dueAt: nowMs + 1000, updatedAt: nowMs });
     expect(filterWeek([task], now)).toEqual([]);
   });
 
@@ -241,8 +241,8 @@ describe('filterMonth（"月" tab）', () => {
     expect(filterMonth([task], now).map((t) => t.id)).toEqual(['a']);
   });
 
-  it('excludes abandoned tasks', () => {
-    const task = makeTask({ id: 'a', status: 'abandoned', dueAt: monthStart + 1000, updatedAt: monthStart });
+  it('excludes cancelled tasks', () => {
+    const task = makeTask({ id: 'a', status: 'cancelled', dueAt: monthStart + 1000, updatedAt: monthStart });
     expect(filterMonth([task], now)).toEqual([]);
   });
 });

--- a/tests/unit/ui/tasks-page-today-view.test.tsx
+++ b/tests/unit/ui/tasks-page-today-view.test.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+﻿import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { TasksPage } from '@/ui/app/pages/TasksPage';
@@ -19,7 +19,7 @@ vi.mock('@/lib/services', () => ({
     createTask: vi.fn(),
     getTask: vi.fn(),
     updateTask: vi.fn(),
-    abandonTask: vi.fn(),
+    cancelTask: vi.fn(),
     transitionTask: vi.fn(),
     getAvailableTransitions: vi.fn(async () => []),
     getChildTasks: vi.fn(async () => []),
@@ -42,7 +42,7 @@ function makeTask(overrides: Partial<TaskNode> & { id: string; title: string }):
     id: overrides.id,
     title: overrides.title,
     description: undefined,
-    status: 'not_started',
+    status: 'pending',
     priority: 'medium',
     dependsOn: [],
     tags: [],
@@ -89,7 +89,7 @@ describe('TasksPage today view（任务页今日时间块视图）', () => {
       makeTask({
         id: 'task-2',
         title: '实现下午编码任务',
-        status: 'not_started',
+        status: 'pending',
         dueAt: afternoon,
         createdAt: 100,
         updatedAt: afternoon,

--- a/tests/unit/ui/tasks-today-timeblock-view.test.ts
+++ b/tests/unit/ui/tasks-today-timeblock-view.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+﻿import { describe, expect, it } from 'vitest';
 import type { TaskNode } from '@/lib/types/task';
 import type { TimeBlock } from '@/lib/types/event';
 import { buildTasksTodayViewModel } from '@/ui/app/pages/tasks-today-view';
@@ -8,7 +8,7 @@ function makeTask(overrides: Partial<TaskNode> & { id: string; title: string }):
     id: overrides.id,
     title: overrides.title,
     description: undefined,
-    status: 'not_started',
+    status: 'pending',
     priority: 'medium',
     dependsOn: [],
     tags: [],
@@ -60,7 +60,7 @@ describe('buildTasksTodayViewModel（任务页 today 时间块视图模型）', 
       tasks: [
         makeTask({ id: 'task-1', title: '完成 Task List 视图设计', status: 'in_progress', updatedAt: morning }),
         makeTask({ id: 'task-2', title: '实现 Today 时间块卡片', status: 'in_progress', updatedAt: afternoon }),
-        makeTask({ id: 'task-3', title: '补充回归测试', status: 'not_started', dueAt: night, updatedAt: night }),
+        makeTask({ id: 'task-3', title: '补充回归测试', status: 'pending', dueAt: night, updatedAt: night }),
       ],
       blocks: [],
       now: today,

--- a/tests/unit/ui/timeblock-detail-back-link.issue406.test.tsx
+++ b/tests/unit/ui/timeblock-detail-back-link.issue406.test.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+﻿import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { TaskDetailPage } from '@/ui/app/pages/TaskDetailPage';
@@ -8,7 +8,7 @@ import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
 
 const navigateMock = vi.fn();
 
-const listTasksMock = vi.fn<(includeAbandoned?: boolean) => Promise<TaskNode[]>>();
+const listTasksMock = vi.fn<(includeCancelled?: boolean) => Promise<TaskNode[]>>();
 const loadTimeBlocksMock = vi.fn<() => Promise<TimeBlock[]>>();
 const loadActiveBlockMock = vi.fn<() => Promise<ActiveBlockData | null>>();
 const onBlockChangeMock = vi.fn(() => () => {});
@@ -75,7 +75,7 @@ vi.mock('@/lib/services', () => ({
     onTaskChange: onTaskChangeMock,
     transitionTask: vi.fn(),
     updateTask: vi.fn(),
-    abandonTask: vi.fn(),
+    cancelTask: vi.fn(),
   }),
   getTimeBlockService: () => ({
     loadTimeBlocks: loadTimeBlocksMock,


### PR DESCRIPTION
## 摘要
- 在 TS 域类型、service、adapter、UI 文案以及针对性测试中，把公开任务状态语义统一为 `pending / in_progress / suspended / completed / cancelled`
- 仅在持久化 / runtime 边界保留兼容层：Pouch 与 SQLite 在读取时归一化 legacy `not_started` / `abandoned`，并在现有存储仍依赖旧值时继续写回 legacy 值
- 将 runtime task HTTP 语义迁移为 `POST /tasks/:id/cancel`，同时保留 `DELETE /tasks/:id` 作为兼容别名
- 更新 task MCP 文档 / 计划到 `includeCancelled` / `cancelled`，并把包含 `suspended` 的 5 态状态机写入说明

## 验证
- `bunx tsc --noEmit`
  - 当前仅剩仓库已有缺依赖问题：`src/ui/app/pages/agents/TiledGrid.tsx` 缺少 `@dnd-kit/core`、`@dnd-kit/sortable`、`@dnd-kit/utilities`
- `npx vitest run src/lib/types/task.test.ts tests/unit/adapters/task-rt-adapter.test.ts tests/unit/adapters/task-pouch-adapter.test.ts src/lib/adapters/mock/task-mock-adapter.test.ts src/lib/adapters/mock/task-crud-integration.test.ts tests/unit/ui/task-tab-filters.issue338.test.ts tests/unit/ui/task-dag-graph.issue394.test.ts tests/unit/ui/task-dag-page.issue394.test.tsx tests/unit/ui/task-dependency-view.issue398-p1.test.ts tests/unit/ui/task-current-root-card.issue411.test.tsx tests/unit/services/task-hierarchy.issue336.test.ts tests/unit/services/task-timer.issue337.test.ts tests/unit/storage/task-storage.test.ts`
  - 结果：13 files, 163 tests passed
- `cargo test -p exomind-runtime task`
  - 结果：42 个相关测试通过
- `bun run build`
  - 在 `ensure:build-deps` 阶段被阻塞：`lockfile had changes, but lockfile is frozen`

## 冲突分析
- 前端 runtime adapter 已经切到 `cancelTask()` 与 `POST /tasks/:id/cancel`，但 runtime routes 仍保留 delete / abandon 语义；本 PR 解决了这处失配
- 已持久化任务数据中仍可能存在 legacy `not_started` / `abandoned`；本阶段在存储边界保留兼容映射，保证迁移非破坏性
- 文档 / spec 以及周边 issue 语境中仍在使用 `includeAbandoned` 与 4 态 union，容易继续误导后续 agent；本 PR 已把活跃 task MCP 文档更新到新语义
- 当前仍保留旧术语的地方都属于兼容层：task type / storage / runtime tests 中的 legacy alias / mapping，以及一个 JSON import fixture 用于验证向后兼容

## 范围
- 仅为 Phase 1；不会直接关闭 `#383`
- 后续阶段可以基于本分支 / PR 历史继续推进，而无需继续沿用旧的公开语义

Refs #383
