### PR TITLE
feat(app): 任务系统批量优化与跨页面交互/主题收口

### DIFF
--- a/crates/exomind-runtime/src/routes/tasks.rs
+++ b/crates/exomind-runtime/src/routes/tasks.rs
@@ -760,6 +760,113 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_task_dependency_cycle_returns_conflict() {
+        let state = test_state();
+        let task_a = state.task_store.create(CreateTaskInput {
+            title: "A".to_string(),
+            description: None,
+            done_condition: None,
+            priority: None,
+            tags: vec![],
+            source: None,
+            parent_id: None,
+            depends_on: vec![],
+            due_at: None,
+            estimated_minutes: None,
+            time_block_ids: vec![],
+        });
+        let task_b = state.task_store.create(CreateTaskInput {
+            title: "B".to_string(),
+            description: None,
+            done_condition: None,
+            priority: None,
+            tags: vec![],
+            source: None,
+            parent_id: None,
+            depends_on: vec![],
+            due_at: None,
+            estimated_minutes: None,
+            time_block_ids: vec![],
+        });
+        let task_c = state.task_store.create(CreateTaskInput {
+            title: "C".to_string(),
+            description: None,
+            done_condition: None,
+            priority: None,
+            tags: vec![],
+            source: None,
+            parent_id: None,
+            depends_on: vec![],
+            due_at: None,
+            estimated_minutes: None,
+            time_block_ids: vec![],
+        });
+
+        state
+            .task_store
+            .update_scoped(
+                None,
+                &task_a.id,
+                UpdateTaskInput {
+                    title: None,
+                    description: None,
+                    done_condition: None,
+                    priority: None,
+                    tags: None,
+                    depends_on: Some(vec![crate::task::TaskDependency {
+                        task_id: task_b.id.clone(),
+                        relation_type: crate::task::TaskDependencyType::Hard,
+                    }]),
+                    due_at: None,
+                    estimated_minutes: None,
+                    parent_id: None,
+                    time_block_ids: None,
+                },
+            )
+            .unwrap();
+        state
+            .task_store
+            .update_scoped(
+                None,
+                &task_b.id,
+                UpdateTaskInput {
+                    title: None,
+                    description: None,
+                    done_condition: None,
+                    priority: None,
+                    tags: None,
+                    depends_on: Some(vec![crate::task::TaskDependency {
+                        task_id: task_c.id.clone(),
+                        relation_type: crate::task::TaskDependencyType::Hard,
+                    }]),
+                    due_at: None,
+                    estimated_minutes: None,
+                    parent_id: None,
+                    time_block_ids: None,
+                },
+            )
+            .unwrap();
+
+        let app = test_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/tasks/{}", task_c.id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(format!(
+                        r#"{{"depends_on":[{{"task_id":"{}","type":"hard"}}]}}"#,
+                        task_a.id
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
     async fn transition_task_status() {
         let state = test_state();
         let task = state.task_store.create(CreateTaskInput {

--- a/crates/exomind-runtime/src/routes/tasks.rs
+++ b/crates/exomind-runtime/src/routes/tasks.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::AppState;
 use crate::signal::types::SignalEvent;
+use crate::task::store::TaskStoreError;
 use crate::task::{CreateTaskInput, Task, TaskStatus, TransitionInput, UpdateTaskInput};
 
 // ── Query types ─────────────────────────────────────────────────
@@ -131,7 +132,10 @@ async fn update_task(
     let task = state
         .task_store
         .update_scoped(scope_key, &id, input)
-        .map_err(|_| StatusCode::NOT_FOUND)?;
+        .map_err(|error| match error {
+            TaskStoreError::NotFound(_) => StatusCode::NOT_FOUND,
+            _ => StatusCode::CONFLICT,
+        })?;
 
     publish_task_signal(&state, "task.updated", &task);
 
@@ -637,6 +641,122 @@ mod tests {
         let updated: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(updated["title"], "Updated");
         assert_eq!(updated["priority"], "high");
+    }
+
+    #[tokio::test]
+    async fn update_terminal_task_allows_non_frozen_fields() {
+        let state = test_state();
+        let task = state.task_store.create(CreateTaskInput {
+            title: "Original".to_string(),
+            description: None,
+            done_condition: None,
+            priority: None,
+            tags: vec![],
+            source: None,
+            parent_id: None,
+            depends_on: vec![],
+            due_at: None,
+            estimated_minutes: Some(30),
+            time_block_ids: vec![],
+        });
+        state
+            .task_store
+            .transition(&task.id, TaskStatus::InProgress)
+            .unwrap();
+        state
+            .task_store
+            .transition(&task.id, TaskStatus::Completed)
+            .unwrap();
+        let app = test_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/tasks/{}", task.id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"title":"Renamed after completion"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let updated: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(updated["title"], "Renamed after completion");
+        assert_eq!(updated["estimated_minutes"], 30);
+        assert_eq!(updated["status"], "completed");
+    }
+
+    #[tokio::test]
+    async fn update_terminal_task_frozen_fields_return_conflict() {
+        let state = test_state();
+        let upstream = state.task_store.create(CreateTaskInput {
+            title: "Upstream".to_string(),
+            description: None,
+            done_condition: None,
+            priority: None,
+            tags: vec![],
+            source: None,
+            parent_id: None,
+            depends_on: vec![],
+            due_at: None,
+            estimated_minutes: None,
+            time_block_ids: vec![],
+        });
+        let task = state.task_store.create(CreateTaskInput {
+            title: "Original".to_string(),
+            description: None,
+            done_condition: None,
+            priority: None,
+            tags: vec![],
+            source: None,
+            parent_id: None,
+            depends_on: vec![],
+            due_at: None,
+            estimated_minutes: Some(30),
+            time_block_ids: vec![],
+        });
+        state
+            .task_store
+            .transition(&task.id, TaskStatus::InProgress)
+            .unwrap();
+        state
+            .task_store
+            .transition(&task.id, TaskStatus::Completed)
+            .unwrap();
+        let app = test_router(state.clone());
+
+        let estimate_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/tasks/{}", task.id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"estimated_minutes":45}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(estimate_response.status(), StatusCode::CONFLICT);
+
+        let dependency_response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/tasks/{}", task.id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(format!(
+                        r#"{{"depends_on":[{{"task_id":"{}","type":"hard"}}]}}"#,
+                        upstream.id
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(dependency_response.status(), StatusCode::CONFLICT);
     }
 
     #[tokio::test]

--- a/crates/exomind-runtime/src/task/sqlite_store.rs
+++ b/crates/exomind-runtime/src/task/sqlite_store.rs
@@ -175,7 +175,7 @@ impl SqliteTaskStore {
             task.due_at = Some(due_at);
         }
         if let Some(estimated_minutes) = input.estimated_minutes {
-            task.estimated_minutes = Some(estimated_minutes);
+            task.estimated_minutes = estimated_minutes;
         }
         if let Some(parent_id) = input.parent_id {
             task.parent_id = Some(parent_id);

--- a/crates/exomind-runtime/src/task/sqlite_store.rs
+++ b/crates/exomind-runtime/src/task/sqlite_store.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 
 use rusqlite::{params, Connection, OptionalExtension};
 
-use super::store::TaskStoreError;
+use super::store::{TaskStoreError, validate_terminal_task_update};
 use super::types::{
     CreateTaskInput, Task, TaskDependency, TaskPriority, TaskStatus, UpdateTaskInput,
 };
@@ -149,9 +149,7 @@ impl SqliteTaskStore {
             .get_scoped(scope_key, id)?
             .ok_or_else(|| TaskStoreError::NotFound(id.to_string()))?;
 
-        if task.status.is_terminal() {
-            return Err(TaskStoreError::TerminalState(task.status));
-        }
+        validate_terminal_task_update(task.status, &input)?;
 
         if let Some(title) = input.title {
             task.title = title;

--- a/crates/exomind-runtime/src/task/sqlite_store.rs
+++ b/crates/exomind-runtime/src/task/sqlite_store.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 
 use rusqlite::{params, Connection, OptionalExtension};
 
-use super::store::{TaskStoreError, validate_terminal_task_update};
+use super::store::{TaskStoreError, validate_dependency_update, validate_terminal_task_update};
 use super::types::{
     CreateTaskInput, Task, TaskDependency, TaskPriority, TaskStatus, UpdateTaskInput,
 };
@@ -150,6 +150,10 @@ impl SqliteTaskStore {
             .ok_or_else(|| TaskStoreError::NotFound(id.to_string()))?;
 
         validate_terminal_task_update(task.status, &input)?;
+        if let Some(depends_on) = input.depends_on.as_ref() {
+            let tasks = self.list_scoped(scope_key)?;
+            validate_dependency_update(id, depends_on, tasks.iter())?;
+        }
 
         if let Some(title) = input.title {
             task.title = title;

--- a/crates/exomind-runtime/src/task/store.rs
+++ b/crates/exomind-runtime/src/task/store.rs
@@ -15,6 +15,11 @@ pub enum TaskStoreError {
     InvalidTransition { from: TaskStatus, to: TaskStatus },
     #[error("task is in terminal state: {0:?}")]
     TerminalState(TaskStatus),
+    #[error("field `{field}` is immutable once task is terminal: {status:?}")]
+    TerminalFieldImmutable {
+        status: TaskStatus,
+        field: &'static str,
+    },
     #[error("sqlite error: {0}")]
     Sqlite(#[from] rusqlite::Error),
     #[error("io error: {0}")]
@@ -43,12 +48,39 @@ pub struct TaskStore {
 }
 
 const DEFAULT_SCOPE_KEY: &str = "anonymous";
+pub(crate) const TASK_FIELD_DEPENDS_ON: &str = "depends_on";
+pub(crate) const TASK_FIELD_ESTIMATED_MINUTES: &str = "estimated_minutes";
 
 fn normalize_scope_key(scope_key: Option<&str>) -> &str {
     scope_key
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or(DEFAULT_SCOPE_KEY)
+}
+
+pub(crate) fn validate_terminal_task_update(
+    status: TaskStatus,
+    input: &UpdateTaskInput,
+) -> Result<(), TaskStoreError> {
+    if !status.is_terminal() {
+        return Ok(());
+    }
+
+    if input.depends_on.is_some() {
+        return Err(TaskStoreError::TerminalFieldImmutable {
+            status,
+            field: TASK_FIELD_DEPENDS_ON,
+        });
+    }
+
+    if input.estimated_minutes.is_some() {
+        return Err(TaskStoreError::TerminalFieldImmutable {
+            status,
+            field: TASK_FIELD_ESTIMATED_MINUTES,
+        });
+    }
+
+    Ok(())
 }
 
 impl TaskStore {
@@ -180,9 +212,7 @@ impl TaskStore {
                 .get_mut(id)
                 .ok_or_else(|| TaskStoreError::NotFound(id.to_string()))?;
 
-            if task.status.is_terminal() {
-                return Err(TaskStoreError::TerminalState(task.status.clone()));
-            }
+            validate_terminal_task_update(task.status, &input)?;
 
             if let Some(title) = input.title {
                 task.title = title;
@@ -678,8 +708,39 @@ mod tests {
     }
 
     #[test]
-    fn update_terminal_task_fails() {
+    fn update_terminal_task_allows_non_frozen_updates() {
         let store = make_store();
+        let task = store.create(create_input("Done task"));
+        store.transition(&task.id, TaskStatus::InProgress).unwrap();
+        store.transition(&task.id, TaskStatus::Completed).unwrap();
+
+        let updated = store
+            .update(
+                &task.id,
+                UpdateTaskInput {
+                    title: Some("Retitled".to_string()),
+                    description: Some("Still editable".to_string()),
+                    done_condition: None,
+                    priority: None,
+                    tags: None,
+                    depends_on: None,
+                    due_at: None,
+                    estimated_minutes: None,
+                    parent_id: None,
+                    time_block_ids: None,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(updated.title, "Retitled");
+        assert_eq!(updated.description.as_deref(), Some("Still editable"));
+        assert_eq!(updated.status, TaskStatus::Completed);
+    }
+
+    #[test]
+    fn update_terminal_task_rejects_dependency_changes() {
+        let store = make_store();
+        let upstream = store.create(create_input("Upstream"));
         let task = store.create(create_input("Done task"));
         store.transition(&task.id, TaskStatus::InProgress).unwrap();
         store.transition(&task.id, TaskStatus::Completed).unwrap();
@@ -692,14 +753,170 @@ mod tests {
                 done_condition: None,
                 priority: None,
                 tags: None,
-                depends_on: None,
+                depends_on: Some(vec![TaskDependency {
+                    task_id: upstream.id,
+                    relation_type: TaskDependencyType::Hard,
+                }]),
                 due_at: None,
                 estimated_minutes: None,
                 parent_id: None,
                 time_block_ids: None,
             },
         );
-        assert!(matches!(result, Err(TaskStoreError::TerminalState(_))));
+        assert!(matches!(
+            result,
+            Err(TaskStoreError::TerminalFieldImmutable {
+                field: TASK_FIELD_DEPENDS_ON,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn update_terminal_task_rejects_estimated_minutes_changes() {
+        let store = make_store();
+        let task = store.create(create_input("Done task"));
+        store.transition(&task.id, TaskStatus::InProgress).unwrap();
+        store.transition(&task.id, TaskStatus::Completed).unwrap();
+
+        let result = store.update(
+            &task.id,
+            UpdateTaskInput {
+                title: None,
+                description: None,
+                done_condition: None,
+                priority: None,
+                tags: None,
+                depends_on: None,
+                due_at: None,
+                estimated_minutes: Some(Some(25)),
+                parent_id: None,
+                time_block_ids: None,
+            },
+        );
+        assert!(matches!(
+            result,
+            Err(TaskStoreError::TerminalFieldImmutable {
+                field: TASK_FIELD_ESTIMATED_MINUTES,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn active_task_can_depend_on_terminal_upstream() {
+        let store = make_store();
+        let upstream = store.create(create_input("Finished upstream"));
+        let downstream = store.create(create_input("Still active"));
+        store
+            .transition(&upstream.id, TaskStatus::InProgress)
+            .unwrap();
+        store
+            .transition(&upstream.id, TaskStatus::Completed)
+            .unwrap();
+
+        let updated = store
+            .update(
+                &downstream.id,
+                UpdateTaskInput {
+                    title: None,
+                    description: None,
+                    done_condition: None,
+                    priority: None,
+                    tags: None,
+                    depends_on: Some(vec![TaskDependency {
+                        task_id: upstream.id.clone(),
+                        relation_type: TaskDependencyType::Hard,
+                    }]),
+                    due_at: None,
+                    estimated_minutes: None,
+                    parent_id: None,
+                    time_block_ids: None,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(updated.depends_on.len(), 1);
+        assert_eq!(updated.depends_on[0].task_id, upstream.id);
+    }
+
+    #[test]
+    fn sqlite_terminal_task_update_closure_matches_memory() {
+        let dir = tempdir().unwrap();
+        let sqlite_path = dir.path().join("tasks.sqlite");
+        let store = TaskStore::with_sqlite_path(&sqlite_path).unwrap();
+        let upstream = store.create(create_input("Upstream"));
+        let task = store.create(create_input("Done task"));
+        store.transition(&task.id, TaskStatus::InProgress).unwrap();
+        store.transition(&task.id, TaskStatus::Completed).unwrap();
+
+        let allowed = store
+            .update(
+                &task.id,
+                UpdateTaskInput {
+                    title: Some("Retitled".to_string()),
+                    description: Some("Still editable".to_string()),
+                    done_condition: None,
+                    priority: None,
+                    tags: None,
+                    depends_on: None,
+                    due_at: None,
+                    estimated_minutes: None,
+                    parent_id: None,
+                    time_block_ids: None,
+                },
+            )
+            .unwrap();
+        assert_eq!(allowed.title, "Retitled");
+
+        let dependency_result = store.update(
+            &task.id,
+            UpdateTaskInput {
+                title: None,
+                description: None,
+                done_condition: None,
+                priority: None,
+                tags: None,
+                depends_on: Some(vec![TaskDependency {
+                    task_id: upstream.id,
+                    relation_type: TaskDependencyType::Hard,
+                }]),
+                due_at: None,
+                estimated_minutes: None,
+                parent_id: None,
+                time_block_ids: None,
+            },
+        );
+        assert!(matches!(
+            dependency_result,
+            Err(TaskStoreError::TerminalFieldImmutable {
+                field: TASK_FIELD_DEPENDS_ON,
+                ..
+            })
+        ));
+
+        let estimate_result = store.update(
+            &task.id,
+            UpdateTaskInput {
+                title: None,
+                description: None,
+                done_condition: None,
+                priority: None,
+                tags: None,
+                depends_on: None,
+                due_at: None,
+                estimated_minutes: Some(Some(25)),
+                parent_id: None,
+                time_block_ids: None,
+            },
+        );
+        assert!(matches!(
+            estimate_result,
+            Err(TaskStoreError::TerminalFieldImmutable {
+                field: TASK_FIELD_ESTIMATED_MINUTES,
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/crates/exomind-runtime/src/task/store.rs
+++ b/crates/exomind-runtime/src/task/store.rs
@@ -206,7 +206,7 @@ impl TaskStore {
                 task.due_at = Some(due_at);
             }
             if let Some(estimated_minutes) = input.estimated_minutes {
-                task.estimated_minutes = Some(estimated_minutes);
+                task.estimated_minutes = estimated_minutes;
             }
             if let Some(parent_id) = input.parent_id {
                 task.parent_id = Some(parent_id);
@@ -641,7 +641,7 @@ mod tests {
                     tags: Some(vec!["urgent".to_string()]),
                     depends_on: None,
                     due_at: None,
-                    estimated_minutes: Some(60),
+                    estimated_minutes: Some(Some(60)),
                     parent_id: None,
                     time_block_ids: None,
                 },

--- a/crates/exomind-runtime/src/task/store.rs
+++ b/crates/exomind-runtime/src/task/store.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::RwLock;
 
@@ -19,6 +19,11 @@ pub enum TaskStoreError {
     TerminalFieldImmutable {
         status: TaskStatus,
         field: &'static str,
+    },
+    #[error("dependency update would create a cycle for task `{task_id}` via `{dependency_id}`")]
+    DependencyCycle {
+        task_id: String,
+        dependency_id: String,
     },
     #[error("sqlite error: {0}")]
     Sqlite(#[from] rusqlite::Error),
@@ -81,6 +86,61 @@ pub(crate) fn validate_terminal_task_update(
     }
 
     Ok(())
+}
+
+pub(crate) fn validate_dependency_update<'a>(
+    task_id: &str,
+    depends_on: &[TaskDependency],
+    tasks: impl IntoIterator<Item = &'a Task>,
+) -> Result<(), TaskStoreError> {
+    let adjacency = tasks
+        .into_iter()
+        .map(|task| {
+            (
+                task.id.clone(),
+                task.depends_on
+                    .iter()
+                    .map(|dependency| dependency.task_id.clone())
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+    for dependency in depends_on {
+        if dependency.task_id == task_id
+            || dependency_reaches_task(&adjacency, &dependency.task_id, task_id)
+        {
+            return Err(TaskStoreError::DependencyCycle {
+                task_id: task_id.to_string(),
+                dependency_id: dependency.task_id.clone(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn dependency_reaches_task(
+    adjacency: &HashMap<String, Vec<String>>,
+    start_id: &str,
+    target_id: &str,
+) -> bool {
+    let mut stack = vec![start_id.to_string()];
+    let mut visited = HashSet::new();
+
+    while let Some(current) = stack.pop() {
+        if current == target_id {
+            return true;
+        }
+        if !visited.insert(current.clone()) {
+            continue;
+        }
+        if let Some(next) = adjacency.get(&current) {
+            stack.extend(next.iter().cloned());
+        }
+    }
+
+    false
 }
 
 impl TaskStore {
@@ -208,11 +268,18 @@ impl TaskStore {
         }
 
         self.with_memory_scope_mut(scope_key, |tasks| {
+            let current = tasks
+                .get(id)
+                .ok_or_else(|| TaskStoreError::NotFound(id.to_string()))?;
+
+            validate_terminal_task_update(current.status, &input)?;
+            if let Some(depends_on) = input.depends_on.as_ref() {
+                validate_dependency_update(id, depends_on, tasks.values())?;
+            }
+
             let task = tasks
                 .get_mut(id)
                 .ok_or_else(|| TaskStoreError::NotFound(id.to_string()))?;
-
-            validate_terminal_task_update(task.status, &input)?;
 
             if let Some(title) = input.title {
                 task.title = title;
@@ -841,6 +908,112 @@ mod tests {
     }
 
     #[test]
+    fn update_rejects_direct_self_dependency_cycle() {
+        let store = make_store();
+        let task = store.create(create_input("Self"));
+
+        let result = store.update(
+            &task.id,
+            UpdateTaskInput {
+                title: None,
+                description: None,
+                done_condition: None,
+                priority: None,
+                tags: None,
+                depends_on: Some(vec![TaskDependency {
+                    task_id: task.id.clone(),
+                    relation_type: TaskDependencyType::Hard,
+                }]),
+                due_at: None,
+                estimated_minutes: None,
+                parent_id: None,
+                time_block_ids: None,
+            },
+        );
+
+        assert!(matches!(
+            result,
+            Err(TaskStoreError::DependencyCycle { .. })
+        ));
+    }
+
+    #[test]
+    fn update_rejects_indirect_dependency_cycle() {
+        let store = make_store();
+        let task_a = store.create(create_input("A"));
+        let task_b = store.create(create_input("B"));
+        let task_c = store.create(create_input("C"));
+
+        store
+            .update(
+                &task_a.id,
+                UpdateTaskInput {
+                    title: None,
+                    description: None,
+                    done_condition: None,
+                    priority: None,
+                    tags: None,
+                    depends_on: Some(vec![TaskDependency {
+                        task_id: task_b.id.clone(),
+                        relation_type: TaskDependencyType::Hard,
+                    }]),
+                    due_at: None,
+                    estimated_minutes: None,
+                    parent_id: None,
+                    time_block_ids: None,
+                },
+            )
+            .unwrap();
+        store
+            .update(
+                &task_b.id,
+                UpdateTaskInput {
+                    title: None,
+                    description: None,
+                    done_condition: None,
+                    priority: None,
+                    tags: None,
+                    depends_on: Some(vec![TaskDependency {
+                        task_id: task_c.id.clone(),
+                        relation_type: TaskDependencyType::Hard,
+                    }]),
+                    due_at: None,
+                    estimated_minutes: None,
+                    parent_id: None,
+                    time_block_ids: None,
+                },
+            )
+            .unwrap();
+
+        let result = store.update(
+            &task_c.id,
+            UpdateTaskInput {
+                title: None,
+                description: None,
+                done_condition: None,
+                priority: None,
+                tags: None,
+                depends_on: Some(vec![TaskDependency {
+                    task_id: task_a.id.clone(),
+                    relation_type: TaskDependencyType::Hard,
+                }]),
+                due_at: None,
+                estimated_minutes: None,
+                parent_id: None,
+                time_block_ids: None,
+            },
+        );
+
+        assert!(matches!(
+            result,
+            Err(TaskStoreError::DependencyCycle {
+                task_id,
+                dependency_id,
+            }) if task_id == task_c.id && dependency_id == task_a.id
+        ));
+    }
+
+    #[test]
     fn sqlite_terminal_task_update_closure_matches_memory() {
         let dir = tempdir().unwrap();
         let sqlite_path = dir.path().join("tasks.sqlite");
@@ -916,6 +1089,84 @@ mod tests {
                 field: TASK_FIELD_ESTIMATED_MINUTES,
                 ..
             })
+        ));
+    }
+
+    #[test]
+    fn sqlite_update_rejects_indirect_dependency_cycle() {
+        let dir = tempdir().unwrap();
+        let sqlite_path = dir.path().join("tasks.sqlite");
+        let store = TaskStore::with_sqlite_path(&sqlite_path).unwrap();
+        let task_a = store.create(create_input("A"));
+        let task_b = store.create(create_input("B"));
+        let task_c = store.create(create_input("C"));
+
+        store
+            .update(
+                &task_a.id,
+                UpdateTaskInput {
+                    title: None,
+                    description: None,
+                    done_condition: None,
+                    priority: None,
+                    tags: None,
+                    depends_on: Some(vec![TaskDependency {
+                        task_id: task_b.id.clone(),
+                        relation_type: TaskDependencyType::Hard,
+                    }]),
+                    due_at: None,
+                    estimated_minutes: None,
+                    parent_id: None,
+                    time_block_ids: None,
+                },
+            )
+            .unwrap();
+        store
+            .update(
+                &task_b.id,
+                UpdateTaskInput {
+                    title: None,
+                    description: None,
+                    done_condition: None,
+                    priority: None,
+                    tags: None,
+                    depends_on: Some(vec![TaskDependency {
+                        task_id: task_c.id.clone(),
+                        relation_type: TaskDependencyType::Hard,
+                    }]),
+                    due_at: None,
+                    estimated_minutes: None,
+                    parent_id: None,
+                    time_block_ids: None,
+                },
+            )
+            .unwrap();
+
+        let result = store.update(
+            &task_c.id,
+            UpdateTaskInput {
+                title: None,
+                description: None,
+                done_condition: None,
+                priority: None,
+                tags: None,
+                depends_on: Some(vec![TaskDependency {
+                    task_id: task_a.id.clone(),
+                    relation_type: TaskDependencyType::Hard,
+                }]),
+                due_at: None,
+                estimated_minutes: None,
+                parent_id: None,
+                time_block_ids: None,
+            },
+        );
+
+        assert!(matches!(
+            result,
+            Err(TaskStoreError::DependencyCycle {
+                task_id,
+                dependency_id,
+            }) if task_id == task_c.id && dependency_id == task_a.id
         ));
     }
 

--- a/crates/exomind-runtime/src/task/types.rs
+++ b/crates/exomind-runtime/src/task/types.rs
@@ -1,4 +1,16 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Deserialize a JSON field into `Option<Option<T>>`:
+/// - absent → `None` (don't change)
+/// - `null` → `Some(None)` (clear)
+/// - value → `Some(Some(value))` (set)
+fn deserialize_nullable<'de, D, T>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Ok(Some(Option::deserialize(deserializer)?))
+}
 
 /// 5-state machine matching front-end TaskStatus.
 /// pending → in_progress ⇌ suspended → completed / cancelled
@@ -147,8 +159,8 @@ pub struct UpdateTaskInput {
     pub depends_on: Option<Vec<TaskDependency>>,
     #[serde(default)]
     pub due_at: Option<u64>,
-    #[serde(default)]
-    pub estimated_minutes: Option<u32>,
+    #[serde(default, deserialize_with = "deserialize_nullable")]
+    pub estimated_minutes: Option<Option<u32>>,
     #[serde(default)]
     pub parent_id: Option<String>,
     #[serde(default)]

--- a/crates/exomind-runtime/src/timeblock.rs
+++ b/crates/exomind-runtime/src/timeblock.rs
@@ -14,7 +14,9 @@ pub struct TimeBlockData {
     pub name: String,
     pub start_id: String,
     pub end_id: String,
+    #[serde(default)]
     pub note: Option<String>,
+    #[serde(default)]
     pub tags: Vec<String>,
     pub start_time: u64,
     pub end_time: u64,

--- a/crates/exomind-runtime/src/timeblock_sqlite.rs
+++ b/crates/exomind-runtime/src/timeblock_sqlite.rs
@@ -71,7 +71,7 @@ impl SqliteTimeBlockStore {
         )?;
         for block in blocks {
             tx.execute(
-                "INSERT INTO completed_timeblocks (
+                "INSERT OR REPLACE INTO completed_timeblocks (
                     scope_key, id, name, start_id, end_id, note, tags_json, start_time, end_time
                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
                 params![

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "clipboard-manager:allow-read-text",
     "clipboard-manager:allow-write-text",
     "core:window:allow-set-title",
+    "core:window:allow-set-fullscreen",
     "mcp-bridge:default",
     "global-shortcut:allow-register",
     "global-shortcut:allow-unregister",

--- a/src/App.css
+++ b/src/App.css
@@ -52,3 +52,14 @@ body {
 .dark ::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.25);
 }
+
+.scrollbar-none {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}

--- a/src/components/Chat/ChatPage.tsx
+++ b/src/components/Chat/ChatPage.tsx
@@ -47,6 +47,7 @@ interface ChatPageProps {
 
 const UNKNOWN_DEVICE_LABEL = '未知设备';
 const UNKNOWN_PLATFORM_LABEL = '未知平台';
+const CLOSED_PROFILE_EVENTLOG_NAME = '未名';
 
 function resolvePlatformLabel(platform?: string): string {
   if (!platform) {
@@ -66,6 +67,15 @@ function resolveAvatarInitial(name: string): string {
   const trimmed = name.trim();
   if (!trimmed) return '我';
   return trimmed.charAt(0).toUpperCase();
+}
+
+function resolveEventLogUserDisplayName(currentUser?: string | null): string {
+  if (typeof currentUser !== 'string') {
+    return CLOSED_PROFILE_EVENTLOG_NAME;
+  }
+
+  const trimmed = currentUser.trim();
+  return trimmed.length > 0 ? trimmed : CLOSED_PROFILE_EVENTLOG_NAME;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -124,7 +134,7 @@ export function ChatPage({ variant = 'default', hideHeader = false }: ChatPagePr
   const voiceMessageInputRef = useRef<VoiceMessageInputHandle | null>(null);
   const timeBlockWidgetRef = useRef<TimeBlockWidgetHandle | null>(null);
   const focusTimerWidgetRef = useRef<FocusTimerWidgetHandle | null>(null);
-  const userDisplayName = currentUser || 'Hailay';
+  const userDisplayName = useMemo(() => resolveEventLogUserDisplayName(currentUser), [currentUser]);
   const userAvatarInitial = useMemo(() => resolveAvatarInitial(userDisplayName), [userDisplayName]);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {

--- a/src/config/agent-page-enabled.ts
+++ b/src/config/agent-page-enabled.ts
@@ -2,7 +2,7 @@ const AGENT_PAGE_ENABLED_STORAGE_KEY = 'exomind:agentPageEnabled'; // agent 页�
 const AGENT_PAGE_ENABLED_CHANGED_EVENT = 'exomind:agent-page-enabled-changed'; // 自定义事件
 
 function normalizeBoolean(rawValue: string | null | undefined): boolean {
-  return rawValue === 'true';
+  return rawValue !== 'false';
 }
 
 export function getAgentPageEnabled(): boolean {

--- a/src/config/input-send-mode.ts
+++ b/src/config/input-send-mode.ts
@@ -1,0 +1,30 @@
+import { createConfigModule } from './config-factory';
+
+export const INPUT_SEND_MODE_VALUES = ['enter-send', 'ctrl-enter-send'] as const;
+export type InputSendMode = (typeof INPUT_SEND_MODE_VALUES)[number];
+
+function normalizeMode(rawValue: string | null | undefined): InputSendMode {
+  if (rawValue === 'enter-send') return 'enter-send';
+  return 'ctrl-enter-send';
+}
+
+const _module = createConfigModule<InputSendMode>({
+  storageKey: 'exomind:inputSendMode',
+  eventName: 'exomind:input-send-mode-changed',
+  defaultValue: 'ctrl-enter-send',
+  normalize: normalizeMode,
+});
+
+export function getInputSendMode(): InputSendMode {
+  return _module.get();
+}
+
+export function setInputSendMode(mode: InputSendMode): InputSendMode {
+  return _module.set(mode);
+}
+
+export function subscribeInputSendModeChanges(
+  listener: (mode: InputSendMode) => void,
+): () => void {
+  return _module.subscribe(listener);
+}

--- a/src/config/me-page-enabled.ts
+++ b/src/config/me-page-enabled.ts
@@ -1,0 +1,41 @@
+const ME_PAGE_ENABLED_STORAGE_KEY = 'exomind:mePageEnabled';
+const ME_PAGE_ENABLED_CHANGED_EVENT = 'exomind:me-page-enabled-changed';
+
+function normalizeBoolean(rawValue: string | null | undefined): boolean {
+  return rawValue === 'true';
+}
+
+export function getMePageEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  return normalizeBoolean(window.localStorage.getItem(ME_PAGE_ENABLED_STORAGE_KEY));
+}
+
+export function setMePageEnabled(enabled: boolean): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(ME_PAGE_ENABLED_STORAGE_KEY, String(enabled));
+  window.dispatchEvent(new CustomEvent<boolean>(ME_PAGE_ENABLED_CHANGED_EVENT, { detail: enabled }));
+}
+
+export function subscribeMePageEnabledChanges(listener: (enabled: boolean) => void): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key !== ME_PAGE_ENABLED_STORAGE_KEY) return;
+    listener(normalizeBoolean(event.newValue));
+  };
+
+  const handleCustomEvent = (event: Event) => {
+    const customEvent = event as CustomEvent<boolean>;
+    listener(Boolean(customEvent.detail));
+  };
+
+  window.addEventListener('storage', handleStorage);
+  window.addEventListener(ME_PAGE_ENABLED_CHANGED_EVENT, handleCustomEvent);
+
+  return () => {
+    window.removeEventListener('storage', handleStorage);
+    window.removeEventListener(ME_PAGE_ENABLED_CHANGED_EVENT, handleCustomEvent);
+  };
+}

--- a/src/config/task-create-success-action.ts
+++ b/src/config/task-create-success-action.ts
@@ -1,0 +1,30 @@
+import { createConfigModule } from './config-factory';
+
+export const TASK_CREATE_SUCCESS_ACTION_VALUES = ['refocus', 'open-detail'] as const;
+export type TaskCreateSuccessAction = (typeof TASK_CREATE_SUCCESS_ACTION_VALUES)[number];
+
+function normalizeAction(rawValue: string | null | undefined): TaskCreateSuccessAction {
+  if (rawValue === 'open-detail') return 'open-detail';
+  return 'refocus';
+}
+
+const _module = createConfigModule<TaskCreateSuccessAction>({
+  storageKey: 'exomind:taskCreateSuccessAction',
+  eventName: 'exomind:task-create-success-action-changed',
+  defaultValue: 'refocus',
+  normalize: normalizeAction,
+});
+
+export function getTaskCreateSuccessAction(): TaskCreateSuccessAction {
+  return _module.get();
+}
+
+export function setTaskCreateSuccessAction(action: TaskCreateSuccessAction): TaskCreateSuccessAction {
+  return _module.set(action);
+}
+
+export function subscribeTaskCreateSuccessActionChanges(
+  listener: (action: TaskCreateSuccessAction) => void,
+): () => void {
+  return _module.subscribe(listener);
+}

--- a/src/config/task-page-fuzzy-search.ts
+++ b/src/config/task-page-fuzzy-search.ts
@@ -1,0 +1,25 @@
+import { createConfigModule } from './config-factory';
+
+function normalizeBoolean(rawValue: string | null | undefined): boolean {
+  return rawValue !== 'false';
+}
+
+const _module = createConfigModule<boolean>({
+  storageKey: 'exomind:taskPageFuzzySearchEnabled',
+  eventName: 'exomind:task-page-fuzzy-search-changed',
+  defaultValue: true,
+  normalize: normalizeBoolean,
+  serialize: (value) => String(Boolean(value)),
+});
+
+export function getTaskPageFuzzySearchEnabled(): boolean {
+  return _module.get();
+}
+
+export function setTaskPageFuzzySearchEnabled(enabled: boolean): boolean {
+  return _module.set(enabled);
+}
+
+export function subscribeTaskPageFuzzySearchChanges(listener: (enabled: boolean) => void): () => void {
+  return _module.subscribe(listener);
+}

--- a/src/config/tasks-default-tab.ts
+++ b/src/config/tasks-default-tab.ts
@@ -1,6 +1,6 @@
 export const TASKS_DEFAULT_TAB_STORAGE_KEY = 'exomind:tasks-default-tab';
 
-export const TASKS_DEFAULT_TAB_VALUES = ['now', 'today', 'week', 'month'] as const;
+export const TASKS_DEFAULT_TAB_VALUES = ['now', 'today', 'week', 'month', 'dag'] as const;
 export type TasksDefaultTab = (typeof TASKS_DEFAULT_TAB_VALUES)[number];
 
 function normalizeTab(rawValue: string | null): TasksDefaultTab | null {

--- a/src/index.css
+++ b/src/index.css
@@ -130,6 +130,24 @@
     opacity: 0.2;
   }
 
+  .settings-range::-webkit-slider-runnable-track {
+    background: linear-gradient(
+      to right,
+      var(--settings-tone-color, var(--settings-tone-default)) 0%,
+      var(--settings-tone-color, var(--settings-tone-default)) var(--settings-range-progress, 0%),
+      hsl(var(--border-card)) var(--settings-range-progress, 0%),
+      hsl(var(--border-card)) 100%
+    );
+  }
+
+  .settings-range::-moz-range-track {
+    background-color: hsl(var(--border-card));
+  }
+
+  .settings-range::-moz-range-progress {
+    background-color: var(--settings-tone-color, var(--settings-tone-default));
+  }
+
   .settings-dialog-input {
     @apply w-full rounded-xl border bg-white px-4 py-3 text-sm text-[#1C1917] outline-none placeholder:text-[#D6D3D1] dark:border-[#292524] dark:bg-[#1C1917] dark:text-[#FAFAF9] dark:placeholder:text-[#57534E];
     border-color: #F0ECE8;

--- a/src/index.css
+++ b/src/index.css
@@ -130,22 +130,102 @@
     opacity: 0.2;
   }
 
+  .settings-range {
+    --settings-range-track-height: 8px;
+    --settings-range-thumb-size: 18px;
+    --settings-range-track-color: hsl(var(--border-card));
+    --settings-range-active-color: var(--settings-tone-color, var(--settings-tone-default));
+    --settings-range-thumb-fill: hsl(var(--bg-card));
+    --settings-range-thumb-shadow:
+      0 1px 2px rgba(28, 25, 23, 0.18),
+      0 6px 18px rgba(28, 25, 23, 0.14);
+    -webkit-appearance: none;
+    appearance: none;
+    height: var(--settings-range-thumb-size);
+    background: transparent;
+    border: 0;
+    padding: 0;
+    cursor: pointer;
+  }
+
+  .settings-range:focus {
+    outline: none;
+  }
+
   .settings-range::-webkit-slider-runnable-track {
+    height: var(--settings-range-track-height);
+    border-radius: 999px;
     background: linear-gradient(
       to right,
-      var(--settings-tone-color, var(--settings-tone-default)) 0%,
-      var(--settings-tone-color, var(--settings-tone-default)) var(--settings-range-progress, 0%),
-      hsl(var(--border-card)) var(--settings-range-progress, 0%),
-      hsl(var(--border-card)) 100%
+      var(--settings-range-active-color) 0,
+      var(--settings-range-active-color) var(--settings-range-progress, 0%),
+      var(--settings-range-track-color) var(--settings-range-progress, 0%),
+      var(--settings-range-track-color) 100%
     );
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--settings-range-track-color) 88%, white 12%);
+  }
+
+  .settings-range::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: var(--settings-range-thumb-size);
+    height: var(--settings-range-thumb-size);
+    margin-top: calc((var(--settings-range-track-height) - var(--settings-range-thumb-size)) / 2);
+    border-radius: 999px;
+    border: 2px solid var(--settings-range-active-color);
+    background: var(--settings-range-thumb-fill);
+    box-shadow: var(--settings-range-thumb-shadow);
+    transition:
+      transform 120ms ease,
+      box-shadow 120ms ease;
+  }
+
+  .settings-range:hover::-webkit-slider-thumb {
+    transform: scale(1.04);
+    box-shadow:
+      0 2px 4px rgba(28, 25, 23, 0.18),
+      0 8px 22px rgba(28, 25, 23, 0.18);
+  }
+
+  .settings-range:active::-webkit-slider-thumb {
+    transform: scale(1.08);
   }
 
   .settings-range::-moz-range-track {
-    background-color: hsl(var(--border-card));
+    height: var(--settings-range-track-height);
+    border: 0;
+    border-radius: 999px;
+    background: var(--settings-range-track-color);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--settings-range-track-color) 88%, white 12%);
   }
 
   .settings-range::-moz-range-progress {
-    background-color: var(--settings-tone-color, var(--settings-tone-default));
+    height: var(--settings-range-track-height);
+    border-radius: 999px;
+    background: var(--settings-range-active-color);
+  }
+
+  .settings-range::-moz-range-thumb {
+    width: var(--settings-range-thumb-size);
+    height: var(--settings-range-thumb-size);
+    border: 2px solid var(--settings-range-active-color);
+    border-radius: 999px;
+    background: var(--settings-range-thumb-fill);
+    box-shadow: var(--settings-range-thumb-shadow);
+    transition:
+      transform 120ms ease,
+      box-shadow 120ms ease;
+  }
+
+  .settings-range:hover::-moz-range-thumb {
+    transform: scale(1.04);
+    box-shadow:
+      0 2px 4px rgba(28, 25, 23, 0.18),
+      0 8px 22px rgba(28, 25, 23, 0.18);
+  }
+
+  .settings-range:active::-moz-range-thumb {
+    transform: scale(1.08);
   }
 
   .settings-dialog-input {

--- a/src/lib/adapters/task-rt-adapter.ts
+++ b/src/lib/adapters/task-rt-adapter.ts
@@ -100,18 +100,20 @@ function toRuntimeCreatePayload(input: CreateTaskInput): Record<string, unknown>
 }
 
 function toRuntimeUpdatePayload(input: UpdateTaskInput): Record<string, unknown> {
+  // Use `'key' in input` to detect explicitly provided fields (including undefined).
+  // When a field is explicitly set to undefined, send `null` so the backend clears it.
   return {
-    ...(input.title !== undefined ? { title: input.title } : {}),
-    ...(input.description !== undefined ? { description: input.description } : {}),
-    ...(input.doneCondition !== undefined ? { done_condition: input.doneCondition } : {}),
-    ...(input.priority !== undefined ? { priority: input.priority } : {}),
-    ...(input.dueAt !== undefined ? { due_at: input.dueAt } : {}),
-    ...(input.source !== undefined ? { source: input.source } : {}),
-    ...(input.parentId !== undefined ? { parent_id: input.parentId } : {}),
-    ...(input.dependsOn !== undefined ? { depends_on: input.dependsOn.map(toRuntimeDependency) } : {}),
-    ...(input.tags !== undefined ? { tags: input.tags } : {}),
-    ...(input.estimatedMinutes !== undefined ? { estimated_minutes: input.estimatedMinutes } : {}),
-    ...(input.timeBlockIds !== undefined ? { time_block_ids: input.timeBlockIds } : {}),
+    ...('title' in input ? { title: input.title } : {}),
+    ...('description' in input ? { description: input.description ?? null } : {}),
+    ...('doneCondition' in input ? { done_condition: input.doneCondition ?? null } : {}),
+    ...('priority' in input ? { priority: input.priority } : {}),
+    ...('dueAt' in input ? { due_at: input.dueAt ?? null } : {}),
+    ...('source' in input ? { source: input.source ?? null } : {}),
+    ...('parentId' in input ? { parent_id: input.parentId ?? null } : {}),
+    ...('dependsOn' in input && input.dependsOn ? { depends_on: input.dependsOn.map(toRuntimeDependency) } : {}),
+    ...('tags' in input ? { tags: input.tags } : {}),
+    ...('estimatedMinutes' in input ? { estimated_minutes: input.estimatedMinutes ?? null } : {}),
+    ...('timeBlockIds' in input ? { time_block_ids: input.timeBlockIds } : {}),
   };
 }
 

--- a/src/lib/adapters/timeblock-rt-adapter.ts
+++ b/src/lib/adapters/timeblock-rt-adapter.ts
@@ -48,7 +48,9 @@ export class TimeBlockRtAdapter {
       body: JSON.stringify(blocks),
     });
     if (!response.ok && response.status !== 204) {
-      throw new Error(`RT timeblocks replace failed: ${response.status}`);
+      const body = await response.text().catch(() => '(no body)');
+      console.error('[TB-RT] replaceCompletedBlocks failed', { status: response.status, body, blockCount: blocks.length, payload: JSON.stringify(blocks).slice(0, 500) });
+      throw new Error(`RT timeblocks replace failed: ${response.status} — ${body}`);
     }
   }
 

--- a/src/lib/services/command-palette.commands.ts
+++ b/src/lib/services/command-palette.commands.ts
@@ -5,11 +5,16 @@ export type CoreNavigationPath = '/eventlog' | '/tasks' | '/reminders' | '/setti
 interface CreateCoreNavigationCommandsOptions {
   navigate: (path: CoreNavigationPath) => Promise<void> | void;
   openReminderComposer?: () => void;
+  featureFlags?: {
+    mePageEnabled?: boolean;
+  };
 }
 
 export function createCoreNavigationCommands(
   options: CreateCoreNavigationCommandsOptions,
 ): CommandDefinition[] {
+  const mePageEnabled = options.featureFlags?.mePageEnabled ?? true;
+
   return [
     {
       id: 'navigate:now',
@@ -63,7 +68,7 @@ export function createCoreNavigationCommands(
         return { ok: true };
       },
     },
-    {
+    ...(mePageEnabled ? [{
       id: 'navigate:me',
       title: '打开 Me',
       description: '跳转到用户页面',
@@ -75,7 +80,7 @@ export function createCoreNavigationCommands(
         await options.navigate('/me');
         return { ok: true };
       },
-    },
+    } satisfies CommandDefinition] : []),
     {
       id: 'navigate:reminders',
       title: '打开提醒',

--- a/src/lib/services/command-palette.commands.ts
+++ b/src/lib/services/command-palette.commands.ts
@@ -1,4 +1,3 @@
-import { setTasksDefaultTab } from '@/config/tasks-default-tab';
 import type { CommandDefinition } from '@/lib/types/command-palette';
 
 export type CoreNavigationPath = '/eventlog' | '/tasks' | '/reminders' | '/settings' | '/me' | '/agents';
@@ -135,7 +134,6 @@ export function createCoreNavigationCommands(
       aliases: ['目标', 'goals', '长期'],
       keywords: ['长期任务', 'strategy'],
       async execute() {
-        setTasksDefaultTab('now');
         await options.navigate('/tasks');
         return { ok: true };
       },

--- a/src/lib/services/task-timer.service.ts
+++ b/src/lib/services/task-timer.service.ts
@@ -26,6 +26,9 @@ export interface TaskTimerService {
 
   /** 计算任务已花费总时间（从关联时间块累计） */
   calculateSpentMinutes(taskId: string): Promise<number>
+
+  /** 计算剩余预期分钟数（至少 1 分钟） */
+  calculateRemainingMinutes(estimatedMinutes: number, spentMinutes: number): number
 }
 
 export class TaskTimerServiceImpl implements TaskTimerService {
@@ -88,6 +91,10 @@ export class TaskTimerServiceImpl implements TaskTimerService {
     const task = await this.taskSvc.getTask(taskId)
     if (!task) return []
     return task.timeBlockIds ?? []
+  }
+
+  calculateRemainingMinutes(estimatedMinutes: number, spentMinutes: number): number {
+    return Math.max(1, Math.round(estimatedMinutes - spentMinutes));
   }
 
   async calculateSpentMinutes(taskId: string): Promise<number> {

--- a/src/lib/services/timeblock.service.ts
+++ b/src/lib/services/timeblock.service.ts
@@ -583,6 +583,7 @@ export class TimeBlockServiceImpl implements TimeBlockService {
   }
 
   private notifyChange(block: ActiveBlockData | null): void {
+    console.log('[TB-SVC] notifyChange', block ? { startId: block.startId, phase: block.phase, paused: block.paused, feedbackSubmittedAt: block.feedbackSubmittedAt } : 'NULL', new Error().stack?.split('\n').slice(1, 4).join(' <- '));
     this.listeners.forEach(cb => cb(block));
   }
 
@@ -754,6 +755,7 @@ export class TimeBlockServiceImpl implements TimeBlockService {
 
   private async writeCompletedBlockData(blocks: TimeBlockData[]): Promise<void> {
     if (this.backendMode === 'rt-sqlite') {
+      console.log('[TB-SVC] writeCompletedBlockData', { count: blocks.length, payload: JSON.stringify(blocks).slice(0, 1000) });
       await this.rtAdapter?.replaceCompletedBlocks(blocks);
       return;
     }

--- a/src/lib/storage/input-draft-storage.ts
+++ b/src/lib/storage/input-draft-storage.ts
@@ -1,0 +1,49 @@
+function getStorage(): Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> | null {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return null;
+  }
+
+  const storage = window.localStorage as Partial<Storage>;
+  if (
+    typeof storage.getItem !== 'function'
+    || typeof storage.setItem !== 'function'
+    || typeof storage.removeItem !== 'function'
+  ) {
+    return null;
+  }
+
+  return storage as Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+}
+
+export function readInputDraft(key: string): string | null {
+  const storage = getStorage();
+  if (!storage) return null;
+
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function writeInputDraft(key: string, value: string): void {
+  const storage = getStorage();
+  if (!storage) return;
+
+  try {
+    storage.setItem(key, value);
+  } catch {
+    // Ignore storage write failures.
+  }
+}
+
+export function clearInputDraft(key: string): void {
+  const storage = getStorage();
+  if (!storage) return;
+
+  try {
+    storage.removeItem(key);
+  } catch {
+    // Ignore storage delete failures.
+  }
+}

--- a/src/lib/task/task-dag-visibility.ts
+++ b/src/lib/task/task-dag-visibility.ts
@@ -69,7 +69,27 @@ function normalizeTaskDagVisibilityState(
   }
 }
 
-function collectUpstreamNodeIds(
+/**
+ * Build outgoing (children) edge map: nodeId → edges where nodeId is source.
+ */
+function buildOutgoingEdgeMap(graph: TaskGraph): Map<string, TaskGraphEdge[]> {
+  const outgoing = new Map<string, TaskGraphEdge[]>()
+  for (const edge of graph.edges) {
+    const list = outgoing.get(edge.source)
+    if (list) {
+      list.push(edge)
+    } else {
+      outgoing.set(edge.source, [edge])
+    }
+  }
+  return outgoing
+}
+
+/**
+ * Collect ALL upstream ancestor IDs (for hiddenUpstreamCount display).
+ * This is the simple transitive closure — no leak check.
+ */
+function collectAllUpstreamNodeIds(
   nodeId: string,
   incomingEdgesByTarget: Map<string, TaskGraphEdge[]>,
 ): Set<string> {
@@ -92,6 +112,47 @@ function collectUpstreamNodeIds(
   return upstreamNodeIds
 }
 
+/**
+ * Calculate the safe collapsible upstream set using the no-leak constraint.
+ *
+ * Algorithm (from #424):
+ * BFS upward from anchor. A candidate node is safe to collapse ONLY if
+ * ALL its children (outgoing edges) point to nodes already in the collapsed set.
+ * The anchor itself is exempt (it's allowed to have external outputs).
+ */
+function calculateSafeCollapseScope(
+  anchorId: string,
+  incomingEdgesByTarget: Map<string, TaskGraphEdge[]>,
+  outgoingEdgesBySource: Map<string, TaskGraphEdge[]>,
+): Set<string> {
+  const collapsedSet = new Set<string>([anchorId])
+  const visited = new Set<string>([anchorId])
+  const queue: string[] = (incomingEdgesByTarget.get(anchorId) ?? []).map((e) => e.source)
+
+  while (queue.length > 0) {
+    const candidate = queue.shift()!
+    if (visited.has(candidate)) continue
+    visited.add(candidate)
+
+    // No-leak check: ALL children of candidate must be in collapsedSet
+    const children = (outgoingEdgesBySource.get(candidate) ?? []).map((e) => e.target)
+    const isSafe = children.every((child) => collapsedSet.has(child))
+
+    if (isSafe) {
+      collapsedSet.add(candidate)
+      // Continue exploring upstream
+      for (const edge of incomingEdgesByTarget.get(candidate) ?? []) {
+        if (!visited.has(edge.source)) {
+          queue.push(edge.source)
+        }
+      }
+    }
+    // If not safe, skip — this blocks upstream exploration through this path
+  }
+
+  return collapsedSet
+}
+
 export function projectVisibleTaskGraph(
   graph: TaskGraph,
   state: TaskDagVisibilityState = EMPTY_TASK_DAG_VISIBILITY_STATE,
@@ -99,28 +160,26 @@ export function projectVisibleTaskGraph(
   const normalizedState = normalizeTaskDagVisibilityState(graph, state)
   const topologicalIndex = buildTopologicalIndex(graph)
   const incomingEdgesByTarget = buildIncomingEdgeMap(graph)
+  const outgoingEdgesBySource = buildOutgoingEdgeMap(graph)
   const collapsedTargetIdSet = new Set(normalizedState.collapsedUpstreamOf)
   const hiddenNodeIdSet = new Set<string>()
-  const upstreamNodeIdsByNodeId = new Map<string, Set<string>>()
+  const allUpstreamCache = new Map<string, Set<string>>()
 
-  const getUpstreamNodeIds = (nodeId: string): Set<string> => {
-    const cachedUpstreamNodeIds = upstreamNodeIdsByNodeId.get(nodeId)
-    if (cachedUpstreamNodeIds) {
-      return cachedUpstreamNodeIds
-    }
-
-    const upstreamNodeIds = collectUpstreamNodeIds(nodeId, incomingEdgesByTarget)
-    upstreamNodeIdsByNodeId.set(nodeId, upstreamNodeIds)
-    return upstreamNodeIds
+  const getAllUpstreamNodeIds = (nodeId: string): Set<string> => {
+    const cached = allUpstreamCache.get(nodeId)
+    if (cached) return cached
+    const result = collectAllUpstreamNodeIds(nodeId, incomingEdgesByTarget)
+    allUpstreamCache.set(nodeId, result)
+    return result
   }
 
-  for (const nodeId of normalizedState.collapsedUpstreamOf) {
-    for (const upstreamNodeId of getUpstreamNodeIds(nodeId)) {
-      if (collapsedTargetIdSet.has(upstreamNodeId)) {
-        continue
+  // For each collapse target, compute safe scope using no-leak algorithm (#424)
+  for (const anchorId of normalizedState.collapsedUpstreamOf) {
+    const safeScope = calculateSafeCollapseScope(anchorId, incomingEdgesByTarget, outgoingEdgesBySource)
+    for (const nodeId of safeScope) {
+      if (nodeId !== anchorId && !collapsedTargetIdSet.has(nodeId)) {
+        hiddenNodeIdSet.add(nodeId)
       }
-
-      hiddenNodeIdSet.add(upstreamNodeId)
     }
   }
 
@@ -136,7 +195,7 @@ export function projectVisibleTaskGraph(
     .map((node) => {
       let hiddenUpstreamCount = 0
 
-      for (const upstreamNodeId of getUpstreamNodeIds(node.id)) {
+      for (const upstreamNodeId of getAllUpstreamNodeIds(node.id)) {
         if (hiddenNodeIdSet.has(upstreamNodeId)) {
           hiddenUpstreamCount += 1
         }

--- a/src/lib/task/task-dag-visibility.ts
+++ b/src/lib/task/task-dag-visibility.ts
@@ -192,7 +192,10 @@ export function projectVisibleTaskGraph(
     const otherTargets = new Set(normalizedState.collapsedUpstreamOf.filter((id) => id !== anchorId))
     const safeScope = calculateSafeCollapseScope(anchorId, incomingEdgesByTarget, outgoingEdgesBySource, otherTargets)
     for (const nodeId of safeScope) {
-      if (nodeId !== anchorId && !collapsedTargetIdSet.has(nodeId)) {
+      // Hide all nodes in scope except the anchor itself.
+      // Other collapse targets that fall within this scope ARE hidden
+      // (nested folding: upstream fold target gets absorbed by downstream fold).
+      if (nodeId !== anchorId) {
         hiddenNodeIdSet.add(nodeId)
       }
     }

--- a/src/lib/task/task-dag-visibility.ts
+++ b/src/lib/task/task-dag-visibility.ts
@@ -119,11 +119,17 @@ function collectAllUpstreamNodeIds(
  * BFS upward from anchor. A candidate node is safe to collapse ONLY if
  * ALL its children (outgoing edges) point to nodes already in the collapsed set.
  * The anchor itself is exempt (it's allowed to have external outputs).
+ *
+ * Nested folding: when encountering a node that is itself a collapse target
+ * for another fold, treat it as an atomic/opaque node — include it in the
+ * collapsed set but do NOT expand its parents (they belong to that node's
+ * own fold scope).
  */
 function calculateSafeCollapseScope(
   anchorId: string,
   incomingEdgesByTarget: Map<string, TaskGraphEdge[]>,
   outgoingEdgesBySource: Map<string, TaskGraphEdge[]>,
+  otherCollapseTargets: Set<string>,
 ): Set<string> {
   const collapsedSet = new Set<string>([anchorId])
   const visited = new Set<string>([anchorId])
@@ -140,6 +146,13 @@ function calculateSafeCollapseScope(
 
     if (isSafe) {
       collapsedSet.add(candidate)
+
+      // Nested folding boundary: if this candidate is itself a collapse target,
+      // treat it as atomic — don't expand its parents (they're its own fold scope).
+      if (otherCollapseTargets.has(candidate)) {
+        continue
+      }
+
       // Continue exploring upstream
       for (const edge of incomingEdgesByTarget.get(candidate) ?? []) {
         if (!visited.has(edge.source)) {
@@ -175,7 +188,9 @@ export function projectVisibleTaskGraph(
 
   // For each collapse target, compute safe scope using no-leak algorithm (#424)
   for (const anchorId of normalizedState.collapsedUpstreamOf) {
-    const safeScope = calculateSafeCollapseScope(anchorId, incomingEdgesByTarget, outgoingEdgesBySource)
+    // Pass other collapse targets so nested folds are treated as atomic boundaries
+    const otherTargets = new Set(normalizedState.collapsedUpstreamOf.filter((id) => id !== anchorId))
+    const safeScope = calculateSafeCollapseScope(anchorId, incomingEdgesByTarget, outgoingEdgesBySource, otherTargets)
     for (const nodeId of safeScope) {
       if (nodeId !== anchorId && !collapsedTargetIdSet.has(nodeId)) {
         hiddenNodeIdSet.add(nodeId)

--- a/src/lib/task/task-dag-visibility.ts
+++ b/src/lib/task/task-dag-visibility.ts
@@ -2,10 +2,14 @@
 
 export interface TaskDagVisibilityState {
   collapsedUpstreamOf: string[]
+  collapsedDownstreamOf: string[]
 }
 
 export interface VisibleTaskGraphNode extends TaskGraphNode {
   hiddenUpstreamCount: number
+  hiddenDownstreamCount: number
+  isCollapsedUpstreamTarget: boolean
+  isCollapsedDownstreamTarget: boolean
   isCollapsedTarget: boolean
 }
 
@@ -23,6 +27,7 @@ export interface VisibleTaskGraph {
 
 export const EMPTY_TASK_DAG_VISIBILITY_STATE: TaskDagVisibilityState = {
   collapsedUpstreamOf: [],
+  collapsedDownstreamOf: [],
 }
 
 function isTerminalStatus(status: TaskGraphNode['status']): boolean {
@@ -54,8 +59,8 @@ function normalizeTaskDagVisibilityState(
   state: TaskDagVisibilityState | undefined,
 ): TaskDagVisibilityState {
   const topologicalIndex = buildTopologicalIndex(graph)
-  const normalizedCollapsedUpstreamOf = Array.from(
-    new Set((state?.collapsedUpstreamOf ?? []).filter((nodeId) => topologicalIndex.has(nodeId))),
+  const sortNodeIds = (nodeIds: string[]) => Array.from(
+    new Set(nodeIds.filter((nodeId) => topologicalIndex.has(nodeId))),
   ).sort((leftNodeId, rightNodeId) => {
     const orderDiff = (topologicalIndex.get(leftNodeId) ?? Number.MAX_SAFE_INTEGER)
       - (topologicalIndex.get(rightNodeId) ?? Number.MAX_SAFE_INTEGER)
@@ -65,7 +70,8 @@ function normalizeTaskDagVisibilityState(
   })
 
   return {
-    collapsedUpstreamOf: normalizedCollapsedUpstreamOf,
+    collapsedUpstreamOf: sortNodeIds(state?.collapsedUpstreamOf ?? []),
+    collapsedDownstreamOf: sortNodeIds(state?.collapsedDownstreamOf ?? []),
   }
 }
 
@@ -112,6 +118,29 @@ function collectAllUpstreamNodeIds(
   return upstreamNodeIds
 }
 
+function collectAllDownstreamNodeIds(
+  nodeId: string,
+  outgoingEdgesBySource: Map<string, TaskGraphEdge[]>,
+): Set<string> {
+  const downstreamNodeIds = new Set<string>()
+  const pendingNodeIds = (outgoingEdgesBySource.get(nodeId) ?? []).map((edge) => edge.target)
+
+  while (pendingNodeIds.length > 0) {
+    const currentNodeId = pendingNodeIds.pop()
+    if (!currentNodeId || downstreamNodeIds.has(currentNodeId)) {
+      continue
+    }
+
+    downstreamNodeIds.add(currentNodeId)
+
+    for (const edge of outgoingEdgesBySource.get(currentNodeId) ?? []) {
+      pendingNodeIds.push(edge.target)
+    }
+  }
+
+  return downstreamNodeIds
+}
+
 /**
  * Calculate the safe collapsible upstream set using the no-leak constraint.
  *
@@ -125,7 +154,7 @@ function collectAllUpstreamNodeIds(
  * collapsed set but do NOT expand its parents (they belong to that node's
  * own fold scope).
  */
-function calculateSafeCollapseScope(
+function calculateSafeUpstreamCollapseScope(
   anchorId: string,
   incomingEdgesByTarget: Map<string, TaskGraphEdge[]>,
   outgoingEdgesBySource: Map<string, TaskGraphEdge[]>,
@@ -166,6 +195,73 @@ function calculateSafeCollapseScope(
   return collapsedSet
 }
 
+function calculateSafeDownstreamCollapseScope(
+  anchorId: string,
+  incomingEdgesByTarget: Map<string, TaskGraphEdge[]>,
+  outgoingEdgesBySource: Map<string, TaskGraphEdge[]>,
+  otherCollapseTargets: Set<string>,
+): Set<string> {
+  const collapsedSet = new Set<string>([anchorId])
+  const visited = new Set<string>([anchorId])
+  const queue: string[] = (outgoingEdgesBySource.get(anchorId) ?? []).map((e) => e.target)
+
+  while (queue.length > 0) {
+    const candidate = queue.shift()!
+    if (visited.has(candidate)) continue
+    visited.add(candidate)
+
+    // No-contamination check: ALL parents of candidate must be in collapsedSet.
+    const parents = (incomingEdgesByTarget.get(candidate) ?? []).map((e) => e.source)
+    const isSafe = parents.every((parent) => collapsedSet.has(parent))
+
+    if (isSafe) {
+      collapsedSet.add(candidate)
+
+      if (otherCollapseTargets.has(candidate)) {
+        continue
+      }
+
+      for (const edge of outgoingEdgesBySource.get(candidate) ?? []) {
+        if (!visited.has(edge.target)) {
+          queue.push(edge.target)
+        }
+      }
+    }
+  }
+
+  return collapsedSet
+}
+
+export type TaskDagCollapseDirection = 'upstream' | 'downstream'
+
+export function calculateTaskDagCollapseScope(
+  graph: TaskGraph,
+  state: TaskDagVisibilityState,
+  direction: TaskDagCollapseDirection,
+  anchorId: string,
+): Set<string> {
+  const normalizedState = normalizeTaskDagVisibilityState(graph, state)
+  const topologicalIndex = buildTopologicalIndex(graph)
+  if (!topologicalIndex.has(anchorId)) {
+    return new Set()
+  }
+
+  const incomingEdgesByTarget = buildIncomingEdgeMap(graph)
+  const outgoingEdgesBySource = buildOutgoingEdgeMap(graph)
+  const otherCollapseTargets = new Set(
+    [
+      ...normalizedState.collapsedUpstreamOf,
+      ...normalizedState.collapsedDownstreamOf,
+    ].filter((nodeId) => nodeId !== anchorId),
+  )
+
+  if (direction === 'upstream') {
+    return calculateSafeUpstreamCollapseScope(anchorId, incomingEdgesByTarget, outgoingEdgesBySource, otherCollapseTargets)
+  }
+
+  return calculateSafeDownstreamCollapseScope(anchorId, incomingEdgesByTarget, outgoingEdgesBySource, otherCollapseTargets)
+}
+
 export function projectVisibleTaskGraph(
   graph: TaskGraph,
   state: TaskDagVisibilityState = EMPTY_TASK_DAG_VISIBILITY_STATE,
@@ -175,8 +271,15 @@ export function projectVisibleTaskGraph(
   const incomingEdgesByTarget = buildIncomingEdgeMap(graph)
   const outgoingEdgesBySource = buildOutgoingEdgeMap(graph)
   const collapsedTargetIdSet = new Set(normalizedState.collapsedUpstreamOf)
+  const collapsedDownstreamTargetIdSet = new Set(normalizedState.collapsedDownstreamOf)
+  const collapsedTargetIdUnion = new Set([
+    ...normalizedState.collapsedUpstreamOf,
+    ...normalizedState.collapsedDownstreamOf,
+  ])
   const hiddenNodeIdSet = new Set<string>()
+  const hiddenNodeDownstreamOwnerById = new Map<string, string>()
   const allUpstreamCache = new Map<string, Set<string>>()
+  const allDownstreamCache = new Map<string, Set<string>>()
 
   const getAllUpstreamNodeIds = (nodeId: string): Set<string> => {
     const cached = allUpstreamCache.get(nodeId)
@@ -186,11 +289,17 @@ export function projectVisibleTaskGraph(
     return result
   }
 
+  const getAllDownstreamNodeIds = (nodeId: string): Set<string> => {
+    const cached = allDownstreamCache.get(nodeId)
+    if (cached) return cached
+    const result = collectAllDownstreamNodeIds(nodeId, outgoingEdgesBySource)
+    allDownstreamCache.set(nodeId, result)
+    return result
+  }
+
   // For each collapse target, compute safe scope using no-leak algorithm (#424)
   for (const anchorId of normalizedState.collapsedUpstreamOf) {
-    // Pass other collapse targets so nested folds are treated as atomic boundaries
-    const otherTargets = new Set(normalizedState.collapsedUpstreamOf.filter((id) => id !== anchorId))
-    const safeScope = calculateSafeCollapseScope(anchorId, incomingEdgesByTarget, outgoingEdgesBySource, otherTargets)
+    const safeScope = calculateTaskDagCollapseScope(graph, normalizedState, 'upstream', anchorId)
     for (const nodeId of safeScope) {
       // Hide all nodes in scope except the anchor itself.
       // Other collapse targets that fall within this scope ARE hidden
@@ -201,11 +310,54 @@ export function projectVisibleTaskGraph(
     }
   }
 
+  for (const anchorId of normalizedState.collapsedDownstreamOf) {
+    const safeScope = calculateTaskDagCollapseScope(graph, normalizedState, 'downstream', anchorId)
+    for (const nodeId of safeScope) {
+      if (nodeId !== anchorId) {
+        hiddenNodeIdSet.add(nodeId)
+        if (!hiddenNodeDownstreamOwnerById.has(nodeId)) {
+          hiddenNodeDownstreamOwnerById.set(nodeId, anchorId)
+        }
+      }
+    }
+  }
+
   const hiddenNodeIds = graph.topologicalOrder.filter((nodeId) => hiddenNodeIdSet.has(nodeId))
   const visibleNodeIdSet = new Set(graph.topologicalOrder.filter((nodeId) => !hiddenNodeIdSet.has(nodeId)))
+  const visibleEdgeByKey = new Map<string, TaskGraphEdge>()
+  const addVisibleEdge = (edge: TaskGraphEdge) => {
+    const key = `${edge.source}|${edge.target}|${edge.type}`
+    if (!visibleEdgeByKey.has(key)) {
+      visibleEdgeByKey.set(key, edge)
+    }
+  }
 
-  const visibleEdges = graph.edges.filter((edge) => (
-    visibleNodeIdSet.has(edge.source) && visibleNodeIdSet.has(edge.target)
+  for (const edge of graph.edges) {
+    if (visibleNodeIdSet.has(edge.source) && visibleNodeIdSet.has(edge.target)) {
+      addVisibleEdge(edge)
+    }
+  }
+
+  for (const edge of graph.edges) {
+    if (!hiddenNodeIdSet.has(edge.source) || !visibleNodeIdSet.has(edge.target)) {
+      continue
+    }
+
+    const downstreamAnchorId = hiddenNodeDownstreamOwnerById.get(edge.source)
+    if (!downstreamAnchorId || !visibleNodeIdSet.has(downstreamAnchorId) || downstreamAnchorId === edge.target) {
+      continue
+    }
+
+    addVisibleEdge({
+      id: `edge:${downstreamAnchorId}->${edge.target}:${edge.type}:collapsed-downstream`,
+      source: downstreamAnchorId,
+      target: edge.target,
+      type: edge.type,
+    })
+  }
+
+  const visibleEdges = graph.topologicalOrder.flatMap((sourceId) => (
+    [...visibleEdgeByKey.values()].filter((edge) => edge.source === sourceId)
   ))
 
   const visibleNodes = graph.nodes
@@ -219,10 +371,20 @@ export function projectVisibleTaskGraph(
         }
       }
 
+      let hiddenDownstreamCount = 0
+      for (const downstreamNodeId of getAllDownstreamNodeIds(node.id)) {
+        if (hiddenNodeIdSet.has(downstreamNodeId)) {
+          hiddenDownstreamCount += 1
+        }
+      }
+
       return {
         ...node,
         hiddenUpstreamCount,
-        isCollapsedTarget: collapsedTargetIdSet.has(node.id),
+        hiddenDownstreamCount,
+        isCollapsedUpstreamTarget: collapsedTargetIdSet.has(node.id),
+        isCollapsedDownstreamTarget: collapsedDownstreamTargetIdSet.has(node.id),
+        isCollapsedTarget: collapsedTargetIdUnion.has(node.id),
       }
     })
     .sort((leftNode, rightNode) => {

--- a/src/lib/types/command-palette.ts
+++ b/src/lib/types/command-palette.ts
@@ -12,6 +12,7 @@ export interface CommandContext {
   developerModeEnabled: boolean;
   commandPaletteEnabled: boolean;
   featureFlags: {
+    mePageEnabled: boolean;
     agentPageEnabled: boolean;
     goalsV2Enabled: boolean;
     [key: string]: boolean | undefined;

--- a/src/pages/NowWorkbenchOverlayPage.tsx
+++ b/src/pages/NowWorkbenchOverlayPage.tsx
@@ -21,6 +21,7 @@ import type { TaskNode } from '@/lib/types/task';
 import type { NowWorkbenchOverlayModel } from '@/ui/app/overlay/now-workbench-overlay-model';
 import type { ActiveBlockData } from '@/lib/types/event';
 import { useNowWorkbenchOverlayController } from '@/ui/app/overlay/use-now-workbench-overlay-controller';
+import { TaskStatusSelector, type TaskStatusChoice } from '@/ui/app/components/TaskStatusSelector';
 import { useRef } from 'react';
 import { log } from '@/lib/logger';
 
@@ -54,7 +55,9 @@ interface NowWorkbenchOverlayPageContentProps {
   onSend: (content: string, tags?: string[]) => void;
   feedbackOpen: boolean;
   feedback: string;
+  taskStatusChoice: TaskStatusChoice;
   setFeedback(value: string): void;
+  setTaskStatusChoice(value: TaskStatusChoice): void;
   onConfirmEnd: () => void | Promise<void>;
 }
 
@@ -265,7 +268,9 @@ export function NowWorkbenchOverlayPage(props: NowWorkbenchOverlayPageProps) {
         }}
         feedbackOpen={false}
         feedback=""
+        taskStatusChoice="continue"
         setFeedback={() => {}}
+        setTaskStatusChoice={() => {}}
         onConfirmEnd={() => {}}
       />
     );
@@ -303,7 +308,9 @@ export function NowWorkbenchOverlayPage(props: NowWorkbenchOverlayPageProps) {
       debugInfo={controller.debugInfo}
       feedbackOpen={controller.feedbackOpen}
       feedback={controller.feedback}
+      taskStatusChoice={controller.taskStatusChoice}
       setFeedback={controller.setFeedback}
+      setTaskStatusChoice={controller.setTaskStatusChoice}
       onConfirmEnd={() => {
         void controller.handleConfirmEnd();
       }}
@@ -323,7 +330,9 @@ function NowWorkbenchOverlayPageContent(props: NowWorkbenchOverlayPageContentPro
     onSend,
     feedbackOpen,
     feedback,
+    taskStatusChoice,
     setFeedback,
+    setTaskStatusChoice,
     onConfirmEnd,
   } = props;
   const now = Date.now();
@@ -487,6 +496,13 @@ function NowWorkbenchOverlayPageContent(props: NowWorkbenchOverlayPageContentPro
           >
             Enter / Ctrl+Enter 提交 · Shift+Enter 换行
           </div>
+          {model.activeBlock?.taskId && (
+            <TaskStatusSelector
+              value={taskStatusChoice}
+              onChange={setTaskStatusChoice}
+              linkedTaskTitle={model.title || undefined}
+            />
+          )}
           <Button
             type="button"
             data-testid="now-overlay-feedback-confirm"

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -10,6 +10,7 @@ import { getCommandPaletteEnabled, subscribeCommandPaletteEnabledChanges } from 
 import { getCommandRegistryService } from '@/lib/services/command-registry.service';
 import { getCommandPaletteService } from '@/lib/services/command-palette.service';
 import { createCoreNavigationCommands, type CoreNavigationPath } from '@/lib/services/command-palette.commands';
+import { useTauriFullscreenShortcut } from '@/ui/app/hooks/useTauriFullscreenShortcut';
 import { CommandPalette } from '@/ui/app/components/CommandPalette';
 import { DesktopSidebarAccountEntry } from '@/ui/app/components/DesktopSidebarAccountEntry';
 import { ReminderNotifier } from '@/ui/app/components/ReminderNotifier';
@@ -425,6 +426,7 @@ function MeRouteGate() {
 
 function NewLayout() {
   const location = useLocation();
+  useTauriFullscreenShortcut();
   const navigate = useNavigate();
   const isDesktop = useIsDesktop();
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -17,6 +17,11 @@ import { ReminderNotifier } from '@/ui/app/components/ReminderNotifier';
 import { UpdateToast } from '@/ui/components/UpdateToast';
 import { requestReminderCompose } from '@/ui/stores/reminder-ui-store';
 import type { CommandContext } from '@/lib/types/command-palette';
+import {
+  TASKS_LAST_PATH_KEY,
+  resolveTasksRestorePath,
+  shouldForceTasksMain,
+} from '@/ui/app/pages/task-route-memory';
 
 const FocusPage = lazy(async () => {
   const module = await import('@/ui/app/pages/FocusPage');
@@ -638,8 +643,6 @@ const newEventlogRoute = createRoute({
   },
 });
 
-const TASKS_LAST_PATH_KEY = 'exomind:last-tasks-path';
-
 const newTasksRoute = createRoute({
   getParentRoute: () => newRootRoute,
   path: '/tasks',
@@ -648,13 +651,18 @@ const newTasksRoute = createRoute({
 
     // Redirect to the last visited tasks sub-path (e.g. /tasks/dag, /tasks/:id)
     useEffect(() => {
+      const currentSearch = typeof window !== 'undefined' ? window.location.search : '';
       const saved = sessionStorage.getItem(TASKS_LAST_PATH_KEY);
-      console.log('[Routes] /tasks mount, saved:', saved, 'current:', window.location.pathname);
-      if (saved && saved.startsWith('/tasks/')) {
-        console.log('[Routes] redirecting to', saved);
-        void navigate({ to: saved, replace: true });
-      } else {
-        console.log('[Routes] no redirect, showing default');
+
+      if (shouldForceTasksMain(currentSearch)) {
+        sessionStorage.removeItem(TASKS_LAST_PATH_KEY);
+        void navigate({ to: '/tasks', replace: true });
+        return;
+      }
+
+      const restorePath = resolveTasksRestorePath(saved, currentSearch);
+      if (restorePath) {
+        void navigate({ to: restorePath, replace: true });
       }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [navigate]);

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -520,15 +520,14 @@ const newTasksRoute = createRoute({
   getParentRoute: () => newRootRoute,
   path: '/tasks',
   component: function NewTasks() {
-    const navigate = useNavigate();
-
     // Redirect to the last visited tasks sub-path (e.g. /tasks/dag, /tasks/:id)
     useEffect(() => {
       const saved = sessionStorage.getItem(TASKS_LAST_PATH_KEY);
-      if (saved && saved !== '/tasks' && saved.startsWith('/tasks')) {
-        void navigate({ to: saved, replace: true });
+      if (saved && saved !== '/tasks' && saved !== window.location.pathname && saved.startsWith('/tasks')) {
+        window.location.replace(saved);
       }
-    }, [navigate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     return (
       <LazyPage>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -3,6 +3,7 @@ import { Suspense, lazy, useEffect, useMemo, useState } from 'react';
 import { Target, Settings, Waypoints, SquareCheckBig, UserRound, Brain, PanelLeftClose, PanelLeftOpen, type LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getAgentPageEnabled, subscribeAgentPageEnabledChanges } from '@/config/agent-page-enabled';
+import { getMePageEnabled, subscribeMePageEnabledChanges } from '@/config/me-page-enabled';
 import { getDesktopAdaptiveEnabled, subscribeDesktopAdaptiveChanges } from '@/config/desktop-adaptive';
 import { getDeveloperModeEnabled, subscribeDeveloperModeChanges } from '@/config/developer-mode';
 import { getCommandPaletteEnabled, subscribeCommandPaletteEnabledChanges } from '@/config/command-palette-enabled';
@@ -253,18 +254,26 @@ function MobileShell({
 function DesktopSidebar({
   activePath,
   agentPageEnabled,
+  mePageEnabled,
   collapsed,
   onToggleCollapsed,
 }: {
   activePath: string;
   agentPageEnabled: boolean;
+  mePageEnabled: boolean;
   collapsed: boolean;
   onToggleCollapsed: () => void;
 }) {
   const desktopNavItems = [
     { key: 'now', title: '当下', path: '/eventlog', icon: Target, match: (path: string) => path === '/eventlog' || path === '/' },
     { key: 'tasks', title: '任务', path: '/tasks', icon: SquareCheckBig, match: (path: string) => path === '/tasks' || path.startsWith('/tasks/') },
-    { key: 'me', title: 'Me', path: '/me', icon: UserRound, match: (path: string) => path === '/me' || path.startsWith('/me/') },
+    ...(mePageEnabled ? [{
+      key: 'me',
+      title: 'Me',
+      path: '/me',
+      icon: UserRound,
+      match: (path: string) => path === '/me' || path.startsWith('/me/'),
+    }] : []),
     ...(agentPageEnabled ? [{
       key: 'agents',
       title: '网络',
@@ -361,11 +370,13 @@ function DesktopSidebar({
 function DesktopLayout({
   activePath,
   agentPageEnabled,
+  mePageEnabled,
   collapsed,
   onToggleCollapsed,
 }: {
   activePath: string;
   agentPageEnabled: boolean;
+  mePageEnabled: boolean;
   collapsed: boolean;
   onToggleCollapsed: () => void;
 }) {
@@ -375,6 +386,7 @@ function DesktopLayout({
         <DesktopSidebar
           activePath={activePath}
           agentPageEnabled={agentPageEnabled}
+          mePageEnabled={mePageEnabled}
           collapsed={collapsed}
           onToggleCollapsed={onToggleCollapsed}
         />
@@ -386,12 +398,38 @@ function DesktopLayout({
   );
 }
 
+function MeRouteGate() {
+  const navigate = useNavigate();
+  const [mePageEnabled, setMePageEnabled] = useState(() => getMePageEnabled());
+
+  useEffect(() => {
+    return subscribeMePageEnabledChanges(setMePageEnabled);
+  }, []);
+
+  useEffect(() => {
+    if (!mePageEnabled) {
+      void navigate({ to: '/settings', replace: true });
+    }
+  }, [mePageEnabled, navigate]);
+
+  if (!mePageEnabled) {
+    return <PageFallback />;
+  }
+
+  return (
+    <LazyPage>
+      <MePage />
+    </LazyPage>
+  );
+}
+
 function NewLayout() {
   const location = useLocation();
   const navigate = useNavigate();
   const isDesktop = useIsDesktop();
 
   const [agentPageEnabled, setAgentPageEnabled] = useState(() => getAgentPageEnabled());
+  const [mePageEnabled, setMePageEnabled] = useState(() => getMePageEnabled());
   const [desktopSidebarCollapsed, setDesktopSidebarCollapsed] = useState(false);
   const [desktopAdaptiveEnabled, setDesktopAdaptiveEnabledState] = useState(() => getDesktopAdaptiveEnabled());
   const [developerModeEnabled, setDeveloperModeEnabled] = useState(() => getDeveloperModeEnabled());
@@ -402,6 +440,9 @@ function NewLayout() {
 
   useEffect(() => {
     return subscribeAgentPageEnabledChanges(setAgentPageEnabled);
+  }, []);
+  useEffect(() => {
+    return subscribeMePageEnabledChanges(setMePageEnabled);
   }, []);
   useEffect(() => {
     return subscribeDesktopAdaptiveChanges(setDesktopAdaptiveEnabledState);
@@ -421,12 +462,15 @@ function NewLayout() {
     registryService.setCommands('core-navigation', createCoreNavigationCommands({
       navigate: navigateTo,
       openReminderComposer: requestReminderCompose,
+      featureFlags: {
+        mePageEnabled,
+      },
     }));
 
     return () => {
       registryService.removeScope('core-navigation');
     };
-  }, [navigate, registryService]);
+  }, [mePageEnabled, navigate, registryService]);
 
   useEffect(() => {
     if (!commandPaletteActive) {
@@ -456,15 +500,16 @@ function NewLayout() {
     developerModeEnabled,
     commandPaletteEnabled: commandPaletteActive,
     featureFlags: {
+      mePageEnabled,
       agentPageEnabled,
       goalsV2Enabled: false,
     },
-  }), [agentPageEnabled, commandPaletteActive, developerModeEnabled, location.pathname]);
+  }), [agentPageEnabled, commandPaletteActive, developerModeEnabled, location.pathname, mePageEnabled]);
 
   const navItems = [
     { title: '当下', path: '/eventlog', icon: Target },
     { title: '任务', path: '/tasks', icon: SquareCheckBig },
-    { title: 'Me', path: '/me', icon: UserRound },
+    ...(mePageEnabled ? [{ title: 'Me', path: '/me', icon: UserRound }] : []),
     ...(agentPageEnabled ? [{ title: '网络', path: '/agents', icon: Waypoints }] : []),
     { title: '设置', path: '/settings', icon: Settings },
   ];
@@ -489,6 +534,7 @@ function NewLayout() {
         <DesktopLayout
           activePath={location.pathname}
           agentPageEnabled={agentPageEnabled}
+          mePageEnabled={mePageEnabled}
           collapsed={desktopSidebarCollapsed}
           onToggleCollapsed={() => setDesktopSidebarCollapsed((current) => !current)}
         />
@@ -683,11 +729,7 @@ const newMeRoute = createRoute({
   getParentRoute: () => newRootRoute,
   path: '/me',
   component: function NewMe() {
-    return (
-      <LazyPage>
-        <MePage />
-      </LazyPage>
-    );
+    return <MeRouteGate />;
   },
 });
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -41,6 +41,11 @@ const TaskDagPage = lazy(async () => {
   return { default: module.TaskDagPage };
 });
 
+const TaskTimeblocksPage = lazy(async () => {
+  const module = await import('@/ui/app/pages/TaskTimeblocksPage');
+  return { default: module.TaskTimeblocksPage };
+});
+
 const RemindersPage = lazy(async () => {
   const module = await import('@/ui/app/pages/RemindersPage');
   return { default: module.RemindersPage };
@@ -567,6 +572,18 @@ const newTaskDagRoute = createRoute({
   },
 });
 
+const newTaskTimeblocksRoute = createRoute({
+  getParentRoute: () => newRootRoute,
+  path: '/tasks/timeblocks',
+  component: function NewTaskTimeblocks() {
+    return (
+      <LazyPage>
+        <TaskTimeblocksPage />
+      </LazyPage>
+    );
+  },
+});
+
 const newTaskDetailRoute = createRoute({
   getParentRoute: () => newRootRoute,
   path: '/tasks/$taskId',
@@ -756,6 +773,7 @@ const newRouteTree = newRootRoute.addChildren([
   newEventlogRoute,
   newTasksRoute,
   newTaskDagRoute,
+  newTaskTimeblocksRoute,
   newRemindersRoute,
   newTimeblockDetailRoute,
   newTaskDetailRoute,

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,6 +1,6 @@
 import { createRootRoute, createRouter, createRoute, Outlet, Link, useLocation, useNavigate, useParams, type ErrorComponentProps } from '@tanstack/react-router';
 import { Suspense, lazy, useEffect, useMemo, useState } from 'react';
-import { Target, Settings, Waypoints, SquareCheckBig, UserRound, Brain, type LucideIcon } from 'lucide-react';
+import { Target, Settings, Waypoints, SquareCheckBig, UserRound, Brain, PanelLeftClose, PanelLeftOpen, type LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getAgentPageEnabled, subscribeAgentPageEnabledChanges } from '@/config/agent-page-enabled';
 import { getDesktopAdaptiveEnabled, subscribeDesktopAdaptiveChanges } from '@/config/desktop-adaptive';
@@ -9,7 +9,6 @@ import { getCommandPaletteEnabled, subscribeCommandPaletteEnabledChanges } from 
 import { getCommandRegistryService } from '@/lib/services/command-registry.service';
 import { getCommandPaletteService } from '@/lib/services/command-palette.service';
 import { createCoreNavigationCommands, type CoreNavigationPath } from '@/lib/services/command-palette.commands';
-import { useTauriFullscreenShortcut } from '@/ui/app/hooks/useTauriFullscreenShortcut';
 import { CommandPalette } from '@/ui/app/components/CommandPalette';
 import { DesktopSidebarAccountEntry } from '@/ui/app/components/DesktopSidebarAccountEntry';
 import { ReminderNotifier } from '@/ui/app/components/ReminderNotifier';
@@ -251,7 +250,17 @@ function MobileShell({
   );
 }
 
-function DesktopSidebar({ activePath, agentPageEnabled }: { activePath: string; agentPageEnabled: boolean }) {
+function DesktopSidebar({
+  activePath,
+  agentPageEnabled,
+  collapsed,
+  onToggleCollapsed,
+}: {
+  activePath: string;
+  agentPageEnabled: boolean;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+}) {
   const desktopNavItems = [
     { key: 'now', title: '当下', path: '/eventlog', icon: Target, match: (path: string) => path === '/eventlog' || path === '/' },
     { key: 'tasks', title: '任务', path: '/tasks', icon: SquareCheckBig, match: (path: string) => path === '/tasks' || path.startsWith('/tasks/') },
@@ -269,18 +278,50 @@ function DesktopSidebar({ activePath, agentPageEnabled }: { activePath: string; 
   return (
     <aside
       data-testid="desktop-sidebar"
-      className="flex h-full w-64 shrink-0 flex-col border-r border-[hsl(var(--sidebar-border))] bg-[hsl(var(--sidebar))] text-[hsl(var(--sidebar-foreground))]"
+      data-state={collapsed ? 'collapsed' : 'expanded'}
+      className={cn(
+        'flex h-full shrink-0 flex-col border-r border-[hsl(var(--sidebar-border))] bg-[hsl(var(--sidebar))] text-[hsl(var(--sidebar-foreground))] transition-[width] duration-200 ease-out',
+        collapsed ? 'w-16' : 'w-64',
+      )}
     >
-      <div className="border-b border-[hsl(var(--sidebar-border))] p-3">
-        <div className="flex items-center gap-3 rounded-md px-2 py-2">
-          <div className="flex h-8 w-8 items-center justify-center rounded-md bg-[hsl(var(--sidebar-accent))] text-[hsl(var(--sidebar-accent-foreground))]">
-            <Brain size={16} />
+      <div className={cn('border-b border-[hsl(var(--sidebar-border))]', collapsed ? 'p-2' : 'p-3')}>
+        {collapsed ? (
+          <div className="flex flex-col items-center gap-2 rounded-md py-2">
+            <div className="flex h-8 w-8 items-center justify-center rounded-md bg-[hsl(var(--sidebar-accent))] text-[hsl(var(--sidebar-accent-foreground))]">
+              <Brain size={16} />
+            </div>
+            <button
+              type="button"
+              data-testid="desktop-sidebar-toggle"
+              aria-label="展开侧边栏"
+              aria-expanded="false"
+              onClick={onToggleCollapsed}
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[hsl(var(--sidebar-border))] text-[hsl(var(--sidebar-muted))] transition-colors hover:bg-[hsl(var(--sidebar-accent))] hover:text-[hsl(var(--sidebar-accent-foreground))]"
+            >
+              <PanelLeftOpen size={16} />
+            </button>
           </div>
-          <div className="min-w-0">
-            <p className="truncate text-sm font-semibold">ExoMind</p>
-            <p className="truncate text-xs text-[hsl(var(--sidebar-muted))]">外心</p>
+        ) : (
+          <div className="flex items-center gap-3 rounded-md px-2 py-2">
+            <div className="flex h-8 w-8 items-center justify-center rounded-md bg-[hsl(var(--sidebar-accent))] text-[hsl(var(--sidebar-accent-foreground))]">
+              <Brain size={16} />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-semibold">ExoMind</p>
+              <p className="truncate text-xs text-[hsl(var(--sidebar-muted))]">外心</p>
+            </div>
+            <button
+              type="button"
+              data-testid="desktop-sidebar-toggle"
+              aria-label="收起侧边栏"
+              aria-expanded="true"
+              onClick={onToggleCollapsed}
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-[hsl(var(--sidebar-border))] text-[hsl(var(--sidebar-muted))] transition-colors hover:bg-[hsl(var(--sidebar-accent))] hover:text-[hsl(var(--sidebar-accent-foreground))]"
+            >
+              <PanelLeftClose size={16} />
+            </button>
           </div>
-        </div>
+        )}
       </div>
 
       <nav className="flex-1 space-y-1 p-2">
@@ -288,7 +329,8 @@ function DesktopSidebar({ activePath, agentPageEnabled }: { activePath: string; 
           const Icon = item.icon;
           const active = item.match(activePath);
           const itemClassName = cn(
-            'flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors',
+            'flex w-full items-center rounded-md text-sm transition-colors',
+            collapsed ? 'justify-center px-0 py-3' : 'gap-2 px-3 py-2',
             active
               ? 'bg-[hsl(var(--sidebar-accent))] text-[hsl(var(--sidebar-accent-foreground))] font-medium'
               : 'text-[hsl(var(--sidebar-foreground))]'
@@ -298,27 +340,44 @@ function DesktopSidebar({ activePath, agentPageEnabled }: { activePath: string; 
               key={item.path}
               to={item.path}
               data-testid={`desktop-sidebar-item-${item.key}`}
+              aria-label={item.title}
+              title={item.title}
               className={itemClassName}
             >
               <Icon size={16} />
-              <span>{item.title}</span>
+              {collapsed ? <span className="sr-only">{item.title}</span> : <span>{item.title}</span>}
             </Link>
           );
         })}
       </nav>
 
-      <div className="border-t border-[hsl(var(--sidebar-border))] p-3">
-        <DesktopSidebarAccountEntry />
+      <div className={cn('border-t border-[hsl(var(--sidebar-border))]', collapsed ? 'p-2' : 'p-3')}>
+        <DesktopSidebarAccountEntry collapsed={collapsed} />
       </div>
     </aside>
   );
 }
 
-function DesktopLayout({ activePath, agentPageEnabled }: { activePath: string; agentPageEnabled: boolean }) {
+function DesktopLayout({
+  activePath,
+  agentPageEnabled,
+  collapsed,
+  onToggleCollapsed,
+}: {
+  activePath: string;
+  agentPageEnabled: boolean;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+}) {
   return (
     <div className="h-[100dvh] overflow-hidden bg-[#FAF7F5] dark:bg-[#0C0A09]">
       <div className="flex h-full w-full overflow-hidden bg-[#FAF7F5] dark:bg-[#0C0A09]">
-        <DesktopSidebar activePath={activePath} agentPageEnabled={agentPageEnabled} />
+        <DesktopSidebar
+          activePath={activePath}
+          agentPageEnabled={agentPageEnabled}
+          collapsed={collapsed}
+          onToggleCollapsed={onToggleCollapsed}
+        />
         <main data-testid="desktop-settings-content" className="min-w-0 flex-1 overflow-y-auto bg-[#FAF7F5] dark:bg-[#0C0A09]">
           <Outlet />
         </main>
@@ -329,11 +388,11 @@ function DesktopLayout({ activePath, agentPageEnabled }: { activePath: string; a
 
 function NewLayout() {
   const location = useLocation();
-  useTauriFullscreenShortcut();
   const navigate = useNavigate();
   const isDesktop = useIsDesktop();
 
   const [agentPageEnabled, setAgentPageEnabled] = useState(() => getAgentPageEnabled());
+  const [desktopSidebarCollapsed, setDesktopSidebarCollapsed] = useState(false);
   const [desktopAdaptiveEnabled, setDesktopAdaptiveEnabledState] = useState(() => getDesktopAdaptiveEnabled());
   const [developerModeEnabled, setDeveloperModeEnabled] = useState(() => getDeveloperModeEnabled());
   const [commandPaletteEnabled, setCommandPaletteEnabled] = useState(() => getCommandPaletteEnabled());
@@ -427,7 +486,12 @@ function NewLayout() {
   if (isDesktop && desktopAdaptiveEnabled && isDesktopAdaptiveRoute) {
     return (
       <>
-        <DesktopLayout activePath={location.pathname} agentPageEnabled={agentPageEnabled} />
+        <DesktopLayout
+          activePath={location.pathname}
+          agentPageEnabled={agentPageEnabled}
+          collapsed={desktopSidebarCollapsed}
+          onToggleCollapsed={() => setDesktopSidebarCollapsed((current) => !current)}
+        />
         {commandPaletteActive ? <CommandPalette context={commandContext} /> : null}
         <ReminderNotifier />
       </>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -525,8 +525,12 @@ const newTasksRoute = createRoute({
     // Redirect to the last visited tasks sub-path (e.g. /tasks/dag, /tasks/:id)
     useEffect(() => {
       const saved = sessionStorage.getItem(TASKS_LAST_PATH_KEY);
-      if (saved && saved !== '/tasks' && saved.startsWith('/tasks/')) {
+      console.log('[Routes] /tasks mount, saved:', saved, 'current:', window.location.pathname);
+      if (saved && saved.startsWith('/tasks/')) {
+        console.log('[Routes] redirecting to', saved);
         void navigate({ to: saved, replace: true });
+      } else {
+        console.log('[Routes] no redirect, showing default');
       }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [navigate]);

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -520,14 +520,16 @@ const newTasksRoute = createRoute({
   getParentRoute: () => newRootRoute,
   path: '/tasks',
   component: function NewTasks() {
+    const navigate = useNavigate();
+
     // Redirect to the last visited tasks sub-path (e.g. /tasks/dag, /tasks/:id)
     useEffect(() => {
       const saved = sessionStorage.getItem(TASKS_LAST_PATH_KEY);
-      if (saved && saved !== '/tasks' && saved !== window.location.pathname && saved.startsWith('/tasks')) {
-        window.location.replace(saved);
+      if (saved && saved !== '/tasks' && saved.startsWith('/tasks/')) {
+        void navigate({ to: saved, replace: true });
       }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [navigate]);
 
     return (
       <LazyPage>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -101,6 +101,11 @@ const ActorDetailPage = lazy(async () => {
   return { default: module.ActorDetailPage };
 });
 
+const SignalDetailPage = lazy(async () => {
+  const module = await import('@/ui/app/pages/agents/SignalDetailPage');
+  return { default: module.SignalDetailPage };
+});
+
 const AgentConversationPage = lazy(async () => {
   const module = await import('@/ui/app/pages/agents/AgentConversationPage');
   return { default: module.AgentConversationPage };
@@ -742,6 +747,18 @@ const newActorDetailRoute = createRoute({
   },
 });
 
+const newSignalDetailRoute = createRoute({
+  getParentRoute: () => newRootRoute,
+  path: '/agents/signal/$signalId',
+  component: function NewSignalDetail() {
+    return (
+      <LazyPage>
+        <SignalDetailPage />
+      </LazyPage>
+    );
+  },
+});
+
 const newAgentConversationRoute = createRoute({
   getParentRoute: () => newRootRoute,
   path: '/agents/chat/$agentId',
@@ -788,6 +805,7 @@ const newRouteTree = newRootRoute.addChildren([
   newUpdateRoute,
   newAgentDetailRoute,
   newActorDetailRoute,
+  newSignalDetailRoute,
   newAgentConversationRoute,
   newAgentMarketRoute,
 ]);

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -514,10 +514,22 @@ const newEventlogRoute = createRoute({
   },
 });
 
+const TASKS_LAST_PATH_KEY = 'exomind:last-tasks-path';
+
 const newTasksRoute = createRoute({
   getParentRoute: () => newRootRoute,
   path: '/tasks',
   component: function NewTasks() {
+    const navigate = useNavigate();
+
+    // Redirect to the last visited tasks sub-path (e.g. /tasks/dag, /tasks/:id)
+    useEffect(() => {
+      const saved = sessionStorage.getItem(TASKS_LAST_PATH_KEY);
+      if (saved && saved !== '/tasks' && saved.startsWith('/tasks')) {
+        void navigate({ to: saved, replace: true });
+      }
+    }, [navigate]);
+
     return (
       <LazyPage>
         <TasksPage />

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -9,6 +9,7 @@ import { getCommandPaletteEnabled, subscribeCommandPaletteEnabledChanges } from 
 import { getCommandRegistryService } from '@/lib/services/command-registry.service';
 import { getCommandPaletteService } from '@/lib/services/command-palette.service';
 import { createCoreNavigationCommands, type CoreNavigationPath } from '@/lib/services/command-palette.commands';
+import { useTauriFullscreenShortcut } from '@/ui/app/hooks/useTauriFullscreenShortcut';
 import { CommandPalette } from '@/ui/app/components/CommandPalette';
 import { DesktopSidebarAccountEntry } from '@/ui/app/components/DesktopSidebarAccountEntry';
 import { ReminderNotifier } from '@/ui/app/components/ReminderNotifier';
@@ -328,6 +329,7 @@ function DesktopLayout({ activePath, agentPageEnabled }: { activePath: string; a
 
 function NewLayout() {
   const location = useLocation();
+  useTauriFullscreenShortcut();
   const navigate = useNavigate();
   const isDesktop = useIsDesktop();
 

--- a/src/ui/app/components/DesktopSidebarAccountEntry.tsx
+++ b/src/ui/app/components/DesktopSidebarAccountEntry.tsx
@@ -26,7 +26,7 @@ function getAvatarText(name: string | null): string {
   return normalized ? normalized.charAt(0).toUpperCase() : '?';
 }
 
-export function DesktopSidebarAccountEntry() {
+export function DesktopSidebarAccountEntry({ collapsed = false }: { collapsed?: boolean }) {
   const { isLoggedIn, currentUser, activeProfileId } = useSyncStore();
   const [sheetOpen, setSheetOpen] = useState(false);
   const [sheetMode, setSheetMode] = useState<'switch' | 'login' | 'register'>('login');
@@ -45,20 +45,37 @@ export function DesktopSidebarAccountEntry() {
 
   return (
     <>
-      <button
-        type="button"
-        data-testid="desktop-sidebar-account-entry"
-        onClick={handleOpen}
-        className="flex w-full items-center gap-3 rounded-md px-2 py-2 text-left transition-colors hover:bg-[hsl(var(--sidebar-accent))]"
-      >
-        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-[hsl(var(--sidebar-accent))] text-xs font-semibold text-[hsl(var(--sidebar-accent-foreground))]">
-          {getAvatarText(title)}
-        </div>
-        <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-medium">{title}</p>
-          <p className="truncate text-xs text-[hsl(var(--sidebar-muted))]">{subtitle}</p>
-        </div>
-      </button>
+      {collapsed ? (
+        <button
+          type="button"
+          data-testid="desktop-sidebar-account-entry"
+          aria-label={`${title}，${subtitle}`}
+          title={`${title} · ${subtitle}`}
+          onClick={handleOpen}
+          className="flex w-full items-center justify-center rounded-md px-2 py-2 transition-colors hover:bg-[hsl(var(--sidebar-accent))]"
+        >
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-[hsl(var(--sidebar-accent))] text-xs font-semibold text-[hsl(var(--sidebar-accent-foreground))]">
+            {getAvatarText(title)}
+          </div>
+          <span className="sr-only">{title}</span>
+          <span className="sr-only">{subtitle}</span>
+        </button>
+      ) : (
+        <button
+          type="button"
+          data-testid="desktop-sidebar-account-entry"
+          onClick={handleOpen}
+          className="flex w-full items-center gap-3 rounded-md px-2 py-2 text-left transition-colors hover:bg-[hsl(var(--sidebar-accent))]"
+        >
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-[hsl(var(--sidebar-accent))] text-xs font-semibold text-[hsl(var(--sidebar-accent-foreground))]">
+            {getAvatarText(title)}
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium">{title}</p>
+            <p className="truncate text-xs text-[hsl(var(--sidebar-muted))]">{subtitle}</p>
+          </div>
+        </button>
+      )}
 
       <SwitchAccountSheet
         open={sheetOpen}

--- a/src/ui/app/components/EstimatedTimeEditor.tsx
+++ b/src/ui/app/components/EstimatedTimeEditor.tsx
@@ -26,9 +26,6 @@ function normalizePositiveMinutes(value: string): number | undefined {
   return parsed;
 }
 
-function formatCurrentMinutes(minutes: number | undefined): string {
-  return minutes ? `${minutes} 分钟` : '未估时';
-}
 
 export interface EstimatedTimeEditorProps {
   taskId: string;
@@ -145,36 +142,7 @@ export function EstimatedTimeEditor({
   }
 
   return (
-    <div className={`mt-3 flex min-w-0 flex-col gap-2${disabled ? ' opacity-50 cursor-not-allowed' : ''}`} data-testid="estimated-time-editor">
-      <div className="flex flex-wrap items-start justify-between gap-2">
-        <div className="min-w-0">
-          <p className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">任务估时</p>
-          <p
-            data-testid="estimated-time-current"
-            className="mt-1 text-xs font-semibold text-[#1C1917] dark:text-[#FAFAF9]"
-          >
-            当前：{formatCurrentMinutes(minutes)}
-          </p>
-        </div>
-
-        <button
-          type="button"
-          data-testid="estimated-time-clear"
-          aria-pressed={minutes === undefined}
-          disabled={disabled || isSaving}
-          onClick={() => {
-            void persistMinutes(undefined);
-          }}
-          className={`rounded-full border px-3 py-1 text-[11px] transition-colors ${
-            minutes === undefined
-              ? 'border-[#C75B3A] bg-[#FFF7ED] text-[#C75B3A] dark:border-[#E8734E] dark:bg-[#2A1510] dark:text-[#F4A589]'
-              : 'border-[#E7E5E4] text-[#78716C] hover:text-[#57534E] dark:border-[#292524] dark:text-[#A8A29E] dark:hover:text-[#D6D3D1]'
-          } disabled:cursor-not-allowed disabled:opacity-60`}
-        >
-          {isSaving && minutes === undefined ? '保存中...' : '清空'}
-        </button>
-      </div>
-
+    <div className={`flex min-w-0 flex-col gap-2${disabled ? ' opacity-50 cursor-not-allowed' : ''}`} data-testid="estimated-time-editor">
       <div
         className="relative min-w-0 overflow-hidden rounded-[10px] border border-[#E7E5E4] bg-[#F5F0ED]/50 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]"
         data-testid="estimated-time-selector"

--- a/src/ui/app/components/EstimatedTimeEditor.tsx
+++ b/src/ui/app/components/EstimatedTimeEditor.tsx
@@ -149,7 +149,7 @@ export function EstimatedTimeEditor({
       >
         <div
           data-testid="estimated-time-active-indicator"
-          className="pointer-events-none absolute inset-y-0 left-0 rounded-[8px] border border-[#FFFFFFCC] bg-white/55 shadow-[0_1px_2px_rgba(0,0,0,0.05)] transition-transform duration-200 ease-out dark:border-[#FFFFFF66] dark:bg-[#FFFFFF14]"
+          className="pointer-events-none absolute inset-y-0 left-0 rounded-[8px] border border-brand-accent/40 bg-brand-accent/15 shadow-[0_1px_2px_rgba(0,0,0,0.05)] transition-transform duration-200 ease-out"
           style={{ width: `${100 / 6}%`, transform: `translateX(${activeIndex * 100}%)` }}
         />
 

--- a/src/ui/app/components/EstimatedTimeEditor.tsx
+++ b/src/ui/app/components/EstimatedTimeEditor.tsx
@@ -33,12 +33,14 @@ function formatCurrentMinutes(minutes: number | undefined): string {
 export interface EstimatedTimeEditorProps {
   taskId: string;
   currentMinutes?: number;
+  disabled?: boolean;
   onUpdate?: (minutes: number | undefined) => void;
 }
 
 export function EstimatedTimeEditor({
   taskId,
   currentMinutes,
+  disabled = false,
   onUpdate,
 }: EstimatedTimeEditorProps) {
   const activeTaskIdRef = useRef(taskId);
@@ -143,7 +145,7 @@ export function EstimatedTimeEditor({
   }
 
   return (
-    <div className="mt-3 flex min-w-0 flex-col gap-2" data-testid="estimated-time-editor">
+    <div className={`mt-3 flex min-w-0 flex-col gap-2${disabled ? ' opacity-50 cursor-not-allowed' : ''}`} data-testid="estimated-time-editor">
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div className="min-w-0">
           <p className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">任务估时</p>
@@ -159,7 +161,7 @@ export function EstimatedTimeEditor({
           type="button"
           data-testid="estimated-time-clear"
           aria-pressed={minutes === undefined}
-          disabled={isSaving}
+          disabled={disabled || isSaving}
           onClick={() => {
             void persistMinutes(undefined);
           }}
@@ -192,7 +194,7 @@ export function EstimatedTimeEditor({
               type="button"
               data-testid={`estimated-time-preset-${preset}`}
               aria-pressed={minutes === preset}
-              disabled={isSaving}
+              disabled={disabled || isSaving}
               onClick={() => {
                 void persistMinutes(preset);
               }}
@@ -207,7 +209,7 @@ export function EstimatedTimeEditor({
               ref={customInputRef}
               data-testid="estimated-time-custom-input"
               value={customDraft}
-              disabled={isSaving}
+              disabled={disabled || isSaving}
               onChange={(event) => {
                 setCustomDraft(event.target.value.replace(/[^\d]/g, ''));
               }}
@@ -222,7 +224,7 @@ export function EstimatedTimeEditor({
               type="button"
               data-testid="estimated-time-custom-trigger"
               aria-pressed={isCustomSelected}
-              disabled={isSaving}
+              disabled={disabled || isSaving}
               onClick={openCustomEditor}
               className={`relative z-10 flex h-8 w-full items-center justify-center gap-1 whitespace-nowrap rounded-[8px] px-[8px] text-[12px] transition-colors duration-200 ${
                 isCustomSelected
@@ -243,6 +245,7 @@ export function EstimatedTimeEditor({
           {errorMessage}
         </p>
       ) : null}
+      {disabled ? <p className="text-xs text-[#A8A29E]">终态任务不可编辑</p> : null}
     </div>
   );
 }

--- a/src/ui/app/components/EstimatedTimeEditor.tsx
+++ b/src/ui/app/components/EstimatedTimeEditor.tsx
@@ -74,10 +74,10 @@ export function EstimatedTimeEditor({
   }, [isCustomEditing]);
 
   const activeIndex = minutes === undefined
-    ? null
+    ? 0
     : isPresetEstimatedMinutes(minutes)
-      ? PRESET_ESTIMATED_MINUTES.indexOf(minutes as (typeof PRESET_ESTIMATED_MINUTES)[number])
-      : PRESET_ESTIMATED_MINUTES.length;
+      ? PRESET_ESTIMATED_MINUTES.indexOf(minutes as (typeof PRESET_ESTIMATED_MINUTES)[number]) + 1
+      : PRESET_ESTIMATED_MINUTES.length + 1;
   const isCustomSelected = minutes !== undefined && !isPresetEstimatedMinutes(minutes);
 
   async function persistMinutes(nextMinutes: number | undefined): Promise<void> {
@@ -179,15 +179,25 @@ export function EstimatedTimeEditor({
         className="relative min-w-0 overflow-hidden rounded-[10px] border border-[#E7E5E4] bg-[#F5F0ED]/50 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]"
         data-testid="estimated-time-selector"
       >
-        {activeIndex !== null ? (
-          <div
-            data-testid="estimated-time-active-indicator"
-            className="pointer-events-none absolute inset-y-0 left-0 w-1/5 rounded-[8px] border border-[#FFFFFFCC] bg-white/55 shadow-[0_1px_2px_rgba(0,0,0,0.05)] transition-transform duration-200 ease-out dark:border-[#FFFFFF66] dark:bg-[#FFFFFF14]"
-            style={{ transform: `translateX(${activeIndex * 100}%)` }}
-          />
-        ) : null}
+        <div
+          data-testid="estimated-time-active-indicator"
+          className="pointer-events-none absolute inset-y-0 left-0 rounded-[8px] border border-[#FFFFFFCC] bg-white/55 shadow-[0_1px_2px_rgba(0,0,0,0.05)] transition-transform duration-200 ease-out dark:border-[#FFFFFF66] dark:bg-[#FFFFFF14]"
+          style={{ width: `${100 / 6}%`, transform: `translateX(${activeIndex * 100}%)` }}
+        />
 
-        <div className="relative z-10 grid min-w-0 grid-cols-5 gap-0">
+        <div className="relative z-10 grid min-w-0 grid-cols-6 gap-0">
+          <button
+            type="button"
+            data-testid="estimated-time-preset-none"
+            aria-pressed={minutes === undefined}
+            disabled={disabled || isSaving}
+            onClick={() => {
+              void persistMinutes(undefined);
+            }}
+            className={expectedOptionClass(minutes === undefined)}
+          >
+            无
+          </button>
           {PRESET_ESTIMATED_MINUTES.map((preset) => (
             <button
               key={preset}

--- a/src/ui/app/components/FocusTimerWidget.tsx
+++ b/src/ui/app/components/FocusTimerWidget.tsx
@@ -655,7 +655,7 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
   const endActionTitle = feedbackInProgress ? '反馈中' : '结束';
   const endActionButtonClass = feedbackInProgress
     ? 'h-11 w-11 rounded-[12px] bg-brand p-0 text-white hover:bg-brand/90 hover:text-white'
-    : 'h-11 w-11 rounded-[12px] bg-[#FDECEB] dark:bg-[#C75B3A] p-0 text-[#C75B3A] dark:text-[#FAFAF9] hover:bg-[#F8DED9] dark:hover:bg-[#B24D2F]';
+    : 'h-11 w-11 rounded-[12px] bg-[#C75B3A] p-0 text-white hover:bg-[#B24D2F] hover:text-white';
   const endActionIcon = feedbackInProgress
     ? <NotepadText size={18} className="text-white" />
     : <Square size={18} />;

--- a/src/ui/app/components/FocusTimerWidget.tsx
+++ b/src/ui/app/components/FocusTimerWidget.tsx
@@ -247,6 +247,7 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
   }, [timerPreferences.countdownEndSoundEnabled, timerPreferences.countdownEndSoundPresetId]);
 
   const applyActiveBlock = useCallback((block: ActiveBlockData | null) => {
+    console.log('[FocusTimer] applyActiveBlock', block ? { startId: block.startId, mode: block.mode, phase: block.phase, paused: block.paused, taskId: block.taskId, feedbackSubmittedAt: block.feedbackSubmittedAt } : 'NULL', new Error().stack?.split('\n').slice(1, 4).join(' <- '));
     activeBlockDataRef.current = block;
     if (!block) {
       taskStatusChoiceBlockRef.current = null;
@@ -306,13 +307,16 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
 
   useEffect(() => {
     let cancelled = false;
+    console.log('[FocusTimer] useEffect: subscribing to onBlockChange');
     const unsubscribe = timeBlockServiceRef.current.onBlockChange((block) => {
-      if (cancelled) return;
+      console.log('[FocusTimer] onBlockChange fired', block ? { startId: block.startId, mode: block.mode, phase: block.phase, paused: block.paused, feedbackSubmittedAt: block.feedbackSubmittedAt } : 'NULL');
+      if (cancelled) { console.log('[FocusTimer] onBlockChange: cancelled, skipping'); return; }
       applyActiveBlock(block);
     });
 
     const load = async () => {
       const block = await timeBlockServiceRef.current.loadActiveBlock();
+      console.log('[FocusTimer] loadActiveBlock on mount', block ? { startId: block.startId, mode: block.mode, phase: block.phase } : 'NULL');
       if (cancelled) return;
       if (block) {
         applyActiveBlock(block);
@@ -321,6 +325,7 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
 
     void load();
     return () => {
+      console.log('[FocusTimer] useEffect cleanup: unsubscribing');
       cancelled = true;
       unsubscribe();
     };

--- a/src/ui/app/components/FocusTimerWidget.tsx
+++ b/src/ui/app/components/FocusTimerWidget.tsx
@@ -776,12 +776,12 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
               <div className="flex min-w-0 flex-col gap-1.5">
                 <span className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">预期时长</span>
                 <div
-                  className="relative min-w-0 overflow-hidden rounded-[10px] border border-[#FFFFFF60] bg-white/35 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]"
+                  className="relative min-w-0 overflow-hidden rounded-[10px] border border-[#E7E5E4] bg-[#F5F0ED]/50 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]"
                   data-testid="new-focus-expected-time-row"
                 >
                   <div
                     data-testid="new-focus-expected-active-indicator"
-                    className="pointer-events-none absolute inset-y-0 left-0 w-1/5 rounded-[8px] border border-[#FFFFFFCC] bg-white/55 shadow-[0_1px_2px_rgba(0,0,0,0.05)] transition-transform duration-200 ease-out dark:border-[#FFFFFF66] dark:bg-[#FFFFFF14]"
+                    className="pointer-events-none absolute inset-y-0 left-0 w-1/5 rounded-[8px] border border-brand-accent/40 bg-brand-accent/15 shadow-[0_1px_2px_rgba(0,0,0,0.05)] transition-transform duration-200 ease-out"
                     style={{ transform: `translateX(${activeExpectedIndex * 100}%)` }}
                   />
                   <div className="relative z-10 grid min-w-0 grid-cols-5 gap-0">
@@ -993,7 +993,7 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
               onClick={() => {
                 void handleConfirmEnd();
               }}
-              className="dark:rounded-[10px] dark:bg-[#C75B3A] dark:text-white dark:hover:bg-[#B24D2F]"
+              className="rounded-[10px] bg-brand-accent text-white hover:bg-brand-accent/90"
             >
               {feedbackConfirmLabel}
             </Button>

--- a/src/ui/app/components/FocusTimerWidget.tsx
+++ b/src/ui/app/components/FocusTimerWidget.tsx
@@ -36,8 +36,7 @@ import { resolveCountdownEndTimeDisplay } from '@/lib/timeblock/expected-end-tim
 import type { ActiveBlockData } from '@/lib/types/event';
 import type { TaskNode, TaskStatus } from '@/lib/types/task';
 import { FocusBgmPanel } from '@/ui/app/components/settings/settings-custom-items';
-
-type TaskStatusChoice = 'continue' | 'suspended' | 'completed' | 'cancelled';
+import { TaskStatusSelector, type TaskStatusChoice } from '@/ui/app/components/TaskStatusSelector';
 
 type FocusUiState = 'idle' | 'config' | 'running'; // UI State Machine（界面状态机）
 type RunningSubState = 'running' | 'paused'; // Running Sub-state（运行子状态）
@@ -975,39 +974,11 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
             className="min-h-[96px] resize-none dark:bg-[rgba(255,255,255,0.06)] dark:border-[#FFFFFF15] dark:text-[#FAFAF9] dark:placeholder:text-[#78716C]"
           />
           {linkedTask && (
-            <div data-testid="feedback-task-status-section" className="flex flex-col gap-1.5">
-              <div className="flex items-center gap-2">
-                <span className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">关联任务</span>
-                <span className="truncate text-[12px] text-[#1C1917] dark:text-[#FAFAF9]">{linkedTask.title}</span>
-              </div>
-              <div
-                className="relative overflow-hidden rounded-[10px] border border-[#E7E5E4] bg-[#F5F0ED]/50 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]"
-                data-testid="feedback-task-status-selector"
-              >
-                <div className="relative z-10 grid grid-cols-4 gap-0">
-                  {([
-                    { key: 'suspended' as TaskStatusChoice, label: '挂起' },
-                    { key: 'continue' as TaskStatusChoice, label: '继续' },
-                    { key: 'completed' as TaskStatusChoice, label: '完成' },
-                    { key: 'cancelled' as TaskStatusChoice, label: '取消' },
-                  ] as const).map(({ key, label }) => (
-                    <button
-                      key={key}
-                      type="button"
-                      data-testid={`feedback-task-status-${key}`}
-                      onClick={() => setTaskStatusChoice(key)}
-                      className={`relative z-10 h-8 w-full whitespace-nowrap rounded-[8px] px-[8px] text-center text-[12px] transition-colors duration-200 ${
-                        taskStatusChoice === key
-                          ? 'font-semibold text-[#1C1917] dark:text-[#FAFAF9] bg-white/55 dark:bg-[#FFFFFF14] border border-[#FFFFFFCC] dark:border-[#FFFFFF66] shadow-[0_1px_2px_rgba(0,0,0,0.05)]'
-                          : 'text-[#78716C] hover:text-[#57534E] dark:hover:text-[#D6D3D1]'
-                      }`}
-                    >
-                      {label}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </div>
+            <TaskStatusSelector
+              value={taskStatusChoice}
+              onChange={setTaskStatusChoice}
+              linkedTaskTitle={linkedTask.title}
+            />
           )}
           <DialogFooter>
             <Button

--- a/src/ui/app/components/NowInputRow.tsx
+++ b/src/ui/app/components/NowInputRow.tsx
@@ -200,7 +200,7 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
   }), []);
 
   return (
-    <div className="mb-2 shrink-0 border-t border-[#E7E5E4] bg-[#FAF7F5] dark:border-[#292524] dark:bg-[#0C0A09]" data-testid="new-now-input-row">
+    <div className="shrink-0 border-t border-[#E7E5E4] bg-[#FAF7F5] dark:border-[#292524] dark:bg-[#0C0A09]" data-testid="new-now-input-row">
       <div className="px-4 py-2">
         <div className="flex items-center gap-2">
           <button

--- a/src/ui/app/components/NowInputRow.tsx
+++ b/src/ui/app/components/NowInputRow.tsx
@@ -64,7 +64,7 @@ function shouldSendOnEnter(mode: InputSendMode, event: KeyboardEvent<HTMLTextAre
   if (event.altKey) return false;
 
   if (mode === 'enter-send') {
-    return !event.shiftKey || event.ctrlKey || event.metaKey;
+    return !event.shiftKey && !event.ctrlKey && !event.metaKey;
   }
 
   if (event.shiftKey) return false;
@@ -75,6 +75,20 @@ function mergeTranscriptText(currentValue: string, transcript: string): string {
   const trimmedCurrent = currentValue.trim();
   if (!trimmedCurrent) return transcript;
   return `${trimmedCurrent} ${transcript}`;
+}
+
+function insertTextareaNewline(textarea: HTMLTextAreaElement, onChangeValue: (nextValue: string) => void): void {
+  const start = textarea.selectionStart ?? textarea.value.length;
+  const end = textarea.selectionEnd ?? textarea.value.length;
+  const nextValue = `${textarea.value.slice(0, start)}\n${textarea.value.slice(end)}`;
+  const nextCursor = start + 1;
+
+  onChangeValue(nextValue);
+  requestAnimationFrame(() => {
+    textarea.selectionStart = nextCursor;
+    textarea.selectionEnd = nextCursor;
+    textarea.focus();
+  });
 }
 
 function focusTextarea(textarea: HTMLTextAreaElement | null): void {
@@ -285,16 +299,29 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
       textareaRef.current?.blur();
       return;
     }
-    if (!shouldSendOnEnter(inputSendMode, event)) return;
+
+    if (event.key !== 'Enter' || event.altKey) return;
+
+    if (shouldSendOnEnter(inputSendMode, event)) {
+      event.preventDefault();
+      if (value.trim()) {
+        void submitInput();
+      } else if (inputSendMode === 'ctrl-enter-send' && (event.ctrlKey || event.metaKey)) {
+        textareaRef.current?.blur();
+        voiceButtonRef.current?.start();
+      }
+      return;
+    }
+
+    const textarea = textareaRef.current;
+    if (!textarea) return;
 
     event.preventDefault();
-    if (value.trim()) {
-      void submitInput();
-    } else if (inputSendMode === 'ctrl-enter-send' && (event.ctrlKey || event.metaKey)) {
-      textareaRef.current?.blur();
-      voiceButtonRef.current?.start();
-    }
-  }, [inputSendMode, submitInput, value]);
+    insertTextareaNewline(textarea, (nextValue) => {
+      setValue(nextValue);
+      resizeTextarea(textarea);
+    });
+  }, [inputSendMode, resizeTextarea, submitInput, value]);
 
   const handleAttachmentClick = useCallback(() => {
     if (attachmentFeedbackTimerRef.current) {

--- a/src/ui/app/components/NowInputRow.tsx
+++ b/src/ui/app/components/NowInputRow.tsx
@@ -31,6 +31,7 @@ import {
 
 interface NowInputRowProps {
   onSend: (content: string, tags?: string[]) => void | Promise<void>;
+  onValueChange?: (value: string) => void;
   placeholder?: string;
   draftStorageKey?: string | null;
   draftDebounceMs?: number;
@@ -100,6 +101,7 @@ function focusTextarea(textarea: HTMLTextAreaElement | null): void {
 
 export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>(function NowInputRow({
   onSend,
+  onValueChange,
   placeholder = '记录当下的事实...',
   draftStorageKey,
   draftDebounceMs = 300,
@@ -132,6 +134,10 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
   useEffect(() => {
     resizeTextarea();
   }, [value, resizeTextarea]);
+
+  useEffect(() => {
+    onValueChange?.(value);
+  }, [onValueChange, value]);
 
   useEffect(() => subscribeVoiceTranscriptSendModeChanges(setVoiceTranscriptSendMode), []);
 

--- a/src/ui/app/components/NowInputRow.tsx
+++ b/src/ui/app/components/NowInputRow.tsx
@@ -17,10 +17,29 @@ import { VoiceInputButton, type VoiceInputButtonHandle } from '@/components/Voic
 import type { VoiceMessageInputHandle } from '@/components/VoiceMessageInput';
 import { publishVoiceTranscriptSignal } from '@/lib/services/voice-signal.service';
 import { log } from '@/lib/logger';
+import { clearInputDraft, readInputDraft, writeInputDraft } from '@/lib/storage/input-draft-storage';
+import {
+  getVoiceTranscriptSendMode,
+  subscribeVoiceTranscriptSendModeChanges,
+  type VoiceTranscriptSendMode,
+} from '@/config/voice-transcript-send-mode';
+import {
+  getInputSendMode,
+  subscribeInputSendModeChanges,
+  type InputSendMode,
+} from '@/config/input-send-mode';
 
 interface NowInputRowProps {
   onSend: (content: string, tags?: string[]) => void | Promise<void>;
   placeholder?: string;
+  draftStorageKey?: string | null;
+  draftDebounceMs?: number;
+}
+
+function buildAutoDraftStorageKey(placeholder: string): string {
+  const pathname = typeof window !== 'undefined' ? window.location.pathname || '/' : '/';
+  const normalizedPlaceholder = placeholder.trim() || 'default';
+  return `exomind:draft:now-input:${pathname}:${normalizedPlaceholder}`;
 }
 
 const getClipboardDebugSnapshot = () => {
@@ -40,11 +59,41 @@ function getPasteFailureLabel(reason: ClipboardFailureReason): string {
   return '未粘贴';
 }
 
+function shouldSendOnEnter(mode: InputSendMode, event: KeyboardEvent<HTMLTextAreaElement>): boolean {
+  if (event.key !== 'Enter') return false;
+  if (event.altKey) return false;
+
+  if (mode === 'enter-send') {
+    return !event.shiftKey || event.ctrlKey || event.metaKey;
+  }
+
+  if (event.shiftKey) return false;
+  return event.ctrlKey || event.metaKey;
+}
+
+function mergeTranscriptText(currentValue: string, transcript: string): string {
+  const trimmedCurrent = currentValue.trim();
+  if (!trimmedCurrent) return transcript;
+  return `${trimmedCurrent} ${transcript}`;
+}
+
+function focusTextarea(textarea: HTMLTextAreaElement | null): void {
+  textarea?.focus();
+  requestAnimationFrame(() => {
+    textarea?.focus();
+  });
+}
+
 export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>(function NowInputRow({
   onSend,
   placeholder = '记录当下的事实...',
+  draftStorageKey,
+  draftDebounceMs = 300,
 }, ref) {
+  const effectiveDraftStorageKey = draftStorageKey === null ? null : draftStorageKey ?? buildAutoDraftStorageKey(placeholder);
   const [value, setValue] = useState('');
+  const [voiceTranscriptSendMode, setVoiceTranscriptSendMode] = useState<VoiceTranscriptSendMode>(() => getVoiceTranscriptSendMode());
+  const [inputSendMode, setInputSendMode] = useState<InputSendMode>(() => getInputSendMode());
   const [pasteFeedback, setPasteFeedback] = useState<'idle' | 'success' | 'error'>('idle');
   const [attachmentFeedback, setAttachmentFeedback] = useState<'idle' | 'pending'>('idle');
   const [pasteFailureLabel, setPasteFailureLabel] = useState('未粘贴');
@@ -52,6 +101,7 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
   const voiceButtonRef = useRef<VoiceInputButtonHandle | null>(null);
   const pasteFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const attachmentFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const draftPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const resizeTextarea = useCallback((target?: HTMLTextAreaElement | null) => {
     const el = target ?? textareaRef.current;
@@ -69,6 +119,10 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
     resizeTextarea();
   }, [value, resizeTextarea]);
 
+  useEffect(() => subscribeVoiceTranscriptSendModeChanges(setVoiceTranscriptSendMode), []);
+
+  useEffect(() => subscribeInputSendModeChanges(setInputSendMode), []);
+
   useEffect(() => () => {
     if (pasteFeedbackTimerRef.current) {
       clearTimeout(pasteFeedbackTimerRef.current);
@@ -78,7 +132,45 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
       clearTimeout(attachmentFeedbackTimerRef.current);
       attachmentFeedbackTimerRef.current = null;
     }
+    if (draftPersistTimerRef.current) {
+      clearTimeout(draftPersistTimerRef.current);
+      draftPersistTimerRef.current = null;
+    }
   }, []);
+
+  useEffect(() => {
+    if (!effectiveDraftStorageKey) return;
+
+    const savedDraft = readInputDraft(effectiveDraftStorageKey);
+    if (savedDraft !== null) {
+      setValue(savedDraft);
+    }
+  }, [effectiveDraftStorageKey]);
+
+  useEffect(() => {
+    if (!effectiveDraftStorageKey) return;
+
+    if (draftPersistTimerRef.current) {
+      clearTimeout(draftPersistTimerRef.current);
+      draftPersistTimerRef.current = null;
+    }
+
+    draftPersistTimerRef.current = setTimeout(() => {
+      if (!value.trim()) {
+        clearInputDraft(effectiveDraftStorageKey);
+      } else {
+        writeInputDraft(effectiveDraftStorageKey, value);
+      }
+      draftPersistTimerRef.current = null;
+    }, draftDebounceMs);
+
+    return () => {
+      if (draftPersistTimerRef.current) {
+        clearTimeout(draftPersistTimerRef.current);
+        draftPersistTimerRef.current = null;
+      }
+    };
+  }, [draftDebounceMs, effectiveDraftStorageKey, value]);
 
   const submitInput = useCallback(async () => {
     const trimmed = value.trim();
@@ -87,12 +179,28 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
     setValue('');
     try {
       await onSend(trimmed);
+      if (draftPersistTimerRef.current) {
+        clearTimeout(draftPersistTimerRef.current);
+        draftPersistTimerRef.current = null;
+      }
+      if (effectiveDraftStorageKey) {
+        clearInputDraft(effectiveDraftStorageKey);
+      }
+      focusTextarea(textareaRef.current);
     } catch (error) {
       setValue(saved);
+      if (draftPersistTimerRef.current) {
+        clearTimeout(draftPersistTimerRef.current);
+        draftPersistTimerRef.current = null;
+      }
+      if (effectiveDraftStorageKey) {
+        writeInputDraft(effectiveDraftStorageKey, saved);
+      }
+      focusTextarea(textareaRef.current);
       log.error(`[NowInputRow] send failed: ${error instanceof Error ? error.message : String(error)}`);
       toast({ title: '发送失败', description: '请检查网络连接后重试', variant: 'destructive' });
     }
-  }, [onSend, value]);
+  }, [effectiveDraftStorageKey, onSend, value]);
 
   const insertClipboardText = useCallback((text: string) => {
     if (!text) return;
@@ -151,9 +259,22 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
       log.warn(`[new-now-input][voice-signal] ${publishError instanceof Error ? publishError.message : String(publishError)}`);
     });
 
-    // 语音输入始终直接发送到事件日志——语音是即时事件，应该立即入库
-    onSend(normalized, ['voice']);
-  }, [onSend]);
+    if (voiceTranscriptSendMode === 'direct-send') {
+      onSend(normalized, ['voice']);
+      return;
+    }
+
+    setValue((prev) => mergeTranscriptText(prev, normalized));
+    requestAnimationFrame(() => {
+      textareaRef.current?.focus();
+      const nextValue = textareaRef.current?.value ?? '';
+      const end = nextValue.length;
+      if (textareaRef.current) {
+        textareaRef.current.selectionStart = end;
+        textareaRef.current.selectionEnd = end;
+      }
+    });
+  }, [onSend, voiceTranscriptSendMode]);
 
   const handleVoiceError = useCallback((error: string) => {
     log.error(`[new-now-input][voice] ${error}`);
@@ -164,18 +285,16 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
       textareaRef.current?.blur();
       return;
     }
-    if (event.key !== 'Enter') return;
-    if (!(event.ctrlKey || event.metaKey)) return;
-    if (event.altKey || event.shiftKey) return;
+    if (!shouldSendOnEnter(inputSendMode, event)) return;
 
     event.preventDefault();
     if (value.trim()) {
-      submitInput();
-    } else {
+      void submitInput();
+    } else if (inputSendMode === 'ctrl-enter-send' && (event.ctrlKey || event.metaKey)) {
       textareaRef.current?.blur();
       voiceButtonRef.current?.start();
     }
-  }, [submitInput, value]);
+  }, [inputSendMode, submitInput, value]);
 
   const handleAttachmentClick = useCallback(() => {
     if (attachmentFeedbackTimerRef.current) {

--- a/src/ui/app/components/TaskBreadcrumb.tsx
+++ b/src/ui/app/components/TaskBreadcrumb.tsx
@@ -1,0 +1,45 @@
+import { ArrowLeft, type LucideIcon } from 'lucide-react';
+import { Link } from '@tanstack/react-router';
+import { TASKS_LAST_PATH_KEY } from '@/ui/app/pages/TasksPage';
+
+export interface TaskBreadcrumbSegment {
+  label: string;
+  to: string;
+  search?: Record<string, string>;
+  icon?: LucideIcon;
+}
+
+export interface TaskBreadcrumbProps {
+  segments: TaskBreadcrumbSegment[];
+  current: { label: string; icon?: LucideIcon };
+}
+
+function clearTaskPathMemory() {
+  sessionStorage.removeItem(TASKS_LAST_PATH_KEY);
+}
+
+export function TaskBreadcrumb({ segments, current }: TaskBreadcrumbProps) {
+  return (
+    <div className="inline-flex select-none items-center gap-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
+      {segments.map((segment, index) => (
+        <span key={segment.to} className="contents">
+          <Link
+            to={segment.to}
+            search={segment.search}
+            onClick={clearTaskPathMemory}
+            className="inline-flex items-center gap-1 hover:text-[#1C1917] dark:hover:text-[#FAFAF9]"
+          >
+            {index === 0 ? <ArrowLeft size={14} /> : null}
+            {segment.icon ? <segment.icon size={14} /> : null}
+            {segment.label}
+          </Link>
+          <span>/</span>
+        </span>
+      ))}
+      <span className="inline-flex items-center gap-1">
+        {current.icon ? <current.icon size={14} /> : null}
+        {current.label}
+      </span>
+    </div>
+  );
+}

--- a/src/ui/app/components/TaskBreadcrumb.tsx
+++ b/src/ui/app/components/TaskBreadcrumb.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeft, type LucideIcon } from 'lucide-react';
 import { Link } from '@tanstack/react-router';
-import { TASKS_LAST_PATH_KEY } from '@/ui/app/pages/TasksPage';
+import { TASKS_LAST_PATH_KEY, buildTasksMainSearch } from '@/ui/app/pages/task-route-memory';
 
 export interface TaskBreadcrumbSegment {
   label: string;
@@ -18,6 +18,14 @@ function clearTaskPathMemory() {
   sessionStorage.removeItem(TASKS_LAST_PATH_KEY);
 }
 
+function resolveSegmentSearch(segment: TaskBreadcrumbSegment): Record<string, string> | undefined {
+  if (segment.to !== '/tasks') {
+    return segment.search;
+  }
+
+  return buildTasksMainSearch(segment.search);
+}
+
 export function TaskBreadcrumb({ segments, current }: TaskBreadcrumbProps) {
   return (
     <div className="inline-flex select-none items-center gap-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
@@ -25,8 +33,8 @@ export function TaskBreadcrumb({ segments, current }: TaskBreadcrumbProps) {
         <span key={segment.to} className="contents">
           <Link
             to={segment.to}
-            search={segment.search}
-            onClick={clearTaskPathMemory}
+            search={resolveSegmentSearch(segment)}
+            onClick={segment.to === '/tasks' ? clearTaskPathMemory : undefined}
             className="inline-flex items-center gap-1 hover:text-[#1C1917] dark:hover:text-[#FAFAF9]"
           >
             {index === 0 ? <ArrowLeft size={14} /> : null}

--- a/src/ui/app/components/TaskCurrentRootCard.tsx
+++ b/src/ui/app/components/TaskCurrentRootCard.tsx
@@ -1,7 +1,10 @@
-﻿import { Link } from '@tanstack/react-router';
+import { Link } from '@tanstack/react-router';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
 import type { TaskGraph } from '@/lib/task/task-dag-graph';
 import type { TaskNode } from '@/lib/types/task';
 import { cn } from '@/lib/utils';
+import { filterTasksByTitleFuzzySearch } from '@/ui/app/pages/task-title-fuzzy-search';
 
 const STATUS_LABEL: Record<TaskNode['status'], string> = {
   pending: '待办',
@@ -11,21 +14,47 @@ const STATUS_LABEL: Record<TaskNode['status'], string> = {
   cancelled: '已取消',
 };
 
+const STATUS_DOT: Record<string, string> = {
+  pending: 'bg-[#A8A29E]',
+  in_progress: 'bg-[#22C55E]',
+  suspended: 'bg-[#D97706]',
+  completed: 'bg-[#16A34A]',
+  cancelled: 'bg-[#6B7280]',
+};
 
 export function TaskCurrentRootCard({
   graph,
   taskById,
   currentTaskId,
   className,
+  searchQuery,
+  collapsible = false,
+  collapsedVisibleCount = 3,
 }: {
   graph: TaskGraph;
   taskById: Map<string, TaskNode>;
   currentTaskId?: string;
   className?: string;
+  searchQuery?: string;
+  collapsible?: boolean;
+  collapsedVisibleCount?: number;
 }) {
-  const unblockedTasks = graph.currentRootCandidateNodeIds
+  const [collapsed, setCollapsed] = useState(true);
+  const unblockedTasks = useMemo(() => graph.currentRootCandidateNodeIds
     .map((id) => taskById.get(id))
-    .filter((t): t is TaskNode => t != null);
+    .filter((task): task is TaskNode => task != null), [graph.currentRootCandidateNodeIds, taskById]);
+  const filteredTasks = useMemo(
+    () => filterTasksByTitleFuzzySearch(unblockedTasks, searchQuery ?? ''),
+    [searchQuery, unblockedTasks],
+  );
+  const shouldCollapse = collapsible && filteredTasks.length > collapsedVisibleCount;
+  const visibleTasks = shouldCollapse && collapsed
+    ? filteredTasks.slice(0, collapsedVisibleCount)
+    : filteredTasks;
+
+  useEffect(() => {
+    setCollapsed(true);
+  }, [collapsedVisibleCount, searchQuery]);
 
   return (
     <section
@@ -35,17 +64,31 @@ export function TaskCurrentRootCard({
         className,
       )}
     >
-      <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#A8A29E]">
-        未阻塞节点 · {unblockedTasks.length}
-      </p>
-      {unblockedTasks.length > 0 ? (
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#A8A29E]">
+          未阻塞节点 · {filteredTasks.length}
+        </p>
+        {shouldCollapse ? (
+          <button
+            type="button"
+            data-testid="task-current-root-card-collapse-toggle"
+            className="inline-flex shrink-0 items-center gap-1 rounded-full border border-[#E7E5E4] px-2 py-1 text-[11px] font-medium text-[#78716C] dark:border-[#292524] dark:text-[#A8A29E]"
+            onClick={() => setCollapsed((value) => !value)}
+          >
+            {collapsed ? <ChevronDown size={14} /> : <ChevronUp size={14} />}
+            <span>{collapsed ? '展开' : '收起'}</span>
+          </button>
+        ) : null}
+      </div>
+      {filteredTasks.length > 0 ? (
         <ul className="mt-2 space-y-1">
-          {unblockedTasks.map((task) => (
+          {visibleTasks.map((task) => (
             <li key={task.id} className="flex items-center gap-2">
               <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${STATUS_DOT[task.status] ?? 'bg-[#A8A29E]'}`} />
               <Link
                 to="/tasks/$taskId"
                 params={{ taskId: task.id }}
+                data-testid={`task-current-root-card-link-${task.id}`}
                 className={cn(
                   'truncate text-sm hover:underline',
                   currentTaskId === task.id
@@ -61,6 +104,10 @@ export function TaskCurrentRootCard({
             </li>
           ))}
         </ul>
+      ) : searchQuery ? (
+        <p className="mt-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
+          没有匹配标题的未阻塞节点
+        </p>
       ) : (
         <p className="mt-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
           所有未终态节点都被依赖关系阻塞
@@ -69,11 +116,3 @@ export function TaskCurrentRootCard({
     </section>
   );
 }
-
-const STATUS_DOT: Record<string, string> = {
-  pending: 'bg-[#A8A29E]',
-  in_progress: 'bg-[#22C55E]',
-  suspended: 'bg-[#D97706]',
-  completed: 'bg-[#16A34A]',
-  cancelled: 'bg-[#6B7280]',
-};

--- a/src/ui/app/components/TaskCurrentRootCard.tsx
+++ b/src/ui/app/components/TaskCurrentRootCard.tsx
@@ -11,14 +11,6 @@ const STATUS_LABEL: Record<TaskNode['status'], string> = {
   cancelled: '已取消',
 };
 
-function resolveExecutionHint(status: TaskNode['status'], isExecutable: boolean, isBlocked: boolean): string {
-  if (status === 'in_progress') return '进行中';
-  if (status === 'suspended') return '已挂起';
-  if (isExecutable && isBlocked) return '可执行（软阻塞提醒）';
-  if (isExecutable) return '可直接开始';
-  if (isBlocked) return '受阻';
-  return '待处理';
-}
 
 export function TaskCurrentRootCard({
   graph,
@@ -31,12 +23,9 @@ export function TaskCurrentRootCard({
   currentTaskId?: string;
   className?: string;
 }) {
-  const currentRootTask = graph.currentRootNodeId ? taskById.get(graph.currentRootNodeId) ?? null : null;
-  const currentRootNode = graph.currentRootNodeId
-    ? graph.nodes.find((node) => node.id === graph.currentRootNodeId) ?? null
-    : null;
-  const isViewingCurrentRoot = Boolean(currentRootTask && currentTaskId === currentRootTask.id);
-  const currentRootOrder = currentRootTask ? graph.currentRootCandidateNodeIds.indexOf(currentRootTask.id) + 1 : 0;
+  const unblockedTasks = graph.currentRootCandidateNodeIds
+    .map((id) => taskById.get(id))
+    .filter((t): t is TaskNode => t != null);
 
   return (
     <section
@@ -46,52 +35,45 @@ export function TaskCurrentRootCard({
         className,
       )}
     >
-      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#A8A29E]">当前根节点</p>
-          {currentRootTask && currentRootNode ? (
-            <>
-              <div className="mt-2 flex flex-wrap items-center gap-2">
-                {isViewingCurrentRoot ? (
-                  <span className="rounded-full bg-[#FEF3C7] px-2.5 py-1 text-[10px] font-semibold text-[#B45309]">
-                    当前查看中
-                  </span>
-                ) : null}
-                <span className="rounded-full bg-[#F5F0ED] px-2.5 py-1 text-[10px] font-semibold text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]">
-                  {STATUS_LABEL[currentRootTask.status]}
-                </span>
-                <span className="rounded-full bg-[#EFF6FF] px-2.5 py-1 text-[10px] font-semibold text-[#2563EB] dark:bg-[#1E293B] dark:text-[#93C5FD]">
-                  {resolveExecutionHint(currentRootNode.status, currentRootNode.isExecutable, currentRootNode.isBlocked)}
-                </span>
-              </div>
-              <p className="mt-3 truncate text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{currentRootTask.title}</p>
-              <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
-                {`共 ${graph.currentRootCandidateNodeIds.length} 个未阻塞节点 · 当前按稳定顺序排第 ${currentRootOrder} 个`}
-              </p>
-            </>
-          ) : (
-            <>
-              <p className="mt-3 text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">暂无未阻塞节点</p>
-              <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
-                当前所有未终态节点都被依赖关系阻塞，可前往 DAG 视图检查阻塞来源。
-              </p>
-            </>
-          )}
-        </div>
-
-        <div className="flex flex-wrap gap-2 w-full sm:w-auto">
-          {currentRootTask ? (
-            <Link
-              data-testid="task-current-root-link"
-              to="/tasks/$taskId"
-              params={{ taskId: currentRootTask.id }}
-              className="inline-flex items-center rounded-full bg-[#C75B3A] px-3 py-2 text-xs font-semibold text-white"
-            >
-              {isViewingCurrentRoot ? '查看当前根节点' : '跳到当前根节点'}
-            </Link>
-          ) : null}
-        </div>
-      </div>
+      <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#A8A29E]">
+        未阻塞节点 · {unblockedTasks.length}
+      </p>
+      {unblockedTasks.length > 0 ? (
+        <ul className="mt-2 space-y-1">
+          {unblockedTasks.map((task) => (
+            <li key={task.id} className="flex items-center gap-2">
+              <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${STATUS_DOT[task.status] ?? 'bg-[#A8A29E]'}`} />
+              <Link
+                to="/tasks/$taskId"
+                params={{ taskId: task.id }}
+                className={cn(
+                  'truncate text-sm hover:underline',
+                  currentTaskId === task.id
+                    ? 'font-semibold text-[#C75B3A]'
+                    : 'text-[#1C1917] dark:text-[#FAFAF9]',
+                )}
+              >
+                {task.title}
+              </Link>
+              <span className="shrink-0 rounded-full bg-[#F5F0ED] px-1.5 py-0.5 text-[10px] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]">
+                {STATUS_LABEL[task.status]}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
+          所有未终态节点都被依赖关系阻塞
+        </p>
+      )}
     </section>
   );
 }
+
+const STATUS_DOT: Record<string, string> = {
+  pending: 'bg-[#A8A29E]',
+  in_progress: 'bg-[#C75B3A]',
+  suspended: 'bg-[#D97706]',
+  completed: 'bg-[#16A34A]',
+  cancelled: 'bg-[#6B7280]',
+};

--- a/src/ui/app/components/TaskCurrentRootCard.tsx
+++ b/src/ui/app/components/TaskCurrentRootCard.tsx
@@ -46,7 +46,7 @@ export function TaskCurrentRootCard({
         className,
       )}
     >
-      <div className="flex flex-wrap items-start justify-between gap-3">
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
         <div className="min-w-0 flex-1">
           <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#A8A29E]">当前根节点</p>
           {currentRootTask && currentRootNode ? (
@@ -79,7 +79,7 @@ export function TaskCurrentRootCard({
           )}
         </div>
 
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-2 w-full sm:w-auto">
           {currentRootTask ? (
             <Link
               data-testid="task-current-root-link"
@@ -90,13 +90,6 @@ export function TaskCurrentRootCard({
               {isViewingCurrentRoot ? '查看当前根节点' : '跳到当前根节点'}
             </Link>
           ) : null}
-          <Link
-            data-testid="task-current-root-dag-link"
-            to="/tasks/dag"
-            className="inline-flex items-center rounded-full border border-[#E7E5E4] px-3 py-2 text-xs font-semibold text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
-          >
-            查看 DAG 视图
-          </Link>
         </div>
       </div>
     </section>

--- a/src/ui/app/components/TaskCurrentRootCard.tsx
+++ b/src/ui/app/components/TaskCurrentRootCard.tsx
@@ -72,7 +72,7 @@ export function TaskCurrentRootCard({
 
 const STATUS_DOT: Record<string, string> = {
   pending: 'bg-[#A8A29E]',
-  in_progress: 'bg-[#C75B3A]',
+  in_progress: 'bg-[#22C55E]',
   suspended: 'bg-[#D97706]',
   completed: 'bg-[#16A34A]',
   cancelled: 'bg-[#6B7280]',

--- a/src/ui/app/components/TaskDagControlPanel.tsx
+++ b/src/ui/app/components/TaskDagControlPanel.tsx
@@ -1,0 +1,34 @@
+import { Crosshair, LocateFixed } from 'lucide-react';
+
+interface TaskDagControlPanelProps {
+  onFitView: () => void;
+  onJumpToCurrentRoot?: () => void;
+  hasCurrentRoot: boolean;
+}
+
+export function TaskDagControlPanel({ onFitView, onJumpToCurrentRoot, hasCurrentRoot }: TaskDagControlPanelProps) {
+  return (
+    <div className="pointer-events-none absolute right-3 top-3 z-10 flex flex-wrap items-center justify-end gap-2">
+      <button
+        type="button"
+        data-testid="task-dag-fit-view"
+        onClick={onFitView}
+        className="pointer-events-auto inline-flex items-center gap-1 rounded-full border border-[#E7E3E0] bg-white/90 px-3 py-1 text-[11px] font-medium text-[#57534E] shadow-sm backdrop-blur hover:bg-white dark:border-[#3C3836] dark:bg-[#1C1917]/90 dark:text-[#A8A29E] dark:hover:bg-[#292524]"
+      >
+        <Crosshair size={12} />
+        适配视口
+      </button>
+      {hasCurrentRoot && onJumpToCurrentRoot && (
+        <button
+          type="button"
+          data-testid="task-dag-jump-to-root"
+          onClick={onJumpToCurrentRoot}
+          className="pointer-events-auto inline-flex items-center gap-1 rounded-full border border-[#E7E3E0] bg-white/90 px-3 py-1 text-[11px] font-medium text-[#57534E] shadow-sm backdrop-blur hover:bg-white dark:border-[#3C3836] dark:bg-[#1C1917]/90 dark:text-[#A8A29E] dark:hover:bg-[#292524]"
+        >
+          <LocateFixed size={12} />
+          跳到根节点
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/ui/app/components/TaskStatusSelector.tsx
+++ b/src/ui/app/components/TaskStatusSelector.tsx
@@ -1,11 +1,21 @@
 export type TaskStatusChoice = 'continue' | 'suspended' | 'completed' | 'cancelled';
 
+const LINKED_TASK_TITLE_MAX_CHARS = 100;
+
 const STATUS_OPTIONS: readonly { key: TaskStatusChoice; label: string }[] = [
   { key: 'suspended', label: '挂起' },
   { key: 'continue', label: '继续' },
   { key: 'completed', label: '完成' },
   { key: 'cancelled', label: '取消' },
 ] as const;
+
+function formatLinkedTaskTitle(title: string): string {
+  const chars = Array.from(title);
+  if (chars.length <= LINKED_TASK_TITLE_MAX_CHARS) {
+    return title;
+  }
+  return `${chars.slice(0, LINKED_TASK_TITLE_MAX_CHARS).join('')}...`;
+}
 
 interface TaskStatusSelectorProps {
   value: TaskStatusChoice;
@@ -20,12 +30,20 @@ export function TaskStatusSelector({
   linkedTaskTitle,
   'data-testid': testId = 'feedback-task-status-selector',
 }: TaskStatusSelectorProps) {
+  const displayLinkedTaskTitle = linkedTaskTitle ? formatLinkedTaskTitle(linkedTaskTitle) : null;
+
   return (
     <div data-testid="feedback-task-status-section" className="flex flex-col gap-1.5">
-      {linkedTaskTitle && (
-        <div className="flex items-center gap-2">
-          <span className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">关联任务</span>
-          <span className="truncate text-[12px] text-[#1C1917] dark:text-[#FAFAF9]">{linkedTaskTitle}</span>
+      {linkedTaskTitle && displayLinkedTaskTitle && (
+        <div className="flex items-start gap-2">
+          <span className="shrink-0 text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">关联任务</span>
+          <span
+            data-testid="feedback-task-linked-title"
+            title={linkedTaskTitle}
+            className="min-w-0 flex-1 whitespace-normal break-all text-[12px] leading-5 text-[#1C1917] dark:text-[#FAFAF9]"
+          >
+            {displayLinkedTaskTitle}
+          </span>
         </div>
       )}
       <div

--- a/src/ui/app/components/TaskStatusSelector.tsx
+++ b/src/ui/app/components/TaskStatusSelector.tsx
@@ -1,0 +1,55 @@
+export type TaskStatusChoice = 'continue' | 'suspended' | 'completed' | 'cancelled';
+
+const STATUS_OPTIONS: readonly { key: TaskStatusChoice; label: string }[] = [
+  { key: 'suspended', label: '挂起' },
+  { key: 'continue', label: '继续' },
+  { key: 'completed', label: '完成' },
+  { key: 'cancelled', label: '取消' },
+] as const;
+
+interface TaskStatusSelectorProps {
+  value: TaskStatusChoice;
+  onChange: (choice: TaskStatusChoice) => void;
+  linkedTaskTitle?: string;
+  'data-testid'?: string;
+}
+
+export function TaskStatusSelector({
+  value,
+  onChange,
+  linkedTaskTitle,
+  'data-testid': testId = 'feedback-task-status-selector',
+}: TaskStatusSelectorProps) {
+  return (
+    <div data-testid="feedback-task-status-section" className="flex flex-col gap-1.5">
+      {linkedTaskTitle && (
+        <div className="flex items-center gap-2">
+          <span className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">关联任务</span>
+          <span className="truncate text-[12px] text-[#1C1917] dark:text-[#FAFAF9]">{linkedTaskTitle}</span>
+        </div>
+      )}
+      <div
+        className="relative overflow-hidden rounded-[10px] border border-[#E7E5E4] bg-[#F5F0ED]/50 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]"
+        data-testid={testId}
+      >
+        <div className="relative z-10 grid grid-cols-4 gap-0">
+          {STATUS_OPTIONS.map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              data-testid={`feedback-task-status-${key}`}
+              onClick={() => onChange(key)}
+              className={`relative z-10 h-8 w-full whitespace-nowrap rounded-[8px] px-[8px] text-center text-[12px] transition-colors duration-200 ${
+                value === key
+                  ? 'font-semibold text-[#1C1917] dark:text-[#FAFAF9] bg-white/55 dark:bg-[#FFFFFF14] border border-[#FFFFFFCC] dark:border-[#FFFFFF66] shadow-[0_1px_2px_rgba(0,0,0,0.05)]'
+                  : 'text-[#78716C] hover:text-[#57534E] dark:hover:text-[#D6D3D1]'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/app/components/TaskStatusSelector.tsx
+++ b/src/ui/app/components/TaskStatusSelector.tsx
@@ -31,6 +31,8 @@ export function TaskStatusSelector({
   'data-testid': testId = 'feedback-task-status-selector',
 }: TaskStatusSelectorProps) {
   const displayLinkedTaskTitle = linkedTaskTitle ? formatLinkedTaskTitle(linkedTaskTitle) : null;
+  const activeIndex = Math.max(0, STATUS_OPTIONS.findIndex((option) => option.key === value));
+  const indicatorWidth = `${100 / STATUS_OPTIONS.length}%`;
 
   return (
     <div data-testid="feedback-task-status-section" className="flex flex-col gap-1.5">
@@ -50,6 +52,11 @@ export function TaskStatusSelector({
         className="relative overflow-hidden rounded-[10px] border border-[#E7E5E4] bg-[#F5F0ED]/50 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]"
         data-testid={testId}
       >
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-y-0 left-0 rounded-[8px] border border-brand-accent/40 bg-brand-accent/15 shadow-[0_1px_2px_rgba(0,0,0,0.05)] transition-transform duration-200 ease-out"
+          style={{ width: indicatorWidth, transform: `translateX(${activeIndex * 100}%)` }}
+        />
         <div className="relative z-10 grid grid-cols-4 gap-0">
           {STATUS_OPTIONS.map(({ key, label }) => (
             <button
@@ -59,7 +66,7 @@ export function TaskStatusSelector({
               onClick={() => onChange(key)}
               className={`relative z-10 h-8 w-full whitespace-nowrap rounded-[8px] px-[8px] text-center text-[12px] transition-colors duration-200 ${
                 value === key
-                  ? 'font-semibold text-[#1C1917] dark:text-[#FAFAF9] bg-brand-accent/15 border border-brand-accent/40 shadow-[0_1px_2px_rgba(0,0,0,0.05)]'
+                  ? 'font-semibold text-[#1C1917] dark:text-[#FAFAF9]'
                   : 'text-[#78716C] hover:text-[#57534E] dark:hover:text-[#D6D3D1]'
               }`}
             >

--- a/src/ui/app/components/TaskStatusSelector.tsx
+++ b/src/ui/app/components/TaskStatusSelector.tsx
@@ -59,7 +59,7 @@ export function TaskStatusSelector({
               onClick={() => onChange(key)}
               className={`relative z-10 h-8 w-full whitespace-nowrap rounded-[8px] px-[8px] text-center text-[12px] transition-colors duration-200 ${
                 value === key
-                  ? 'font-semibold text-[#1C1917] dark:text-[#FAFAF9] bg-white/55 dark:bg-[#FFFFFF14] border border-[#FFFFFFCC] dark:border-[#FFFFFF66] shadow-[0_1px_2px_rgba(0,0,0,0.05)]'
+                  ? 'font-semibold text-[#1C1917] dark:text-[#FAFAF9] bg-brand-accent/15 border border-brand-accent/40 shadow-[0_1px_2px_rgba(0,0,0,0.05)]'
                   : 'text-[#78716C] hover:text-[#57534E] dark:hover:text-[#D6D3D1]'
               }`}
             >

--- a/src/ui/app/components/TimerConfigPanel.tsx
+++ b/src/ui/app/components/TimerConfigPanel.tsx
@@ -22,6 +22,12 @@ function resolveCountdownOptionIndex(minutes: number): number {
   return presetIndex >= 0 ? presetIndex : PRESET_COUNTDOWN_MINUTES.length;
 }
 
+function resolveOptionIndex(mode: TimerMode, minutes: number): number {
+  if (mode === 'countup') return 0;
+  const presetIndex = PRESET_COUNTDOWN_MINUTES.indexOf(minutes as (typeof PRESET_COUNTDOWN_MINUTES)[number]);
+  return presetIndex >= 0 ? presetIndex + 1 : PRESET_COUNTDOWN_MINUTES.length + 1;
+}
+
 interface TimerConfigPanelProps {
   timerMode: TimerMode;
   countdownMinutes: number;
@@ -32,6 +38,8 @@ interface TimerConfigPanelProps {
   commitCustomDuration: () => void;
   estimatedMinutes?: number;
   spentMinutes?: number;
+  showCountupOption?: boolean;
+  onSelectCountup?: () => void;
 }
 
 export function TimerConfigPanel({
@@ -44,6 +52,8 @@ export function TimerConfigPanel({
   commitCustomDuration,
   estimatedMinutes,
   spentMinutes,
+  showCountupOption = false,
+  onSelectCountup,
 }: TimerConfigPanelProps) {
   const customDurationInputRef = useRef<HTMLInputElement | null>(null);
   const [isCustomDurationEditing, setIsCustomDurationEditing] = useState(false);
@@ -51,6 +61,8 @@ export function TimerConfigPanel({
   const isCustomDurationSelected = timerMode === 'countdown' && !isPresetCountdownMinutes(countdownMinutes);
   const customDurationTriggerText = isCustomDurationSelected ? `${countdownMinutes}m` : '自定义';
   const activeCountdownOptionIndex = resolveCountdownOptionIndex(countdownMinutes);
+  const activeUnifiedOptionIndex = resolveOptionIndex(timerMode, countdownMinutes);
+  const totalUnifiedColumns = PRESET_COUNTDOWN_MINUTES.length + 2; // countup + presets + custom
 
   useEffect(() => {
     if (timerMode !== 'countdown') {
@@ -91,28 +103,83 @@ export function TimerConfigPanel({
     }
   };
 
+  const countdownPresetButtons = (
+    <>
+      {PRESET_COUNTDOWN_MINUTES.map((minutes) => (
+        <button
+          key={minutes}
+          type="button"
+          data-testid={`task-countdown-preset-${minutes}`}
+          onClick={() => {
+            closeCustomDurationEditor();
+            if (showCountupOption && timerMode !== 'countdown') {
+              setTimerMode('countdown');
+            }
+            setCountdownMinutes(minutes);
+          }}
+          className={expectedOptionClass(timerMode === 'countdown' && countdownMinutes === minutes)}
+        >
+          {minutes}m
+        </button>
+      ))}
+    </>
+  );
+
+  const customDurationButton = isCustomDurationEditing ? (
+    <Input
+      ref={customDurationInputRef}
+      data-testid="task-countdown-custom-input"
+      value={customDurationDraft}
+      onChange={(event) => {
+        setCustomDurationDraft(event.target.value.replace(/[^\d]/g, ''));
+      }}
+      onBlur={handleCustomDurationCommit}
+      onKeyDown={handleCustomDurationKeyDown}
+      aria-label="自定义倒计时分钟（Custom countdown minutes）"
+      placeholder="分钟"
+      className="relative z-10 h-8 w-full border-transparent bg-transparent px-[6px] text-center text-[12px] font-semibold leading-none text-[#1C1917] shadow-none outline-none ring-0 focus-visible:ring-0 dark:text-[#FAFAF9]"
+    />
+  ) : (
+    <button
+      type="button"
+      data-testid="task-countdown-custom-trigger"
+      onClick={() => setIsCustomDurationEditing(true)}
+      className={`relative z-10 flex h-8 w-full items-center justify-center gap-1 whitespace-nowrap rounded-[8px] px-[8px] text-[12px] transition-colors duration-200 ${
+        isCustomDurationSelected
+          ? 'font-semibold text-[#1C1917] dark:text-[#FAFAF9]'
+          : 'text-[#C75B3A] hover:text-[#B24D2F]'
+      }`}
+      aria-label="自定义倒计时（Custom countdown）"
+    >
+      <ChevronDown size={12} className="transition-transform" />
+      {customDurationTriggerText}
+    </button>
+  );
+
   return (
     <>
-      <div className="mt-3 flex gap-2">
-        <button
-          type="button"
-          data-testid="task-mode-countdown"
-          aria-pressed={timerMode === 'countdown'}
-          onClick={() => setTimerMode('countdown')}
-          className={`rounded-xl px-3 py-1.5 text-xs ${timerMode === 'countdown' ? 'bg-[#C75B3A] text-white' : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'}`}
-        >
-          倒计时
-        </button>
-        <button
-          type="button"
-          data-testid="task-mode-countup"
-          aria-pressed={timerMode === 'countup'}
-          onClick={() => setTimerMode('countup')}
-          className={`rounded-xl px-3 py-1.5 text-xs ${timerMode === 'countup' ? 'bg-[#C75B3A] text-white' : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'}`}
-        >
-          正计时
-        </button>
-      </div>
+      {!showCountupOption && (
+        <div className="mt-3 flex gap-2">
+          <button
+            type="button"
+            data-testid="task-mode-countdown"
+            aria-pressed={timerMode === 'countdown'}
+            onClick={() => setTimerMode('countdown')}
+            className={`rounded-xl px-3 py-1.5 text-xs ${timerMode === 'countdown' ? 'bg-[#C75B3A] text-white' : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'}`}
+          >
+            倒计时
+          </button>
+          <button
+            type="button"
+            data-testid="task-mode-countup"
+            aria-pressed={timerMode === 'countup'}
+            onClick={() => setTimerMode('countup')}
+            className={`rounded-xl px-3 py-1.5 text-xs ${timerMode === 'countup' ? 'bg-[#C75B3A] text-white' : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'}`}
+          >
+            正计时
+          </button>
+        </div>
+      )}
 
       {estimatedMinutes != null && spentMinutes != null && estimatedMinutes > spentMinutes && (
         <button
@@ -125,7 +192,37 @@ export function TimerConfigPanel({
         </button>
       )}
 
-      {timerMode === 'countdown' ? (
+      {showCountupOption ? (
+        <div className="mt-3 flex min-w-0 flex-col gap-1.5">
+          <span className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">预期时长</span>
+          <div className="relative min-w-0 overflow-hidden rounded-[10px] border border-[#FFFFFF60] bg-white/35 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]">
+            <div
+              data-testid="task-countdown-active-indicator"
+              className="pointer-events-none absolute inset-y-0 left-0 rounded-[8px] border border-[#FFFFFFCC] bg-white/55 shadow-[0_1px_2px_rgba(0,0,0,0.05)] transition-transform duration-200 ease-out dark:border-[#FFFFFF66] dark:bg-[#FFFFFF14]"
+              style={{
+                width: `${100 / totalUnifiedColumns}%`,
+                transform: `translateX(${activeUnifiedOptionIndex * 100}%)`,
+              }}
+            />
+            <div className="relative z-10 grid min-w-0 gap-0" style={{ gridTemplateColumns: `repeat(${totalUnifiedColumns}, minmax(0, 1fr))` }}>
+              <button
+                type="button"
+                data-testid="task-mode-countup"
+                onClick={() => {
+                  closeCustomDurationEditor();
+                  setTimerMode('countup');
+                  onSelectCountup?.();
+                }}
+                className={expectedOptionClass(timerMode === 'countup')}
+              >
+                正计时
+              </button>
+              {countdownPresetButtons}
+              {customDurationButton}
+            </div>
+          </div>
+        </div>
+      ) : timerMode === 'countdown' ? (
         <div className="mt-3 flex min-w-0 flex-col gap-1.5">
           <span className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">预期时长</span>
           <div className="relative min-w-0 overflow-hidden rounded-[10px] border border-[#FFFFFF60] bg-white/35 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]">
@@ -135,51 +232,8 @@ export function TimerConfigPanel({
               style={{ transform: `translateX(${activeCountdownOptionIndex * 100}%)` }}
             />
             <div className="relative z-10 grid min-w-0 grid-cols-5 gap-0">
-              {PRESET_COUNTDOWN_MINUTES.map((minutes) => (
-                <button
-                  key={minutes}
-                  type="button"
-                  data-testid={`task-countdown-preset-${minutes}`}
-                  onClick={() => {
-                    closeCustomDurationEditor();
-                    setCountdownMinutes(minutes);
-                  }}
-                  className={expectedOptionClass(countdownMinutes === minutes)}
-                >
-                  {minutes}m
-                </button>
-              ))}
-
-              {isCustomDurationEditing ? (
-                <Input
-                  ref={customDurationInputRef}
-                  data-testid="task-countdown-custom-input"
-                  value={customDurationDraft}
-                  onChange={(event) => {
-                    setCustomDurationDraft(event.target.value.replace(/[^\d]/g, ''));
-                  }}
-                  onBlur={handleCustomDurationCommit}
-                  onKeyDown={handleCustomDurationKeyDown}
-                  aria-label="自定义倒计时分钟（Custom countdown minutes）"
-                  placeholder="分钟"
-                  className="relative z-10 h-8 w-full border-transparent bg-transparent px-[6px] text-center text-[12px] font-semibold leading-none text-[#1C1917] shadow-none outline-none ring-0 focus-visible:ring-0 dark:text-[#FAFAF9]"
-                />
-              ) : (
-                <button
-                  type="button"
-                  data-testid="task-countdown-custom-trigger"
-                  onClick={() => setIsCustomDurationEditing(true)}
-                  className={`relative z-10 flex h-8 w-full items-center justify-center gap-1 whitespace-nowrap rounded-[8px] px-[8px] text-[12px] transition-colors duration-200 ${
-                    isCustomDurationSelected
-                      ? 'font-semibold text-[#1C1917] dark:text-[#FAFAF9]'
-                      : 'text-[#C75B3A] hover:text-[#B24D2F]'
-                  }`}
-                  aria-label="自定义倒计时（Custom countdown）"
-                >
-                  <ChevronDown size={12} className="transition-transform" />
-                  {customDurationTriggerText}
-                </button>
-              )}
+              {countdownPresetButtons}
+              {customDurationButton}
             </div>
           </div>
         </div>

--- a/src/ui/app/components/TimerConfigPanel.tsx
+++ b/src/ui/app/components/TimerConfigPanel.tsx
@@ -194,7 +194,7 @@ export function TimerConfigPanel({
 
       {showCountupOption ? (
         <div className="mt-3 flex min-w-0 flex-col gap-1.5">
-          <span className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">预期时长</span>
+          <span className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">计时时长</span>
           <div className="relative min-w-0 overflow-hidden rounded-[10px] border border-[#E7E5E4] bg-[#F5F0ED]/50 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]">
             <div
               data-testid="task-countdown-active-indicator"
@@ -224,7 +224,7 @@ export function TimerConfigPanel({
         </div>
       ) : timerMode === 'countdown' ? (
         <div className="mt-3 flex min-w-0 flex-col gap-1.5">
-          <span className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">预期时长</span>
+          <span className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">计时时长</span>
           <div className="relative min-w-0 overflow-hidden rounded-[10px] border border-[#E7E5E4] bg-[#F5F0ED]/50 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]">
             <div
               data-testid="task-countdown-active-indicator"

--- a/src/ui/app/components/TimerConfigPanel.tsx
+++ b/src/ui/app/components/TimerConfigPanel.tsx
@@ -36,8 +36,6 @@ interface TimerConfigPanelProps {
   customDurationDraft: string;
   setCustomDurationDraft: (draft: string) => void;
   commitCustomDuration: () => void;
-  estimatedMinutes?: number;
-  spentMinutes?: number;
   showCountupOption?: boolean;
   onSelectCountup?: () => void;
 }
@@ -50,8 +48,6 @@ export function TimerConfigPanel({
   customDurationDraft,
   setCustomDurationDraft,
   commitCustomDuration,
-  estimatedMinutes,
-  spentMinutes,
   showCountupOption = false,
   onSelectCountup,
 }: TimerConfigPanelProps) {
@@ -179,17 +175,6 @@ export function TimerConfigPanel({
             正计时
           </button>
         </div>
-      )}
-
-      {estimatedMinutes != null && spentMinutes != null && estimatedMinutes > spentMinutes && (
-        <button
-          type="button"
-          data-testid="task-countdown-auto-remaining"
-          onClick={() => setCountdownMinutes(Math.max(1, Math.round(estimatedMinutes - spentMinutes)))}
-          className="mt-2 rounded-xl px-3 py-1.5 text-xs bg-[#F5F0ED] text-[#78716C] hover:text-[#57534E] dark:bg-[#292524] dark:text-[#A8A29E] dark:hover:text-[#D6D3D1]"
-        >
-          自动：剩余 {Math.max(1, Math.round(estimatedMinutes - spentMinutes))}min
-        </button>
       )}
 
       {showCountupOption ? (

--- a/src/ui/app/components/TimerConfigPanel.tsx
+++ b/src/ui/app/components/TimerConfigPanel.tsx
@@ -30,6 +30,8 @@ interface TimerConfigPanelProps {
   customDurationDraft: string;
   setCustomDurationDraft: (draft: string) => void;
   commitCustomDuration: () => void;
+  estimatedMinutes?: number;
+  spentMinutes?: number;
 }
 
 export function TimerConfigPanel({
@@ -40,6 +42,8 @@ export function TimerConfigPanel({
   customDurationDraft,
   setCustomDurationDraft,
   commitCustomDuration,
+  estimatedMinutes,
+  spentMinutes,
 }: TimerConfigPanelProps) {
   const customDurationInputRef = useRef<HTMLInputElement | null>(null);
   const [isCustomDurationEditing, setIsCustomDurationEditing] = useState(false);
@@ -109,6 +113,17 @@ export function TimerConfigPanel({
           正计时
         </button>
       </div>
+
+      {estimatedMinutes != null && spentMinutes != null && estimatedMinutes > spentMinutes && (
+        <button
+          type="button"
+          data-testid="task-countdown-auto-remaining"
+          onClick={() => setCountdownMinutes(Math.max(1, Math.round(estimatedMinutes - spentMinutes)))}
+          className="mt-2 rounded-xl px-3 py-1.5 text-xs bg-[#F5F0ED] text-[#78716C] hover:text-[#57534E] dark:bg-[#292524] dark:text-[#A8A29E] dark:hover:text-[#D6D3D1]"
+        >
+          自动：剩余 {Math.max(1, Math.round(estimatedMinutes - spentMinutes))}min
+        </button>
+      )}
 
       {timerMode === 'countdown' ? (
         <div className="mt-3 flex min-w-0 flex-col gap-1.5">

--- a/src/ui/app/components/TimerConfigPanel.tsx
+++ b/src/ui/app/components/TimerConfigPanel.tsx
@@ -204,10 +204,16 @@ export function TimerConfigPanel({
                 transform: `translateX(${activeUnifiedOptionIndex * 100}%)`,
               }}
             />
-            <div className="relative z-10 grid min-w-0 gap-0" style={{ gridTemplateColumns: `repeat(${totalUnifiedColumns}, minmax(0, 1fr))` }}>
+            <div
+              data-testid="task-mode-countdown"
+              aria-pressed={timerMode === 'countdown'}
+              className="relative z-10 grid min-w-0 gap-0"
+              style={{ gridTemplateColumns: `repeat(${totalUnifiedColumns}, minmax(0, 1fr))` }}
+            >
               <button
                 type="button"
                 data-testid="task-mode-countup"
+                aria-pressed={timerMode === 'countup'}
                 onClick={() => {
                   closeCustomDurationEditor();
                   setTimerMode('countup');

--- a/src/ui/app/components/TimerConfigPanel.tsx
+++ b/src/ui/app/components/TimerConfigPanel.tsx
@@ -195,10 +195,10 @@ export function TimerConfigPanel({
       {showCountupOption ? (
         <div className="mt-3 flex min-w-0 flex-col gap-1.5">
           <span className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">预期时长</span>
-          <div className="relative min-w-0 overflow-hidden rounded-[10px] border border-[#FFFFFF60] bg-white/35 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]">
+          <div className="relative min-w-0 overflow-hidden rounded-[10px] border border-[#E7E5E4] bg-[#F5F0ED]/50 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]">
             <div
               data-testid="task-countdown-active-indicator"
-              className="pointer-events-none absolute inset-y-0 left-0 rounded-[8px] border border-[#FFFFFFCC] bg-white/55 shadow-[0_1px_2px_rgba(0,0,0,0.05)] transition-transform duration-200 ease-out dark:border-[#FFFFFF66] dark:bg-[#FFFFFF14]"
+              className="pointer-events-none absolute inset-y-0 left-0 rounded-[8px] border border-brand-accent/40 bg-brand-accent/15 shadow-[0_1px_2px_rgba(0,0,0,0.05)] transition-transform duration-200 ease-out"
               style={{
                 width: `${100 / totalUnifiedColumns}%`,
                 transform: `translateX(${activeUnifiedOptionIndex * 100}%)`,
@@ -225,10 +225,10 @@ export function TimerConfigPanel({
       ) : timerMode === 'countdown' ? (
         <div className="mt-3 flex min-w-0 flex-col gap-1.5">
           <span className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">预期时长</span>
-          <div className="relative min-w-0 overflow-hidden rounded-[10px] border border-[#FFFFFF60] bg-white/35 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]">
+          <div className="relative min-w-0 overflow-hidden rounded-[10px] border border-[#E7E5E4] bg-[#F5F0ED]/50 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]">
             <div
               data-testid="task-countdown-active-indicator"
-              className="pointer-events-none absolute inset-y-0 left-0 w-1/5 rounded-[8px] border border-[#FFFFFFCC] bg-white/55 shadow-[0_1px_2px_rgba(0,0,0,0.05)] transition-transform duration-200 ease-out dark:border-[#FFFFFF66] dark:bg-[#FFFFFF14]"
+              className="pointer-events-none absolute inset-y-0 left-0 w-1/5 rounded-[8px] border border-brand-accent/40 bg-brand-accent/15 shadow-[0_1px_2px_rgba(0,0,0,0.05)] transition-transform duration-200 ease-out"
               style={{ transform: `translateX(${activeCountdownOptionIndex * 100}%)` }}
             />
             <div className="relative z-10 grid min-w-0 grid-cols-5 gap-0">

--- a/src/ui/app/components/settings/settings-renderers.tsx
+++ b/src/ui/app/components/settings/settings-renderers.tsx
@@ -697,12 +697,12 @@ function NumberRenderer({ item }: { item: NumberSettingsItem }) {
   const [value, setValue, getCurrent] = useSettingState(item.get, item.subscribe);
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const progressPercent = (() => {
-    if (item.max === item.min) return '0%';
-    const progress = ((value - item.min) / (item.max - item.min)) * 100;
-    const clamped = Math.min(100, Math.max(0, progress));
-    return `${clamped.toFixed(2)}%`;
+  const progressRatio = (() => {
+    if (item.max === item.min) return 0;
+    const progress = (value - item.min) / (item.max - item.min);
+    return Math.min(1, Math.max(0, progress));
   })();
+  const progressPercent = `${(progressRatio * 100).toFixed(2)}%`;
 
   const handleChange = (nextValue: number) => {
     setNotice(null);
@@ -744,23 +744,28 @@ function NumberRenderer({ item }: { item: NumberSettingsItem }) {
         label={item.label}
         right={(
           <div className="flex min-w-[186px] items-center gap-3">
-            <input
-              data-testid={item.controlTestId}
-              type="range"
-              min={item.min}
-              max={item.max}
-              step={item.step}
-              value={value}
-              onChange={(event) => {
-                handleChange(Number(event.target.value));
-              }}
-              style={{
-                ...(buildSettingsToneStyle(toneColor) ?? {}),
-                accentColor: SETTINGS_TONE_RESOLVED_COLOR,
-                '--settings-range-progress': progressPercent,
-              } as CSSProperties & { '--settings-range-progress': string }}
-              className="w-full settings-range"
-            />
+            <div className="min-w-0 flex-1 px-[9px]">
+              <input
+                data-testid={item.controlTestId}
+                type="range"
+                min={item.min}
+                max={item.max}
+                step={item.step}
+                value={value}
+                onChange={(event) => {
+                  handleChange(Number(event.target.value));
+                }}
+                style={{
+                  ...(buildSettingsToneStyle(toneColor) ?? {}),
+                  '--settings-range-progress': progressPercent,
+                  '--settings-range-progress-ratio': progressRatio.toFixed(4),
+                } as CSSProperties & {
+                  '--settings-range-progress': string;
+                  '--settings-range-progress-ratio': string;
+                }}
+                className="block w-full settings-range"
+              />
+            </div>
             <span className="min-w-[44px] text-right text-xs text-[#78716C]">
               {renderedValue}
             </span>

--- a/src/ui/app/components/settings/settings-renderers.tsx
+++ b/src/ui/app/components/settings/settings-renderers.tsx
@@ -758,7 +758,7 @@ function NumberRenderer({ item }: { item: NumberSettingsItem }) {
                 ...(buildSettingsToneStyle(toneColor) ?? {}),
                 accentColor: SETTINGS_TONE_RESOLVED_COLOR,
                 '--settings-range-progress': progressPercent,
-              }}
+              } as CSSProperties & { '--settings-range-progress': string }}
               className="w-full settings-range"
             />
             <span className="min-w-[44px] text-right text-xs text-[#78716C]">

--- a/src/ui/app/components/settings/settings-renderers.tsx
+++ b/src/ui/app/components/settings/settings-renderers.tsx
@@ -697,6 +697,12 @@ function NumberRenderer({ item }: { item: NumberSettingsItem }) {
   const [value, setValue, getCurrent] = useSettingState(item.get, item.subscribe);
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const progressPercent = (() => {
+    if (item.max === item.min) return '0%';
+    const progress = ((value - item.min) / (item.max - item.min)) * 100;
+    const clamped = Math.min(100, Math.max(0, progress));
+    return `${clamped.toFixed(2)}%`;
+  })();
 
   const handleChange = (nextValue: number) => {
     setNotice(null);
@@ -751,8 +757,9 @@ function NumberRenderer({ item }: { item: NumberSettingsItem }) {
               style={{
                 ...(buildSettingsToneStyle(toneColor) ?? {}),
                 accentColor: SETTINGS_TONE_RESOLVED_COLOR,
+                '--settings-range-progress': progressPercent,
               }}
-              className="w-full"
+              className="w-full settings-range"
             />
             <span className="min-w-[44px] text-right text-xs text-[#78716C]">
               {renderedValue}

--- a/src/ui/app/config/settings/desktop-tab-config.ts
+++ b/src/ui/app/config/settings/desktop-tab-config.ts
@@ -6,6 +6,7 @@ export const DESKTOP_TAB_CONFIG: Array<{
   categories: Category[];
 }> = [
   { key: 'appearance', label: '外观主题', categories: ['appearance'] },
+  { key: 'task', label: '任务', categories: ['task'] },
   { key: 'focus', label: '专注设置', categories: ['timer', 'feedback'] },
   { key: 'input', label: '输入', categories: ['input'] },
   { key: 'services', label: '服务', categories: ['ai', 'sync'] },

--- a/src/ui/app/config/settings/desktop-tab-config.ts
+++ b/src/ui/app/config/settings/desktop-tab-config.ts
@@ -6,7 +6,6 @@ export const DESKTOP_TAB_CONFIG: Array<{
   categories: Category[];
 }> = [
   { key: 'appearance', label: '外观主题', categories: ['appearance'] },
-  { key: 'task', label: '任务', categories: ['task'] },
   { key: 'focus', label: '专注设置', categories: ['timer', 'feedback'] },
   { key: 'input', label: '输入', categories: ['input'] },
   { key: 'services', label: '服务', categories: ['ai', 'sync'] },

--- a/src/ui/app/config/settings/settings-registry.ts
+++ b/src/ui/app/config/settings/settings-registry.ts
@@ -93,6 +93,11 @@ import {
   subscribeTaskPageFuzzySearchChanges,
 } from '@/config/task-page-fuzzy-search';
 import {
+  getTaskCreateSuccessAction,
+  setTaskCreateSuccessAction,
+  subscribeTaskCreateSuccessActionChanges,
+} from '@/config/task-create-success-action';
+import {
   getVoiceShortcutHotkey,
   setVoiceShortcutHotkey,
   subscribeVoiceShortcutHotkeyChanges,
@@ -573,6 +578,25 @@ export const SETTINGS_REGISTRY: SettingsItem[] = [
     get: () => getTaskPageFuzzySearchEnabled(),
     set: (value: boolean) => setTaskPageFuzzySearchEnabled(value),
     subscribe: subscribeTaskPageFuzzySearchChanges,
+  },
+  {
+    id: 'task-create-success-action',
+    label: '创建任务后',
+    icon: List,
+    category: 'input',
+    description: '仅作用于任务页快速添加；默认继续回焦，也可切换为直接打开新建任务详情',
+    rowTestId: 'new-settings-task-create-success-action-row',
+    type: 'enum',
+    options: [
+      { label: '继续快速输入', value: 'refocus' },
+      { label: '打开任务详情', value: 'open-detail' },
+    ],
+    optionTestId: (value) => `new-settings-task-create-success-action-${value}`,
+    get: () => getTaskCreateSuccessAction(),
+    set: (value: string) => {
+      setTaskCreateSuccessAction(value as 'refocus' | 'open-detail');
+    },
+    subscribe: subscribeTaskCreateSuccessActionChanges,
   },
   {
     id: 'voice-transcript-send-mode',

--- a/src/ui/app/config/settings/settings-registry.ts
+++ b/src/ui/app/config/settings/settings-registry.ts
@@ -82,6 +82,11 @@ import {
   subscribeVoiceTranscriptSendModeChanges,
 } from '@/config/voice-transcript-send-mode';
 import {
+  getInputSendMode,
+  setInputSendMode,
+  subscribeInputSendModeChanges,
+} from '@/config/input-send-mode';
+import {
   getVoiceShortcutHotkey,
   setVoiceShortcutHotkey,
   subscribeVoiceShortcutHotkeyChanges,
@@ -530,6 +535,25 @@ export const SETTINGS_REGISTRY: SettingsItem[] = [
     get: getFeedbackContentSelection,
     set: setFeedbackContentSelection,
     subscribe: (cb) => subscribeFeedbackPreferencesChanges(() => cb(getFeedbackContentSelection())),
+  },
+  {
+    id: 'input-send-mode',
+    label: '输入框发送方式',
+    icon: Key,
+    category: 'input',
+    description: '统一控制「任务 / 当下」输入框使用 Enter 发送还是 Ctrl/Cmd+Enter 发送',
+    rowTestId: 'new-settings-input-send-mode-row',
+    type: 'enum',
+    options: [
+      { label: 'Enter 发送', value: 'enter-send' },
+      { label: 'Ctrl+Enter 发送', value: 'ctrl-enter-send' },
+    ],
+    optionTestId: (value) => `new-settings-input-send-mode-${value}`,
+    get: () => getInputSendMode(),
+    set: (value: string) => {
+      setInputSendMode(value as 'enter-send' | 'ctrl-enter-send');
+    },
+    subscribe: subscribeInputSendModeChanges,
   },
   {
     id: 'voice-transcript-send-mode',

--- a/src/ui/app/config/settings/settings-registry.ts
+++ b/src/ui/app/config/settings/settings-registry.ts
@@ -25,6 +25,7 @@ import {
   SunMoon,
   Tag,
   Timer,
+  UserRound,
   Waypoints,
   Wifi,
 } from 'lucide-react';
@@ -49,6 +50,11 @@ import {
   setAgentPageEnabled,
   subscribeAgentPageEnabledChanges,
 } from '@/config/agent-page-enabled';
+import {
+  getMePageEnabled,
+  setMePageEnabled,
+  subscribeMePageEnabledChanges,
+} from '@/config/me-page-enabled';
 import {
   getDesktopAdaptiveEnabled,
   setDesktopAdaptiveEnabled,
@@ -358,12 +364,23 @@ function resolveBuildText(): string {
 }
 
 export const FEATURE_TOGGLE_SETTING_IDS = [
+  'me-page-enabled',
   'agent-page-enabled',
   'desktop-adaptive',
   'command-palette-enabled',
 ] as const;
 
 export const FEATURE_TOGGLE_SETTINGS = [
+  {
+    id: 'me-page-enabled',
+    label: 'Me 页面',
+    icon: UserRound,
+    rowTestId: 'feature-toggle-me-page-row',
+    controlTestId: 'feature-toggle-me-page-switch',
+    get: getMePageEnabled,
+    set: setMePageEnabled,
+    subscribe: subscribeMePageEnabledChanges,
+  },
   {
     id: 'agent-page-enabled',
     label: '网络页面',

--- a/src/ui/app/config/settings/settings-registry.ts
+++ b/src/ui/app/config/settings/settings-registry.ts
@@ -164,6 +164,11 @@ import {
   getTimeblockBackendMode,
   setTimeblockBackendMode,
 } from '@/config/domain-backend-mode';
+import {
+  getTasksDefaultTab,
+  setTasksDefaultTab,
+  type TasksDefaultTab,
+} from '@/config/tasks-default-tab';
 
 /*
  * AGENT GUIDE: ADDING SETTINGS
@@ -423,6 +428,27 @@ export const SETTINGS_REGISTRY: SettingsItem[] = [
       setThemePreference(value as 'system' | 'light' | 'dark');
     },
     subscribe: subscribeThemePreferenceChanges,
+  },
+  {
+    id: 'tasks-default-view',
+    label: '默认任务视图',
+    icon: List,
+    category: 'task',
+    type: 'enum',
+    enumStyle: 'dialog',
+    dialogTitle: '默认任务视图',
+    dialogDescription: '打开任务页面时默认显示的视图',
+    options: [
+      { label: '当下', value: 'now' },
+      { label: '今日', value: 'today' },
+      { label: '一周', value: 'week' },
+      { label: '月', value: 'month' },
+      { label: 'DAG 视图', value: 'dag' },
+    ],
+    get: () => getTasksDefaultTab() ?? 'now',
+    set: (value: string) => {
+      setTasksDefaultTab(value as TasksDefaultTab);
+    },
   },
   {
     id: 'countdown-end-mode',

--- a/src/ui/app/config/settings/settings-registry.ts
+++ b/src/ui/app/config/settings/settings-registry.ts
@@ -164,11 +164,6 @@ import {
   getTimeblockBackendMode,
   setTimeblockBackendMode,
 } from '@/config/domain-backend-mode';
-import {
-  getTasksDefaultTab,
-  setTasksDefaultTab,
-  type TasksDefaultTab,
-} from '@/config/tasks-default-tab';
 
 /*
  * AGENT GUIDE: ADDING SETTINGS
@@ -428,27 +423,6 @@ export const SETTINGS_REGISTRY: SettingsItem[] = [
       setThemePreference(value as 'system' | 'light' | 'dark');
     },
     subscribe: subscribeThemePreferenceChanges,
-  },
-  {
-    id: 'tasks-default-view',
-    label: '默认任务视图',
-    icon: List,
-    category: 'task',
-    type: 'enum',
-    enumStyle: 'dialog',
-    dialogTitle: '默认任务视图',
-    dialogDescription: '打开任务页面时默认显示的视图',
-    options: [
-      { label: '当下', value: 'now' },
-      { label: '今日', value: 'today' },
-      { label: '一周', value: 'week' },
-      { label: '月', value: 'month' },
-      { label: 'DAG 视图', value: 'dag' },
-    ],
-    get: () => getTasksDefaultTab() ?? 'now',
-    set: (value: string) => {
-      setTasksDefaultTab(value as TasksDefaultTab);
-    },
   },
   {
     id: 'countdown-end-mode',

--- a/src/ui/app/config/settings/settings-registry.ts
+++ b/src/ui/app/config/settings/settings-registry.ts
@@ -18,6 +18,7 @@ import {
   Monitor,
   Moon,
   MoonStar,
+  Search,
   RefreshCw,
   ScrollText,
   Shield,
@@ -86,6 +87,11 @@ import {
   setInputSendMode,
   subscribeInputSendModeChanges,
 } from '@/config/input-send-mode';
+import {
+  getTaskPageFuzzySearchEnabled,
+  setTaskPageFuzzySearchEnabled,
+  subscribeTaskPageFuzzySearchChanges,
+} from '@/config/task-page-fuzzy-search';
 import {
   getVoiceShortcutHotkey,
   setVoiceShortcutHotkey,
@@ -554,6 +560,19 @@ export const SETTINGS_REGISTRY: SettingsItem[] = [
       setInputSendMode(value as 'enter-send' | 'ctrl-enter-send');
     },
     subscribe: subscribeInputSendModeChanges,
+  },
+  {
+    id: 'task-page-fuzzy-search',
+    label: '任务页输入框模糊搜索',
+    icon: Search,
+    category: 'input',
+    description: '仅作用于任务页；开启后会用输入框第一行对任务标题做防抖模糊过滤',
+    rowTestId: 'new-settings-task-page-fuzzy-search-row',
+    controlTestId: 'new-settings-task-page-fuzzy-search-switch',
+    type: 'boolean',
+    get: () => getTaskPageFuzzySearchEnabled(),
+    set: (value: boolean) => setTaskPageFuzzySearchEnabled(value),
+    subscribe: subscribeTaskPageFuzzySearchChanges,
   },
   {
     id: 'voice-transcript-send-mode',

--- a/src/ui/app/config/settings/settings-types.ts
+++ b/src/ui/app/config/settings/settings-types.ts
@@ -20,7 +20,6 @@ import type { LucideIcon } from 'lucide-react';
 
 export type Category =
   | 'appearance'
-  | 'task'
   | 'timer'
   | 'input'
   | 'feedback'

--- a/src/ui/app/config/settings/settings-types.ts
+++ b/src/ui/app/config/settings/settings-types.ts
@@ -20,6 +20,7 @@ import type { LucideIcon } from 'lucide-react';
 
 export type Category =
   | 'appearance'
+  | 'task'
   | 'timer'
   | 'input'
   | 'feedback'

--- a/src/ui/app/hooks/useTauriFullscreenShortcut.ts
+++ b/src/ui/app/hooks/useTauriFullscreenShortcut.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from 'react';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import { isTauriWindow } from '@/config/runtime-target';
+
+export function useTauriFullscreenShortcut(): void {
+  const togglingRef = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !isTauriWindow()) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.isComposing || event.repeat) return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (event.key !== 'F11') return;
+
+      event.preventDefault();
+
+      if (togglingRef.current) {
+        return;
+      }
+
+      togglingRef.current = true;
+
+      void (async () => {
+        try {
+          const currentWindow = getCurrentWindow();
+          const fullscreen = await currentWindow.isFullscreen();
+          await currentWindow.setFullscreen(!fullscreen);
+        } catch {
+          // Ignore fullscreen toggle failures to avoid breaking unrelated keyboard flows.
+        } finally {
+          togglingRef.current = false;
+        }
+      })();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+}

--- a/src/ui/app/hooks/useTimerConfig.ts
+++ b/src/ui/app/hooks/useTimerConfig.ts
@@ -27,8 +27,10 @@ export function useTimerConfig(initialMinutes?: number, resetKey?: string): UseT
   const normalizedInitialMinutes = normalizeCountdownMinutes(initialMinutes);
   const hasUserConfiguredRef = useRef(false);
   const lastResetKeyRef = useRef(resetKey);
+  const initialMinutesRef = useRef(initialMinutes);
+  initialMinutesRef.current = initialMinutes;
 
-  const [timerMode, setTimerModeState] = useState<TimerMode>('countdown');
+  const [timerMode, setTimerModeState] = useState<TimerMode>(initialMinutes ? 'countdown' : 'countup');
   const [countdownMinutes, setCountdownMinutesState] = useState(normalizedInitialMinutes);
   const [customDurationDraft, setCustomDurationDraftState] = useState(String(normalizedInitialMinutes));
 
@@ -39,7 +41,7 @@ export function useTimerConfig(initialMinutes?: number, resetKey?: string): UseT
 
     lastResetKeyRef.current = resetKey;
     hasUserConfiguredRef.current = false;
-    setTimerModeState('countdown');
+    setTimerModeState(initialMinutesRef.current ? 'countdown' : 'countup');
     setCountdownMinutesState(normalizedInitialMinutes);
     setCustomDurationDraftState(String(normalizedInitialMinutes));
   }, [normalizedInitialMinutes, resetKey]);

--- a/src/ui/app/hooks/useTimerConfig.ts
+++ b/src/ui/app/hooks/useTimerConfig.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { TimerMode } from '@/lib/services';
 
 const DEFAULT_COUNTDOWN_MINUTES = 25;
@@ -17,6 +17,7 @@ export interface UseTimerConfigResult {
   countdownMinutes: number;
   setTimerMode: (mode: 'countup' | 'countdown') => void;
   setCountdownMinutes: (minutes: number) => void;
+  syncTimerConfig: (config: { mode: 'countup' } | { mode: 'countdown'; minutes: number }) => void;
   customDurationDraft: string;
   setCustomDurationDraft: (draft: string) => void;
   commitCustomDuration: () => void;
@@ -33,6 +34,22 @@ export function useTimerConfig(initialMinutes?: number, resetKey?: string): UseT
   const [timerMode, setTimerModeState] = useState<TimerMode>(initialMinutes ? 'countdown' : 'countup');
   const [countdownMinutes, setCountdownMinutesState] = useState(normalizedInitialMinutes);
   const [customDurationDraft, setCustomDurationDraftState] = useState(String(normalizedInitialMinutes));
+
+  const applyTimerConfig = useCallback((
+    config: { mode: 'countup' } | { mode: 'countdown'; minutes: number },
+    markUserConfigured: boolean,
+  ) => {
+    if (markUserConfigured) {
+      hasUserConfiguredRef.current = true;
+    }
+
+    setTimerModeState(config.mode);
+    if (config.mode === 'countdown') {
+      const safeMinutes = normalizeCountdownMinutes(config.minutes);
+      setCountdownMinutesState(safeMinutes);
+      setCustomDurationDraftState(String(safeMinutes));
+    }
+  }, []);
 
   useEffect(() => {
     if (lastResetKeyRef.current === resetKey) {
@@ -62,25 +79,29 @@ export function useTimerConfig(initialMinutes?: number, resetKey?: string): UseT
     }
   }, [initialMinutes, normalizedInitialMinutes]);
 
-  const setTimerMode = (mode: TimerMode) => {
-    hasUserConfiguredRef.current = true;
-    setTimerModeState(mode);
-  };
+  const setTimerMode = useCallback((mode: TimerMode) => {
+    if (mode === 'countdown') {
+      applyTimerConfig({ mode: 'countdown', minutes: countdownMinutes }, true);
+      return;
+    }
 
-  const setCountdownMinutes = (minutes: number) => {
-    const safeMinutes = normalizeCountdownMinutes(minutes);
-    hasUserConfiguredRef.current = true;
-    setTimerModeState('countdown');
-    setCountdownMinutesState(safeMinutes);
-    setCustomDurationDraftState(String(safeMinutes));
-  };
+    applyTimerConfig({ mode: 'countup' }, true);
+  }, [applyTimerConfig, countdownMinutes]);
 
-  const setCustomDurationDraft = (draft: string) => {
+  const setCountdownMinutes = useCallback((minutes: number) => {
+    applyTimerConfig({ mode: 'countdown', minutes }, true);
+  }, [applyTimerConfig]);
+
+  const syncTimerConfig = useCallback((config: { mode: 'countup' } | { mode: 'countdown'; minutes: number }) => {
+    applyTimerConfig(config, false);
+  }, [applyTimerConfig]);
+
+  const setCustomDurationDraft = useCallback((draft: string) => {
     hasUserConfiguredRef.current = true;
     setCustomDurationDraftState(draft);
-  };
+  }, []);
 
-  const commitCustomDuration = () => {
+  const commitCustomDuration = useCallback(() => {
     const parsedValue = Number.parseInt(customDurationDraft.trim(), 10);
     if (Number.isFinite(parsedValue)) {
       setCountdownMinutes(parsedValue);
@@ -88,7 +109,7 @@ export function useTimerConfig(initialMinutes?: number, resetKey?: string): UseT
     }
 
     setCustomDurationDraftState(String(countdownMinutes));
-  };
+  }, [countdownMinutes, customDurationDraft, setCountdownMinutes]);
 
   const timerConfig = useMemo<UseTimerConfigResult['timerConfig']>(() => {
     if (timerMode === 'countdown') {
@@ -103,6 +124,7 @@ export function useTimerConfig(initialMinutes?: number, resetKey?: string): UseT
     countdownMinutes,
     setTimerMode,
     setCountdownMinutes,
+    syncTimerConfig,
     customDurationDraft,
     setCustomDurationDraft,
     commitCustomDuration,

--- a/src/ui/app/hooks/useTimerConfig.ts
+++ b/src/ui/app/hooks/useTimerConfig.ts
@@ -51,9 +51,10 @@ export function useTimerConfig(initialMinutes?: number, resetKey?: string): UseT
       return;
     }
 
+    setTimerModeState(initialMinutes ? 'countdown' : 'countup');
     setCountdownMinutesState(normalizedInitialMinutes);
     setCustomDurationDraftState(String(normalizedInitialMinutes));
-  }, [normalizedInitialMinutes]);
+  }, [initialMinutes, normalizedInitialMinutes]);
 
   const setTimerMode = (mode: TimerMode) => {
     hasUserConfiguredRef.current = true;

--- a/src/ui/app/hooks/useTimerConfig.ts
+++ b/src/ui/app/hooks/useTimerConfig.ts
@@ -52,8 +52,14 @@ export function useTimerConfig(initialMinutes?: number, resetKey?: string): UseT
     }
 
     setTimerModeState(initialMinutes ? 'countdown' : 'countup');
-    setCountdownMinutesState(normalizedInitialMinutes);
-    setCustomDurationDraftState(String(normalizedInitialMinutes));
+    // Only update countdown display when initialMinutes is a real number.
+    // When undefined (countup / no estimation), keep the current countdown value
+    // instead of resetting to the DEFAULT_COUNTDOWN_MINUTES fallback, which would
+    // cause a spurious state change and potential re-render cascade.
+    if (initialMinutes) {
+      setCountdownMinutesState(normalizedInitialMinutes);
+      setCustomDurationDraftState(String(normalizedInitialMinutes));
+    }
   }, [initialMinutes, normalizedInitialMinutes]);
 
   const setTimerMode = (mode: TimerMode) => {

--- a/src/ui/app/layouts/MobileSettingsLayout.tsx
+++ b/src/ui/app/layouts/MobileSettingsLayout.tsx
@@ -6,6 +6,7 @@ import type { Category, SettingsContext, SettingsItem } from '@/ui/app/config/se
 
 const MOBILE_CATEGORY_ORDER: Category[] = [
   'appearance',
+  'task',
   'timer',
   'input',
   'feedback',
@@ -20,6 +21,7 @@ const MOBILE_CATEGORY_ORDER: Category[] = [
 
 const CATEGORY_LABELS: Record<Category, string> = {
   appearance: '外观',
+  task: '任务',
   timer: '计时器',
   input: '输入',
   feedback: '时间块反馈',

--- a/src/ui/app/layouts/MobileSettingsLayout.tsx
+++ b/src/ui/app/layouts/MobileSettingsLayout.tsx
@@ -6,7 +6,6 @@ import type { Category, SettingsContext, SettingsItem } from '@/ui/app/config/se
 
 const MOBILE_CATEGORY_ORDER: Category[] = [
   'appearance',
-  'task',
   'timer',
   'input',
   'feedback',
@@ -21,7 +20,6 @@ const MOBILE_CATEGORY_ORDER: Category[] = [
 
 const CATEGORY_LABELS: Record<Category, string> = {
   appearance: '外观',
-  task: '任务',
   timer: '计时器',
   input: '输入',
   feedback: '时间块反馈',

--- a/src/ui/app/overlay/use-now-workbench-overlay-controller.ts
+++ b/src/ui/app/overlay/use-now-workbench-overlay-controller.ts
@@ -8,7 +8,8 @@ import {
   getTimeBlockService,
 } from '@/lib/services';
 import type { ActiveBlockData, Event as UiEvent } from '@/lib/types/event';
-import type { TaskNode } from '@/lib/types/task';
+import type { TaskNode, TaskStatus } from '@/lib/types/task';
+import type { TaskStatusChoice } from '@/ui/app/components/TaskStatusSelector';
 import { buildNowWorkbenchOverlayModel, type NowWorkbenchOverlayMode } from './now-workbench-overlay-model';
 import { getNowWorkbenchOverlayService } from '@/services/now-workbench-overlay.service';
 
@@ -16,6 +17,7 @@ interface NowWorkbenchOverlayController {
   model: ReturnType<typeof buildNowWorkbenchOverlayModel>;
   feedbackOpen: boolean;
   feedback: string;
+  taskStatusChoice: TaskStatusChoice;
   debugInfo: {
     userId: string;
     mode: string;
@@ -27,6 +29,7 @@ interface NowWorkbenchOverlayController {
     lastAction: string;
   };
   setFeedback(value: string): void;
+  setTaskStatusChoice(value: TaskStatusChoice): void;
   handleHide(): Promise<void>;
   handleReturnToMain(): Promise<void>;
   handlePauseOrResume(): Promise<void>;
@@ -82,6 +85,7 @@ export function useNowWorkbenchOverlayController(): NowWorkbenchOverlayControlle
   const [now, setNow] = useState(() => Date.now());
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   const [feedback, setFeedback] = useState('');
+  const [taskStatusChoice, setTaskStatusChoice] = useState<TaskStatusChoice>('continue');
   const [debugInfo, setDebugInfo] = useState<NowWorkbenchOverlayDebugInfo>(() => ({
     userId: getCurrentUserId(),
     mode: EMPTY_MODEL.mode,
@@ -323,9 +327,22 @@ export function useNowWorkbenchOverlayController(): NowWorkbenchOverlayControlle
 
   const handleConfirmEnd = useCallback(async () => {
     try {
+      const blockBeforeEnd = activeBlock;
       await timeBlockService.endBlock(feedback);
+
+      if (taskStatusChoice !== 'continue' && blockBeforeEnd?.taskId) {
+        try {
+          await taskService.transitionTask(blockBeforeEnd.taskId, taskStatusChoice as TaskStatus);
+        } catch (transitionError) {
+          updateDebugInfo({
+            lastAction: `end-block:task-transition-error:${transitionError instanceof Error ? transitionError.message : String(transitionError)}`,
+          });
+        }
+      }
+
       setFeedback('');
       setFeedbackOpen(false);
+      setTaskStatusChoice('continue');
       await reloadAll();
       updateDebugInfo({ lastAction: 'end-block:success' });
     } catch (error) {
@@ -333,7 +350,7 @@ export function useNowWorkbenchOverlayController(): NowWorkbenchOverlayControlle
         lastAction: `end-block:error:${error instanceof Error ? error.message : String(error)}`,
       });
     }
-  }, [feedback, reloadAll, timeBlockService, updateDebugInfo]);
+  }, [activeBlock, feedback, reloadAll, taskService, taskStatusChoice, timeBlockService, updateDebugInfo]);
 
   const handleStartTask = useCallback(async (task: TaskNode) => {
     updateDebugInfo({ lastAction: `task-select:open-config:${task.id}` });
@@ -361,8 +378,10 @@ export function useNowWorkbenchOverlayController(): NowWorkbenchOverlayControlle
     model: model ?? EMPTY_MODEL,
     feedbackOpen,
     feedback,
+    taskStatusChoice,
     debugInfo,
     setFeedback,
+    setTaskStatusChoice,
     handleHide,
     handleReturnToMain,
     handlePauseOrResume,

--- a/src/ui/app/pages/AgentsPage.tsx
+++ b/src/ui/app/pages/AgentsPage.tsx
@@ -268,6 +268,10 @@ export function AgentsPage() {
     setRightPanel({ state: 'ACTOR_DETAIL', nodeId });
   };
   const openSignalDetail = (signalId: string) => {
+    if (!supportsInlineRightPanel) {
+      navigateToSecondaryPage(`/agents/signal/${encodeURIComponent(signalId)}`);
+      return;
+    }
     setRightPanel({ state: 'SIGNAL_DETAIL', signalId });
   };
   const closeRightPanel = () => {

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -90,11 +90,18 @@ const TASK_DAG_NODE_TYPES = {
 } satisfies NodeTypes;
 
 export function TaskDagPage() {
+  const location = useLocation();
   const [tasks, setTasks] = useState<TaskNode[]>([]);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [dagVisibility, setDagVisibility] = useState<TaskDagVisibilityState>(EMPTY_TASK_DAG_VISIBILITY_STATE);
   const [contextMenu, setContextMenu] = useState<{ nodeId: string; x: number; y: number } | null>(null);
   const flowInstanceRef = useRef<ReactFlowInstance<TaskDagFlowNode, TaskDagFlowEdge> | null>(null);
+
+  // Persist current tasks sub-path for nav tab memory
+  useEffect(() => {
+    const fullPath = location.pathname + (location.searchStr || '');
+    sessionStorage.setItem(TASKS_LAST_PATH_KEY, fullPath);
+  }, [location.pathname, location.searchStr]);
 
   useEffect(() => {
     let disposed = false;
@@ -176,9 +183,6 @@ export function TaskDagPage() {
             </span>
           </div>
           <h1 className="mt-2 text-xl font-semibold text-[#1C1917] dark:text-[#FAFAF9]">任务依赖 DAG</h1>
-          <p className="mt-1 text-sm text-[#78716C] dark:text-[#A8A29E]">
-            基于 `dependsOn` 的只读执行图，不把 `parentId` 并入 DAG 边。
-          </p>
         </div>
         <div className="flex flex-wrap gap-2">
           <button

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -3,7 +3,6 @@ import { Link } from '@tanstack/react-router';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Background,
-  Controls,
   Handle,
   Position,
   ReactFlow,
@@ -12,6 +11,7 @@ import {
   type ReactFlowInstance,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
+import { TaskDagControlPanel } from '@/ui/app/components/TaskDagControlPanel';
 import { buildTaskGraph } from '@/lib/task/task-dag-graph';
 import { getTaskService } from '@/lib/services';
 import type { TaskNode } from '@/lib/types/task';
@@ -258,7 +258,16 @@ export function TaskDagPage() {
             }}
           >
             <Background gap={20} color="#E7E5E4" />
-            <Controls />
+            <TaskDagControlPanel
+              onFitView={() => { void flowInstanceRef.current?.fitView({ padding: 0.2 }); }}
+              onJumpToCurrentRoot={graph.currentRootNodeId ? () => {
+                const node = flowInstanceRef.current?.getNode(graph.currentRootNodeId!);
+                if (node) {
+                  void flowInstanceRef.current?.fitView({ nodes: [node], padding: 0.5, duration: 300 });
+                }
+              } : undefined}
+              hasCurrentRoot={Boolean(graph.currentRootNodeId)}
+            />
           </ReactFlow>
         </div>
       </section>

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -99,6 +99,9 @@ const TASK_DAG_NODE_TYPES = {
   taskDag: TaskDagNode,
 } satisfies NodeTypes;
 
+const TASK_DAG_MIN_ZOOM = 0.01;
+const TASK_DAG_FIT_VIEW_OPTIONS = { padding: 0.2, minZoom: TASK_DAG_MIN_ZOOM } as const;
+
 export function TaskDagPage() {
   console.log('[DAG] TaskDagPage rendered, pathname:', window.location.pathname);
   const location = useLocation();
@@ -175,10 +178,11 @@ export function TaskDagPage() {
     if (!currentRootNode) return;
 
     setSelectedTaskId(graph.currentRootNodeId);
+    const currentZoom = flowInstanceRef.current?.getViewport().zoom ?? 1;
     flowInstanceRef.current?.setCenter(
       currentRootNode.position.x + TASK_DAG_NODE_WIDTH / 2,
       currentRootNode.position.y + TASK_DAG_NODE_HEIGHT / 2,
-      { zoom: 1, duration: 250 },
+      { zoom: currentZoom, duration: 250 },
     );
   };
 
@@ -289,14 +293,15 @@ export function TaskDagPage() {
             nodeTypes={TASK_DAG_NODE_TYPES}
             proOptions={{ hideAttribution: true }}
             fitView
-            fitViewOptions={{ padding: 0.2 }}
+            minZoom={TASK_DAG_MIN_ZOOM}
+            fitViewOptions={TASK_DAG_FIT_VIEW_OPTIONS}
             nodesDraggable={false}
             nodesConnectable={false}
             elementsSelectable
             zoomOnDoubleClick={false}
             onInit={(instance) => {
               flowInstanceRef.current = instance;
-              void instance.fitView({ padding: 0.2 });
+              void instance.fitView(TASK_DAG_FIT_VIEW_OPTIONS);
             }}
             onNodeClick={(_event, node) => {
               setSelectedTaskId(node.id);
@@ -309,11 +314,16 @@ export function TaskDagPage() {
             <Background gap={20} color="#E7E5E4" />
             <Controls className="!rounded-lg !border-[#E7E3E0] !bg-white/90 !shadow-sm dark:!border-[#3C3836] dark:!bg-[#1C1917]/90 [&>button]:!border-[#E7E3E0] [&>button]:!bg-transparent [&>button]:!fill-[#57534E] dark:[&>button]:!border-[#3C3836] dark:[&>button]:!fill-[#A8A29E] [&>button:hover]:!bg-[#F5F0ED] dark:[&>button:hover]:!bg-[#292524]" />
             <TaskDagControlPanel
-              onFitView={() => { void flowInstanceRef.current?.fitView({ padding: 0.2 }); }}
+              onFitView={() => { void flowInstanceRef.current?.fitView(TASK_DAG_FIT_VIEW_OPTIONS); }}
               onJumpToCurrentRoot={graph.currentRootNodeId ? () => {
                 const node = flowInstanceRef.current?.getNode(graph.currentRootNodeId!);
                 if (node) {
-                  void flowInstanceRef.current?.fitView({ nodes: [node], padding: 0.5, duration: 300 });
+                  void flowInstanceRef.current?.fitView({
+                    ...TASK_DAG_FIT_VIEW_OPTIONS,
+                    nodes: [node],
+                    padding: 0.5,
+                    duration: 300,
+                  });
                 }
               } : undefined}
               hasCurrentRoot={Boolean(graph.currentRootNodeId)}

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft, Crosshair, Waypoints } from 'lucide-react';
-import { Link } from '@tanstack/react-router';
+import { Link, useLocation } from '@tanstack/react-router';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { TASKS_LAST_PATH_KEY } from './TasksPage';
 import {
   Background,
   Controls,
@@ -166,7 +167,7 @@ export function TaskDagPage() {
           <div className="inline-flex items-center gap-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
             <Link to="/tasks" className="inline-flex items-center gap-1 hover:text-[#1C1917] dark:hover:text-[#FAFAF9]">
               <ArrowLeft size={14} />
-              返回任务
+              任务
             </Link>
             <span>/</span>
             <span className="inline-flex items-center gap-1">

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -186,7 +186,7 @@ export function TaskDagPage() {
       <header className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <div className="inline-flex items-center gap-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
-            <Link to="/tasks" className="inline-flex items-center gap-1 hover:text-[#1C1917] dark:hover:text-[#FAFAF9]">
+            <Link to="/tasks" onClick={() => sessionStorage.removeItem(TASKS_LAST_PATH_KEY)} className="inline-flex items-center gap-1 hover:text-[#1C1917] dark:hover:text-[#FAFAF9]">
               <ArrowLeft size={14} />
               任务
             </Link>

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -1,7 +1,8 @@
-import { ArrowLeft, Crosshair, Waypoints } from 'lucide-react';
+import { Crosshair, Waypoints } from 'lucide-react';
 import { Link, useLocation } from '@tanstack/react-router';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { TASKS_LAST_PATH_KEY } from './TasksPage';
+import { TaskBreadcrumb } from '@/ui/app/components/TaskBreadcrumb';
 import {
   Background,
   Controls,
@@ -185,17 +186,10 @@ export function TaskDagPage() {
     <div className="min-h-full bg-[#FAF7F5] px-5 py-4 dark:bg-[#0C0A09] md:px-8 lg:px-10" data-testid="task-dag-page">
       <header className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <div className="inline-flex items-center gap-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
-            <Link to="/tasks" onClick={() => sessionStorage.removeItem(TASKS_LAST_PATH_KEY)} className="inline-flex items-center gap-1 hover:text-[#1C1917] dark:hover:text-[#FAFAF9]">
-              <ArrowLeft size={14} />
-              任务
-            </Link>
-            <span>/</span>
-            <span className="inline-flex items-center gap-1">
-              <Waypoints size={14} />
-              DAG 视图
-            </span>
-          </div>
+          <TaskBreadcrumb
+            segments={[{ label: '任务', to: '/tasks' }]}
+            current={{ label: 'DAG 视图', icon: Waypoints }}
+          />
           <h1 className="mt-2 text-xl font-semibold text-[#1C1917] dark:text-[#FAFAF9]">任务依赖 DAG</h1>
         </div>
         <div className="flex flex-wrap gap-2">
@@ -260,15 +254,17 @@ export function TaskDagPage() {
               <>
                 <p className="mt-3 text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{selectedTask.title}</p>
                 <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">状态：{STATUS_LABELS[selectedNode.status] ?? selectedNode.status}</p>
-                <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
-                  {selectedNode.isExecutable && !selectedNode.isBlocked
-                    ? '可直接执行'
-                    : selectedNode.isExecutable && selectedNode.isBlocked
-                      ? '可执行（软阻塞提醒）'
-                      : selectedNode.isBlocked
-                        ? '不可直接执行 · 有阻塞依赖'
-                        : '待处理'}
-                </p>
+                {selectedNode.status !== 'completed' && selectedNode.status !== 'cancelled' && (
+                  <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
+                    {selectedNode.isExecutable && !selectedNode.isBlocked
+                      ? '可直接执行'
+                      : selectedNode.isExecutable && selectedNode.isBlocked
+                        ? '可执行（软阻塞提醒）'
+                        : selectedNode.isBlocked
+                          ? '不可直接执行 · 有阻塞依赖'
+                          : '待处理'}
+                  </p>
+                )}
                 <Link
                   data-testid="task-dag-selected-link"
                   to="/tasks/$taskId"

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -256,8 +256,13 @@ export function TaskDagPage() {
                 <p className="mt-3 text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{selectedTask.title}</p>
                 <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">状态：{STATUS_LABELS[selectedNode.status] ?? selectedNode.status}</p>
                 <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
-                  {selectedNode.isExecutable ? '可执行' : '不可直接执行'}
-                  {selectedNode.isBlocked ? ' · 有阻塞提醒' : ''}
+                  {selectedNode.isExecutable && !selectedNode.isBlocked
+                    ? '可直接执行'
+                    : selectedNode.isExecutable && selectedNode.isBlocked
+                      ? '可执行（软阻塞提醒）'
+                      : selectedNode.isBlocked
+                        ? '不可直接执行 · 有阻塞依赖'
+                        : '待处理'}
                 </p>
                 <Link
                   data-testid="task-dag-selected-link"

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -272,6 +272,7 @@ export function TaskDagPage() {
             nodes={flowGraph.nodes}
             edges={flowGraph.edges}
             nodeTypes={TASK_DAG_NODE_TYPES}
+            proOptions={{ hideAttribution: true }}
             fitView
             fitViewOptions={{ padding: 0.2 }}
             nodesDraggable={false}

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -256,13 +256,11 @@ export function TaskDagPage() {
                 <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">状态：{STATUS_LABELS[selectedNode.status] ?? selectedNode.status}</p>
                 {selectedNode.status !== 'completed' && selectedNode.status !== 'cancelled' && (
                   <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
-                    {selectedNode.isExecutable && !selectedNode.isBlocked
-                      ? '可直接执行'
-                      : selectedNode.isExecutable && selectedNode.isBlocked
-                        ? '可执行（软阻塞提醒）'
-                        : selectedNode.isBlocked
-                          ? '不可直接执行 · 有阻塞依赖'
-                          : '待处理'}
+                    {selectedNode.isBlocked
+                      ? '受阻 · 有未满足的依赖'
+                      : selectedNode.isExecutable
+                        ? '可直接执行'
+                        : '待处理'}
                   </p>
                 )}
                 <Link

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -3,6 +3,7 @@ import { Link } from '@tanstack/react-router';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Background,
+  Controls,
   Handle,
   Position,
   ReactFlow,
@@ -285,6 +286,7 @@ export function TaskDagPage() {
             }}
           >
             <Background gap={20} color="#E7E5E4" />
+            <Controls />
             <TaskDagControlPanel
               onFitView={() => { void flowInstanceRef.current?.fitView({ padding: 0.2 }); }}
               onJumpToCurrentRoot={graph.currentRootNodeId ? () => {

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -17,6 +17,7 @@ import '@xyflow/react/dist/style.css';
 import { TaskDagControlPanel } from '@/ui/app/components/TaskDagControlPanel';
 import { buildTaskGraph } from '@/lib/task/task-dag-graph';
 import {
+  calculateTaskDagCollapseScope,
   type TaskDagVisibilityState,
   EMPTY_TASK_DAG_VISIBILITY_STATE,
   projectVisibleTaskGraph,
@@ -58,6 +59,8 @@ function TaskDagNode({ id, data }: FlowNodeProps<TaskDagFlowNode>) {
         'w-64 rounded-2xl border bg-white px-4 py-3 text-left shadow-sm dark:bg-[#1C1917]',
         nodeData.isCurrentRoot
           ? 'border-[#C75B3A] ring-2 ring-[#FDE7DC] dark:ring-[#4A2317]'
+          : nodeData.isCollapsedTarget
+            ? 'border-[#C75B3A] ring-2 ring-[#FDE7DC] dark:border-[#FDBA74] dark:ring-[#4A2317]'
           : nodeData.isBlocked
             ? 'border-[#EAB308]/60'
             : 'border-[#E7E5E4] dark:border-[#292524]',
@@ -75,6 +78,16 @@ function TaskDagNode({ id, data }: FlowNodeProps<TaskDagFlowNode>) {
             当前根节点
           </span>
         ) : null}
+        {nodeData.isCollapsedUpstreamTarget ? (
+          <span className="rounded-full bg-[#FFF7ED] px-2 py-0.5 text-[10px] font-medium text-[#C75B3A]">
+            已折叠上游
+          </span>
+        ) : null}
+        {nodeData.isCollapsedDownstreamTarget ? (
+          <span className="rounded-full bg-[#ECFDF5] px-2 py-0.5 text-[10px] font-medium text-[#047857]">
+            已折叠下游
+          </span>
+        ) : null}
         <span className="rounded-full bg-[#F5F0ED] px-2 py-0.5 text-[10px] font-medium text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]">
           {nodeData.statusLabel}
         </span>
@@ -84,6 +97,14 @@ function TaskDagNode({ id, data }: FlowNodeProps<TaskDagFlowNode>) {
             className="rounded-full bg-[#DBEAFE] px-2 py-0.5 text-[10px] font-medium text-[#1D4ED8] dark:bg-[#1E3A5F] dark:text-[#93C5FD]"
           >
             {`+${nodeData.hiddenUpstreamCount} 已折叠`}
+          </span>
+        )}
+        {nodeData.hiddenDownstreamCount > 0 && (
+          <span
+            data-testid={`task-dag-hidden-downstream-badge-${id}`}
+            className="rounded-full bg-[#DCFCE7] px-2 py-0.5 text-[10px] font-medium text-[#15803D] dark:bg-[#14532D] dark:text-[#BBF7D0]"
+          >
+            {`+${nodeData.hiddenDownstreamCount} 下游已折叠`}
           </span>
         )}
       </div>
@@ -171,6 +192,36 @@ export function TaskDagPage() {
   const selectedNode = selectedTaskId
     ? graph.nodes.find((node) => node.id === selectedTaskId) ?? null
     : null;
+  const selectedCollapseScope = useMemo(() => {
+    if (!selectedTaskId) {
+      return { upstreamSize: 0, downstreamSize: 0 };
+    }
+
+    return {
+      upstreamSize: calculateTaskDagCollapseScope(graph, dagVisibility, 'upstream', selectedTaskId).size,
+      downstreamSize: calculateTaskDagCollapseScope(graph, dagVisibility, 'downstream', selectedTaskId).size,
+    };
+  }, [dagVisibility, graph, selectedTaskId]);
+
+  const toggleCollapse = (direction: 'upstream' | 'downstream', nodeId: string) => {
+    setDagVisibility((prev) => {
+      if (direction === 'upstream') {
+        return {
+          ...prev,
+          collapsedUpstreamOf: prev.collapsedUpstreamOf.includes(nodeId)
+            ? prev.collapsedUpstreamOf.filter((id) => id !== nodeId)
+            : [...prev.collapsedUpstreamOf, nodeId],
+        };
+      }
+
+      return {
+        ...prev,
+        collapsedDownstreamOf: prev.collapsedDownstreamOf.includes(nodeId)
+          ? prev.collapsedDownstreamOf.filter((id) => id !== nodeId)
+          : [...prev.collapsedDownstreamOf, nodeId],
+      };
+    });
+  };
 
   const handleJumpToCurrentRoot = () => {
     if (!graph.currentRootNodeId) return;
@@ -277,6 +328,26 @@ export function TaskDagPage() {
                 >
                   打开任务详情
                 </Link>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    data-testid="task-dag-selected-toggle-upstream"
+                    disabled={selectedCollapseScope.upstreamSize <= 1 && !dagVisibility.collapsedUpstreamOf.includes(selectedTask.id)}
+                    onClick={() => toggleCollapse('upstream', selectedTask.id)}
+                    className="inline-flex items-center rounded-full border border-[#E7E5E4] px-3 py-2 text-xs font-semibold text-[#57534E] disabled:cursor-not-allowed disabled:opacity-60 dark:border-[#292524] dark:text-[#D6D3D1]"
+                  >
+                    {dagVisibility.collapsedUpstreamOf.includes(selectedTask.id) ? '展开上游' : '折叠上游'}
+                  </button>
+                  <button
+                    type="button"
+                    data-testid="task-dag-selected-toggle-downstream"
+                    disabled={selectedCollapseScope.downstreamSize <= 1 && !dagVisibility.collapsedDownstreamOf.includes(selectedTask.id)}
+                    onClick={() => toggleCollapse('downstream', selectedTask.id)}
+                    className="inline-flex items-center rounded-full border border-[#E7E5E4] px-3 py-2 text-xs font-semibold text-[#57534E] disabled:cursor-not-allowed disabled:opacity-60 dark:border-[#292524] dark:text-[#D6D3D1]"
+                  >
+                    {dagVisibility.collapsedDownstreamOf.includes(selectedTask.id) ? '展开下游' : '折叠下游'}
+                  </button>
+                </div>
               </>
             ) : (
               <p className="mt-3 text-xs text-[#78716C] dark:text-[#A8A29E]">点击节点可查看详情。</p>
@@ -339,17 +410,33 @@ export function TaskDagPage() {
         >
           <button
             type="button"
-            className="block w-full px-4 py-1.5 text-left text-xs text-[#57534E] hover:bg-[#F5F0ED] dark:text-[#A8A29E] dark:hover:bg-[#292524]"
+            data-testid="task-dag-context-toggle-upstream"
+            className="block w-full px-4 py-1.5 text-left text-xs text-[#57534E] hover:bg-[#F5F0ED] disabled:cursor-not-allowed disabled:opacity-60 dark:text-[#A8A29E] dark:hover:bg-[#292524]"
             onClick={() => {
-              setDagVisibility((prev) => ({
-                collapsedUpstreamOf: prev.collapsedUpstreamOf.includes(contextMenu.nodeId)
-                  ? prev.collapsedUpstreamOf.filter((id) => id !== contextMenu.nodeId)
-                  : [...prev.collapsedUpstreamOf, contextMenu.nodeId],
-              }));
+              toggleCollapse('upstream', contextMenu.nodeId);
               setContextMenu(null);
             }}
+            disabled={
+              calculateTaskDagCollapseScope(graph, dagVisibility, 'upstream', contextMenu.nodeId).size <= 1
+              && !dagVisibility.collapsedUpstreamOf.includes(contextMenu.nodeId)
+            }
           >
             {dagVisibility.collapsedUpstreamOf.includes(contextMenu.nodeId) ? '展开上游' : '折叠上游'}
+          </button>
+          <button
+            type="button"
+            data-testid="task-dag-context-toggle-downstream"
+            className="block w-full px-4 py-1.5 text-left text-xs text-[#57534E] hover:bg-[#F5F0ED] disabled:cursor-not-allowed disabled:opacity-60 dark:text-[#A8A29E] dark:hover:bg-[#292524]"
+            onClick={() => {
+              toggleCollapse('downstream', contextMenu.nodeId);
+              setContextMenu(null);
+            }}
+            disabled={
+              calculateTaskDagCollapseScope(graph, dagVisibility, 'downstream', contextMenu.nodeId).size <= 1
+              && !dagVisibility.collapsedDownstreamOf.includes(contextMenu.nodeId)
+            }
+          >
+            {dagVisibility.collapsedDownstreamOf.includes(contextMenu.nodeId) ? '展开下游' : '折叠下游'}
           </button>
         </div>
       )}

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -207,6 +207,7 @@ export function TaskDagPage() {
             <Link
               to="/tasks/$taskId"
               params={{ taskId: graph.currentRootNodeId }}
+              search={{ from: 'dag' }}
               className="inline-flex items-center rounded-full border border-[#E7E5E4] px-4 py-2 text-sm font-semibold text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
             >
               打开当前根节点
@@ -267,6 +268,7 @@ export function TaskDagPage() {
                   data-testid="task-dag-selected-link"
                   to="/tasks/$taskId"
                   params={{ taskId: selectedTask.id }}
+                  search={{ from: 'dag' }}
                   className="mt-3 inline-flex items-center rounded-full border border-[#E7E5E4] px-3 py-2 text-xs font-semibold text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
                 >
                   打开任务详情

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -1,7 +1,7 @@
 import { Crosshair, Waypoints } from 'lucide-react';
 import { Link, useLocation } from '@tanstack/react-router';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { TASKS_LAST_PATH_KEY } from './TasksPage';
+import { TASKS_LAST_PATH_KEY } from './task-route-memory';
 import { TaskBreadcrumb } from '@/ui/app/components/TaskBreadcrumb';
 import {
   Background,

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -30,6 +30,15 @@ import {
   type TaskDagFlowNode,
   type TaskDagFlowNodeData,
 } from './task-dag-flow';
+import type { TaskStatus } from '@/lib/types/task';
+
+const STATUS_LABELS: Record<TaskStatus, string> = {
+  pending: '待办',
+  in_progress: '进行中',
+  suspended: '已挂起',
+  completed: '已完成',
+  cancelled: '已取消',
+};
 
 function TaskDagNode({ id, data }: FlowNodeProps<TaskDagFlowNode>) {
   const nodeData = data as TaskDagFlowNodeData;
@@ -245,7 +254,7 @@ export function TaskDagPage() {
             {selectedTask && selectedNode ? (
               <>
                 <p className="mt-3 text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{selectedTask.title}</p>
-                <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">状态：{selectedNode.status}</p>
+                <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">状态：{STATUS_LABELS[selectedNode.status] ?? selectedNode.status}</p>
                 <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
                   {selectedNode.isExecutable ? '可执行' : '不可直接执行'}
                   {selectedNode.isBlocked ? ' · 有阻塞提醒' : ''}

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -99,6 +99,7 @@ const TASK_DAG_NODE_TYPES = {
 } satisfies NodeTypes;
 
 export function TaskDagPage() {
+  console.log('[DAG] TaskDagPage rendered, pathname:', window.location.pathname);
   const location = useLocation();
   const [tasks, setTasks] = useState<TaskNode[]>([]);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
@@ -109,7 +110,11 @@ export function TaskDagPage() {
   // Persist current tasks sub-path for nav tab memory
   useEffect(() => {
     const fullPath = location.pathname + (location.searchStr || '');
-    sessionStorage.setItem(TASKS_LAST_PATH_KEY, fullPath);
+    // Only save task-related paths; useLocation fires with the NEW target path before unmount
+    if (fullPath.startsWith('/tasks/')) {
+      console.log('[DAG] saving path to sessionStorage:', fullPath);
+      sessionStorage.setItem(TASKS_LAST_PATH_KEY, fullPath);
+    }
   }, [location.pathname, location.searchStr]);
 
   useEffect(() => {

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -286,7 +286,7 @@ export function TaskDagPage() {
             }}
           >
             <Background gap={20} color="#E7E5E4" />
-            <Controls />
+            <Controls className="!rounded-lg !border-[#E7E3E0] !bg-white/90 !shadow-sm dark:!border-[#3C3836] dark:!bg-[#1C1917]/90 [&>button]:!border-[#E7E3E0] [&>button]:!bg-transparent [&>button]:!fill-[#57534E] dark:[&>button]:!border-[#3C3836] dark:[&>button]:!fill-[#A8A29E] [&>button:hover]:!bg-[#F5F0ED] dark:[&>button:hover]:!bg-[#292524]" />
             <TaskDagControlPanel
               onFitView={() => { void flowInstanceRef.current?.fitView({ padding: 0.2 }); }}
               onJumpToCurrentRoot={graph.currentRootNodeId ? () => {

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -227,7 +227,7 @@ export function TaskDagPage() {
               </div>
               <div data-testid="task-dag-legend-soft" className="flex items-center gap-2">
                 <span className="h-px w-8 border-t-2 border-dashed border-[#78716C]" />
-                <span>软依赖：前置待办会提示阻塞，但仍可直接开工</span>
+                <span>软依赖：前置任务开始后即可开始</span>
               </div>
             </div>
           </section>

--- a/src/ui/app/pages/TaskDagPage.tsx
+++ b/src/ui/app/pages/TaskDagPage.tsx
@@ -13,10 +13,15 @@ import {
 import '@xyflow/react/dist/style.css';
 import { TaskDagControlPanel } from '@/ui/app/components/TaskDagControlPanel';
 import { buildTaskGraph } from '@/lib/task/task-dag-graph';
+import {
+  type TaskDagVisibilityState,
+  EMPTY_TASK_DAG_VISIBILITY_STATE,
+  projectVisibleTaskGraph,
+} from '@/lib/task/task-dag-visibility';
 import { getTaskService } from '@/lib/services';
 import type { TaskNode } from '@/lib/types/task';
 import {
-  buildTaskDagFlow,
+  buildVisibleTaskDagFlow,
   TASK_DAG_NODE_HEIGHT,
   TASK_DAG_NODE_WIDTH,
   type TaskDagFlowEdge,
@@ -61,6 +66,14 @@ function TaskDagNode({ id, data }: FlowNodeProps<TaskDagFlowNode>) {
         <span className="rounded-full bg-[#F5F0ED] px-2 py-0.5 text-[10px] font-medium text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]">
           {nodeData.statusLabel}
         </span>
+        {nodeData.hiddenUpstreamCount > 0 && (
+          <span
+            data-testid={`task-dag-hidden-upstream-badge-${id}`}
+            className="rounded-full bg-[#DBEAFE] px-2 py-0.5 text-[10px] font-medium text-[#1D4ED8] dark:bg-[#1E3A5F] dark:text-[#93C5FD]"
+          >
+            {`+${nodeData.hiddenUpstreamCount} 已折叠`}
+          </span>
+        )}
       </div>
 
       <p className="mt-3 text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{nodeData.title}</p>
@@ -77,6 +90,8 @@ const TASK_DAG_NODE_TYPES = {
 export function TaskDagPage() {
   const [tasks, setTasks] = useState<TaskNode[]>([]);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [dagVisibility, setDagVisibility] = useState<TaskDagVisibilityState>(EMPTY_TASK_DAG_VISIBILITY_STATE);
+  const [contextMenu, setContextMenu] = useState<{ nodeId: string; x: number; y: number } | null>(null);
   const flowInstanceRef = useRef<ReactFlowInstance<TaskDagFlowNode, TaskDagFlowEdge> | null>(null);
 
   useEffect(() => {
@@ -102,8 +117,9 @@ export function TaskDagPage() {
   }, []);
 
   const graph = useMemo(() => buildTaskGraph(tasks), [tasks]);
+  const visibleGraph = useMemo(() => projectVisibleTaskGraph(graph, dagVisibility), [graph, dagVisibility]);
   const taskById = useMemo(() => new Map(tasks.map((task) => [task.id, task])), [tasks]);
-  const flowGraph = useMemo(() => buildTaskDagFlow(graph), [graph]);
+  const flowGraph = useMemo(() => buildVisibleTaskDagFlow(visibleGraph), [visibleGraph]);
 
   useEffect(() => {
     if (graph.currentRootNodeId && !selectedTaskId) {
@@ -115,6 +131,13 @@ export function TaskDagPage() {
       setSelectedTaskId(graph.currentRootNodeId ?? graph.topologicalOrder[0] ?? null);
     }
   }, [graph.currentRootNodeId, graph.topologicalOrder, selectedTaskId, tasks]);
+
+  useEffect(() => {
+    if (!contextMenu) return;
+    const handler = () => setContextMenu(null);
+    document.addEventListener('click', handler);
+    return () => document.removeEventListener('click', handler);
+  }, [contextMenu]);
 
   const currentRootTask = graph.currentRootNodeId ? taskById.get(graph.currentRootNodeId) ?? null : null;
   const selectedTask = selectedTaskId ? taskById.get(selectedTaskId) ?? null : null;
@@ -256,6 +279,10 @@ export function TaskDagPage() {
             onNodeClick={(_event, node) => {
               setSelectedTaskId(node.id);
             }}
+            onNodeContextMenu={(event, node) => {
+              event.preventDefault();
+              setContextMenu({ nodeId: node.id, x: event.clientX, y: event.clientY });
+            }}
           >
             <Background gap={20} color="#E7E5E4" />
             <TaskDagControlPanel
@@ -271,6 +298,28 @@ export function TaskDagPage() {
           </ReactFlow>
         </div>
       </section>
+
+      {contextMenu && (
+        <div
+          className="fixed z-50 rounded-lg border border-[#E7E5E4] bg-white py-1 shadow-lg dark:border-[#292524] dark:bg-[#1C1917]"
+          style={{ left: contextMenu.x, top: contextMenu.y }}
+        >
+          <button
+            type="button"
+            className="block w-full px-4 py-1.5 text-left text-xs text-[#57534E] hover:bg-[#F5F0ED] dark:text-[#A8A29E] dark:hover:bg-[#292524]"
+            onClick={() => {
+              setDagVisibility((prev) => ({
+                collapsedUpstreamOf: prev.collapsedUpstreamOf.includes(contextMenu.nodeId)
+                  ? prev.collapsedUpstreamOf.filter((id) => id !== contextMenu.nodeId)
+                  : [...prev.collapsedUpstreamOf, contextMenu.nodeId],
+              }));
+              setContextMenu(null);
+            }}
+          >
+            {dagVisibility.collapsedUpstreamOf.includes(contextMenu.nodeId) ? '展开上游' : '折叠上游'}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -39,18 +39,10 @@ import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 
 type DependencyType = 'soft' | 'hard';
-type TimeblockSourceTab = 'now' | 'today' | 'week' | 'month';
-
-const TIMEBLOCK_SOURCE_LABEL: Record<TimeblockSourceTab, string> = {
-  now: '当下',
-  today: '今日',
-  week: '一周',
-  month: '本月',
+const SOURCE_CONFIG: Record<string, { label: string; to: string }> = {
+  dag: { label: 'DAG', to: '/tasks/dag' },
+  timeblocks: { label: '时间块', to: '/tasks/timeblocks' },
 };
-
-function isTimeblockSourceTab(value: string): value is TimeblockSourceTab {
-  return Object.prototype.hasOwnProperty.call(TIMEBLOCK_SOURCE_LABEL, value);
-}
 
 interface TimeblockSourceBackLink {
   to: string;
@@ -117,14 +109,12 @@ function resolveTimeblockSourceBackLink(): TimeblockSourceBackLink {
 
   const searchParams = new URLSearchParams(window.location.search);
   const from = searchParams.get('from')?.trim();
-  const sourceTab = from && isTimeblockSourceTab(from) ? from : undefined;
-  const sourceLabel = sourceTab ? TIMEBLOCK_SOURCE_LABEL[sourceTab] : '任务';
+  const sourceConfig = from ? SOURCE_CONFIG[from] : undefined;
 
   return {
-    to: '/tasks',
-    search: sourceTab ? { tab: sourceTab } : undefined,
-    label: `← 返回${sourceLabel}`,
-    sourceLabel,
+    to: sourceConfig?.to ?? '/tasks',
+    label: `← 返回${sourceConfig?.label ?? '任务'}`,
+    sourceLabel: sourceConfig?.label ?? '任务',
   };
 }
 

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -29,6 +29,8 @@ import {
 import type { TaskDagVisibilityState } from '@/lib/task/task-dag-visibility';
 import { TimerConfigPanel } from '@/ui/app/components/TimerConfigPanel';
 import { useTimerConfig } from '@/ui/app/hooks/useTimerConfig';
+import { Pencil } from 'lucide-react';
+import { Textarea } from '@/components/ui/textarea';
 
 type DependencyType = 'soft' | 'hard';
 type TimeblockSourceTab = 'now' | 'today' | 'week' | 'month';
@@ -496,6 +498,7 @@ function DependencyCard({
 }
 
 function MobileTimeblockDetail({
+  descriptionBlock,
   task,
   model,
   backLink,
@@ -521,6 +524,7 @@ function MobileTimeblockDetail({
   onRemoveDependency,
   onToggleCollapseUpstream,
 }: {
+  descriptionBlock: ReactNode;
   task: TaskNode;
   model: TaskTimeblockDetailViewModel;
   backLink: TimeblockSourceBackLink;
@@ -570,6 +574,8 @@ function MobileTimeblockDetail({
         </button>
       </header>
 
+      <div className="px-4 pt-3">{descriptionBlock}</div>
+
       <div className="space-y-3 px-4 pt-3">
         <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
           <div className="flex flex-wrap items-center gap-2">
@@ -583,13 +589,6 @@ function MobileTimeblockDetail({
           <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">关联任务：{task.title}</p>
           {task.description ? (
             <p className="mt-2 whitespace-pre-wrap text-xs text-[#78716C] dark:text-[#A8A29E]">{task.description}</p>
-          ) : null}
-          {canEditEstimatedTime ? (
-            <EstimatedTimeEditor
-              taskId={task.id}
-              currentMinutes={task.estimatedMinutes}
-              onUpdate={onEstimatedMinutesUpdate}
-            />
           ) : null}
           <div className="mt-3 grid grid-cols-2 gap-2">
             {model.summary.metrics.map((metric) => (
@@ -679,7 +678,24 @@ function MobileTimeblockDetail({
           className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]"
         >
           <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">计时控制</h3>
-          {timerControls}
+          {canEditEstimatedTime ? (
+            <div className="mt-3">
+              <p className="text-xs font-medium text-[#57534E] dark:text-[#A8A29E]">估计时长</p>
+              <div className="mt-1">
+                <EstimatedTimeEditor
+                  taskId={task.id}
+                  currentMinutes={task.estimatedMinutes}
+                  onUpdate={onEstimatedMinutesUpdate}
+                />
+              </div>
+            </div>
+          ) : null}
+          <div className="mt-3">
+            <p className="text-xs font-medium text-[#57534E] dark:text-[#A8A29E]">预期时长</p>
+            <div className="mt-1">
+              {timerControls}
+            </div>
+          </div>
           <div className="mt-3 flex gap-2">
             <button
               type="button"
@@ -707,6 +723,7 @@ function MobileTimeblockDetail({
 }
 
 function DesktopTimeblockDetail({
+  descriptionBlock,
   task,
   model,
   backLink,
@@ -732,6 +749,7 @@ function DesktopTimeblockDetail({
   onRemoveDependency,
   onToggleCollapseUpstream,
 }: {
+  descriptionBlock: ReactNode;
   task: TaskNode;
   model: TaskTimeblockDetailViewModel;
   backLink: TimeblockSourceBackLink;
@@ -784,6 +802,8 @@ function DesktopTimeblockDetail({
         </div>
       </header>
 
+      {descriptionBlock}
+
       <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
         <section className="rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]">
           <div className="grid grid-cols-2 gap-3 xl:grid-cols-3">
@@ -794,13 +814,6 @@ function DesktopTimeblockDetail({
               </div>
             ))}
           </div>
-          {canEditEstimatedTime ? (
-            <EstimatedTimeEditor
-              taskId={task.id}
-              currentMinutes={task.estimatedMinutes}
-              onUpdate={onEstimatedMinutesUpdate}
-            />
-          ) : null}
         </section>
 
         <section
@@ -808,7 +821,24 @@ function DesktopTimeblockDetail({
           className="rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]"
         >
           <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">计时控制</h3>
-          {timerControls}
+          {canEditEstimatedTime ? (
+            <div className="mt-3">
+              <p className="text-xs font-medium text-[#57534E] dark:text-[#A8A29E]">估计时长</p>
+              <div className="mt-1">
+                <EstimatedTimeEditor
+                  taskId={task.id}
+                  currentMinutes={task.estimatedMinutes}
+                  onUpdate={onEstimatedMinutesUpdate}
+                />
+              </div>
+            </div>
+          ) : null}
+          <div className="mt-3">
+            <p className="text-xs font-medium text-[#57534E] dark:text-[#A8A29E]">预期时长</p>
+            <div className="mt-1">
+              {timerControls}
+            </div>
+          </div>
           <div className="mt-3 flex gap-2">
             <button
               type="button"
@@ -927,6 +957,8 @@ export function TaskDetailPage() {
   const [dependencyActionError, setDependencyActionError] = useState<string | null>(null);
   const [isDependencySaving, setIsDependencySaving] = useState(false);
   const [dependencyReloadKey, setDependencyReloadKey] = useState(0);
+  const [isEditingDescription, setIsEditingDescription] = useState(false);
+  const [descriptionDraft, setDescriptionDraft] = useState('');
   const timerResetKey = taskId ?? preferredBlockId ?? task?.id;
   const timerInitialMinutes = taskId
     ? task?.id === taskId ? task.estimatedMinutes : undefined
@@ -1220,6 +1252,14 @@ export function TaskDetailPage() {
     )));
   }, [task?.id]);
 
+  const handleSaveDescription = useCallback(async () => {
+    if (!task?.id) return;
+    const trimmed = descriptionDraft.trim() || undefined;
+    setIsEditingDescription(false);
+    setTask((current) => current ? { ...current, description: trimmed } : current);
+    await getTaskService().updateTask(task.id, { description: trimmed ?? '' });
+  }, [task?.id, descriptionDraft]);
+
   if (isLoading) {
     return (
       <div className="min-h-full bg-[#FAF7F5] px-6 py-6 dark:bg-[#0C0A09]">
@@ -1240,9 +1280,45 @@ export function TaskDetailPage() {
     );
   }
 
+  const descriptionBlock = (
+    <>
+      {isEditingDescription ? (
+        <div className="mt-3 rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]">
+          <Textarea
+            autoFocus
+            value={descriptionDraft}
+            onChange={(e) => setDescriptionDraft(e.target.value)}
+            placeholder="输入任务描述..."
+            className="min-h-[120px] border-none bg-transparent p-0 text-sm text-[#1C1917] shadow-none focus-visible:ring-0 dark:text-[#FAFAF9]"
+          />
+          <div className="mt-2 flex justify-end gap-2">
+            <button type="button" onClick={() => setIsEditingDescription(false)} className="rounded-lg px-3 py-1 text-xs text-[#78716C] hover:bg-[#F5F0ED] dark:hover:bg-[#292524]">取消</button>
+            <button type="button" onClick={handleSaveDescription} className="rounded-lg bg-[#1C1917] px-3 py-1 text-xs text-white dark:bg-[#FAFAF9] dark:text-[#1C1917]">保存</button>
+          </div>
+        </div>
+      ) : task.description ? (
+        <div className="mt-3 rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]">
+          <div className="flex items-start justify-between gap-3">
+            <p className="whitespace-pre-wrap text-sm text-[#1C1917] dark:text-[#FAFAF9]">{task.description}</p>
+            {!isTerminalTaskStatus(task.status) && (
+              <button type="button" onClick={() => { setDescriptionDraft(task.description ?? ''); setIsEditingDescription(true); }} className="shrink-0 rounded-lg p-1.5 text-[#A8A29E] hover:bg-[#F5F0ED] dark:hover:bg-[#292524]">
+                <Pencil size={14} />
+              </button>
+            )}
+          </div>
+        </div>
+      ) : !isTerminalTaskStatus(task.status) ? (
+        <button type="button" onClick={() => { setDescriptionDraft(''); setIsEditingDescription(true); }} className="mt-3 w-full rounded-2xl border border-dashed border-[#D6D3D1] bg-[#FAF7F5] px-6 py-3 text-left text-sm text-[#A8A29E] hover:bg-[#F5F0ED] dark:border-[#3A3432] dark:bg-[#1C1917] dark:hover:bg-[#292524]">
+          + 添加任务描述
+        </button>
+      ) : null}
+    </>
+  );
+
   if (isDesktop) {
     return (
       <DesktopTimeblockDetail
+        descriptionBlock={descriptionBlock}
         task={task}
         model={viewModel}
         backLink={backLink}
@@ -1273,6 +1349,7 @@ export function TaskDetailPage() {
 
   return (
     <MobileTimeblockDetail
+      descriptionBlock={descriptionBlock}
       task={task}
       model={viewModel}
       backLink={backLink}

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -31,6 +31,9 @@ import { TimerConfigPanel } from '@/ui/app/components/TimerConfigPanel';
 import { useTimerConfig } from '@/ui/app/hooks/useTimerConfig';
 import { Pencil } from 'lucide-react';
 import { Textarea } from '@/components/ui/textarea';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 
 type DependencyType = 'soft' | 'hard';
 type TimeblockSourceTab = 'now' | 'today' | 'week' | 'month';
@@ -881,7 +884,9 @@ function DesktopTimeblockDetail({
             <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">洞察</h3>
             <p className="mt-2 text-sm text-[#44403C] dark:text-[#E7E5E4]">{task.title}</p>
             {task.description ? (
-              <p className="mt-2 whitespace-pre-wrap text-xs text-[#78716C] dark:text-[#A8A29E]">{task.description}</p>
+              <div className="mt-2 prose prose-xs dark:prose-invert max-w-none text-xs text-[#78716C] dark:text-[#A8A29E] prose-p:my-0.5 prose-ul:my-0.5 prose-ol:my-0.5 prose-li:my-0 prose-headings:my-0.5 prose-a:text-[#C75B3A]">
+                <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>{task.description}</ReactMarkdown>
+              </div>
             ) : null}
           </section>
 
@@ -1289,7 +1294,9 @@ export function TaskDetailPage() {
         </div>
       ) : task.description ? (
         <div className="mt-3 flex items-start justify-between gap-3">
-          <p className="whitespace-pre-wrap text-sm text-[#78716C] dark:text-[#A8A29E]">{task.description}</p>
+          <div className="prose prose-sm dark:prose-invert max-w-none text-sm text-[#78716C] dark:text-[#A8A29E] prose-p:my-1 prose-ul:my-1 prose-ol:my-1 prose-li:my-0 prose-headings:my-1 prose-headings:text-[#44403C] dark:prose-headings:text-[#D6D3D1] prose-a:text-[#C75B3A] prose-code:text-[#78716C] dark:prose-code:text-[#A8A29E] prose-pre:bg-[#F5F0ED] dark:prose-pre:bg-[#292524]">
+            <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>{task.description}</ReactMarkdown>
+          </div>
           {!isTerminalTaskStatus(task.status) && (
             <button type="button" onClick={() => { setDescriptionDraft(task.description ?? ''); setIsEditingDescription(true); }} className="shrink-0 rounded-lg p-1.5 text-[#A8A29E] hover:bg-[#F5F0ED] dark:hover:bg-[#292524]">
               <Pencil size={14} />

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -1077,6 +1077,8 @@ export function TaskDetailPage() {
       customDurationDraft={customDurationDraft}
       setCustomDurationDraft={setCustomDurationDraft}
       commitCustomDuration={commitCustomDuration}
+      showCountupOption
+      onSelectCountup={() => setTimerMode('countup')}
     />
   );
 

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -104,7 +104,7 @@ function resolveTimeblockSourceBackLink(): TimeblockSourceBackLink {
     return {
       to: '/tasks',
       label: '← 返回任务',
-      breadcrumb: '任务 > 时间块详情',
+      breadcrumb: '任务 > 任务详情',
       sourceLabel: '任务',
     };
   }
@@ -118,7 +118,7 @@ function resolveTimeblockSourceBackLink(): TimeblockSourceBackLink {
     to: '/tasks',
     search: sourceTab ? { tab: sourceTab } : undefined,
     label: `← 返回${sourceLabel}`,
-    breadcrumb: sourceTab ? `任务 > ${sourceLabel} > 时间块详情` : '任务 > 时间块详情',
+    breadcrumb: sourceTab ? `任务 > ${sourceLabel} > 任务详情` : '任务 > 任务详情',
     sourceLabel,
   };
 }
@@ -558,19 +558,12 @@ function MobileTimeblockDetail({
           search={backLink.search}
           className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
           aria-label={`返回${backLink.sourceLabel}`}
+          data-testid="timeblock-back-link-mobile"
         >
           <ArrowLeft size={16} />
         </Link>
         <div className="min-w-0 flex-1 pt-0.5">
-          <h1 className="text-base font-semibold text-[#1C1917] dark:text-[#FAFAF9]">时间块详情</h1>
-          <Link
-            to={backLink.to}
-            search={backLink.search}
-            className="mt-1 inline-flex text-xs font-medium text-[#78716C] underline-offset-2 hover:underline dark:text-[#A8A29E]"
-            data-testid="timeblock-back-link-mobile"
-          >
-            {backLink.label}
-          </Link>
+          <h1 className="text-base font-semibold text-[#1C1917] dark:text-[#FAFAF9]">任务详情</h1>
         </div>
         <button
           type="button"

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -585,6 +585,9 @@ function MobileTimeblockDetail({
           </div>
           <h2 className="mt-3 text-base font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{model.summary.blockName}</h2>
           <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">关联任务：{task.title}</p>
+          {task.description ? (
+            <p className="mt-2 whitespace-pre-wrap text-xs text-[#78716C] dark:text-[#A8A29E]">{task.description}</p>
+          ) : null}
           {canEditEstimatedTime ? (
             <EstimatedTimeEditor
               taskId={task.id}
@@ -859,6 +862,9 @@ function DesktopTimeblockDetail({
           <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
             <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">洞察</h3>
             <p className="mt-2 text-sm text-[#44403C] dark:text-[#E7E5E4]">{task.title}</p>
+            {task.description ? (
+              <p className="mt-2 whitespace-pre-wrap text-xs text-[#78716C] dark:text-[#A8A29E]">{task.description}</p>
+            ) : null}
           </section>
 
           <DependencyCard

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -791,23 +791,53 @@ function DesktopTimeblockDetail({
         </div>
       </header>
 
-      <section className="mt-4 rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]">
-        <div className="grid grid-cols-5 gap-3">
-          {model.summary.metrics.map((metric) => (
-            <div key={metric.key} className="rounded-xl bg-[#F8F5F2] px-3 py-2 dark:bg-[#292524]">
-              <p className="text-xs text-[#A8A29E]">{metric.label}</p>
-              <p className="mt-1 text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{metric.value}</p>
-            </div>
-          ))}
-        </div>
-        {canEditEstimatedTime ? (
-          <EstimatedTimeEditor
-            taskId={task.id}
-            currentMinutes={task.estimatedMinutes}
-            onUpdate={onEstimatedMinutesUpdate}
-          />
-        ) : null}
-      </section>
+      <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <section className="rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]">
+          <div className="grid grid-cols-2 gap-3 xl:grid-cols-3">
+            {model.summary.metrics.map((metric) => (
+              <div key={metric.key} className="rounded-xl bg-[#F8F5F2] px-3 py-2 dark:bg-[#292524]">
+                <p className="text-xs text-[#A8A29E]">{metric.label}</p>
+                <p className="mt-1 text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{metric.value}</p>
+              </div>
+            ))}
+          </div>
+          {canEditEstimatedTime ? (
+            <EstimatedTimeEditor
+              taskId={task.id}
+              currentMinutes={task.estimatedMinutes}
+              onUpdate={onEstimatedMinutesUpdate}
+            />
+          ) : null}
+        </section>
+
+        <section
+          data-testid="task-timer-card"
+          className="rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]"
+        >
+          <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">计时控制</h3>
+          {timerControls}
+          <div className="mt-3 flex gap-2">
+            <button
+              type="button"
+              onClick={onStartTimer}
+              disabled={hasOtherActiveBlock}
+              className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
+            >
+              <Play size={14} />
+              开始计时
+            </button>
+            <button
+              type="button"
+              data-testid="task-pause-button"
+              onClick={onPauseAndGoEventlog}
+              className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
+            >
+              <Pause size={14} />
+              {hasActiveBlockOnTask ? '暂停并前往当下' : '前往当下'}
+            </button>
+          </div>
+        </section>
+      </div>
 
       <section className="mt-4 grid grid-cols-[minmax(0,1fr)_340px] gap-4">
         <div className="space-y-3">
@@ -873,34 +903,6 @@ function DesktopTimeblockDetail({
             onRestart={onStartTimer}
             onCopySummary={onCopySummary}
           />
-
-          <section
-            data-testid="task-timer-card"
-            className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]"
-          >
-            <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">计时控制</h3>
-            {timerControls}
-            <div className="mt-3 flex gap-2">
-              <button
-                type="button"
-                onClick={onStartTimer}
-                disabled={hasOtherActiveBlock}
-                className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
-              >
-                <Play size={14} />
-                开始计时
-              </button>
-              <button
-                type="button"
-                data-testid="task-pause-button"
-                onClick={onPauseAndGoEventlog}
-                className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
-              >
-                <Pause size={14} />
-                {hasActiveBlockOnTask ? '暂停并前往当下' : '前往当下'}
-              </button>
-            </div>
-          </section>
         </aside>
       </section>
     </div>

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -17,6 +17,7 @@ import {
   type TimeblockEventLog,
   type TaskTimeblockDetailViewModel,
   type TimeblockBadge,
+  type LinkedBlockItem,
 } from './task-timeblock-detail-view';
 import {
   buildTaskDependencyView,
@@ -187,6 +188,49 @@ function DetailActionsCard({
   );
 }
 
+function LinkedBlocksCard({
+  linkedBlocks,
+  taskId,
+}: {
+  linkedBlocks: LinkedBlockItem[];
+  taskId: string;
+}) {
+  if (linkedBlocks.length === 0) {
+    return (
+      <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
+        <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">关联时间块</h3>
+        <p className="mt-2 text-xs text-[#A8A29E]">暂无关联时间块，开始计时后会自动出现。</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
+      <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">关联时间块</h3>
+      <div className="mt-3 space-y-2">
+        {linkedBlocks.map((item) => (
+          <Link
+            key={item.startId}
+            to={`/tasks/${taskId}`}
+            search={{ blockId: item.startId }}
+            className="block rounded-xl border border-[#E7E5E4] px-3 py-2 transition-colors hover:bg-[#FAF7F5] dark:border-[#292524] dark:hover:bg-[#292524]"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span className="truncate text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{item.name}</span>
+              {item.isActive ? (
+                <span className="shrink-0 rounded-full bg-[#DCFCE7] px-2 py-0.5 text-[11px] font-semibold text-[#15803D]">进行中</span>
+              ) : (
+                <span className="shrink-0 text-xs text-[#A8A29E]">{item.durationLabel}</span>
+              )}
+            </div>
+            <p className="mt-1 text-[11px] text-[#A8A29E]">{item.startLabel} ~ {item.endLabel}</p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 function DependencyCard({
   dependencyView,
   taskDagView,
@@ -194,6 +238,7 @@ function DependencyCard({
   selectedType,
   errorMessage,
   isSaving,
+  hideAddDependency,
   onSelectedTaskChange,
   onSelectedTypeChange,
   onAddDependency,
@@ -207,6 +252,7 @@ function DependencyCard({
   selectedType: DependencyType;
   errorMessage: string | null;
   isSaving: boolean;
+  hideAddDependency?: boolean;
   onSelectedTaskChange: (value: string) => void;
   onSelectedTypeChange: (value: DependencyType) => void;
   onAddDependency: () => void;
@@ -411,6 +457,7 @@ function DependencyCard({
           </div>
         </div>
 
+        {!hideAddDependency && (
         <div className="rounded-xl bg-[#F8F5F2] p-3 dark:bg-[#292524]">
           <h4 className="text-xs font-semibold uppercase tracking-[0.12em] text-[#A8A29E]">新增依赖</h4>
           <div className="mt-3 grid gap-2 sm:grid-cols-[minmax(0,1fr)_140px_auto]">
@@ -467,6 +514,8 @@ function DependencyCard({
             </div>
           </div>
         </div>
+        )}
+
 
         <div>
           <h4 className="text-xs font-semibold uppercase tracking-[0.12em] text-[#A8A29E]">谁依赖我</h4>
@@ -513,6 +562,7 @@ function MobileTimeblockDetail({
   timerControls,
   hasOtherActiveBlock,
   hasActiveBlockOnTask,
+  hardBlockingReason,
   onStartTimer,
   onPauseAndGoEventlog,
   onCopySummary,
@@ -539,6 +589,7 @@ function MobileTimeblockDetail({
   timerControls: ReactNode;
   hasOtherActiveBlock: boolean;
   hasActiveBlockOnTask: boolean;
+  hardBlockingReason: string | null;
   onStartTimer: () => void;
   onPauseAndGoEventlog: () => void;
   onCopySummary: () => void;
@@ -641,6 +692,8 @@ function MobileTimeblockDetail({
           </div>
         </section>
 
+        <LinkedBlocksCard linkedBlocks={model.linkedBlocks} taskId={task.id} />
+
         <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
           <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">AI 总结</h3>
           <p className="mt-2 text-sm text-[#44403C] dark:text-[#E7E5E4]">{model.aiSummary.summaryText}</p>
@@ -658,6 +711,7 @@ function MobileTimeblockDetail({
           selectedType={dependencySelectedType}
           errorMessage={dependencyError}
           isSaving={isDependencySaving}
+          hideAddDependency={isTerminalTaskStatus(task.status)}
           onSelectedTaskChange={onDependencySelectedTaskChange}
           onSelectedTypeChange={onDependencySelectedTypeChange}
           onAddDependency={onAddDependency}
@@ -671,6 +725,7 @@ function MobileTimeblockDetail({
           onCopySummary={onCopySummary}
         />
 
+        {!isTerminalTaskStatus(task.status) && (
         <section
           data-testid="task-timer-card"
           className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]"
@@ -712,6 +767,7 @@ function MobileTimeblockDetail({
             </button>
           </div>
         </section>
+        )}
       </div>
     </div>
   );
@@ -818,6 +874,7 @@ function DesktopTimeblockDetail({
           </div>
         </section>
 
+        {!isTerminalTaskStatus(task.status) && (
         <section
           data-testid="task-timer-card"
           className="rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]"
@@ -859,6 +916,7 @@ function DesktopTimeblockDetail({
             </button>
           </div>
         </section>
+        )}
       </div>
 
       <section className="mt-4 grid grid-cols-[minmax(0,1fr)_340px] gap-4">
@@ -892,6 +950,7 @@ function DesktopTimeblockDetail({
             selectedType={dependencySelectedType}
             errorMessage={dependencyError}
             isSaving={isDependencySaving}
+            hideAddDependency={isTerminalTaskStatus(task.status)}
             onSelectedTaskChange={onDependencySelectedTaskChange}
             onSelectedTypeChange={onDependencySelectedTypeChange}
             onAddDependency={onAddDependency}
@@ -1089,6 +1148,19 @@ export function TaskDetailPage() {
     () => (task ? allTasks.some((candidate) => candidate.id === task.id) && !isTerminalTaskStatus(task.status) : false),
     [allTasks, task],
   );
+  const hardBlockingReason = useMemo(() => {
+    if (!task) return null;
+    const incompleteHardDeps = task.dependsOn
+      .filter((dep) => dep.type === 'hard')
+      .map((dep) => {
+        const predecessor = taskById.get(dep.taskId);
+        if (!predecessor || predecessor.status === 'completed') return null;
+        return predecessor.title;
+      })
+      .filter((title): title is string => title !== null);
+    if (incompleteHardDeps.length === 0) return null;
+    return `硬依赖未完成：${incompleteHardDeps.join('、')}`;
+  }, [task, taskById]);
   const timerControls = (
     <TimerConfigPanel
       timerMode={timerMode}
@@ -1201,9 +1273,13 @@ export function TaskDetailPage() {
   };
 
   const handleStartTimer = () => {
-    if (!taskId) return;
-    void getTaskTimerService().startBlockForTask(taskId, timerConfig).then(() => {
+    if (!taskId) { console.error('[TaskDetail] handleStartTimer: no taskId'); return; }
+    console.log('[TaskDetail] handleStartTimer', { taskId, timerConfig, timerMode, countdownMinutes });
+    void getTaskTimerService().startBlockForTask(taskId, timerConfig).then((block) => {
+      console.log('[TaskDetail] startBlockForTask OK', block ? { startId: block.startId, mode: block.mode, phase: block.phase, taskId: block.taskId, paused: block.paused, elapsed: block.elapsed } : 'NULL');
       void navigate({ to: '/eventlog' });
+    }).catch((err) => {
+      console.error('[TaskDetail] startBlockForTask FAILED', err);
     });
   };
 

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeft, Ellipsis, NotepadText, Target, Play } from 'lucide-react';
 import { Link, useNavigate, useParams, useLocation } from '@tanstack/react-router';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState, type ReactNode } from 'react';
-import { TASKS_LAST_PATH_KEY } from './TasksPage';
+import { TASKS_LAST_PATH_KEY, buildTasksMainSearch } from './task-route-memory';
 import { TaskBreadcrumb, type TaskBreadcrumbSegment } from '@/ui/app/components/TaskBreadcrumb';
 import { getEventLogService, getTaskService, getTaskTimerService, getTimeBlockService } from '@/lib/services';
 import { isTerminalTaskStatus } from '@/lib/types/task';
@@ -767,7 +767,7 @@ function MobileTimeblockDetail({
       <header className="sticky top-0 z-10 flex items-start justify-between gap-3 border-b border-[#F0ECE8] bg-[#FAF7F5]/95 px-4 py-3 backdrop-blur dark:border-[#292524] dark:bg-[#0C0A09]/95">
         <Link
           to={backLink.to}
-          search={backLink.search}
+          search={backLink.to === '/tasks' ? buildTasksMainSearch(backLink.search) : backLink.search}
           onClick={() => sessionStorage.removeItem(TASKS_LAST_PATH_KEY)}
           className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
           aria-label={`返回${backLink.sourceLabel}`}
@@ -1631,7 +1631,11 @@ export function TaskDetailPage() {
   if (!task || !viewModel || !dependencyView) {
     return (
       <div className="min-h-full bg-[#FAF7F5] px-6 py-6 dark:bg-[#0C0A09]">
-        <Link to={backLink.to} search={backLink.search} className="inline-flex items-center gap-1 text-sm text-[#78716C] dark:text-[#A8A29E]">
+        <Link
+          to={backLink.to}
+          search={backLink.to === '/tasks' ? buildTasksMainSearch(backLink.search) : backLink.search}
+          className="inline-flex items-center gap-1 text-sm text-[#78716C] dark:text-[#A8A29E]"
+        >
           <ArrowLeft size={16} />
           {backLink.label.replace('← ', '')}
         </Link>

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -1526,7 +1526,7 @@ export function TaskDetailPage() {
   const taskGraph = useMemo(() => buildTaskGraph(allTasks), [allTasks]);
   const taskById = useMemo(() => new Map(allTasks.map((candidate) => [candidate.id, candidate])), [allTasks]);
   const rootGuidance = useMemo(() => (
-    <TaskCurrentRootCard graph={taskGraph} taskById={taskById} currentTaskId={task?.id} />
+    <TaskCurrentRootCard graph={taskGraph} taskById={taskById} currentTaskId={task?.id} collapsible={true} />
   ), [task?.id, taskById, taskGraph]);
   const canEditEstimatedTime = useMemo(
     () => (task ? allTasks.some((candidate) => candidate.id === task.id) && !isTerminalTaskStatus(task.status) : false),

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -562,7 +562,7 @@ function MobileTimeblockDetail({
   timerControls,
   hasOtherActiveBlock,
   hasActiveBlockOnTask,
-  hardBlockingReason,
+  blockingReason,
   onStartTimer,
   onPauseAndGoEventlog,
   onCopySummary,
@@ -589,7 +589,7 @@ function MobileTimeblockDetail({
   timerControls: ReactNode;
   hasOtherActiveBlock: boolean;
   hasActiveBlockOnTask: boolean;
-  hardBlockingReason: string | null;
+  blockingReason: string | null;
   onStartTimer: () => void;
   onPauseAndGoEventlog: () => void;
   onCopySummary: () => void;
@@ -752,7 +752,7 @@ function MobileTimeblockDetail({
               <button
                 type="button"
                 onClick={onStartTimer}
-                disabled={hasOtherActiveBlock || Boolean(hardBlockingReason)}
+                disabled={hasOtherActiveBlock || Boolean(blockingReason)}
                 className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
               >
                 <Play size={14} />
@@ -768,8 +768,8 @@ function MobileTimeblockDetail({
                 {hasActiveBlockOnTask ? '暂停并前往当下' : '前往当下'}
               </button>
             </div>
-            {hardBlockingReason ? (
-              <p className="text-xs text-[#C75B3A] dark:text-[#FDBA74]">{hardBlockingReason}</p>
+            {blockingReason ? (
+              <p className="text-xs text-[#C75B3A] dark:text-[#FDBA74]">{blockingReason}</p>
             ) : null}
           </div>
         </section>
@@ -793,7 +793,7 @@ function DesktopTimeblockDetail({
   timerControls,
   hasOtherActiveBlock,
   hasActiveBlockOnTask,
-  hardBlockingReason,
+  blockingReason,
   onStartTimer,
   onPauseAndGoEventlog,
   onCopySummary,
@@ -820,7 +820,7 @@ function DesktopTimeblockDetail({
   timerControls: ReactNode;
   hasOtherActiveBlock: boolean;
   hasActiveBlockOnTask: boolean;
-  hardBlockingReason: string | null;
+  blockingReason: string | null;
   onStartTimer: () => void;
   onPauseAndGoEventlog: () => void;
   onCopySummary: () => void;
@@ -908,7 +908,7 @@ function DesktopTimeblockDetail({
               <button
                 type="button"
                 onClick={onStartTimer}
-                disabled={hasOtherActiveBlock || Boolean(hardBlockingReason)}
+                disabled={hasOtherActiveBlock || Boolean(blockingReason)}
                 className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
               >
                 <Play size={14} />
@@ -924,8 +924,8 @@ function DesktopTimeblockDetail({
                 {hasActiveBlockOnTask ? '暂停并前往当下' : '前往当下'}
               </button>
             </div>
-            {hardBlockingReason ? (
-              <p className="text-xs text-[#C75B3A] dark:text-[#FDBA74]">{hardBlockingReason}</p>
+            {blockingReason ? (
+              <p className="text-xs text-[#C75B3A] dark:text-[#FDBA74]">{blockingReason}</p>
             ) : null}
           </div>
         </section>
@@ -1165,8 +1165,9 @@ export function TaskDetailPage() {
     () => (task ? allTasks.some((candidate) => candidate.id === task.id) && !isTerminalTaskStatus(task.status) : false),
     [allTasks, task],
   );
-  const hardBlockingReason = useMemo(() => {
+  const blockingReason = useMemo(() => {
     if (!task) return null;
+    const reasons: string[] = [];
     const incompleteHardDeps = task.dependsOn
       .filter((dep) => dep.type === 'hard')
       .map((dep) => {
@@ -1175,8 +1176,22 @@ export function TaskDetailPage() {
         return predecessor.title;
       })
       .filter((title): title is string => title !== null);
-    if (incompleteHardDeps.length === 0) return null;
-    return `硬依赖未完成：${incompleteHardDeps.join('、')}`;
+    if (incompleteHardDeps.length > 0) {
+      reasons.push(`硬依赖未完成：${incompleteHardDeps.join('、')}`);
+    }
+    const pendingSoftDeps = task.dependsOn
+      .filter((dep) => dep.type === 'soft')
+      .map((dep) => {
+        const predecessor = taskById.get(dep.taskId);
+        if (!predecessor || predecessor.status !== 'pending') return null;
+        return predecessor.title;
+      })
+      .filter((title): title is string => title !== null);
+    if (pendingSoftDeps.length > 0) {
+      reasons.push(pendingSoftDeps.map((title) => `软依赖「${title}」尚未开始`).join('、'));
+    }
+    if (reasons.length === 0) return null;
+    return reasons.join('；');
   }, [task, taskById]);
   const timerControls = (
     <TimerConfigPanel
@@ -1427,7 +1442,7 @@ export function TaskDetailPage() {
         timerControls={timerControls}
         hasOtherActiveBlock={hasOtherActiveBlock}
         hasActiveBlockOnTask={Boolean(activeBlock)}
-        hardBlockingReason={hardBlockingReason}
+        blockingReason={blockingReason}
         onStartTimer={handleStartTimer}
         onPauseAndGoEventlog={handlePauseAndGoEventlog}
         onCopySummary={handleCopySummary}
@@ -1459,7 +1474,7 @@ export function TaskDetailPage() {
       timerControls={timerControls}
       hasOtherActiveBlock={hasOtherActiveBlock}
       hasActiveBlockOnTask={Boolean(activeBlock)}
-      hardBlockingReason={hardBlockingReason}
+      blockingReason={blockingReason}
       onStartTimer={handleStartTimer}
       onPauseAndGoEventlog={handlePauseAndGoEventlog}
       onCopySummary={handleCopySummary}

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -3,11 +3,10 @@ import { Link, useNavigate, useParams, useLocation } from '@tanstack/react-route
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState, type ReactNode } from 'react';
 import { TASKS_LAST_PATH_KEY } from './TasksPage';
 import { TaskBreadcrumb, type TaskBreadcrumbSegment } from '@/ui/app/components/TaskBreadcrumb';
-import { getTaskService, getTaskTimerService, getTimeBlockService } from '@/lib/services';
+import { getEventLogService, getTaskService, getTaskTimerService, getTimeBlockService } from '@/lib/services';
 import { isTerminalTaskStatus } from '@/lib/types/task';
 import type { TaskNode } from '@/lib/types/task';
 import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
-import { getEventStorage } from '@/lib/storage/event-storage';
 import { useIsDesktop } from '@/ui/app/hooks/useIsDesktop';
 import { getUseMockDataEnabled } from '@/config/mock-data';
 import { buildTaskGraph } from '@/lib/task/task-dag-graph';
@@ -51,6 +50,25 @@ interface TimeblockSourceBackLink {
   sourceLabel: string;
 }
 
+const MOBILE_ANCHOR_TARGETS = {
+  overview: 'task-detail-overview',
+  info: 'task-detail-info',
+  timer: 'task-detail-timer',
+  root: 'task-detail-root-guidance',
+  linked: 'task-detail-linked-blocks',
+  timeline: 'task-detail-timeline',
+  'ai-summary': 'task-detail-ai-summary',
+  plan: 'task-detail-plan-actual',
+  dependency: 'task-detail-dependency',
+  actions: 'task-detail-actions',
+} as const;
+
+type MobileAnchorId = keyof typeof MOBILE_ANCHOR_TARGETS;
+type MobileSectionAnchor = {
+  id: MobileAnchorId;
+  label: string;
+};
+
 function badgeClassName(badge: TimeblockBadge): string {
   if (badge.tone === 'success') return 'bg-[#DCFCE7] text-[#15803D]';
   if (badge.tone === 'warning') return 'bg-[#FFF7ED] text-[#C75B3A]';
@@ -83,6 +101,94 @@ function selectReviewMarkdown(task: TaskNode, blockName: string, events: Array<{
 
   const preferred = feedbackEvents.find((event) => event.content.includes(task.title) || event.content.includes(blockName));
   return preferred?.content ?? feedbackEvents[0].content;
+}
+
+const EVENT_TYPE_PRIORITY = [
+  'block_start',
+  'block_pause',
+  'block_resume',
+  'block_end',
+  'block_feedback',
+  'agent_feedback',
+  'error',
+];
+
+function resolveEventTypeFromTags(tags?: Set<string>): string | undefined {
+  if (!tags || tags.size === 0) return undefined;
+  for (const type of EVENT_TYPE_PRIORITY) {
+    if (tags.has(type)) return type;
+  }
+  return undefined;
+}
+
+function resolveEventCreatedAt(timestamp: number): string {
+  if (!Number.isFinite(timestamp)) {
+    return new Date().toISOString();
+  }
+  return new Date(timestamp).toISOString();
+}
+
+function scrollToMobileAnchor(anchorId: MobileAnchorId): void {
+  if (typeof document === 'undefined') return;
+  const target = document.getElementById(MOBILE_ANCHOR_TARGETS[anchorId]);
+  target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+function resolveActiveMobileAnchor(): MobileAnchorId {
+  if (typeof document === 'undefined') return 'overview';
+  const offset = 132;
+  let active: MobileAnchorId = 'overview';
+  for (const anchorId of Object.keys(MOBILE_ANCHOR_TARGETS) as MobileAnchorId[]) {
+    const element = document.getElementById(MOBILE_ANCHOR_TARGETS[anchorId]);
+    if (!element) continue;
+    const rect = element.getBoundingClientRect();
+    const hasLayout = rect.height > 0 || rect.bottom > rect.top;
+    if (!hasLayout) continue;
+    if (rect.top <= offset && rect.bottom >= offset) {
+      return anchorId;
+    }
+    if (rect.top <= offset) {
+      active = anchorId;
+    }
+  }
+  return active;
+}
+
+function MobileSectionTabs({
+  anchors,
+  activeAnchorId,
+  onSelect,
+}: {
+  anchors: MobileSectionAnchor[];
+  activeAnchorId: MobileAnchorId;
+  onSelect: (anchorId: MobileAnchorId) => void;
+}) {
+  return (
+    <div
+      data-testid="task-mobile-section-tabs"
+      className="sticky top-[57px] z-[9] border-b border-[#F0ECE8] bg-[#FAF7F5]/95 px-4 py-2 backdrop-blur dark:border-[#292524] dark:bg-[#0C0A09]/95"
+    >
+      <div role="tablist" aria-label="任务详情分区导航" className="scrollbar-none flex gap-2 overflow-x-auto">
+        {anchors.map((anchor) => (
+          <button
+            key={anchor.id}
+            type="button"
+            role="tab"
+            aria-selected={activeAnchorId === anchor.id}
+            aria-controls={MOBILE_ANCHOR_TARGETS[anchor.id]}
+            onClick={() => onSelect(anchor.id)}
+            className={`shrink-0 rounded-full px-3 py-1.5 text-xs transition-colors ${
+              activeAnchorId === anchor.id
+                ? 'bg-[#C75B3A] font-semibold text-white'
+                : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'
+            }`}
+          >
+            {anchor.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 function resolvePreferredBlockId(): string | undefined {
@@ -606,8 +712,58 @@ function MobileTimeblockDetail({
   onRemoveDependency: (taskId: string) => void;
   onToggleCollapseUpstream: (taskId: string) => void;
 }) {
+  const [activeAnchorId, setActiveAnchorId] = useState<MobileAnchorId>('overview');
+  const showTimerCard = !isTerminalTaskStatus(task.status);
+  const mobileAnchors = useMemo<MobileSectionAnchor[]>(() => {
+    const anchors: MobileSectionAnchor[] = [
+      { id: 'overview', label: '概览' },
+      { id: 'info', label: '信息面板' },
+    ];
+
+    if (showTimerCard) {
+      anchors.push({ id: 'timer', label: '计时控制' });
+    }
+
+    anchors.push(
+      { id: 'root', label: '未阻塞节点' },
+      { id: 'linked', label: '关联时间块' },
+      { id: 'timeline', label: '事件时间线' },
+      { id: 'ai-summary', label: 'AI 总结' },
+      { id: 'plan', label: '计划 vs 实际' },
+      { id: 'dependency', label: '依赖关系' },
+      { id: 'actions', label: '操作' },
+    );
+
+    return anchors;
+  }, [showTimerCard]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const syncActiveAnchor = () => {
+      setActiveAnchorId(resolveActiveMobileAnchor());
+    };
+
+    syncActiveAnchor();
+    window.addEventListener('scroll', syncActiveAnchor, { passive: true });
+    window.addEventListener('resize', syncActiveAnchor);
+    return () => {
+      window.removeEventListener('scroll', syncActiveAnchor);
+      window.removeEventListener('resize', syncActiveAnchor);
+    };
+  }, []);
+
+  useEffect(() => {
+    setActiveAnchorId('overview');
+  }, [task.id]);
+
+  const handleSelectAnchor = useCallback((anchorId: MobileAnchorId) => {
+    setActiveAnchorId(anchorId);
+    scrollToMobileAnchor(anchorId);
+  }, []);
+
   return (
-    <div className="min-h-full bg-[#FAF7F5] pb-10 dark:bg-[#0C0A09]" data-testid="new-task-detail-page">
+    <div className="scrollbar-none h-full overflow-y-auto bg-[#FAF7F5] pb-10 dark:bg-[#0C0A09]" data-testid="new-task-detail-page">
       <header className="sticky top-0 z-10 flex items-start justify-between gap-3 border-b border-[#F0ECE8] bg-[#FAF7F5]/95 px-4 py-3 backdrop-blur dark:border-[#292524] dark:bg-[#0C0A09]/95">
         <Link
           to={backLink.to}
@@ -631,8 +787,17 @@ function MobileTimeblockDetail({
         </button>
       </header>
 
+      <MobileSectionTabs
+        anchors={mobileAnchors}
+        activeAnchorId={activeAnchorId}
+        onSelect={handleSelectAnchor}
+      />
+
       <div className="space-y-3 px-4 pt-3">
-        <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
+        <section
+          id={MOBILE_ANCHOR_TARGETS.overview}
+          className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]"
+        >
           <div className="flex flex-wrap items-center gap-2">
             {model.summary.badges.map((badge) => (
               <span key={badge.label} className={`rounded-full px-2.5 py-1 text-xs font-semibold ${badgeClassName(badge)}`}>
@@ -643,7 +808,13 @@ function MobileTimeblockDetail({
           <h2 className="mt-3 text-base font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{model.summary.blockName}</h2>
           <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">关联任务：{task.title}</p>
           {descriptionBlock}
-          <h3 className="mt-4 text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">信息面板</h3>
+        </section>
+
+        <section
+          id={MOBILE_ANCHOR_TARGETS.info}
+          className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]"
+        >
+          <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">信息面板</h3>
           <div className="mt-2 grid grid-cols-2 gap-2">
             {model.summary.metrics.map((metric) => (
               <div key={metric.key} className="rounded-xl bg-[#F8F5F2] px-3 py-2 dark:bg-[#292524]">
@@ -654,90 +825,16 @@ function MobileTimeblockDetail({
           </div>
         </section>
 
-        {rootGuidance}
-
-        <section className="rounded-2xl border border-[#E7E5E4] bg-white p-2 dark:border-[#292524] dark:bg-[#1C1917]">
-          <div className="flex gap-1 overflow-x-auto">
-            {model.anchors.map((anchor) => (
-              <button
-                key={anchor.id}
-                type="button"
-                className={`shrink-0 rounded-xl px-3 py-1.5 text-xs ${anchor.active ? 'bg-[#C75B3A] font-semibold text-white' : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'}`}
-              >
-                {anchor.label}
-              </button>
-            ))}
-          </div>
-        </section>
-
-        <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
-          <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">计划 vs 实际</h3>
-          <p className="mt-2 text-sm text-[#44403C] dark:text-[#E7E5E4]">{model.planActual.planContent}</p>
-          <p className="mt-1 text-sm text-[#44403C] dark:text-[#E7E5E4]">{model.planActual.actualContent}</p>
-          <p className="mt-2 rounded-xl bg-[#FFF7ED] px-3 py-2 text-xs text-[#C75B3A] dark:bg-[#2A231B]">{model.planActual.diffReason}</p>
-        </section>
-
-        <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
-          <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">事件时间线</h3>
-          <div className="mt-3 space-y-3">
-            {model.timeline.items.map((item) => (
-              <article key={item.id} className="flex gap-3">
-                <div className="mt-1 flex flex-col items-center">
-                  <span className={`h-2 w-2 rounded-full ${toneDotClassName(item.tone)}`} />
-                  <span className="mt-1 h-full w-px bg-[#E7E5E4] dark:bg-[#292524]" />
-                </div>
-                <div className="min-w-0 flex-1 pb-2">
-                  <p className="text-xs text-[#A8A29E]">{item.timeLabel}</p>
-                  <p className="mt-1 text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{item.title}</p>
-                  <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">{item.description}</p>
-                </div>
-              </article>
-            ))}
-          </div>
-        </section>
-
-        <LinkedBlocksCard linkedBlocks={model.linkedBlocks} taskId={task.id} />
-
-        <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
-          <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">AI 总结</h3>
-          <p className="mt-2 text-sm text-[#44403C] dark:text-[#E7E5E4]">{model.aiSummary.summaryText}</p>
-          <div className="mt-3 space-y-2 rounded-xl bg-[#F8F5F2] p-3 dark:bg-[#292524]">
-            <p className="text-xs text-[#78716C] dark:text-[#A8A29E]">关键产出：{model.aiSummary.keyOutput}</p>
-            <p className="text-xs text-[#78716C] dark:text-[#A8A29E]">阻塞点：{model.aiSummary.blocker}</p>
-            <p className="text-xs text-[#78716C] dark:text-[#A8A29E]">建议：{model.aiSummary.suggestion}</p>
-          </div>
-        </section>
-
-        <DependencyCard
-          dependencyView={dependencyView}
-          taskDagView={taskDagView}
-          selectedTaskId={dependencySelectedTaskId}
-          selectedType={dependencySelectedType}
-          errorMessage={dependencyError}
-          isSaving={isDependencySaving}
-          hideAddDependency={isTerminalTaskStatus(task.status)}
-          onSelectedTaskChange={onDependencySelectedTaskChange}
-          onSelectedTypeChange={onDependencySelectedTypeChange}
-          onAddDependency={onAddDependency}
-          onChangeDependencyType={onChangeDependencyType}
-          onRemoveDependency={onRemoveDependency}
-          onToggleCollapseUpstream={onToggleCollapseUpstream}
-        />
-
-        <DetailActionsCard
-          model={model}
-          onCopySummary={onCopySummary}
-        />
-
-        {!isTerminalTaskStatus(task.status) && (
+        {showTimerCard && (
         <section
+          id={MOBILE_ANCHOR_TARGETS.timer}
           data-testid="task-timer-card"
           className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]"
         >
           <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">计时控制</h3>
           {canEditEstimatedTime ? (
             <div className="mt-3">
-              <p className="text-xs font-medium text-[#57534E] dark:text-[#A8A29E]">估计时长</p>
+              <p className="text-xs font-medium text-[#57534E] dark:text-[#A8A29E]">任务估时</p>
               <div className="mt-1">
                 <EstimatedTimeEditor
                   taskId={task.id}
@@ -756,6 +853,7 @@ function MobileTimeblockDetail({
                 <button
                   type="button"
                   onClick={onPauseAndGoEventlog}
+                  data-testid="task-pause-button"
                   className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white"
                 >
                   <Target size={14} />
@@ -775,6 +873,7 @@ function MobileTimeblockDetail({
                   <button
                     type="button"
                     onClick={onPauseAndGoEventlog}
+                    data-testid="task-pause-button"
                     className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
                   >
                     <Target size={14} />
@@ -791,6 +890,106 @@ function MobileTimeblockDetail({
           </div>
         </section>
         )}
+
+        <div id={MOBILE_ANCHOR_TARGETS.root}>
+          {rootGuidance}
+        </div>
+
+        <div id={MOBILE_ANCHOR_TARGETS.linked}>
+          <LinkedBlocksCard linkedBlocks={model.linkedBlocks} taskId={task.id} />
+        </div>
+
+        <section
+          id={MOBILE_ANCHOR_TARGETS.timeline}
+          className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]"
+        >
+          <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">事件时间线</h3>
+          {model.timeline.items.length === 0 && (task.timeBlockIds ?? []).length === 0 && model.linkedBlocks.length === 0 ? (
+            <p className="mt-2 text-xs text-[#A8A29E]">暂无关联时间块，开始一个时间块后即可在此查看事件。</p>
+          ) : (
+            <div className="mt-3 space-y-3">
+              {model.timeline.items.map((item) => (
+                <article key={item.id} className="flex gap-3">
+                  <div className="mt-1 flex flex-col items-center">
+                    <span className={`h-2 w-2 rounded-full ${toneDotClassName(item.tone)}`} />
+                    <span className="mt-1 h-full w-px bg-[#E7E5E4] dark:bg-[#292524]" />
+                  </div>
+                  <div className="min-w-0 flex-1 pb-2">
+                    <p className="text-xs text-[#A8A29E]">{item.timeLabel}</p>
+                    <p className="mt-1 text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{item.title}</p>
+                    <div className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
+                      <ReactMarkdown
+                        remarkPlugins={[remarkGfm, remarkBreaks]}
+                        components={{
+                          p: ({ ...props }) => <p className="m-0" {...props} />,
+                          ul: ({ ...props }) => <ul className="my-1 list-disc pl-4" {...props} />,
+                          ol: ({ ...props }) => <ol className="my-1 list-decimal pl-4" {...props} />,
+                          li: ({ ...props }) => <li className="my-0" {...props} />,
+                          code: ({ className, ...props }) => (
+                            <code
+                              className={`rounded bg-[#F5F0ED] px-1 py-0.5 dark:bg-[#292524] ${className ?? ''}`}
+                              {...props}
+                            />
+                          ),
+                        }}
+                      >
+                        {item.description}
+                      </ReactMarkdown>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section
+          id={MOBILE_ANCHOR_TARGETS['ai-summary']}
+          className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]"
+        >
+          <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">AI 总结</h3>
+          <p className="mt-2 text-sm text-[#44403C] dark:text-[#E7E5E4]">{model.aiSummary.summaryText}</p>
+          <div className="mt-3 space-y-2 rounded-xl bg-[#F8F5F2] p-3 dark:bg-[#292524]">
+            <p className="text-xs text-[#78716C] dark:text-[#A8A29E]">关键产出：{model.aiSummary.keyOutput}</p>
+            <p className="text-xs text-[#78716C] dark:text-[#A8A29E]">阻塞点：{model.aiSummary.blocker}</p>
+            <p className="text-xs text-[#78716C] dark:text-[#A8A29E]">建议：{model.aiSummary.suggestion}</p>
+          </div>
+        </section>
+
+        <section
+          id={MOBILE_ANCHOR_TARGETS.plan}
+          className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]"
+        >
+          <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">计划 vs 实际</h3>
+          <p className="mt-2 text-sm text-[#44403C] dark:text-[#E7E5E4]">{model.planActual.planContent}</p>
+          <p className="mt-1 text-sm text-[#44403C] dark:text-[#E7E5E4]">{model.planActual.actualContent}</p>
+          <p className="mt-2 rounded-xl bg-[#FFF7ED] px-3 py-2 text-xs text-[#C75B3A] dark:bg-[#2A231B]">{model.planActual.diffReason}</p>
+        </section>
+
+        <div id={MOBILE_ANCHOR_TARGETS.dependency}>
+          <DependencyCard
+            dependencyView={dependencyView}
+            taskDagView={taskDagView}
+            selectedTaskId={dependencySelectedTaskId}
+            selectedType={dependencySelectedType}
+            errorMessage={dependencyError}
+            isSaving={isDependencySaving}
+            hideAddDependency={isTerminalTaskStatus(task.status)}
+            onSelectedTaskChange={onDependencySelectedTaskChange}
+            onSelectedTypeChange={onDependencySelectedTypeChange}
+            onAddDependency={onAddDependency}
+            onChangeDependencyType={onChangeDependencyType}
+            onRemoveDependency={onRemoveDependency}
+            onToggleCollapseUpstream={onToggleCollapseUpstream}
+          />
+        </div>
+
+        <div id={MOBILE_ANCHOR_TARGETS.actions}>
+          <DetailActionsCard
+            model={model}
+            onCopySummary={onCopySummary}
+          />
+        </div>
       </div>
     </div>
   );
@@ -852,7 +1051,7 @@ function DesktopTimeblockDetail({
   onToggleCollapseUpstream: (taskId: string) => void;
 }) {
   return (
-    <div className="min-h-full bg-[#FAF7F5] px-8 py-6 dark:bg-[#0C0A09]" data-testid="new-task-detail-page">
+    <div className="scrollbar-none h-full overflow-y-auto bg-[#FAF7F5] px-8 py-6 dark:bg-[#0C0A09]" data-testid="new-task-detail-page">
       <TaskBreadcrumb
         segments={buildDetailBreadcrumbSegments(backLink)}
         current={{ label: '任务详情', icon: NotepadText }}
@@ -894,7 +1093,7 @@ function DesktopTimeblockDetail({
           <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">计时控制</h3>
           {canEditEstimatedTime ? (
             <div className="mt-3">
-              <p className="text-xs font-medium text-[#57534E] dark:text-[#A8A29E]">估计时长</p>
+              <p className="text-xs font-medium text-[#57534E] dark:text-[#A8A29E]">任务估时</p>
               <div className="mt-1">
                 <EstimatedTimeEditor
                   taskId={task.id}
@@ -913,6 +1112,7 @@ function DesktopTimeblockDetail({
                 <button
                   type="button"
                   onClick={onPauseAndGoEventlog}
+                  data-testid="task-pause-button"
                   className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white"
                 >
                   <Target size={14} />
@@ -932,6 +1132,7 @@ function DesktopTimeblockDetail({
                   <button
                     type="button"
                     onClick={onPauseAndGoEventlog}
+                    data-testid="task-pause-button"
                     className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
                   >
                     <Target size={14} />
@@ -952,25 +1153,47 @@ function DesktopTimeblockDetail({
 
       <section className="mt-4 grid grid-cols-[minmax(0,1fr)_340px] gap-4">
         <div className="space-y-3">
-          <section className="rounded-2xl border border-[#E7E5E4] bg-white p-5 dark:border-[#292524] dark:bg-[#1C1917]">
-            <h2 className="text-base font-semibold text-[#1C1917] dark:text-[#FAFAF9]">事件时间线</h2>
-            <div className="mt-4 space-y-3">
-              {model.timeline.items.map((item) => (
-                <article key={item.id} className="flex gap-3">
-                  <span className={`mt-1 h-2 w-2 rounded-full ${toneDotClassName(item.tone)}`} />
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center justify-between gap-3">
-                      <p className="text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{item.title}</p>
-                      <p className="text-xs text-[#A8A29E]">{item.timeLabel}</p>
-                    </div>
-                    <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">{item.description}</p>
-                  </div>
-                </article>
-              ))}
-            </div>
-          </section>
-
           <LinkedBlocksCard linkedBlocks={model.linkedBlocks} taskId={task.id} />
+
+          <section className="rounded-2xl border border-[#E7E5E4] bg-white p-5 dark:border-[#292524] dark:bg-[#1C1917]">
+            <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">事件时间线</h3>
+            {model.timeline.items.length === 0 && (task.timeBlockIds ?? []).length === 0 && model.linkedBlocks.length === 0 ? (
+              <p className="mt-2 text-xs text-[#A8A29E]">暂无关联时间块，开始一个时间块后即可在此查看事件。</p>
+            ) : (
+              <div className="mt-4 space-y-3">
+                {model.timeline.items.map((item) => (
+                  <article key={item.id} className="flex gap-3">
+                    <span className={`mt-1 h-2 w-2 rounded-full ${toneDotClassName(item.tone)}`} />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{item.title}</p>
+                        <p className="text-xs text-[#A8A29E]">{item.timeLabel}</p>
+                      </div>
+                      <div className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
+                        <ReactMarkdown
+                          remarkPlugins={[remarkGfm, remarkBreaks]}
+                          components={{
+                            p: ({ ...props }) => <p className="m-0" {...props} />,
+                            ul: ({ ...props }) => <ul className="my-1 list-disc pl-4" {...props} />,
+                            ol: ({ ...props }) => <ol className="my-1 list-decimal pl-4" {...props} />,
+                            li: ({ ...props }) => <li className="my-0" {...props} />,
+                            code: ({ className, ...props }) => (
+                              <code
+                                className={`rounded bg-[#F5F0ED] px-1 py-0.5 dark:bg-[#292524] ${className ?? ''}`}
+                                {...props}
+                              />
+                            ),
+                          }}
+                        >
+                          {item.description}
+                        </ReactMarkdown>
+                      </div>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            )}
+          </section>
         </div>
 
         <aside className="space-y-3">
@@ -1126,18 +1349,19 @@ export function TaskDetailPage() {
       setHasOtherActiveBlock(Boolean(currentBlock && nextTask && currentBlock.taskId !== nextTask.id));
 
       if (nextTask) {
-        const events = await getEventStorage().getEvents();
+        const events = await getEventLogService().loadEvents();
         const matchedBlockName = preferredBlockId
           ? blocks.find((block) => block.id === preferredBlockId || block.startId === preferredBlockId)?.name
           : undefined;
         if (!disposed) {
-          setEventLogs(events.map((event) => ({
+          const normalizedEvents = events.map((event) => ({
             id: event.id,
-            createdAt: event.createdAt,
+            createdAt: resolveEventCreatedAt(event.timestamp),
             content: event.content,
-            type: event.type,
-          })));
-          setReviewMarkdown(selectReviewMarkdown(nextTask, matchedBlockName ?? nextTask.title, events));
+            type: resolveEventTypeFromTags(event.tags),
+          }));
+          setEventLogs(normalizedEvents);
+          setReviewMarkdown(selectReviewMarkdown(nextTask, matchedBlockName ?? nextTask.title, normalizedEvents));
         }
       } else {
         setEventLogs([]);
@@ -1220,8 +1444,6 @@ export function TaskDetailPage() {
       customDurationDraft={customDurationDraft}
       setCustomDurationDraft={setCustomDurationDraft}
       commitCustomDuration={commitCustomDuration}
-      showCountupOption
-      onSelectCountup={() => setTimerMode('countup')}
     />
   );
 

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -1278,6 +1278,12 @@ export function TaskDetailPage() {
             autoFocus
             value={descriptionDraft}
             onChange={(e) => setDescriptionDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                e.preventDefault();
+                void handleSaveDescription();
+              }
+            }}
             placeholder="输入任务描述..."
             className="min-h-[120px] border-none bg-transparent p-0 text-sm text-[#1C1917] shadow-none focus-visible:ring-0 dark:text-[#FAFAF9]"
           />

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft, Ellipsis, NotepadText, Target, Play } from 'lucide-react';
-import { Link, useNavigate, useParams } from '@tanstack/react-router';
+import { Link, useNavigate, useParams, useLocation } from '@tanstack/react-router';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState, type ReactNode } from 'react';
+import { TASKS_LAST_PATH_KEY } from './TasksPage';
 import { getTaskService, getTaskTimerService, getTimeBlockService } from '@/lib/services';
 import { isTerminalTaskStatus } from '@/lib/types/task';
 import type { TaskNode } from '@/lib/types/task';
@@ -920,9 +921,16 @@ function DesktopTimeblockDetail({
 export function TaskDetailPage() {
   const { taskId, blockId: blockIdParam } = useParams({ strict: false }) as { taskId?: string; blockId?: string };
   const navigate = useNavigate();
+  const location = useLocation();
   const isDesktop = useIsDesktop();
   const preferredBlockId = blockIdParam || resolvePreferredBlockId();
   const backLink = resolveTimeblockSourceBackLink();
+
+  // Persist current tasks sub-path for nav tab memory
+  useEffect(() => {
+    const fullPath = location.pathname + (location.searchStr || '');
+    sessionStorage.setItem(TASKS_LAST_PATH_KEY, fullPath);
+  }, [location.pathname, location.searchStr]);
 
   const [task, setTask] = useState<TaskNode | null>(null);
   const [timeBlocks, setTimeBlocks] = useState<TimeBlock[]>([]);

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -574,8 +574,6 @@ function MobileTimeblockDetail({
         </button>
       </header>
 
-      <div className="px-4 pt-3">{descriptionBlock}</div>
-
       <div className="space-y-3 px-4 pt-3">
         <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
           <div className="flex flex-wrap items-center gap-2">
@@ -587,9 +585,7 @@ function MobileTimeblockDetail({
           </div>
           <h2 className="mt-3 text-base font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{model.summary.blockName}</h2>
           <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">关联任务：{task.title}</p>
-          {task.description ? (
-            <p className="mt-2 whitespace-pre-wrap text-xs text-[#78716C] dark:text-[#A8A29E]">{task.description}</p>
-          ) : null}
+          {descriptionBlock}
           <h3 className="mt-4 text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">信息面板</h3>
           <div className="mt-2 grid grid-cols-2 gap-2">
             {model.summary.metrics.map((metric) => (
@@ -798,9 +794,8 @@ function DesktopTimeblockDetail({
             ))}
           </div>
         </div>
+        {descriptionBlock}
       </header>
-
-      {descriptionBlock}
 
       <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
         <section className="rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]">
@@ -1279,7 +1274,7 @@ export function TaskDetailPage() {
   const descriptionBlock = (
     <>
       {isEditingDescription ? (
-        <div className="mt-3 rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]">
+        <div className="mt-3">
           <Textarea
             autoFocus
             value={descriptionDraft}
@@ -1293,18 +1288,16 @@ export function TaskDetailPage() {
           </div>
         </div>
       ) : task.description ? (
-        <div className="mt-3 rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]">
-          <div className="flex items-start justify-between gap-3">
-            <p className="whitespace-pre-wrap text-sm text-[#1C1917] dark:text-[#FAFAF9]">{task.description}</p>
-            {!isTerminalTaskStatus(task.status) && (
-              <button type="button" onClick={() => { setDescriptionDraft(task.description ?? ''); setIsEditingDescription(true); }} className="shrink-0 rounded-lg p-1.5 text-[#A8A29E] hover:bg-[#F5F0ED] dark:hover:bg-[#292524]">
-                <Pencil size={14} />
-              </button>
-            )}
-          </div>
+        <div className="mt-3 flex items-start justify-between gap-3">
+          <p className="whitespace-pre-wrap text-sm text-[#78716C] dark:text-[#A8A29E]">{task.description}</p>
+          {!isTerminalTaskStatus(task.status) && (
+            <button type="button" onClick={() => { setDescriptionDraft(task.description ?? ''); setIsEditingDescription(true); }} className="shrink-0 rounded-lg p-1.5 text-[#A8A29E] hover:bg-[#F5F0ED] dark:hover:bg-[#292524]">
+              <Pencil size={14} />
+            </button>
+          )}
         </div>
       ) : !isTerminalTaskStatus(task.status) ? (
-        <button type="button" onClick={() => { setDescriptionDraft(''); setIsEditingDescription(true); }} className="mt-3 w-full rounded-2xl border border-dashed border-[#D6D3D1] bg-[#FAF7F5] px-6 py-3 text-left text-sm text-[#A8A29E] hover:bg-[#F5F0ED] dark:border-[#3A3432] dark:bg-[#1C1917] dark:hover:bg-[#292524]">
+        <button type="button" onClick={() => { setDescriptionDraft(''); setIsEditingDescription(true); }} className="mt-3 text-sm text-[#A8A29E] hover:text-[#78716C] dark:hover:text-[#D6D3D1]">
           + 添加任务描述
         </button>
       ) : null}

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -12,6 +12,7 @@ import { getUseMockDataEnabled } from '@/config/mock-data';
 import { buildTaskGraph } from '@/lib/task/task-dag-graph';
 import { TaskCurrentRootCard } from '@/ui/app/components/TaskCurrentRootCard';
 import { EstimatedTimeEditor } from '@/ui/app/components/EstimatedTimeEditor';
+import { Switch } from '@/components/ui/switch';
 import {
   buildTaskTimeblockDetailViewModel,
   type TimeblockEventLog,
@@ -42,12 +43,49 @@ const SOURCE_CONFIG: Record<string, { label: string; to: string }> = {
   dag: { label: 'DAG', to: '/tasks/dag' },
   timeblocks: { label: '时间块', to: '/tasks/timeblocks' },
 };
+const TASK_TIMER_AUTO_FILL_STORAGE_KEY = 'exomind:task-timer:auto-fill';
 
 interface TimeblockSourceBackLink {
   to: string;
   search?: Record<string, string>;
   label: string;
   sourceLabel: string;
+}
+
+function readTaskTimerAutoFillEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+
+  try {
+    return window.localStorage.getItem(TASK_TIMER_AUTO_FILL_STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function writeTaskTimerAutoFillEnabled(enabled: boolean): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(TASK_TIMER_AUTO_FILL_STORAGE_KEY, enabled ? '1' : '0');
+  } catch {
+    // Ignore storage failures and keep the preference in-memory only.
+  }
+}
+
+function resolveAutoTimerConfig(
+  estimatedMinutes?: number,
+  spentMinutes?: number,
+): { mode: 'countup' } | { mode: 'countdown'; minutes: number } | null {
+  if (estimatedMinutes == null || spentMinutes == null) {
+    return null;
+  }
+
+  const remainingMinutes = Math.round(estimatedMinutes - spentMinutes);
+  if (remainingMinutes > 0) {
+    return { mode: 'countdown', minutes: remainingMinutes };
+  }
+
+  return { mode: 'countup' };
 }
 
 const MOBILE_ANCHOR_TARGETS = {
@@ -669,6 +707,7 @@ function MobileTimeblockDetail({
   dependencyError,
   isDependencySaving,
   timerControls,
+  autoTimerToggle,
   hasOtherActiveBlock,
   hasActiveBlockOnTask,
   blockingReason,
@@ -696,6 +735,7 @@ function MobileTimeblockDetail({
   dependencyError: string | null;
   isDependencySaving: boolean;
   timerControls: ReactNode;
+  autoTimerToggle: ReactNode;
   hasOtherActiveBlock: boolean;
   hasActiveBlockOnTask: boolean;
   blockingReason: string | null;
@@ -848,39 +888,42 @@ function MobileTimeblockDetail({
             {timerControls}
           </div>
           <div className="mt-3 flex flex-col gap-2">
-            <div className="flex gap-2">
-              {hasActiveBlockOnTask ? (
-                <button
-                  type="button"
-                  onClick={onPauseAndGoEventlog}
-                  data-testid="task-pause-button"
-                  className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white"
-                >
-                  <Target size={14} />
-                  前往当下
-                </button>
-              ) : (
-                <>
-                  <button
-                    type="button"
-                    onClick={onStartTimer}
-                    disabled={hasOtherActiveBlock || Boolean(blockingReason)}
-                    className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
-                  >
-                    <Play size={14} />
-                    开始计时
-                  </button>
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="flex flex-wrap gap-2">
+                {hasActiveBlockOnTask ? (
                   <button
                     type="button"
                     onClick={onPauseAndGoEventlog}
                     data-testid="task-pause-button"
-                    className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
+                    className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white"
                   >
                     <Target size={14} />
                     前往当下
                   </button>
-                </>
-              )}
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      onClick={onStartTimer}
+                      disabled={hasOtherActiveBlock || Boolean(blockingReason)}
+                      className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
+                    >
+                      <Play size={14} />
+                      开始计时
+                    </button>
+                    <button
+                      type="button"
+                      onClick={onPauseAndGoEventlog}
+                      data-testid="task-pause-button"
+                      className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
+                    >
+                      <Target size={14} />
+                      前往当下
+                    </button>
+                  </>
+                )}
+              </div>
+              {autoTimerToggle}
             </div>
             {blockingReason ? (
               <p className="text-xs text-[#C75B3A] dark:text-[#FDBA74]">{blockingReason}</p>
@@ -1007,6 +1050,7 @@ function DesktopTimeblockDetail({
   dependencyError,
   isDependencySaving,
   timerControls,
+  autoTimerToggle,
   hasOtherActiveBlock,
   hasActiveBlockOnTask,
   blockingReason,
@@ -1034,6 +1078,7 @@ function DesktopTimeblockDetail({
   dependencyError: string | null;
   isDependencySaving: boolean;
   timerControls: ReactNode;
+  autoTimerToggle: ReactNode;
   hasOtherActiveBlock: boolean;
   hasActiveBlockOnTask: boolean;
   blockingReason: string | null;
@@ -1107,39 +1152,42 @@ function DesktopTimeblockDetail({
             {timerControls}
           </div>
           <div className="mt-3 flex flex-col gap-2">
-            <div className="flex gap-2">
-              {hasActiveBlockOnTask ? (
-                <button
-                  type="button"
-                  onClick={onPauseAndGoEventlog}
-                  data-testid="task-pause-button"
-                  className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white"
-                >
-                  <Target size={14} />
-                  前往当下
-                </button>
-              ) : (
-                <>
-                  <button
-                    type="button"
-                    onClick={onStartTimer}
-                    disabled={hasOtherActiveBlock || Boolean(blockingReason)}
-                    className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
-                  >
-                    <Play size={14} />
-                    开始计时
-                  </button>
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="flex flex-wrap gap-2">
+                {hasActiveBlockOnTask ? (
                   <button
                     type="button"
                     onClick={onPauseAndGoEventlog}
                     data-testid="task-pause-button"
-                    className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
+                    className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white"
                   >
                     <Target size={14} />
                     前往当下
                   </button>
-                </>
-              )}
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      onClick={onStartTimer}
+                      disabled={hasOtherActiveBlock || Boolean(blockingReason)}
+                      className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
+                    >
+                      <Play size={14} />
+                      开始计时
+                    </button>
+                    <button
+                      type="button"
+                      onClick={onPauseAndGoEventlog}
+                      data-testid="task-pause-button"
+                      className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
+                    >
+                      <Target size={14} />
+                      前往当下
+                    </button>
+                  </>
+                )}
+              </div>
+              {autoTimerToggle}
             </div>
             {blockingReason ? (
               <p className="text-xs text-[#C75B3A] dark:text-[#FDBA74]">{blockingReason}</p>
@@ -1274,20 +1322,51 @@ export function TaskDetailPage() {
   const [dependencyReloadKey, setDependencyReloadKey] = useState(0);
   const [isEditingDescription, setIsEditingDescription] = useState(false);
   const [descriptionDraft, setDescriptionDraft] = useState('');
+  const [isTimerAutoFillEnabled, setIsTimerAutoFillEnabled] = useState(() => readTaskTimerAutoFillEnabled());
   const timerResetKey = taskId ?? preferredBlockId ?? task?.id;
-  const timerInitialMinutes = taskId
+  const taskEstimatedMinutes = taskId
     ? task?.id === taskId ? task.estimatedMinutes : undefined
     : task?.estimatedMinutes;
+  const autoTimerConfig = useMemo(
+    () => resolveAutoTimerConfig(taskEstimatedMinutes, spentMinutes),
+    [spentMinutes, taskEstimatedMinutes],
+  );
+  const timerInitialMinutes = useMemo(() => {
+    if (isTimerAutoFillEnabled) {
+      if (autoTimerConfig?.mode === 'countdown') {
+        return autoTimerConfig.minutes;
+      }
+
+      if (autoTimerConfig?.mode === 'countup') {
+        return undefined;
+      }
+    }
+
+    return taskEstimatedMinutes;
+  }, [autoTimerConfig, isTimerAutoFillEnabled, taskEstimatedMinutes]);
   const {
     timerMode,
     countdownMinutes,
     setTimerMode,
     setCountdownMinutes,
+    syncTimerConfig,
     customDurationDraft,
     setCustomDurationDraft,
     commitCustomDuration,
     timerConfig,
   } = useTimerConfig(timerInitialMinutes, timerResetKey);
+
+  useEffect(() => {
+    writeTaskTimerAutoFillEnabled(isTimerAutoFillEnabled);
+  }, [isTimerAutoFillEnabled]);
+
+  useEffect(() => {
+    if (!isTimerAutoFillEnabled || !autoTimerConfig) {
+      return;
+    }
+
+    syncTimerConfig(autoTimerConfig);
+  }, [autoTimerConfig, isTimerAutoFillEnabled, syncTimerConfig]);
 
   useLayoutEffect(() => {
     setIsLoading(true);
@@ -1451,10 +1530,35 @@ export function TaskDetailPage() {
       customDurationDraft={customDurationDraft}
       setCustomDurationDraft={setCustomDurationDraft}
       commitCustomDuration={commitCustomDuration}
-      estimatedMinutes={task?.estimatedMinutes}
-      spentMinutes={spentMinutes}
       showCountupOption
     />
+  );
+  const autoTimerStatusText = taskEstimatedMinutes == null
+    ? '未设估时'
+    : spentMinutes == null
+      ? '等待时间块统计'
+      : autoTimerConfig?.mode === 'countdown'
+        ? `剩余 ${autoTimerConfig.minutes}min`
+        : '已超预期，自动正计时';
+  const autoTimerToggle = (
+    <label
+      data-testid="task-countdown-auto-fill-toggle"
+      className="ml-auto inline-flex items-center gap-2 rounded-xl border border-[#E7E5E4] bg-[#FAF7F5] px-3 py-2 dark:border-[#292524] dark:bg-[#0C0A09]"
+    >
+      <div className="text-right">
+        <p className="text-[11px] font-medium text-[#57534E] dark:text-[#D6D3D1]">自动补全</p>
+        <p data-testid="task-countdown-auto-fill-status" className="text-[11px] text-[#A8A29E] dark:text-[#78716C]">
+          {autoTimerStatusText}
+        </p>
+      </div>
+      <Switch
+        checked={isTimerAutoFillEnabled}
+        onCheckedChange={setIsTimerAutoFillEnabled}
+        disabled={taskEstimatedMinutes == null || spentMinutes == null}
+        aria-label="自动补全计时时长"
+        data-testid="task-countdown-auto-fill-switch"
+      />
+    </label>
   );
 
   const dependencyView = useMemo(() => {
@@ -1588,7 +1692,10 @@ export function TaskDetailPage() {
     if (!sourceTaskId) return;
 
     const updatedAt = Date.now();
-    if (minutes == null) {
+    const nextAutoTimerConfig = resolveAutoTimerConfig(minutes, spentMinutes);
+    if (isTimerAutoFillEnabled && nextAutoTimerConfig) {
+      syncTimerConfig(nextAutoTimerConfig);
+    } else if (minutes == null) {
       setTimerMode('countup');
     } else {
       setCountdownMinutes(minutes);
@@ -1610,7 +1717,7 @@ export function TaskDetailPage() {
           }
         : candidate
     )));
-  }, [setCountdownMinutes, setTimerMode, task?.id]);
+  }, [isTimerAutoFillEnabled, setCountdownMinutes, setTimerMode, spentMinutes, syncTimerConfig, task?.id]);
 
   const handleSaveDescription = useCallback(async () => {
     if (!task?.id) return;
@@ -1699,6 +1806,7 @@ export function TaskDetailPage() {
         dependencyError={dependencyError}
         isDependencySaving={isDependencySaving}
         timerControls={timerControls}
+        autoTimerToggle={autoTimerToggle}
         hasOtherActiveBlock={hasOtherActiveBlock}
         hasActiveBlockOnTask={Boolean(activeBlock)}
         blockingReason={blockingReason}
@@ -1731,6 +1839,7 @@ export function TaskDetailPage() {
       dependencyError={dependencyError}
       isDependencySaving={isDependencySaving}
       timerControls={timerControls}
+      autoTimerToggle={autoTimerToggle}
       hasOtherActiveBlock={hasOtherActiveBlock}
       hasActiveBlockOnTask={Boolean(activeBlock)}
       blockingReason={blockingReason}

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -773,16 +773,23 @@ function DesktopTimeblockDetail({
   return (
     <div className="min-h-full bg-[#FAF7F5] px-8 py-6 dark:bg-[#0C0A09]" data-testid="new-task-detail-page">
       <header className="rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]">
-        <p className="inline-flex select-none items-center gap-1 text-xs text-[#A8A29E]">
-          <Link to="/tasks" className="inline-flex items-center gap-1 hover:text-[#78716C] dark:hover:text-[#D6D3D1]"><ArrowLeft size={12} />任务</Link>
+        <div className="inline-flex select-none items-center gap-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
+          <Link to="/tasks" className="inline-flex items-center gap-1 hover:text-[#1C1917] dark:hover:text-[#FAFAF9]">
+            <ArrowLeft size={14} />
+            任务
+          </Link>
           {backLink.sourceLabel !== '任务' && (
             <>
-              <span> &gt; </span>
-              <Link to={backLink.to} search={backLink.search} className="hover:text-[#78716C] dark:hover:text-[#D6D3D1]">{backLink.sourceLabel}</Link>
+              <span>/</span>
+              <Link to={backLink.to} search={backLink.search} className="hover:text-[#1C1917] dark:hover:text-[#FAFAF9]">{backLink.sourceLabel}</Link>
             </>
           )}
-          <span className="inline-flex items-center gap-1"> &gt; <NotepadText size={12} />任务详情</span>
-        </p>
+          <span>/</span>
+          <span className="inline-flex items-center gap-1">
+            <NotepadText size={14} />
+            任务详情
+          </span>
+        </div>
         <div className="mt-2 flex items-center justify-between gap-3">
           <div className="min-w-0">
             <h1 className="text-2xl font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{model.summary.blockName}</h1>

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -762,27 +762,41 @@ function MobileTimeblockDetail({
           </div>
           <div className="mt-3 flex flex-col gap-2">
             <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={onStartTimer}
-                disabled={hasOtherActiveBlock || Boolean(blockingReason)}
-                className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
-              >
-                <Play size={14} />
-                开始计时
-              </button>
-              <button
-                type="button"
-                data-testid="task-pause-button"
-                onClick={onPauseAndGoEventlog}
-                className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
-              >
-                <Target size={14} />
-                {hasActiveBlockOnTask ? '暂停并前往当下' : '前往当下'}
-              </button>
+              {hasActiveBlockOnTask ? (
+                <button
+                  type="button"
+                  onClick={onPauseAndGoEventlog}
+                  className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white"
+                >
+                  <Target size={14} />
+                  前往当下
+                </button>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    onClick={onStartTimer}
+                    disabled={hasOtherActiveBlock || Boolean(blockingReason)}
+                    className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
+                  >
+                    <Play size={14} />
+                    开始计时
+                  </button>
+                  <button
+                    type="button"
+                    onClick={onPauseAndGoEventlog}
+                    className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
+                  >
+                    <Target size={14} />
+                    前往当下
+                  </button>
+                </>
+              )}
             </div>
             {blockingReason ? (
               <p className="text-xs text-[#C75B3A] dark:text-[#FDBA74]">{blockingReason}</p>
+            ) : hasOtherActiveBlock ? (
+              <p className="text-xs text-[#A8A29E]">其他任务正在计时中</p>
             ) : null}
           </div>
         </section>
@@ -905,27 +919,41 @@ function DesktopTimeblockDetail({
           </div>
           <div className="mt-3 flex flex-col gap-2">
             <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={onStartTimer}
-                disabled={hasOtherActiveBlock || Boolean(blockingReason)}
-                className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
-              >
-                <Play size={14} />
-                开始计时
-              </button>
-              <button
-                type="button"
-                data-testid="task-pause-button"
-                onClick={onPauseAndGoEventlog}
-                className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
-              >
-                <Target size={14} />
-                {hasActiveBlockOnTask ? '暂停并前往当下' : '前往当下'}
-              </button>
+              {hasActiveBlockOnTask ? (
+                <button
+                  type="button"
+                  onClick={onPauseAndGoEventlog}
+                  className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white"
+                >
+                  <Target size={14} />
+                  前往当下
+                </button>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    onClick={onStartTimer}
+                    disabled={hasOtherActiveBlock || Boolean(blockingReason)}
+                    className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
+                  >
+                    <Play size={14} />
+                    开始计时
+                  </button>
+                  <button
+                    type="button"
+                    onClick={onPauseAndGoEventlog}
+                    className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
+                  >
+                    <Target size={14} />
+                    前往当下
+                  </button>
+                </>
+              )}
             </div>
             {blockingReason ? (
               <p className="text-xs text-[#C75B3A] dark:text-[#FDBA74]">{blockingReason}</p>
+            ) : hasOtherActiveBlock ? (
+              <p className="text-xs text-[#A8A29E]">其他任务正在计时中</p>
             ) : null}
           </div>
         </section>

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -773,14 +773,6 @@ function DesktopTimeblockDetail({
         <div className="mt-2 flex items-center justify-between gap-3">
           <div className="min-w-0">
             <h1 className="text-2xl font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{model.summary.blockName}</h1>
-            <Link
-              to={backLink.to}
-              search={backLink.search}
-              className="mt-2 inline-flex text-sm font-medium text-[#78716C] underline-offset-2 hover:underline dark:text-[#A8A29E]"
-              data-testid="timeblock-back-link-desktop"
-            >
-              {backLink.label}
-            </Link>
           </div>
           <div className="flex flex-wrap items-center gap-2">
             {model.summary.badges.map((badge) => (

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -2,6 +2,7 @@ import { ArrowLeft, Ellipsis, Pause, Play } from 'lucide-react';
 import { Link, useNavigate, useParams } from '@tanstack/react-router';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState, type ReactNode } from 'react';
 import { getTaskService, getTaskTimerService, getTimeBlockService } from '@/lib/services';
+import { isTerminalTaskStatus } from '@/lib/types/task';
 import type { TaskNode } from '@/lib/types/task';
 import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
 import { getEventStorage } from '@/lib/storage/event-storage';
@@ -1063,7 +1064,7 @@ export function TaskDetailPage() {
     <TaskCurrentRootCard graph={taskGraph} taskById={taskById} currentTaskId={task?.id} />
   ), [task?.id, taskById, taskGraph]);
   const canEditEstimatedTime = useMemo(
-    () => (task ? allTasks.some((candidate) => candidate.id === task.id) : false),
+    () => (task ? allTasks.some((candidate) => candidate.id === task.id) && !isTerminalTaskStatus(task.status) : false),
     [allTasks, task],
   );
   const timerControls = (

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -609,6 +609,7 @@ function MobileTimeblockDetail({
         <Link
           to={backLink.to}
           search={backLink.search}
+          onClick={() => sessionStorage.removeItem(TASKS_LAST_PATH_KEY)}
           className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]"
           aria-label={`返回${backLink.sourceLabel}`}
           data-testid="timeblock-back-link-mobile"
@@ -837,7 +838,7 @@ function DesktopTimeblockDetail({
     <div className="min-h-full bg-[#FAF7F5] px-8 py-6 dark:bg-[#0C0A09]" data-testid="new-task-detail-page">
       <header className="rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]">
         <div className="inline-flex select-none items-center gap-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
-          <Link to="/tasks" className="inline-flex items-center gap-1 hover:text-[#1C1917] dark:hover:text-[#FAFAF9]">
+          <Link to="/tasks" onClick={() => sessionStorage.removeItem(TASKS_LAST_PATH_KEY)} className="inline-flex items-center gap-1 hover:text-[#1C1917] dark:hover:text-[#FAFAF9]">
             <ArrowLeft size={14} />
             任务
           </Link>

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -880,16 +880,6 @@ function DesktopTimeblockDetail({
         <aside className="space-y-3">
           {rootGuidance}
 
-          <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
-            <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">洞察</h3>
-            <p className="mt-2 text-sm text-[#44403C] dark:text-[#E7E5E4]">{task.title}</p>
-            {task.description ? (
-              <div className="mt-2 prose prose-xs dark:prose-invert max-w-none text-xs text-[#78716C] dark:text-[#A8A29E] prose-p:my-0.5 prose-ul:my-0.5 prose-ol:my-0.5 prose-li:my-0 prose-headings:my-0.5 prose-a:text-[#C75B3A]">
-                <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>{task.description}</ReactMarkdown>
-              </div>
-            ) : null}
-          </section>
-
           <DependencyCard
             dependencyView={dependencyView}
             taskDagView={taskDagView}

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -692,10 +692,7 @@ function MobileTimeblockDetail({
             </div>
           ) : null}
           <div className="mt-3">
-            <p className="text-xs font-medium text-[#57534E] dark:text-[#A8A29E]">预期时长</p>
-            <div className="mt-1">
-              {timerControls}
-            </div>
+            {timerControls}
           </div>
           <div className="mt-3 flex gap-2">
             <button
@@ -836,10 +833,7 @@ function DesktopTimeblockDetail({
             </div>
           ) : null}
           <div className="mt-3">
-            <p className="text-xs font-medium text-[#57534E] dark:text-[#A8A29E]">预期时长</p>
-            <div className="mt-1">
-              {timerControls}
-            </div>
+            {timerControls}
           </div>
           <div className="mt-3 flex gap-2">
             <button

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -145,16 +145,14 @@ function buildVirtualTaskFromBlock(block: TimeBlock): TaskNode {
 
 function DetailActionsCard({
   model,
-  onRestart,
   onCopySummary,
 }: {
   model: TaskTimeblockDetailViewModel;
-  onRestart: () => void;
   onCopySummary: () => void;
 }) {
   return (
     <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
-      <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">操作</h3>
+      <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">其他操作</h3>
       <div className="mt-3 space-y-2">
         {model.actions.map((action) => {
           if (action.id === 'open-task') {
@@ -175,11 +173,11 @@ function DetailActionsCard({
             <button
               key={action.id}
               type="button"
-              onClick={action.id === 'restart' ? onRestart : onCopySummary}
+              onClick={onCopySummary}
               className="flex w-full items-center justify-between rounded-xl border border-[#E7E5E4] px-3 py-2 text-left text-sm text-[#44403C] transition-colors hover:bg-[#FAF7F5] dark:border-[#292524] dark:text-[#E7E5E4] dark:hover:bg-[#292524]"
             >
               <span>{action.label}</span>
-              <span className="text-xs text-[#A8A29E]">{action.id === 'restart' ? '执行' : '复制'}</span>
+              <span className="text-xs text-[#A8A29E]">复制</span>
             </button>
           );
         })}
@@ -669,7 +667,6 @@ function MobileTimeblockDetail({
 
         <DetailActionsCard
           model={model}
-          onRestart={onStartTimer}
           onCopySummary={onCopySummary}
         />
 
@@ -912,7 +909,6 @@ function DesktopTimeblockDetail({
 
           <DetailActionsCard
             model={model}
-            onRestart={onStartTimer}
             onCopySummary={onCopySummary}
           />
         </aside>

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -590,7 +590,8 @@ function MobileTimeblockDetail({
           {task.description ? (
             <p className="mt-2 whitespace-pre-wrap text-xs text-[#78716C] dark:text-[#A8A29E]">{task.description}</p>
           ) : null}
-          <div className="mt-3 grid grid-cols-2 gap-2">
+          <h3 className="mt-4 text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">信息面板</h3>
+          <div className="mt-2 grid grid-cols-2 gap-2">
             {model.summary.metrics.map((metric) => (
               <div key={metric.key} className="rounded-xl bg-[#F8F5F2] px-3 py-2 dark:bg-[#292524]">
                 <p className="text-[11px] text-[#A8A29E]">{metric.label}</p>
@@ -806,7 +807,8 @@ function DesktopTimeblockDetail({
 
       <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
         <section className="rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]">
-          <div className="grid grid-cols-2 gap-3 xl:grid-cols-3">
+          <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">信息面板</h3>
+          <div className="mt-3 grid grid-cols-2 gap-3 xl:grid-cols-3">
             {model.summary.metrics.map((metric) => (
               <div key={metric.key} className="rounded-xl bg-[#F8F5F2] px-3 py-2 dark:bg-[#292524]">
                 <p className="text-xs text-[#A8A29E]">{metric.label}</p>

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Ellipsis, Pause, Play } from 'lucide-react';
+import { ArrowLeft, Ellipsis, Target, Play } from 'lucide-react';
 import { Link, useNavigate, useParams } from '@tanstack/react-router';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState, type ReactNode } from 'react';
 import { getTaskService, getTaskTimerService, getTimeBlockService } from '@/lib/services';
@@ -154,7 +154,7 @@ function DetailActionsCard({
       <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">操作</h3>
       <div className="mt-3 space-y-2">
         {model.actions.map((action) => {
-          if (action.id === 'open-task' || action.id === 'open-eventlog') {
+          if (action.id === 'open-task') {
             return (
               <Link
                 key={action.id}
@@ -712,7 +712,7 @@ function MobileTimeblockDetail({
               onClick={onPauseAndGoEventlog}
               className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
             >
-              <Pause size={14} />
+              <Target size={14} />
               {hasActiveBlockOnTask ? '暂停并前往当下' : '前往当下'}
             </button>
           </div>
@@ -855,7 +855,7 @@ function DesktopTimeblockDetail({
               onClick={onPauseAndGoEventlog}
               className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
             >
-              <Pause size={14} />
+              <Target size={14} />
               {hasActiveBlockOnTask ? '暂停并前往当下' : '前往当下'}
             </button>
           </div>

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -853,12 +853,12 @@ function DesktopTimeblockDetail({
 }) {
   return (
     <div className="min-h-full bg-[#FAF7F5] px-8 py-6 dark:bg-[#0C0A09]" data-testid="new-task-detail-page">
-      <header className="rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]">
-        <TaskBreadcrumb
-          segments={buildDetailBreadcrumbSegments(backLink)}
-          current={{ label: '任务详情', icon: NotepadText }}
-        />
-        <div className="mt-2 flex items-center justify-between gap-3">
+      <TaskBreadcrumb
+        segments={buildDetailBreadcrumbSegments(backLink)}
+        current={{ label: '任务详情', icon: NotepadText }}
+      />
+      <header className="mt-3 rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]">
+        <div className="flex items-center justify-between gap-3">
           <div className="min-w-0">
             <h1 className="text-2xl font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{model.summary.blockName}</h1>
           </div>

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -1201,12 +1201,8 @@ export function TaskDetailPage() {
 
   const handleStartTimer = () => {
     if (!taskId) return;
-    console.log('[TaskDetail] handleStartTimer', { taskId, timerConfig, timerMode, countdownMinutes });
-    void getTaskTimerService().startBlockForTask(taskId, timerConfig).then((block) => {
-      console.log('[TaskDetail] startBlockForTask result', { block: block ? { startId: block.startId, mode: block.mode, phase: block.phase } : null });
+    void getTaskTimerService().startBlockForTask(taskId, timerConfig).then(() => {
       void navigate({ to: '/eventlog' });
-    }).catch((err) => {
-      console.error('[TaskDetail] startBlockForTask failed', err);
     });
   };
 

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -392,6 +392,7 @@ function DependencyCard({
   onChangeDependencyType,
   onRemoveDependency,
   onToggleCollapseUpstream,
+  onToggleCollapseDownstream,
 }: {
   dependencyView: TaskDependencyViewModel;
   taskDagView: TaskDagDetailView | null;
@@ -406,6 +407,7 @@ function DependencyCard({
   onChangeDependencyType: (taskId: string, type: DependencyType) => void;
   onRemoveDependency: (taskId: string) => void;
   onToggleCollapseUpstream: (taskId: string) => void;
+  onToggleCollapseDownstream: (taskId: string) => void;
 }) {
   const selectedCandidate = dependencyView.candidates.find((candidate) => candidate.id === selectedTaskId) ?? null;
 
@@ -446,7 +448,7 @@ function DependencyCard({
 
             {taskDagView.hiddenNodeCount > 0 ? (
               <p className="mt-2 text-xs text-[#C75B3A] dark:text-[#FDBA74]">
-                当前折叠共隐藏 {taskDagView.hiddenNodeCount} 个上游节点。
+                当前折叠共隐藏 {taskDagView.hiddenNodeCount} 个相关节点。
               </p>
             ) : null}
 
@@ -461,7 +463,11 @@ function DependencyCard({
                 <article
                   key={node.id}
                   data-testid={`task-dag-node-${node.id}`}
-                  className="rounded-xl border border-[#E7E5E4] bg-white px-3 py-3 dark:border-[#3F3F46] dark:bg-[#1C1917]"
+                  className={`rounded-xl bg-white px-3 py-3 dark:bg-[#1C1917] ${
+                    node.isCollapsedTarget
+                      ? 'border-2 border-[#C75B3A] ring-2 ring-[#FDE7DC] dark:border-[#FDBA74] dark:ring-[#4A2317]'
+                      : 'border border-[#E7E5E4] dark:border-[#3F3F46]'
+                  }`}
                 >
                   <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                     <div className="min-w-0 flex-1">
@@ -498,7 +504,9 @@ function DependencyCard({
 
                       <div className="mt-2 flex flex-wrap gap-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
                         <span>上游节点：{node.upstreamNodeCount}</span>
-                        {node.isCollapsedTarget ? <span>已折叠上游</span> : null}
+                        <span>下游节点：{node.downstreamNodeCount}</span>
+                        {node.isCollapsedUpstreamTarget ? <span>已折叠上游</span> : null}
+                        {node.isCollapsedDownstreamTarget ? <span>已折叠下游</span> : null}
                       </div>
 
                       {node.hiddenUpstreamCount > 0 ? (
@@ -509,17 +517,36 @@ function DependencyCard({
                           已隐藏 {node.hiddenUpstreamCount} 项
                         </p>
                       ) : null}
+                      {node.hiddenDownstreamCount > 0 ? (
+                        <p
+                          data-testid={`task-dag-hidden-downstream-summary-${node.id}`}
+                          className="mt-2 rounded-lg bg-[#ECFDF5] px-2.5 py-1.5 text-xs text-[#047857] dark:bg-[#052E2B] dark:text-[#6EE7B7]"
+                        >
+                          下游已隐藏 {node.hiddenDownstreamCount} 项
+                        </p>
+                      ) : null}
                     </div>
 
-                    <button
-                      type="button"
-                      data-testid={`task-dag-toggle-upstream-${node.id}`}
-                      disabled={!node.canCollapseUpstream}
-                      onClick={() => onToggleCollapseUpstream(node.id)}
-                      className="rounded-xl border border-[#E7E5E4] px-3 py-2 text-sm text-[#57534E] transition-colors hover:bg-[#FAF7F5] disabled:cursor-not-allowed disabled:opacity-60 dark:border-[#3F3F46] dark:text-[#D6D3D1] dark:hover:bg-[#292524]"
-                    >
-                      {node.isCollapsedTarget ? '展开上游' : '折叠上游'}
-                    </button>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        data-testid={`task-dag-toggle-upstream-${node.id}`}
+                        disabled={!node.canCollapseUpstream}
+                        onClick={() => onToggleCollapseUpstream(node.id)}
+                        className="rounded-xl border border-[#E7E5E4] px-3 py-2 text-sm text-[#57534E] transition-colors hover:bg-[#FAF7F5] disabled:cursor-not-allowed disabled:opacity-60 dark:border-[#3F3F46] dark:text-[#D6D3D1] dark:hover:bg-[#292524]"
+                      >
+                        {node.isCollapsedUpstreamTarget ? '展开上游' : '折叠上游'}
+                      </button>
+                      <button
+                        type="button"
+                        data-testid={`task-dag-toggle-downstream-${node.id}`}
+                        disabled={!node.canCollapseDownstream}
+                        onClick={() => onToggleCollapseDownstream(node.id)}
+                        className="rounded-xl border border-[#E7E5E4] px-3 py-2 text-sm text-[#57534E] transition-colors hover:bg-[#FAF7F5] disabled:cursor-not-allowed disabled:opacity-60 dark:border-[#3F3F46] dark:text-[#D6D3D1] dark:hover:bg-[#292524]"
+                      >
+                        {node.isCollapsedDownstreamTarget ? '展开下游' : '折叠下游'}
+                      </button>
+                    </div>
                   </div>
                 </article>
               ))}
@@ -723,6 +750,7 @@ function MobileTimeblockDetail({
   onChangeDependencyType,
   onRemoveDependency,
   onToggleCollapseUpstream,
+  onToggleCollapseDownstream,
 }: {
   descriptionBlock: ReactNode;
   task: TaskNode;
@@ -751,6 +779,7 @@ function MobileTimeblockDetail({
   onChangeDependencyType: (taskId: string, type: DependencyType) => void;
   onRemoveDependency: (taskId: string) => void;
   onToggleCollapseUpstream: (taskId: string) => void;
+  onToggleCollapseDownstream: (taskId: string) => void;
 }) {
   const [activeAnchorId, setActiveAnchorId] = useState<MobileAnchorId>('overview');
   const showTimerCard = !isTerminalTaskStatus(task.status);
@@ -1024,6 +1053,7 @@ function MobileTimeblockDetail({
             onChangeDependencyType={onChangeDependencyType}
             onRemoveDependency={onRemoveDependency}
             onToggleCollapseUpstream={onToggleCollapseUpstream}
+            onToggleCollapseDownstream={onToggleCollapseDownstream}
           />
         </div>
 
@@ -1066,6 +1096,7 @@ function DesktopTimeblockDetail({
   onChangeDependencyType,
   onRemoveDependency,
   onToggleCollapseUpstream,
+  onToggleCollapseDownstream,
 }: {
   descriptionBlock: ReactNode;
   task: TaskNode;
@@ -1094,6 +1125,7 @@ function DesktopTimeblockDetail({
   onChangeDependencyType: (taskId: string, type: DependencyType) => void;
   onRemoveDependency: (taskId: string) => void;
   onToggleCollapseUpstream: (taskId: string) => void;
+  onToggleCollapseDownstream: (taskId: string) => void;
 }) {
   return (
     <div className="scrollbar-none h-full overflow-y-auto bg-[#FAF7F5] px-8 py-6 dark:bg-[#0C0A09]" data-testid="new-task-detail-page">
@@ -1261,6 +1293,7 @@ function DesktopTimeblockDetail({
             onChangeDependencyType={onChangeDependencyType}
             onRemoveDependency={onRemoveDependency}
             onToggleCollapseUpstream={onToggleCollapseUpstream}
+            onToggleCollapseDownstream={onToggleCollapseDownstream}
           />
 
           <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
@@ -1315,7 +1348,10 @@ export function TaskDetailPage() {
   const [allTasks, setAllTasks] = useState<TaskNode[]>([]);
   const [dependencySelectedTaskId, setDependencySelectedTaskId] = useState('');
   const [dependencySelectedType, setDependencySelectedType] = useState<DependencyType>('soft');
-  const [dagVisibilityState, setDagVisibilityState] = useState<TaskDagVisibilityState>({ collapsedUpstreamOf: [] });
+  const [dagVisibilityState, setDagVisibilityState] = useState<TaskDagVisibilityState>({
+    collapsedUpstreamOf: [],
+    collapsedDownstreamOf: [],
+  });
   const [dependencyLoadError, setDependencyLoadError] = useState<string | null>(null);
   const [dependencyActionError, setDependencyActionError] = useState<string | null>(null);
   const [isDependencySaving, setIsDependencySaving] = useState(false);
@@ -1379,7 +1415,10 @@ export function TaskDetailPage() {
   }, [dependencyReloadKey, preferredBlockId, taskId]);
 
   useEffect(() => {
-    setDagVisibilityState({ collapsedUpstreamOf: [] });
+    setDagVisibilityState({
+      collapsedUpstreamOf: [],
+      collapsedDownstreamOf: [],
+    });
   }, [task?.id]);
 
   useEffect(() => {
@@ -1579,9 +1618,19 @@ export function TaskDetailPage() {
 
   const handleToggleCollapseUpstream = (targetTaskId: string) => {
     setDagVisibilityState((currentState) => ({
+      ...currentState,
       collapsedUpstreamOf: currentState.collapsedUpstreamOf.includes(targetTaskId)
         ? currentState.collapsedUpstreamOf.filter((taskId) => taskId !== targetTaskId)
         : [...currentState.collapsedUpstreamOf, targetTaskId],
+    }));
+  };
+
+  const handleToggleCollapseDownstream = (targetTaskId: string) => {
+    setDagVisibilityState((currentState) => ({
+      ...currentState,
+      collapsedDownstreamOf: currentState.collapsedDownstreamOf.includes(targetTaskId)
+        ? currentState.collapsedDownstreamOf.filter((taskId) => taskId !== targetTaskId)
+        : [...currentState.collapsedDownstreamOf, targetTaskId],
     }));
   };
 
@@ -1822,6 +1871,7 @@ export function TaskDetailPage() {
         onChangeDependencyType={handleChangeDependencyType}
         onRemoveDependency={handleRemoveDependency}
         onToggleCollapseUpstream={handleToggleCollapseUpstream}
+        onToggleCollapseDownstream={handleToggleCollapseDownstream}
       />
     );
   }
@@ -1855,6 +1905,7 @@ export function TaskDetailPage() {
       onChangeDependencyType={handleChangeDependencyType}
       onRemoveDependency={handleRemoveDependency}
       onToggleCollapseUpstream={handleToggleCollapseUpstream}
+      onToggleCollapseDownstream={handleToggleCollapseDownstream}
     />
   );
 }

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -1260,6 +1260,7 @@ export function TaskDetailPage() {
   const [timeBlocks, setTimeBlocks] = useState<TimeBlock[]>([]);
   const [activeBlock, setActiveBlock] = useState<ActiveBlockData | null>(null);
   const [hasOtherActiveBlock, setHasOtherActiveBlock] = useState(false);
+  const [spentMinutes, setSpentMinutes] = useState<number | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(true);
   const [reviewMarkdown, setReviewMarkdown] = useState('');
   const [eventLogs, setEventLogs] = useState<TimeblockEventLog[]>([]);
@@ -1293,6 +1294,7 @@ export function TaskDetailPage() {
     setTask(null);
     setActiveBlock(null);
     setHasOtherActiveBlock(false);
+    setSpentMinutes(undefined);
     setEventLogs([]);
     setReviewMarkdown('');
   }, [dependencyReloadKey, preferredBlockId, taskId]);
@@ -1349,7 +1351,10 @@ export function TaskDetailPage() {
       setHasOtherActiveBlock(Boolean(currentBlock && nextTask && currentBlock.taskId !== nextTask.id));
 
       if (nextTask) {
-        const events = await getEventLogService().loadEvents();
+        const [events, calculatedSpentMinutes] = await Promise.all([
+          getEventLogService().loadEvents(),
+          getTaskTimerService().calculateSpentMinutes(nextTask.id).catch(() => 0),
+        ]);
         const matchedBlockName = preferredBlockId
           ? blocks.find((block) => block.id === preferredBlockId || block.startId === preferredBlockId)?.name
           : undefined;
@@ -1360,10 +1365,12 @@ export function TaskDetailPage() {
             content: event.content,
             type: resolveEventTypeFromTags(event.tags),
           }));
+          setSpentMinutes(calculatedSpentMinutes);
           setEventLogs(normalizedEvents);
           setReviewMarkdown(selectReviewMarkdown(nextTask, matchedBlockName ?? nextTask.title, normalizedEvents));
         }
       } else {
+        setSpentMinutes(undefined);
         setEventLogs([]);
         setReviewMarkdown('');
       }
@@ -1444,6 +1451,8 @@ export function TaskDetailPage() {
       customDurationDraft={customDurationDraft}
       setCustomDurationDraft={setCustomDurationDraft}
       commitCustomDuration={commitCustomDuration}
+      estimatedMinutes={task?.estimatedMinutes}
+      spentMinutes={spentMinutes}
       showCountupOption
     />
   );
@@ -1579,6 +1588,11 @@ export function TaskDetailPage() {
     if (!sourceTaskId) return;
 
     const updatedAt = Date.now();
+    if (minutes == null) {
+      setTimerMode('countup');
+    } else {
+      setCountdownMinutes(minutes);
+    }
     setTask((current) => {
       if (!current || current.id !== sourceTaskId) return current;
       return {
@@ -1596,7 +1610,7 @@ export function TaskDetailPage() {
           }
         : candidate
     )));
-  }, [task?.id]);
+  }, [setCountdownMinutes, setTimerMode, task?.id]);
 
   const handleSaveDescription = useCallback(async () => {
     if (!task?.id) return;

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -746,25 +746,30 @@ function MobileTimeblockDetail({
           <div className="mt-3">
             {timerControls}
           </div>
-          <div className="mt-3 flex gap-2">
-            <button
-              type="button"
-              onClick={onStartTimer}
-              disabled={hasOtherActiveBlock}
-              className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
-            >
-              <Play size={14} />
-              开始计时
-            </button>
-            <button
-              type="button"
-              data-testid="task-pause-button"
-              onClick={onPauseAndGoEventlog}
-              className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
-            >
-              <Target size={14} />
-              {hasActiveBlockOnTask ? '暂停并前往当下' : '前往当下'}
-            </button>
+          <div className="mt-3 flex flex-col gap-2">
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={onStartTimer}
+                disabled={hasOtherActiveBlock || Boolean(hardBlockingReason)}
+                className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
+              >
+                <Play size={14} />
+                开始计时
+              </button>
+              <button
+                type="button"
+                data-testid="task-pause-button"
+                onClick={onPauseAndGoEventlog}
+                className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
+              >
+                <Target size={14} />
+                {hasActiveBlockOnTask ? '暂停并前往当下' : '前往当下'}
+              </button>
+            </div>
+            {hardBlockingReason ? (
+              <p className="text-xs text-[#C75B3A] dark:text-[#FDBA74]">{hardBlockingReason}</p>
+            ) : null}
           </div>
         </section>
         )}
@@ -787,6 +792,7 @@ function DesktopTimeblockDetail({
   timerControls,
   hasOtherActiveBlock,
   hasActiveBlockOnTask,
+  hardBlockingReason,
   onStartTimer,
   onPauseAndGoEventlog,
   onCopySummary,
@@ -813,6 +819,7 @@ function DesktopTimeblockDetail({
   timerControls: ReactNode;
   hasOtherActiveBlock: boolean;
   hasActiveBlockOnTask: boolean;
+  hardBlockingReason: string | null;
   onStartTimer: () => void;
   onPauseAndGoEventlog: () => void;
   onCopySummary: () => void;
@@ -895,25 +902,30 @@ function DesktopTimeblockDetail({
           <div className="mt-3">
             {timerControls}
           </div>
-          <div className="mt-3 flex gap-2">
-            <button
-              type="button"
-              onClick={onStartTimer}
-              disabled={hasOtherActiveBlock}
-              className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
-            >
-              <Play size={14} />
-              开始计时
-            </button>
-            <button
-              type="button"
-              data-testid="task-pause-button"
-              onClick={onPauseAndGoEventlog}
-              className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
-            >
-              <Target size={14} />
-              {hasActiveBlockOnTask ? '暂停并前往当下' : '前往当下'}
-            </button>
+          <div className="mt-3 flex flex-col gap-2">
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={onStartTimer}
+                disabled={hasOtherActiveBlock || Boolean(hardBlockingReason)}
+                className="inline-flex items-center gap-1 rounded-xl bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
+              >
+                <Play size={14} />
+                开始计时
+              </button>
+              <button
+                type="button"
+                data-testid="task-pause-button"
+                onClick={onPauseAndGoEventlog}
+                className="inline-flex items-center gap-1 rounded-xl border border-[#E7E5E4] px-4 py-2 text-sm font-medium text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
+              >
+                <Target size={14} />
+                {hasActiveBlockOnTask ? '暂停并前往当下' : '前往当下'}
+              </button>
+            </div>
+            {hardBlockingReason ? (
+              <p className="text-xs text-[#C75B3A] dark:text-[#FDBA74]">{hardBlockingReason}</p>
+            ) : null}
           </div>
         </section>
         )}
@@ -938,6 +950,8 @@ function DesktopTimeblockDetail({
               ))}
             </div>
           </section>
+
+          <LinkedBlocksCard linkedBlocks={model.linkedBlocks} taskId={task.id} />
         </div>
 
         <aside className="space-y-3">
@@ -1410,6 +1424,7 @@ export function TaskDetailPage() {
         timerControls={timerControls}
         hasOtherActiveBlock={hasOtherActiveBlock}
         hasActiveBlockOnTask={Boolean(activeBlock)}
+        hardBlockingReason={hardBlockingReason}
         onStartTimer={handleStartTimer}
         onPauseAndGoEventlog={handlePauseAndGoEventlog}
         onCopySummary={handleCopySummary}
@@ -1441,6 +1456,7 @@ export function TaskDetailPage() {
       timerControls={timerControls}
       hasOtherActiveBlock={hasOtherActiveBlock}
       hasActiveBlockOnTask={Boolean(activeBlock)}
+      hardBlockingReason={hardBlockingReason}
       onStartTimer={handleStartTimer}
       onPauseAndGoEventlog={handlePauseAndGoEventlog}
       onCopySummary={handleCopySummary}

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Ellipsis, Target, Play } from 'lucide-react';
+import { ArrowLeft, Ellipsis, NotepadText, Target, Play } from 'lucide-react';
 import { Link, useNavigate, useParams } from '@tanstack/react-router';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState, type ReactNode } from 'react';
 import { getTaskService, getTaskTimerService, getTimeBlockService } from '@/lib/services';
@@ -772,15 +772,15 @@ function DesktopTimeblockDetail({
   return (
     <div className="min-h-full bg-[#FAF7F5] px-8 py-6 dark:bg-[#0C0A09]" data-testid="new-task-detail-page">
       <header className="rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]">
-        <p className="select-none text-xs text-[#A8A29E]">
-          <Link to="/tasks" className="hover:text-[#78716C] dark:hover:text-[#D6D3D1]">任务</Link>
+        <p className="inline-flex select-none items-center gap-1 text-xs text-[#A8A29E]">
+          <Link to="/tasks" className="inline-flex items-center gap-1 hover:text-[#78716C] dark:hover:text-[#D6D3D1]"><ArrowLeft size={12} />任务</Link>
           {backLink.sourceLabel !== '任务' && (
             <>
               <span> &gt; </span>
               <Link to={backLink.to} search={backLink.search} className="hover:text-[#78716C] dark:hover:text-[#D6D3D1]">{backLink.sourceLabel}</Link>
             </>
           )}
-          <span> &gt; 任务详情</span>
+          <span className="inline-flex items-center gap-1"> &gt; <NotepadText size={12} />任务详情</span>
         </p>
         <div className="mt-2 flex items-center justify-between gap-3">
           <div className="min-w-0">

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -1444,6 +1444,7 @@ export function TaskDetailPage() {
       customDurationDraft={customDurationDraft}
       setCustomDurationDraft={setCustomDurationDraft}
       commitCustomDuration={commitCustomDuration}
+      showCountupOption
     />
   );
 

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -48,7 +48,6 @@ interface TimeblockSourceBackLink {
   to: string;
   search?: Record<string, string>;
   label: string;
-  breadcrumb: string;
   sourceLabel: string;
 }
 
@@ -104,7 +103,6 @@ function resolveTimeblockSourceBackLink(): TimeblockSourceBackLink {
     return {
       to: '/tasks',
       label: '← 返回任务',
-      breadcrumb: '任务 > 任务详情',
       sourceLabel: '任务',
     };
   }
@@ -118,7 +116,6 @@ function resolveTimeblockSourceBackLink(): TimeblockSourceBackLink {
     to: '/tasks',
     search: sourceTab ? { tab: sourceTab } : undefined,
     label: `← 返回${sourceLabel}`,
-    breadcrumb: sourceTab ? `任务 > ${sourceLabel} > 任务详情` : '任务 > 任务详情',
     sourceLabel,
   };
 }
@@ -155,17 +152,16 @@ function DetailActionsCard({
       <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">操作</h3>
       <div className="mt-3 space-y-2">
         {model.actions.map((action) => {
-          if (action.id === 'back-source' || action.id === 'open-task' || action.id === 'open-eventlog') {
+          if (action.id === 'open-task' || action.id === 'open-eventlog') {
             return (
               <Link
                 key={action.id}
                 to={action.to!}
                 search={action.search}
                 className="flex w-full items-center justify-between rounded-xl border border-[#E7E5E4] px-3 py-2 text-sm text-[#44403C] transition-colors hover:bg-[#FAF7F5] dark:border-[#292524] dark:text-[#E7E5E4] dark:hover:bg-[#292524]"
-                data-testid={action.id === 'back-source' ? 'timeblock-action-back-link' : undefined}
               >
                 <span>{action.label}</span>
-                <span className="text-xs text-[#A8A29E]">{action.id === 'back-source' ? '返回' : '打开'}</span>
+                <span className="text-xs text-[#A8A29E]">打开</span>
               </Link>
             );
           }
@@ -764,7 +760,16 @@ function DesktopTimeblockDetail({
   return (
     <div className="min-h-full bg-[#FAF7F5] px-8 py-6 dark:bg-[#0C0A09]" data-testid="new-task-detail-page">
       <header className="rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]">
-        <p className="text-xs text-[#A8A29E]">{backLink.breadcrumb}</p>
+        <p className="select-none text-xs text-[#A8A29E]">
+          <Link to="/tasks" className="hover:text-[#78716C] dark:hover:text-[#D6D3D1]">任务</Link>
+          {backLink.sourceLabel !== '任务' && (
+            <>
+              <span> &gt; </span>
+              <Link to={backLink.to} search={backLink.search} className="hover:text-[#78716C] dark:hover:text-[#D6D3D1]">{backLink.sourceLabel}</Link>
+            </>
+          )}
+          <span> &gt; 任务详情</span>
+        </p>
         <div className="mt-2 flex items-center justify-between gap-3">
           <div className="min-w-0">
             <h1 className="text-2xl font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{model.summary.blockName}</h1>
@@ -1051,13 +1056,8 @@ export function TaskDetailPage() {
       eventLogs,
       reviewMarkdown,
       useMockData: getUseMockDataEnabled(),
-      backAction: {
-        label: backLink.label,
-        to: backLink.to,
-        search: backLink.search,
-      },
     });
-  }, [activeBlock, backLink.label, backLink.search, backLink.to, eventLogs, preferredBlockId, reviewMarkdown, task, timeBlocks]);
+  }, [activeBlock, eventLogs, preferredBlockId, reviewMarkdown, task, timeBlocks]);
 
   const taskGraph = useMemo(() => buildTaskGraph(allTasks), [allTasks]);
   const taskById = useMemo(() => new Map(allTasks.map((candidate) => [candidate.id, candidate])), [allTasks]);

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -1009,7 +1009,9 @@ export function TaskDetailPage() {
   // Persist current tasks sub-path for nav tab memory
   useEffect(() => {
     const fullPath = location.pathname + (location.searchStr || '');
-    sessionStorage.setItem(TASKS_LAST_PATH_KEY, fullPath);
+    if (fullPath.startsWith('/tasks/')) {
+      sessionStorage.setItem(TASKS_LAST_PATH_KEY, fullPath);
+    }
   }, [location.pathname, location.searchStr]);
 
   const [task, setTask] = useState<TaskNode | null>(null);

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -2,6 +2,7 @@ import { ArrowLeft, Ellipsis, NotepadText, Target, Play } from 'lucide-react';
 import { Link, useNavigate, useParams, useLocation } from '@tanstack/react-router';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState, type ReactNode } from 'react';
 import { TASKS_LAST_PATH_KEY } from './TasksPage';
+import { TaskBreadcrumb, type TaskBreadcrumbSegment } from '@/ui/app/components/TaskBreadcrumb';
 import { getTaskService, getTaskTimerService, getTimeBlockService } from '@/lib/services';
 import { isTerminalTaskStatus } from '@/lib/types/task';
 import type { TaskNode } from '@/lib/types/task';
@@ -125,6 +126,18 @@ function resolveTimeblockSourceBackLink(): TimeblockSourceBackLink {
     label: `← 返回${sourceLabel}`,
     sourceLabel,
   };
+}
+
+function buildDetailBreadcrumbSegments(backLink: TimeblockSourceBackLink): TaskBreadcrumbSegment[] {
+  const segments: TaskBreadcrumbSegment[] = [{ label: '任务', to: '/tasks' }];
+  if (backLink.sourceLabel !== '任务') {
+    segments.push({
+      label: backLink.sourceLabel,
+      to: backLink.to,
+      search: backLink.search,
+    });
+  }
+  return segments;
 }
 
 function buildVirtualTaskFromBlock(block: TimeBlock): TaskNode {
@@ -837,23 +850,10 @@ function DesktopTimeblockDetail({
   return (
     <div className="min-h-full bg-[#FAF7F5] px-8 py-6 dark:bg-[#0C0A09]" data-testid="new-task-detail-page">
       <header className="rounded-2xl border border-[#E7E5E4] bg-white px-6 py-4 dark:border-[#292524] dark:bg-[#1C1917]">
-        <div className="inline-flex select-none items-center gap-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
-          <Link to="/tasks" onClick={() => sessionStorage.removeItem(TASKS_LAST_PATH_KEY)} className="inline-flex items-center gap-1 hover:text-[#1C1917] dark:hover:text-[#FAFAF9]">
-            <ArrowLeft size={14} />
-            任务
-          </Link>
-          {backLink.sourceLabel !== '任务' && (
-            <>
-              <span>/</span>
-              <Link to={backLink.to} search={backLink.search} className="hover:text-[#1C1917] dark:hover:text-[#FAFAF9]">{backLink.sourceLabel}</Link>
-            </>
-          )}
-          <span>/</span>
-          <span className="inline-flex items-center gap-1">
-            <NotepadText size={14} />
-            任务详情
-          </span>
-        </div>
+        <TaskBreadcrumb
+          segments={buildDetailBreadcrumbSegments(backLink)}
+          current={{ label: '任务详情', icon: NotepadText }}
+        />
         <div className="mt-2 flex items-center justify-between gap-3">
           <div className="min-w-0">
             <h1 className="text-2xl font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{model.summary.blockName}</h1>

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -1201,8 +1201,12 @@ export function TaskDetailPage() {
 
   const handleStartTimer = () => {
     if (!taskId) return;
-    void getTaskTimerService().startBlockForTask(taskId, timerConfig).then(() => {
+    console.log('[TaskDetail] handleStartTimer', { taskId, timerConfig, timerMode, countdownMinutes });
+    void getTaskTimerService().startBlockForTask(taskId, timerConfig).then((block) => {
+      console.log('[TaskDetail] startBlockForTask result', { block: block ? { startId: block.startId, mode: block.mode, phase: block.phase } : null });
       void navigate({ to: '/eventlog' });
+    }).catch((err) => {
+      console.error('[TaskDetail] startBlockForTask failed', err);
     });
   };
 

--- a/src/ui/app/pages/TaskTimeblocksPage.tsx
+++ b/src/ui/app/pages/TaskTimeblocksPage.tsx
@@ -1,0 +1,202 @@
+import { ArrowLeft, Clock } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Link } from '@tanstack/react-router';
+import { getTimeBlockService } from '@/lib/services';
+import type { TimeBlock } from '@/lib/types/event';
+import { TASKS_LAST_PATH_KEY } from './TasksPage';
+
+interface DaySection {
+  dateKey: string;
+  label: string;
+  blocks: TimeBlock[];
+}
+
+function formatDateLabel(date: Date): string {
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  if (date.toDateString() === today.toDateString()) return '今日';
+  if (date.toDateString() === yesterday.toDateString()) return '昨日';
+
+  return `${date.getMonth() + 1}月${date.getDate()}日`;
+}
+
+function formatTime(timestamp: number): string {
+  const d = new Date(timestamp);
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+
+function formatDuration(startTime: number, endTime: number): string {
+  const diffMs = endTime - startTime;
+  const minutes = Math.round(diffMs / 60000);
+  if (minutes < 60) return `${minutes}min`;
+  const hours = Math.floor(minutes / 60);
+  const remaining = minutes % 60;
+  return remaining > 0 ? `${hours}h${remaining}min` : `${hours}h`;
+}
+
+function getDayRange(date: Date): { start: number; end: number } {
+  const start = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+  return { start, end: start + 86_400_000 };
+}
+
+export function TaskTimeblocksPage() {
+  const [allBlocks, setAllBlocks] = useState<TimeBlock[]>([]);
+  const [loadedDays, setLoadedDays] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  // Persist path for route memory
+  useEffect(() => {
+    sessionStorage.setItem(TASKS_LAST_PATH_KEY, '/tasks/timeblocks');
+  }, []);
+
+  // Load all blocks once, then slice by day count
+  useEffect(() => {
+    let disposed = false;
+    const load = async () => {
+      setIsLoading(true);
+      const blocks = await getTimeBlockService().loadTimeBlocks();
+      if (!disposed) {
+        setAllBlocks(blocks);
+        setIsLoading(false);
+      }
+    };
+    void load();
+    return () => { disposed = true; };
+  }, []);
+
+  // Compute visible sections based on loadedDays
+  const daySections: DaySection[] = (() => {
+    const today = new Date();
+    const sections: DaySection[] = [];
+
+    for (let i = 0; i < loadedDays; i++) {
+      const date = new Date(today);
+      date.setDate(date.getDate() - i);
+      const { start, end } = getDayRange(date);
+      const dayBlocks = allBlocks.filter((b) => b.startTime >= start && b.startTime < end);
+      sections.push({
+        dateKey: date.toDateString(),
+        label: formatDateLabel(date),
+        blocks: dayBlocks.sort((a, b) => b.endTime - a.endTime),
+      });
+    }
+
+    return sections;
+  })();
+
+  // Infinite scroll: load more days when sentinel enters viewport
+  const loadMore = useCallback(() => {
+    setLoadedDays((prev) => {
+      const next = prev + 1;
+      // Stop after 90 days
+      if (next > 90) {
+        setHasMore(false);
+        return prev;
+      }
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!hasMore || isLoading) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          loadMore();
+        }
+      },
+      { rootMargin: '200px' },
+    );
+
+    const sentinel = sentinelRef.current;
+    if (sentinel) observer.observe(sentinel);
+
+    return () => observer.disconnect();
+  }, [hasMore, isLoading, loadMore]);
+
+  return (
+    <div className="flex h-full min-h-full flex-col bg-[#FAF7F5] dark:bg-[#0C0A09]" data-testid="task-timeblocks-page">
+      <header className="flex items-center justify-between border-b border-[#F0ECE8] px-5 py-3 dark:border-[#292524] md:px-8 lg:px-10">
+        <div className="inline-flex select-none items-center gap-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
+          <Link
+            to="/tasks"
+            onClick={() => sessionStorage.removeItem(TASKS_LAST_PATH_KEY)}
+            className="inline-flex items-center gap-1 hover:text-[#1C1917] dark:hover:text-[#FAFAF9]"
+          >
+            <ArrowLeft size={14} />
+            任务
+          </Link>
+          <span>/</span>
+          <span className="inline-flex items-center gap-1">
+            <Clock size={14} />
+            时间块
+          </span>
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 pt-3 pb-24 md:px-8 lg:px-10">
+        {isLoading ? (
+          <p className="text-sm text-[#A8A29E]">加载中...</p>
+        ) : (
+          <div className="space-y-6">
+            {daySections.map((section) => (
+              <div key={section.dateKey}>
+                <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{section.label}</p>
+                {section.blocks.length > 0 ? (
+                  <div className="mt-2 space-y-2">
+                    {section.blocks.map((block) => (
+                      <Link
+                        key={block.id}
+                        to="/tasks/block/$blockId"
+                        params={{ blockId: block.startId ?? block.id }}
+                        search={{ from: 'timeblocks' }}
+                        className="block"
+                      >
+                        <article className="overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white transition-colors hover:bg-[#FAF7F5] dark:border-[#292524] dark:bg-[#1C1917] dark:hover:bg-[#292524]">
+                          <div className="flex">
+                            <div className="w-1 shrink-0 self-stretch bg-[#C75B3A]" />
+                            <div className="min-w-0 flex-1 px-4 py-3">
+                              <p className="text-[11px] font-medium text-[#A8A29E]">
+                                {formatTime(block.startTime)} — {formatTime(block.endTime)}
+                              </p>
+                              <p className="mt-1 text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{block.name}</p>
+                              <div className="mt-1 flex items-center gap-2 text-xs text-[#A8A29E]">
+                                <span>{formatDuration(block.startTime, block.endTime)}</span>
+                              </div>
+                              {block.note ? (
+                                <p className="mt-1 text-[11px] text-[#78716C] dark:text-[#A8A29E]">
+                                  {`💬 "${block.note}"`}
+                                </p>
+                              ) : null}
+                            </div>
+                          </div>
+                        </article>
+                      </Link>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="mt-2 text-xs text-[#A8A29E]">无时间块</p>
+                )}
+              </div>
+            ))}
+
+            {/* Infinite scroll sentinel */}
+            {hasMore && (
+              <div ref={sentinelRef} className="py-4 text-center text-xs text-[#A8A29E]">
+                加载更多...
+              </div>
+            )}
+            {!hasMore && (
+              <p className="py-4 text-center text-xs text-[#A8A29E]">已加载全部历史</p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/app/pages/TaskTimeblocksPage.tsx
+++ b/src/ui/app/pages/TaskTimeblocksPage.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from '@tanstack/react-router';
 import { getTimeBlockService } from '@/lib/services';
 import type { TimeBlock } from '@/lib/types/event';
-import { TASKS_LAST_PATH_KEY } from './TasksPage';
+import { TASKS_LAST_PATH_KEY, buildTasksMainSearch } from './task-route-memory';
 
 interface DaySection {
   dateKey: string;
@@ -125,6 +125,7 @@ export function TaskTimeblocksPage() {
         <div className="inline-flex select-none items-center gap-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
           <Link
             to="/tasks"
+            search={buildTasksMainSearch()}
             onClick={() => sessionStorage.removeItem(TASKS_LAST_PATH_KEY)}
             className="inline-flex items-center gap-1 hover:text-[#1C1917] dark:hover:text-[#FAFAF9]"
           >

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -1,25 +1,14 @@
-﻿import { SlidersHorizontal, Waypoints } from 'lucide-react';
+﻿import { Clock, Waypoints } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useLocation } from '@tanstack/react-router';
-import { getTaskService, getTimeBlockService } from '@/lib/services';
+import { Link } from '@tanstack/react-router';
+import { getTaskService } from '@/lib/services';
 import type { TaskNode } from '@/lib/types/task';
-import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
 import { PageMoreMenu } from '@/ui/app/components/PageMoreMenu';
 import { NowInputRow } from '@/ui/app/components/NowInputRow';
 import type { VoiceMessageInputHandle } from '@/components/VoiceMessageInput';
-import { filterMonth, filterNow, filterToday, filterWeek } from './task-tab-filters';
-import { buildTasksTodayViewModel } from './tasks-today-view';
+import { filterNow } from './task-tab-filters';
 import { buildTaskGraph } from '@/lib/task/task-dag-graph';
 import { TaskCurrentRootCard } from '@/ui/app/components/TaskCurrentRootCard';
-
-type TaskTab = 'now' | 'today' | 'week' | 'month';
-
-const TAB_ITEMS: Array<{ id: TaskTab; label: string }> = [
-  { id: 'now', label: '当下' },
-  { id: 'today', label: '今日' },
-  { id: 'week', label: '一周' },
-  { id: 'month', label: '月' },
-];
 
 const STATUS_DOT: Record<string, string> = {
   pending: 'bg-[#A8A29E]',
@@ -37,29 +26,10 @@ const STATUS_LABEL: Record<string, string> = {
   cancelled: '已取消',
 };
 
-const TAB_EMPTY_TEXT: Record<TaskTab, string> = {
-  now: '当前没有进行中的任务，开始一个吧。',
-  today: '今天没有待处理的任务。',
-  week: '本周没有截止的任务。',
-  month: '本月没有截止的任务。',
-};
+const EMPTY_TEXT = '当前没有进行中的任务，开始一个吧。';
 
 function formatTaskMeta(task: TaskNode): string {
   return task.estimatedMinutes ? `预计 ${task.estimatedMinutes}min` : '未估时';
-}
-
-function formatTaskMetaCompact(task: TaskNode): string {
-  if (!task.estimatedMinutes) {
-    return '未估时';
-  }
-  if (task.estimatedMinutes % 60 === 0) {
-    return `预计 ${task.estimatedMinutes / 60}h`;
-  }
-  return `预计 ${task.estimatedMinutes}min`;
-}
-
-function formatSpentMeta(task: TaskNode): string {
-  return `${formatTaskMetaCompact(task)} · ${task.status === 'in_progress' ? '进行中' : '待开始'}`;
 }
 
 function CurrentRootBadge({
@@ -83,77 +53,11 @@ function CurrentRootBadge({
   );
 }
 
-function resolveToneClasses(tone: 'green' | 'orange' | 'blue' | 'red' | 'stone'): {
-  rail: string;
-  tag: string;
-  dot: string;
-  actual: string;
-} {
-  if (tone === 'green') {
-    return {
-      rail: 'bg-[#16A34A]',
-      tag: 'bg-[#DCFCE7] text-[#15803D]',
-      dot: 'bg-[#16A34A]',
-      actual: 'text-[#15803D]',
-    };
-  }
-  if (tone === 'blue') {
-    return {
-      rail: 'bg-[#3B82F6]',
-      tag: 'bg-[#EFF6FF] text-[#2563EB]',
-      dot: 'bg-[#3B82F6]',
-      actual: 'text-[#2563EB]',
-    };
-  }
-  if (tone === 'red') {
-    return {
-      rail: 'bg-[#E7000B]',
-      tag: 'bg-[#FEE2E2] text-[#DC2626]',
-      dot: 'bg-[#E7000B]',
-      actual: 'text-[#DC2626]',
-    };
-  }
-  if (tone === 'orange') {
-    return {
-      rail: 'bg-[#C75B3A]',
-      tag: 'bg-[#FFF7ED] text-[#C75B3A]',
-      dot: 'bg-[#C75B3A]',
-      actual: 'text-[#C75B3A]',
-    };
-  }
-  return {
-    rail: 'bg-[#78716C]',
-    tag: 'bg-[#F5F0ED] text-[#78716C]',
-    dot: 'bg-[#78716C]',
-    actual: 'text-[#57534E]',
-  };
-}
-
-function resolveInitialTaskTab(): TaskTab {
-  if (typeof window === 'undefined') {
-    return 'now';
-  }
-
-  const urlTab = new URLSearchParams(window.location.search).get('tab');
-  if (urlTab && TAB_ITEMS.some((t) => t.id === urlTab)) {
-    return urlTab as TaskTab;
-  }
-
-  return 'now';
-}
-
 export const TASKS_LAST_PATH_KEY = 'exomind:last-tasks-path';
 
 export function TasksPage() {
-  const location = useLocation();
-  const [activeTab, setActiveTab] = useState<TaskTab>(() => resolveInitialTaskTab());
   const [tasks, setTasks] = useState<TaskNode[]>([]);
-  const [timeBlocks, setTimeBlocks] = useState<TimeBlock[]>([]);
-  const [activeBlock, setActiveBlock] = useState<ActiveBlockData | null>(null);
   const inputRef = useRef<VoiceMessageInputHandle>(null);
-
-  // Note: do NOT clear sessionStorage here — the /tasks route's redirect
-  // reads it before this component mounts. Clearing would race with redirect.
 
   // Auto-focus input on Enter key when nothing is focused
   useEffect(() => {
@@ -170,54 +74,28 @@ export function TasksPage() {
   useEffect(() => {
     let disposed = false;
     const svc = getTaskService();
-    const timeBlockService = getTimeBlockService();
     const load = async () => {
-      const [list, blocks, nextActiveBlock] = await Promise.all([
-        svc.listTasks(true),
-        timeBlockService.loadTimeBlocks(),
-        timeBlockService.loadActiveBlock(),
-      ]);
+      const list = await svc.listTasks(true);
       if (!disposed) {
         setTasks(list);
-        setTimeBlocks(blocks);
-        setActiveBlock(nextActiveBlock);
       }
     };
     void load();
 
-    // Refresh list when remote sync delivers changes
     const unsubscribe = svc.onTaskChange(() => {
-      void load();
-    });
-    const unsubscribeBlocks = timeBlockService.onBlockChange(() => {
       void load();
     });
 
     return () => {
       disposed = true;
       unsubscribe();
-      unsubscribeBlocks();
     };
   }, []);
 
   const taskGraph = useMemo(() => buildTaskGraph(tasks), [tasks]);
   const taskById = useMemo(() => new Map(tasks.map((task) => [task.id, task])), [tasks]);
 
-  const visibleTasks = useMemo(() => {
-    const now = new Date();
-    if (activeTab === 'now') return filterNow(tasks, taskGraph);
-    if (activeTab === 'today') return filterToday(tasks, now);
-    if (activeTab === 'week') return filterWeek(tasks, now);
-    if (activeTab === 'month') return filterMonth(tasks, now);
-    return tasks;
-  }, [activeTab, tasks, taskGraph]);
-
-  const todayViewModel = useMemo(() => buildTasksTodayViewModel({
-    tasks: visibleTasks,
-    blocks: timeBlocks,
-    now: new Date(),
-    activeBlock,
-  }), [activeBlock, timeBlocks, visibleTasks]);
+  const visibleTasks = useMemo(() => filterNow(tasks, taskGraph), [tasks, taskGraph]);
 
   const handleQuickAdd = useCallback(async (content: string) => {
     const lines = content.trim().split('\n');
@@ -238,153 +116,28 @@ export function TasksPage() {
         <h1 className="text-lg font-semibold text-[#1C1917] dark:text-[#FAFAF9]">任务</h1>
         <div className="flex items-center gap-2">
           <Link
+            to="/tasks/timeblocks"
+            className="inline-flex items-center gap-1 rounded-full border border-[#E7E5E4] px-3 py-2 text-xs font-semibold text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
+          >
+            <Clock size={16} />
+            <span className="hidden md:inline">时间块</span>
+          </Link>
+          <Link
             to="/tasks/dag"
             className="inline-flex items-center gap-1 rounded-full border border-[#E7E5E4] px-3 py-2 text-xs font-semibold text-[#57534E] dark:border-[#292524] dark:text-[#D6D3D1]"
           >
             <Waypoints size={16} />
             <span className="hidden md:inline">DAG</span>
           </Link>
-          <button type="button" className="flex h-9 w-9 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]">
-            <SlidersHorizontal size={18} />
-          </button>
           <PageMoreMenu />
         </div>
       </header>
 
       <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-[calc(env(safe-area-inset-bottom,0px)+108px)] pt-3 md:px-8 md:pb-24 lg:px-10">
-        <div className="mb-4 flex gap-1 overflow-x-auto pb-1">
-          {TAB_ITEMS.map((tab) => {
-            const active = tab.id === activeTab;
-            return (
-              <button
-                key={tab.id}
-                type="button"
-                onClick={() => setActiveTab(tab.id)}
-                className={`shrink-0 rounded-2xl px-4 py-1.5 text-[13px] ${
-                  active ? 'bg-[#C75B3A] font-semibold text-white' : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'
-                }`}
-              >
-                {tab.label}
-              </button>
-            );
-          })}
-        </div>
+        <TaskCurrentRootCard graph={taskGraph} taskById={taskById} className="mb-4" />
 
-        {activeTab === 'now' && (
-          <TaskCurrentRootCard graph={taskGraph} taskById={taskById} className="mb-4" />
-        )}
-
-        {activeTab === 'today' ? (
-          <div className="space-y-4">
-            {todayViewModel.inProgressCount > 0 ? (
-              <section className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <span className="h-2 w-2 rounded-full bg-[#C75B3A]" />
-                  <p className="text-[13px] font-semibold text-[#1C1917] dark:text-[#FAFAF9]">进行中</p>
-                  <span className="text-[13px] text-[#A8A29E]">{todayViewModel.inProgressCount}</span>
-                </div>
-                <div className="space-y-2">
-                  {todayViewModel.inProgressTasks.map((task) => (
-                    <Link key={task.id} to="/tasks/$taskId" params={{ taskId: task.id }} className="block">
-                      <article className="rounded-2xl border border-[#E7E5E4] bg-white px-4 py-3 dark:border-[#292524] dark:bg-[#1C1917]">
-                        <div className="flex items-start gap-3">
-                          <div className="mt-1 h-5 w-5 rounded-full border-2 border-[#C75B3A]" />
-                          <div className="min-w-0 flex-1">
-                            <div className="flex flex-wrap items-center gap-2">
-                              <p className="text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{task.title}</p>
-                              <CurrentRootBadge taskId={task.id} currentRootNodeId={taskGraph.currentRootNodeId} />
-                            </div>
-                            {task.description && (
-                              <p className="mt-1 line-clamp-2 text-xs text-[#78716C] dark:text-[#A8A29E]">{task.description.slice(0, 100)}</p>
-                            )}
-                            <p className="mt-1 text-xs text-[#A8A29E]">{formatSpentMeta(task)}</p>
-                          </div>
-                        </div>
-                      </article>
-                    </Link>
-                  ))}
-                </div>
-              </section>
-            ) : null}
-
-            {todayViewModel.timelineSections.length > 0 ? (
-              <>
-                <div className="h-px w-full bg-[#E7E5E4] dark:bg-[#292524]" />
-                <section className="space-y-5">
-                  {todayViewModel.timelineSections.map((section) => (
-                    <div key={section.id} className="space-y-2.5">
-                      <div className="flex items-center justify-between gap-3">
-                        <div className="flex items-center gap-2">
-                          <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{section.label}</p>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <p className="text-xs text-[#A8A29E]">{section.rangeLabel}</p>
-                          <span className="rounded-full bg-[#F5F0ED] px-2 py-0.5 text-[11px] font-medium text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]">
-                            {section.durationLabel}
-                          </span>
-                        </div>
-                      </div>
-
-                      <div className="space-y-2">
-                        {section.items.map((item) => {
-                          const tone = resolveToneClasses(item.tone);
-                          return (
-                            <Link
-                              key={item.id}
-                              to="/tasks/block/$blockId"
-                              params={{ blockId: item.blockId }}
-                              search={{ from: activeTab }}
-                              data-testid={`tasks-today-block-link-${item.blockId}`}
-                              className="block"
-                            >
-                              <article className="overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white transition-colors hover:bg-[#FAF7F5] dark:border-[#292524] dark:bg-[#1C1917] dark:hover:bg-[#292524]">
-                                <div className="flex">
-                                  <div className={`w-1 shrink-0 self-stretch ${tone.rail}`} />
-                                  <div className="min-w-0 flex-1 px-4 py-3">
-                                    <p className="text-[11px] font-medium text-[#A8A29E]">{item.timeLabel}</p>
-                                    <div className={`mt-1 inline-flex rounded-full px-2 py-0.5 text-[10px] font-semibold ${tone.tag}`}>
-                                      {item.tagLabel}
-                                    </div>
-                                    {item.planText ? (
-                                      <div className="mt-2 flex items-center gap-2 text-xs text-[#A8A29E]">
-                                        <span className="h-1.5 w-1.5 rounded-full bg-[#D6D3D1]" />
-                                        <span>计划: {item.planText}</span>
-                                      </div>
-                                    ) : null}
-                                    <div className={`mt-2 flex items-center gap-2 text-xs font-medium ${tone.actual}`}>
-                                      <span className={`h-1.5 w-1.5 rounded-full ${tone.dot}`} />
-                                      <span>实际: {item.actualText}</span>
-                                    </div>
-                                    <p className="mt-1 text-sm text-[#1C1917] dark:text-[#FAFAF9]">{item.title}</p>
-                                    <p className="mt-1 text-[11px] text-[#78716C] dark:text-[#A8A29E]">{item.meta}</p>
-                                    {item.note ? (
-                                      <p className="mt-1 text-[11px] text-[#78716C] dark:text-[#A8A29E]">
-                                        {`💬 "${item.note}"`}
-                                      </p>
-                                    ) : null}
-                                  </div>
-                                </div>
-                              </article>
-                            </Link>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  ))}
-                </section>
-              </>
-            ) : todayViewModel.inProgressCount === 0 ? (
-              <p
-                data-testid="tasks-tab-empty"
-                className="rounded-2xl border border-dashed border-[#D6D3D1] bg-[#FAF7F5] px-4 py-5 text-center text-sm text-[#A8A29E] dark:border-[#3A3432] dark:bg-[#1C1917] dark:text-[#B8B1AC]"
-              >
-                {TAB_EMPTY_TEXT.today}
-              </p>
-            ) : null}
-          </div>
-        ) : (
-          <div className="space-y-3">
-            {visibleTasks.length > 0 ? (
+        <div className="space-y-3">
+          {visibleTasks.length > 0 ? (
             visibleTasks.map((task) => (
               <Link key={task.id} to="/tasks/$taskId" params={{ taskId: task.id }} className="block">
                 <article className="flex overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white dark:border-[#292524] dark:bg-[#1C1917]">
@@ -415,11 +168,10 @@ export function TasksPage() {
               data-testid="tasks-tab-empty"
               className="rounded-2xl border border-dashed border-[#D6D3D1] bg-[#FAF7F5] px-4 py-5 text-center text-sm text-[#A8A29E] dark:border-[#3A3432] dark:bg-[#1C1917] dark:text-[#B8B1AC]"
             >
-              {TAB_EMPTY_TEXT[activeTab]}
+              {EMPTY_TEXT}
             </p>
           )}
-          </div>
-        )}
+        </div>
       </div>
 
       <NowInputRow

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -158,6 +158,18 @@ export function TasksPage() {
     sessionStorage.setItem(TASKS_LAST_PATH_KEY, fullPath);
   }, [location.pathname, location.searchStr]);
 
+  // Auto-focus input on Enter key when nothing is focused
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' && document.activeElement === document.body) {
+        e.preventDefault();
+        inputRef.current?.focusText();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
   useEffect(() => {
     let disposed = false;
     const svc = getTaskService();

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -1,6 +1,6 @@
 import { Clock, Waypoints } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Link } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { getTaskService } from '@/lib/services';
 import type { TaskNode } from '@/lib/types/task';
 import { PageMoreMenu } from '@/ui/app/components/PageMoreMenu';
@@ -13,6 +13,10 @@ import {
   getTaskPageFuzzySearchEnabled,
   subscribeTaskPageFuzzySearchChanges,
 } from '@/config/task-page-fuzzy-search';
+import {
+  getTaskCreateSuccessAction,
+  subscribeTaskCreateSuccessActionChanges,
+} from '@/config/task-create-success-action';
 import {
   extractTaskTitleSearchQuery,
   filterTasksByTitleFuzzySearch,
@@ -69,7 +73,9 @@ export function TasksPage() {
   const [quickAddValue, setQuickAddValue] = useState('');
   const [debouncedQuickAddValue, setDebouncedQuickAddValue] = useState('');
   const [taskPageFuzzySearchEnabled, setTaskPageFuzzySearchEnabled] = useState<boolean>(() => getTaskPageFuzzySearchEnabled());
+  const [taskCreateSuccessAction, setTaskCreateSuccessAction] = useState(() => getTaskCreateSuccessAction());
   const inputRef = useRef<VoiceMessageInputHandle>(null);
+  const navigate = useNavigate();
 
   // Auto-focus input on Enter key when nothing is focused
   useEffect(() => {
@@ -109,6 +115,7 @@ export function TasksPage() {
   const taskTitleSearchQuery = useMemo(() => extractTaskTitleSearchQuery(debouncedQuickAddValue), [debouncedQuickAddValue]);
 
   useEffect(() => subscribeTaskPageFuzzySearchChanges(setTaskPageFuzzySearchEnabled), []);
+  useEffect(() => subscribeTaskCreateSuccessActionChanges(setTaskCreateSuccessAction), []);
 
   useEffect(() => {
     if (!taskPageFuzzySearchEnabled) {
@@ -144,7 +151,13 @@ export function TasksPage() {
       description,
     });
     setTasks((prev) => [created, ...prev]);
-  }, []);
+    if (taskCreateSuccessAction === 'open-detail') {
+      await navigate({
+        to: '/tasks/$taskId',
+        params: { taskId: created.id },
+      });
+    }
+  }, [navigate, taskCreateSuccessAction]);
 
   const emptyText = taskPageFuzzySearchEnabled && taskTitleSearchQuery ? EMPTY_SEARCH_TEXT : EMPTY_TEXT;
 

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -171,7 +171,13 @@ export function TasksPage() {
       </header>
 
       <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-[calc(env(safe-area-inset-bottom,0px)+108px)] pt-3 md:px-8 md:pb-24 lg:px-10">
-        <TaskCurrentRootCard graph={taskGraph} taskById={taskById} className="mb-4" />
+        <TaskCurrentRootCard
+          graph={taskGraph}
+          taskById={taskById}
+          className="mb-4"
+          searchQuery={taskPageFuzzySearchEnabled ? taskTitleSearchQuery : ''}
+          collapsible={true}
+        />
 
         <div className="space-y-3">
           {visibleTasks.length > 0 ? (

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -10,7 +10,6 @@ import { NowInputRow } from '@/ui/app/components/NowInputRow';
 import type { VoiceMessageInputHandle } from '@/components/VoiceMessageInput';
 import { filterMonth, filterNow, filterToday, filterWeek } from './task-tab-filters';
 import { buildTasksTodayViewModel } from './tasks-today-view';
-import { useIsDesktop } from '@/ui/app/hooks/useIsDesktop';
 import { buildTaskGraph } from '@/lib/task/task-dag-graph';
 import { TaskCurrentRootCard } from '@/ui/app/components/TaskCurrentRootCard';
 
@@ -155,7 +154,6 @@ function resolveInitialTaskTab(): { tab: TaskTab; redirectDag: boolean } {
 }
 
 export function TasksPage() {
-  const isDesktop = useIsDesktop();
   const navigate = useNavigate();
   const [initialResolution] = useState(() => resolveInitialTaskTab());
   const [activeTab, setActiveTab] = useState<TaskTab>(initialResolution.tab);
@@ -417,13 +415,11 @@ export function TasksPage() {
         )}
       </div>
 
-      <div className={`sticky px-4 pb-2 md:px-8 lg:px-10 ${isDesktop ? 'bottom-4' : 'bottom-[calc(env(safe-area-inset-bottom,0px)+62px)]'}`}>
-        <NowInputRow
-          ref={inputRef}
-          onSend={handleQuickAdd}
-          placeholder="添加新任务..."
-        />
-      </div>
+      <NowInputRow
+        ref={inputRef}
+        onSend={handleQuickAdd}
+        placeholder="添加新任务..."
+      />
     </div>
   );
 }

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -1,4 +1,4 @@
-﻿import { Plus, SlidersHorizontal, Waypoints } from 'lucide-react';
+﻿import { CornerDownLeft, Plus, SlidersHorizontal, Waypoints } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { getTaskService, getTimeBlockService } from '@/lib/services';
@@ -164,7 +164,21 @@ export function TasksPage() {
   const [quickInput, setQuickInput] = useState(() => {
     try { return localStorage.getItem(DRAFT_KEY) ?? ''; } catch { return ''; }
   });
-  const quickInputRef = useRef<HTMLInputElement>(null);
+  const quickInputRef = useRef<HTMLTextAreaElement>(null);
+
+  const SEND_MODE_KEY = 'exomind:task-input-send-mode';
+  type SendMode = 'enter' | 'ctrl-enter';
+  const [sendMode, setSendMode] = useState<SendMode>(() => {
+    try {
+      const stored = localStorage.getItem(SEND_MODE_KEY);
+      return stored === 'ctrl-enter' ? 'ctrl-enter' : 'enter';
+    } catch { return 'enter'; }
+  });
+  const toggleSendMode = () => {
+    const next: SendMode = sendMode === 'enter' ? 'ctrl-enter' : 'enter';
+    setSendMode(next);
+    try { localStorage.setItem(SEND_MODE_KEY, next); } catch { /* ignore */ }
+  };
 
   useEffect(() => {
     if (initialResolution.redirectDag) {
@@ -443,25 +457,38 @@ export function TasksPage() {
           </div>
         )}
         <div className="flex items-center gap-2 rounded-[24px] border border-[#E7E5E4] bg-white px-3 py-2 dark:border-[#292524] dark:bg-[#1C1917]">
-          <input
+          <textarea
             ref={quickInputRef}
             value={quickInput}
+            rows={1}
             onChange={(event) => handleQuickInputChange(event.target.value)}
             onKeyDown={(event) => {
-              if (event.key === 'Enter') {
+              if (sendMode === 'enter' && event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault();
+                void handleQuickAdd();
+              } else if (sendMode === 'ctrl-enter' && event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
                 event.preventDefault();
                 void handleQuickAdd();
               }
             }}
             placeholder="快速添加任务..."
-            className="flex-1 bg-transparent text-sm text-[#44403C] outline-none placeholder:text-[#A8A29E] dark:text-[#E7E5E4] dark:placeholder:text-[#78716C]"
+            className="max-h-20 flex-1 resize-none bg-transparent text-sm text-[#44403C] outline-none placeholder:text-[#A8A29E] dark:text-[#E7E5E4] dark:placeholder:text-[#78716C]"
           />
+          <button
+            type="button"
+            onClick={toggleSendMode}
+            title={sendMode === 'enter' ? '当前：Enter 发送（点击切换为 Ctrl+Enter）' : '当前：Ctrl+Enter 发送（点击切换为 Enter）'}
+            className="flex h-7 shrink-0 items-center gap-0.5 rounded-full px-1.5 text-[10px] font-medium text-[#A8A29E] transition-colors hover:bg-[#F5F0ED] hover:text-[#78716C] dark:hover:bg-[#292524] dark:hover:text-[#D6D3D1]"
+          >
+            <CornerDownLeft size={12} />
+            <span>{sendMode === 'enter' ? '↵' : '⌃↵'}</span>
+          </button>
           <button
             type="button"
             onClick={() => {
               void handleQuickAdd();
             }}
-            className="flex h-9 w-9 items-center justify-center rounded-full bg-[#C75B3A] text-white"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#C75B3A] text-white"
             aria-label="添加任务（Add Task）"
           >
             <Plus size={18} />

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -223,10 +223,13 @@ export function TasksPage() {
   const taskById = useMemo(() => new Map(tasks.map((task) => [task.id, task])), [tasks]);
 
   const handleQuickAdd = useCallback(async (content: string) => {
-    const title = content.trim();
+    const lines = content.trim().split('\n');
+    const title = lines[0].trim();
+    const description = lines.slice(1).join('\n').trim() || undefined;
     if (!title) return;
     const created = await getTaskService().createTask({
       title,
+      description,
       estimatedMinutes: 25,
     });
     setTasks((prev) => [created, ...prev]);

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -9,6 +9,14 @@ import type { VoiceMessageInputHandle } from '@/components/VoiceMessageInput';
 import { filterNow } from './task-tab-filters';
 import { buildTaskGraph } from '@/lib/task/task-dag-graph';
 import { TaskCurrentRootCard } from '@/ui/app/components/TaskCurrentRootCard';
+import {
+  getTaskPageFuzzySearchEnabled,
+  subscribeTaskPageFuzzySearchChanges,
+} from '@/config/task-page-fuzzy-search';
+import {
+  extractTaskTitleSearchQuery,
+  filterTasksByTitleFuzzySearch,
+} from './task-title-fuzzy-search';
 
 const STATUS_DOT: Record<string, string> = {
   pending: 'bg-[#A8A29E]',
@@ -27,7 +35,9 @@ const STATUS_LABEL: Record<string, string> = {
 };
 
 const EMPTY_TEXT = '当前没有进行中的任务，开始一个吧。';
+const EMPTY_SEARCH_TEXT = '没有匹配标题的任务，可继续输入后直接创建。';
 export const TASKS_QUICK_ADD_DRAFT_KEY = 'exomind:draft:task-quick-add';
+const TASKS_QUICK_ADD_SEARCH_DEBOUNCE_MS = 180;
 
 function formatTaskMeta(task: TaskNode): string {
   return task.estimatedMinutes ? `预计 ${task.estimatedMinutes}min` : '未估时';
@@ -56,6 +66,9 @@ function CurrentRootBadge({
 
 export function TasksPage() {
   const [tasks, setTasks] = useState<TaskNode[]>([]);
+  const [quickAddValue, setQuickAddValue] = useState('');
+  const [debouncedQuickAddValue, setDebouncedQuickAddValue] = useState('');
+  const [taskPageFuzzySearchEnabled, setTaskPageFuzzySearchEnabled] = useState<boolean>(() => getTaskPageFuzzySearchEnabled());
   const inputRef = useRef<VoiceMessageInputHandle>(null);
 
   // Auto-focus input on Enter key when nothing is focused
@@ -93,8 +106,32 @@ export function TasksPage() {
 
   const taskGraph = useMemo(() => buildTaskGraph(tasks), [tasks]);
   const taskById = useMemo(() => new Map(tasks.map((task) => [task.id, task])), [tasks]);
+  const taskTitleSearchQuery = useMemo(() => extractTaskTitleSearchQuery(debouncedQuickAddValue), [debouncedQuickAddValue]);
 
-  const visibleTasks = useMemo(() => filterNow(tasks, taskGraph), [tasks, taskGraph]);
+  useEffect(() => subscribeTaskPageFuzzySearchChanges(setTaskPageFuzzySearchEnabled), []);
+
+  useEffect(() => {
+    if (!taskPageFuzzySearchEnabled) {
+      setDebouncedQuickAddValue('');
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedQuickAddValue(quickAddValue);
+    }, TASKS_QUICK_ADD_SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [quickAddValue, taskPageFuzzySearchEnabled]);
+
+  const visibleTasks = useMemo(() => {
+    const baseTasks = filterNow(tasks, taskGraph);
+    if (!taskPageFuzzySearchEnabled) {
+      return baseTasks;
+    }
+    return filterTasksByTitleFuzzySearch(baseTasks, taskTitleSearchQuery);
+  }, [taskPageFuzzySearchEnabled, taskGraph, taskTitleSearchQuery, tasks]);
 
   const handleQuickAdd = useCallback(async (content: string) => {
     const lines = content.trim().split('\n');
@@ -107,6 +144,8 @@ export function TasksPage() {
     });
     setTasks((prev) => [created, ...prev]);
   }, []);
+
+  const emptyText = taskPageFuzzySearchEnabled && taskTitleSearchQuery ? EMPTY_SEARCH_TEXT : EMPTY_TEXT;
 
   return (
     <div className="flex h-full min-h-full flex-col bg-[#FAF7F5] dark:bg-[#0C0A09]" data-testid="new-tasks-page">
@@ -137,7 +176,13 @@ export function TasksPage() {
         <div className="space-y-3">
           {visibleTasks.length > 0 ? (
             visibleTasks.map((task) => (
-              <Link key={task.id} to="/tasks/$taskId" params={{ taskId: task.id }} className="block">
+              <Link
+                key={task.id}
+                to="/tasks/$taskId"
+                params={{ taskId: task.id }}
+                className="block"
+                data-testid={`tasks-page-task-link-${task.id}`}
+              >
                 <article className="flex overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white dark:border-[#292524] dark:bg-[#1C1917]">
                   <div className={`w-[3px] shrink-0 self-stretch ${STATUS_DOT[task.status] ?? 'bg-[#A8A29E]'}`} />
                   <div className="flex-1 px-4 py-3">
@@ -166,7 +211,7 @@ export function TasksPage() {
               data-testid="tasks-tab-empty"
               className="rounded-2xl border border-dashed border-[#D6D3D1] bg-[#FAF7F5] px-4 py-5 text-center text-sm text-[#A8A29E] dark:border-[#3A3432] dark:bg-[#1C1917] dark:text-[#B8B1AC]"
             >
-              {EMPTY_TEXT}
+              {emptyText}
             </p>
           )}
         </div>
@@ -175,6 +220,7 @@ export function TasksPage() {
       <NowInputRow
         ref={inputRef}
         onSend={handleQuickAdd}
+        onValueChange={setQuickAddValue}
         placeholder="添加任务与描述..."
         draftStorageKey={TASKS_QUICK_ADD_DRAFT_KEY}
       />

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -1,4 +1,4 @@
-﻿import { Clock, Waypoints } from 'lucide-react';
+import { Clock, Waypoints } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from '@tanstack/react-router';
 import { getTaskService } from '@/lib/services';
@@ -27,6 +27,7 @@ const STATUS_LABEL: Record<string, string> = {
 };
 
 const EMPTY_TEXT = '当前没有进行中的任务，开始一个吧。';
+export const TASKS_QUICK_ADD_DRAFT_KEY = 'exomind:draft:task-quick-add';
 
 function formatTaskMeta(task: TaskNode): string {
   return task.estimatedMinutes ? `预计 ${task.estimatedMinutes}min` : '未估时';
@@ -105,7 +106,6 @@ export function TasksPage() {
     const created = await getTaskService().createTask({
       title,
       description,
-      estimatedMinutes: 25,
     });
     setTasks((prev) => [created, ...prev]);
   }, []);
@@ -178,6 +178,7 @@ export function TasksPage() {
         ref={inputRef}
         onSend={handleQuickAdd}
         placeholder="添加任务与描述..."
+        draftStorageKey={TASKS_QUICK_ADD_DRAFT_KEY}
       />
     </div>
   );

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -54,8 +54,6 @@ function CurrentRootBadge({
   );
 }
 
-export const TASKS_LAST_PATH_KEY = 'exomind:last-tasks-path';
-
 export function TasksPage() {
   const [tasks, setTasks] = useState<TaskNode[]>([]);
   const inputRef = useRef<VoiceMessageInputHandle>(null);

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -224,6 +224,12 @@ export function TasksPage() {
   const taskGraph = useMemo(() => buildTaskGraph(tasks), [tasks]);
   const taskById = useMemo(() => new Map(tasks.map((task) => [task.id, task])), [tasks]);
 
+  const duplicateCandidates = useMemo(() => {
+    const q = quickInput.toLowerCase().trim();
+    if (q.length < 2) return [];
+    return tasks.filter((t) => t.title.toLowerCase().includes(q));
+  }, [quickInput, tasks]);
+
   const handleQuickInputChange = (value: string) => {
     setQuickInput(value);
     try { localStorage.setItem(DRAFT_KEY, value); } catch { /* ignore */ }
@@ -428,6 +434,14 @@ export function TasksPage() {
       </div>
 
       <div className={`sticky px-4 pb-2 md:px-8 lg:px-10 ${isDesktop ? 'bottom-4' : 'bottom-[calc(env(safe-area-inset-bottom,0px)+62px)]'}`}>
+        {duplicateCandidates.length > 0 && (
+          <div className="mx-4 mb-2 rounded-lg border border-amber-200 bg-amber-50 p-2 text-xs text-amber-700 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300">
+            <span className="font-medium">可能重复：</span>
+            {duplicateCandidates.slice(0, 3).map(t => (
+              <span key={t.id} className="ml-1">「{t.title}」</span>
+            ))}
+          </div>
+        )}
         <div className="flex items-center gap-2 rounded-[24px] border border-[#E7E5E4] bg-white px-3 py-2 dark:border-[#292524] dark:bg-[#1C1917]">
           <input
             ref={quickInputRef}

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -203,7 +203,7 @@ export function TasksPage() {
 
   const visibleTasks = useMemo(() => {
     const now = new Date();
-    if (activeTab === 'now') return filterNow(tasks);
+    if (activeTab === 'now') return filterNow(tasks, taskGraph);
     if (activeTab === 'today') return filterToday(tasks, now);
     if (activeTab === 'week') return filterWeek(tasks, now);
     if (activeTab === 'month') return filterMonth(tasks, now);

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -160,7 +160,10 @@ export function TasksPage() {
   const [tasks, setTasks] = useState<TaskNode[]>([]);
   const [timeBlocks, setTimeBlocks] = useState<TimeBlock[]>([]);
   const [activeBlock, setActiveBlock] = useState<ActiveBlockData | null>(null);
-  const [quickInput, setQuickInput] = useState('');
+  const DRAFT_KEY = 'exomind:task-quick-add-draft';
+  const [quickInput, setQuickInput] = useState(() => {
+    try { return localStorage.getItem(DRAFT_KEY) ?? ''; } catch { return ''; }
+  });
   const quickInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -221,6 +224,11 @@ export function TasksPage() {
   const taskGraph = useMemo(() => buildTaskGraph(tasks), [tasks]);
   const taskById = useMemo(() => new Map(tasks.map((task) => [task.id, task])), [tasks]);
 
+  const handleQuickInputChange = (value: string) => {
+    setQuickInput(value);
+    try { localStorage.setItem(DRAFT_KEY, value); } catch { /* ignore */ }
+  };
+
   const handleQuickAdd = async () => {
     const title = quickInput.trim();
     if (!title) {
@@ -233,6 +241,8 @@ export function TasksPage() {
     });
     setTasks((prev) => [created, ...prev]);
     setQuickInput('');
+    try { localStorage.removeItem(DRAFT_KEY); } catch { /* ignore */ }
+    quickInputRef.current?.focus();
   };
 
   return (
@@ -422,7 +432,7 @@ export function TasksPage() {
           <input
             ref={quickInputRef}
             value={quickInput}
-            onChange={(event) => setQuickInput(event.target.value)}
+            onChange={(event) => handleQuickInputChange(event.target.value)}
             onKeyDown={(event) => {
               if (event.key === 'Enter') {
                 event.preventDefault();

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -1,6 +1,6 @@
 ﻿import { SlidersHorizontal, Waypoints } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { Link, useNavigate, useLocation } from '@tanstack/react-router';
 import { getTaskService, getTimeBlockService } from '@/lib/services';
 import type { TaskNode } from '@/lib/types/task';
 import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
@@ -153,14 +153,23 @@ function resolveInitialTaskTab(): { tab: TaskTab; redirectDag: boolean } {
   return { tab: 'now', redirectDag: false };
 }
 
+export const TASKS_LAST_PATH_KEY = 'exomind:last-tasks-path';
+
 export function TasksPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const [initialResolution] = useState(() => resolveInitialTaskTab());
   const [activeTab, setActiveTab] = useState<TaskTab>(initialResolution.tab);
   const [tasks, setTasks] = useState<TaskNode[]>([]);
   const [timeBlocks, setTimeBlocks] = useState<TimeBlock[]>([]);
   const [activeBlock, setActiveBlock] = useState<ActiveBlockData | null>(null);
   const inputRef = useRef<VoiceMessageInputHandle>(null);
+
+  // Persist current tasks sub-path for nav tab memory
+  useEffect(() => {
+    const fullPath = location.pathname + (location.searchStr || '');
+    sessionStorage.setItem(TASKS_LAST_PATH_KEY, fullPath);
+  }, [location.pathname, location.searchStr]);
 
   useEffect(() => {
     if (initialResolution.redirectDag) {

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -152,11 +152,8 @@ export function TasksPage() {
   const [activeBlock, setActiveBlock] = useState<ActiveBlockData | null>(null);
   const inputRef = useRef<VoiceMessageInputHandle>(null);
 
-  // Persist current tasks sub-path for nav tab memory
-  useEffect(() => {
-    const fullPath = location.pathname + (location.searchStr || '');
-    sessionStorage.setItem(TASKS_LAST_PATH_KEY, fullPath);
-  }, [location.pathname, location.searchStr]);
+  // Note: do NOT clear sessionStorage here — the /tasks route's redirect
+  // reads it before this component mounts. Clearing would race with redirect.
 
   // Auto-focus input on Enter key when nothing is focused
   useEffect(() => {

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -271,7 +271,9 @@ export function TasksPage() {
           })}
         </div>
 
-        <TaskCurrentRootCard graph={taskGraph} taskById={taskById} className="mb-4" />
+        {activeTab === 'now' && (
+          <TaskCurrentRootCard graph={taskGraph} taskById={taskById} className="mb-4" />
+        )}
 
         {activeTab === 'today' ? (
           <div className="space-y-4">

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -126,7 +126,8 @@ export function TasksPage() {
   }, [quickAddValue, taskPageFuzzySearchEnabled]);
 
   const visibleTasks = useMemo(() => {
-    const baseTasks = filterNow(tasks, taskGraph);
+    const isSearching = taskPageFuzzySearchEnabled && Boolean(taskTitleSearchQuery);
+    const baseTasks = isSearching ? tasks : filterNow(tasks, taskGraph);
     if (!taskPageFuzzySearchEnabled) {
       return baseTasks;
     }

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -201,6 +201,9 @@ export function TasksPage() {
     };
   }, []);
 
+  const taskGraph = useMemo(() => buildTaskGraph(tasks), [tasks]);
+  const taskById = useMemo(() => new Map(tasks.map((task) => [task.id, task])), [tasks]);
+
   const visibleTasks = useMemo(() => {
     const now = new Date();
     if (activeTab === 'now') return filterNow(tasks, taskGraph);
@@ -208,7 +211,7 @@ export function TasksPage() {
     if (activeTab === 'week') return filterWeek(tasks, now);
     if (activeTab === 'month') return filterMonth(tasks, now);
     return tasks;
-  }, [activeTab, tasks]);
+  }, [activeTab, tasks, taskGraph]);
 
   const todayViewModel = useMemo(() => buildTasksTodayViewModel({
     tasks: visibleTasks,
@@ -216,9 +219,6 @@ export function TasksPage() {
     now: new Date(),
     activeBlock,
   }), [activeBlock, timeBlocks, visibleTasks]);
-
-  const taskGraph = useMemo(() => buildTaskGraph(tasks), [tasks]);
-  const taskById = useMemo(() => new Map(tasks.map((task) => [task.id, task])), [tasks]);
 
   const handleQuickAdd = useCallback(async (content: string) => {
     const lines = content.trim().split('\n');

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -1,11 +1,13 @@
-﻿import { CornerDownLeft, Plus, SlidersHorizontal, Waypoints } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+﻿import { SlidersHorizontal, Waypoints } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { getTaskService, getTimeBlockService } from '@/lib/services';
 import type { TaskNode } from '@/lib/types/task';
 import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
 import { getTasksDefaultTab } from '@/config/tasks-default-tab';
 import { PageMoreMenu } from '@/ui/app/components/PageMoreMenu';
+import { NowInputRow } from '@/ui/app/components/NowInputRow';
+import type { VoiceMessageInputHandle } from '@/components/VoiceMessageInput';
 import { filterMonth, filterNow, filterToday, filterWeek } from './task-tab-filters';
 import { buildTasksTodayViewModel } from './tasks-today-view';
 import { useIsDesktop } from '@/ui/app/hooks/useIsDesktop';
@@ -160,25 +162,7 @@ export function TasksPage() {
   const [tasks, setTasks] = useState<TaskNode[]>([]);
   const [timeBlocks, setTimeBlocks] = useState<TimeBlock[]>([]);
   const [activeBlock, setActiveBlock] = useState<ActiveBlockData | null>(null);
-  const DRAFT_KEY = 'exomind:task-quick-add-draft';
-  const [quickInput, setQuickInput] = useState(() => {
-    try { return localStorage.getItem(DRAFT_KEY) ?? ''; } catch { return ''; }
-  });
-  const quickInputRef = useRef<HTMLTextAreaElement>(null);
-
-  const SEND_MODE_KEY = 'exomind:task-input-send-mode';
-  type SendMode = 'enter' | 'ctrl-enter';
-  const [sendMode, setSendMode] = useState<SendMode>(() => {
-    try {
-      const stored = localStorage.getItem(SEND_MODE_KEY);
-      return stored === 'ctrl-enter' ? 'ctrl-enter' : 'enter';
-    } catch { return 'enter'; }
-  });
-  const toggleSendMode = () => {
-    const next: SendMode = sendMode === 'enter' ? 'ctrl-enter' : 'enter';
-    setSendMode(next);
-    try { localStorage.setItem(SEND_MODE_KEY, next); } catch { /* ignore */ }
-  };
+  const inputRef = useRef<VoiceMessageInputHandle>(null);
 
   useEffect(() => {
     if (initialResolution.redirectDag) {
@@ -238,32 +222,15 @@ export function TasksPage() {
   const taskGraph = useMemo(() => buildTaskGraph(tasks), [tasks]);
   const taskById = useMemo(() => new Map(tasks.map((task) => [task.id, task])), [tasks]);
 
-  const duplicateCandidates = useMemo(() => {
-    const q = quickInput.toLowerCase().trim();
-    if (q.length < 2) return [];
-    return tasks.filter((t) => t.title.toLowerCase().includes(q));
-  }, [quickInput, tasks]);
-
-  const handleQuickInputChange = (value: string) => {
-    setQuickInput(value);
-    try { localStorage.setItem(DRAFT_KEY, value); } catch { /* ignore */ }
-  };
-
-  const handleQuickAdd = async () => {
-    const title = quickInput.trim();
-    if (!title) {
-      quickInputRef.current?.focus();
-      return;
-    }
+  const handleQuickAdd = useCallback(async (content: string) => {
+    const title = content.trim();
+    if (!title) return;
     const created = await getTaskService().createTask({
       title,
       estimatedMinutes: 25,
     });
     setTasks((prev) => [created, ...prev]);
-    setQuickInput('');
-    try { localStorage.removeItem(DRAFT_KEY); } catch { /* ignore */ }
-    quickInputRef.current?.focus();
-  };
+  }, []);
 
   return (
     <div className="flex h-full min-h-full flex-col bg-[#FAF7F5] dark:bg-[#0C0A09]" data-testid="new-tasks-page">
@@ -448,52 +415,11 @@ export function TasksPage() {
       </div>
 
       <div className={`sticky px-4 pb-2 md:px-8 lg:px-10 ${isDesktop ? 'bottom-4' : 'bottom-[calc(env(safe-area-inset-bottom,0px)+62px)]'}`}>
-        {duplicateCandidates.length > 0 && (
-          <div className="mx-4 mb-2 rounded-lg border border-amber-200 bg-amber-50 p-2 text-xs text-amber-700 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300">
-            <span className="font-medium">可能重复：</span>
-            {duplicateCandidates.slice(0, 3).map(t => (
-              <span key={t.id} className="ml-1">「{t.title}」</span>
-            ))}
-          </div>
-        )}
-        <div className="flex items-center gap-2 rounded-[24px] border border-[#E7E5E4] bg-white px-3 py-2 dark:border-[#292524] dark:bg-[#1C1917]">
-          <textarea
-            ref={quickInputRef}
-            value={quickInput}
-            rows={1}
-            onChange={(event) => handleQuickInputChange(event.target.value)}
-            onKeyDown={(event) => {
-              if (sendMode === 'enter' && event.key === 'Enter' && !event.shiftKey) {
-                event.preventDefault();
-                void handleQuickAdd();
-              } else if (sendMode === 'ctrl-enter' && event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
-                event.preventDefault();
-                void handleQuickAdd();
-              }
-            }}
-            placeholder="快速添加任务..."
-            className="max-h-20 flex-1 resize-none bg-transparent text-sm text-[#44403C] outline-none placeholder:text-[#A8A29E] dark:text-[#E7E5E4] dark:placeholder:text-[#78716C]"
-          />
-          <button
-            type="button"
-            onClick={toggleSendMode}
-            title={sendMode === 'enter' ? '当前：Enter 发送（点击切换为 Ctrl+Enter）' : '当前：Ctrl+Enter 发送（点击切换为 Enter）'}
-            className="flex h-7 shrink-0 items-center gap-0.5 rounded-full px-1.5 text-[10px] font-medium text-[#A8A29E] transition-colors hover:bg-[#F5F0ED] hover:text-[#78716C] dark:hover:bg-[#292524] dark:hover:text-[#D6D3D1]"
-          >
-            <CornerDownLeft size={12} />
-            <span>{sendMode === 'enter' ? '↵' : '⌃↵'}</span>
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              void handleQuickAdd();
-            }}
-            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#C75B3A] text-white"
-            aria-label="添加任务（Add Task）"
-          >
-            <Plus size={18} />
-          </button>
-        </div>
+        <NowInputRow
+          ref={inputRef}
+          onSend={handleQuickAdd}
+          placeholder="添加新任务..."
+        />
       </div>
     </div>
   );

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -293,6 +293,9 @@ export function TasksPage() {
                               <p className="text-sm font-medium text-[#1C1917] dark:text-[#FAFAF9]">{task.title}</p>
                               <CurrentRootBadge taskId={task.id} currentRootNodeId={taskGraph.currentRootNodeId} />
                             </div>
+                            {task.description && (
+                              <p className="mt-1 line-clamp-2 text-xs text-[#78716C] dark:text-[#A8A29E]">{task.description.slice(0, 100)}</p>
+                            )}
                             <p className="mt-1 text-xs text-[#A8A29E]">{formatSpentMeta(task)}</p>
                           </div>
                         </div>
@@ -398,6 +401,9 @@ export function TasksPage() {
                         </span>
                       </span>
                     </div>
+                    {task.description && (
+                      <p className="mt-1 line-clamp-2 text-xs text-[#78716C] dark:text-[#A8A29E]">{task.description.slice(0, 100)}</p>
+                    )}
                     <p className="mt-1 text-xs text-[#A8A29E]">{formatTaskMeta(task)}</p>
                   </div>
                 </article>

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -177,7 +177,7 @@ export function TasksPage() {
       <NowInputRow
         ref={inputRef}
         onSend={handleQuickAdd}
-        placeholder="添加新任务..."
+        placeholder="添加任务与描述..."
       />
     </div>
   );

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -1,10 +1,9 @@
 ﻿import { SlidersHorizontal, Waypoints } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useNavigate, useLocation } from '@tanstack/react-router';
+import { Link, useLocation } from '@tanstack/react-router';
 import { getTaskService, getTimeBlockService } from '@/lib/services';
 import type { TaskNode } from '@/lib/types/task';
 import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
-import { getTasksDefaultTab } from '@/config/tasks-default-tab';
 import { PageMoreMenu } from '@/ui/app/components/PageMoreMenu';
 import { NowInputRow } from '@/ui/app/components/NowInputRow';
 import type { VoiceMessageInputHandle } from '@/components/VoiceMessageInput';
@@ -130,36 +129,24 @@ function resolveToneClasses(tone: 'green' | 'orange' | 'blue' | 'red' | 'stone')
   };
 }
 
-function resolveInitialTaskTab(): { tab: TaskTab; redirectDag: boolean } {
-  const preferredTab = getTasksDefaultTab();
-
-  if (preferredTab === 'dag') {
-    return { tab: 'now', redirectDag: true };
-  }
-
-  if (preferredTab && TAB_ITEMS.some((t) => t.id === preferredTab)) {
-    return { tab: preferredTab as TaskTab, redirectDag: false };
-  }
-
+function resolveInitialTaskTab(): TaskTab {
   if (typeof window === 'undefined') {
-    return { tab: 'now', redirectDag: false };
+    return 'now';
   }
 
   const urlTab = new URLSearchParams(window.location.search).get('tab');
   if (urlTab && TAB_ITEMS.some((t) => t.id === urlTab)) {
-    return { tab: urlTab as TaskTab, redirectDag: false };
+    return urlTab as TaskTab;
   }
 
-  return { tab: 'now', redirectDag: false };
+  return 'now';
 }
 
 export const TASKS_LAST_PATH_KEY = 'exomind:last-tasks-path';
 
 export function TasksPage() {
-  const navigate = useNavigate();
   const location = useLocation();
-  const [initialResolution] = useState(() => resolveInitialTaskTab());
-  const [activeTab, setActiveTab] = useState<TaskTab>(initialResolution.tab);
+  const [activeTab, setActiveTab] = useState<TaskTab>(() => resolveInitialTaskTab());
   const [tasks, setTasks] = useState<TaskNode[]>([]);
   const [timeBlocks, setTimeBlocks] = useState<TimeBlock[]>([]);
   const [activeBlock, setActiveBlock] = useState<ActiveBlockData | null>(null);
@@ -170,12 +157,6 @@ export function TasksPage() {
     const fullPath = location.pathname + (location.searchStr || '');
     sessionStorage.setItem(TASKS_LAST_PATH_KEY, fullPath);
   }, [location.pathname, location.searchStr]);
-
-  useEffect(() => {
-    if (initialResolution.redirectDag) {
-      void navigate({ to: '/tasks/dag' });
-    }
-  }, [initialResolution.redirectDag, navigate]);
 
   useEffect(() => {
     let disposed = false;

--- a/src/ui/app/pages/TasksPage.tsx
+++ b/src/ui/app/pages/TasksPage.tsx
@@ -1,10 +1,10 @@
 ﻿import { Plus, SlidersHorizontal, Waypoints } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Link } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { getTaskService, getTimeBlockService } from '@/lib/services';
 import type { TaskNode } from '@/lib/types/task';
 import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
-import { consumeTasksDefaultTab } from '@/config/tasks-default-tab';
+import { getTasksDefaultTab } from '@/config/tasks-default-tab';
 import { PageMoreMenu } from '@/ui/app/components/PageMoreMenu';
 import { filterMonth, filterNow, filterToday, filterWeek } from './task-tab-filters';
 import { buildTasksTodayViewModel } from './tasks-today-view';
@@ -129,32 +129,45 @@ function resolveToneClasses(tone: 'green' | 'orange' | 'blue' | 'red' | 'stone')
   };
 }
 
-function resolveInitialTaskTab(): TaskTab {
-  const preferredTab = consumeTasksDefaultTab();
-  if (preferredTab && TAB_ITEMS.some((tab) => tab.id === preferredTab)) {
-    return preferredTab as TaskTab;
+function resolveInitialTaskTab(): { tab: TaskTab; redirectDag: boolean } {
+  const preferredTab = getTasksDefaultTab();
+
+  if (preferredTab === 'dag') {
+    return { tab: 'now', redirectDag: true };
+  }
+
+  if (preferredTab && TAB_ITEMS.some((t) => t.id === preferredTab)) {
+    return { tab: preferredTab as TaskTab, redirectDag: false };
   }
 
   if (typeof window === 'undefined') {
-    return 'now';
+    return { tab: 'now', redirectDag: false };
   }
 
   const urlTab = new URLSearchParams(window.location.search).get('tab');
-  if (urlTab && TAB_ITEMS.some((tab) => tab.id === urlTab)) {
-    return urlTab as TaskTab;
+  if (urlTab && TAB_ITEMS.some((t) => t.id === urlTab)) {
+    return { tab: urlTab as TaskTab, redirectDag: false };
   }
 
-  return 'now';
+  return { tab: 'now', redirectDag: false };
 }
 
 export function TasksPage() {
   const isDesktop = useIsDesktop();
-  const [activeTab, setActiveTab] = useState<TaskTab>(() => resolveInitialTaskTab());
+  const navigate = useNavigate();
+  const [initialResolution] = useState(() => resolveInitialTaskTab());
+  const [activeTab, setActiveTab] = useState<TaskTab>(initialResolution.tab);
   const [tasks, setTasks] = useState<TaskNode[]>([]);
   const [timeBlocks, setTimeBlocks] = useState<TimeBlock[]>([]);
   const [activeBlock, setActiveBlock] = useState<ActiveBlockData | null>(null);
   const [quickInput, setQuickInput] = useState('');
   const quickInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (initialResolution.redirectDag) {
+      void navigate({ to: '/tasks/dag' });
+    }
+  }, [initialResolution.redirectDag, navigate]);
 
   useEffect(() => {
     let disposed = false;

--- a/src/ui/app/pages/agents/SignalDetailPage.tsx
+++ b/src/ui/app/pages/agents/SignalDetailPage.tsx
@@ -1,0 +1,192 @@
+import { ArrowLeft } from 'lucide-react';
+import { Link, useParams } from '@tanstack/react-router';
+import { useEffect, useMemo, useState } from 'react';
+import type { SignalEvent, SignalRoute } from '@/lib/types/signal-pool';
+import type { SignalGraphNode } from '@/ui/app/pages/agents-signal-topology';
+import { buildSignalGraph } from '@/ui/app/pages/agents-signal-topology';
+import type { RuntimeAggregatedAgent } from '@/services/runtime-manager';
+import {
+  formatSignalPayload,
+  formatSignalTime,
+  signalNodeTypeBadgeLabel,
+  signalTopicTint,
+} from '@/ui/app/pages/agents/agents-utils';
+import { getSelectedRuntimeTarget, formatHostForUrl } from '@/config/runtime-target';
+
+export function SignalDetailPage() {
+  const { signalId } = useParams({ strict: false }) as { signalId?: string };
+  const [signalRoutes, setSignalRoutes] = useState<SignalRoute[]>([]);
+  const [signalHistory, setSignalHistory] = useState<SignalEvent[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Build graph from routes only (no agent data needed for signal detail)
+  const signalGraph = useMemo(
+    () => buildSignalGraph(signalRoutes, [] as RuntimeAggregatedAgent[]),
+    [signalRoutes],
+  );
+
+  useEffect(() => {
+    let disposed = false;
+    const load = async () => {
+      try {
+        const target = getSelectedRuntimeTarget();
+        const baseUrl = `http://${formatHostForUrl(target.host)}:${target.port}`;
+
+        const [routesResponse, historyResponse] = await Promise.all([
+          fetch(`${baseUrl}/signal-routes`).then((r) => r.ok ? r.json() as Promise<SignalRoute[]> : []),
+          fetch(`${baseUrl}/signals/history`).then((r) => r.ok ? r.json() as Promise<SignalEvent[]> : []),
+        ]);
+        const routes = routesResponse as SignalRoute[];
+
+        if (!disposed) {
+          setSignalRoutes(routes);
+          setSignalHistory(historyResponse as SignalEvent[]);
+          setIsLoading(false);
+        }
+      } catch {
+        if (!disposed) setIsLoading(false);
+      }
+    };
+    void load();
+    return () => { disposed = true; };
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-full bg-surface px-6 py-6">
+        <p className="text-sm text-muted-foreground">加载中...</p>
+      </div>
+    );
+  }
+
+  const nodeId = signalId ?? '';
+  const historyEvent = signalHistory.find((e) => e.id === nodeId);
+  const normalizedNodeId = nodeId.includes(':') ? nodeId.split(':').slice(1).join(':') : nodeId;
+  const routeMatchKey = historyEvent?.topic ?? normalizedNodeId ?? nodeId;
+  const node: SignalGraphNode | undefined =
+    signalGraph.nodes.find((n) => n.id === nodeId) ??
+    signalGraph.nodes.find((n) => n.label === normalizedNodeId || n.id.endsWith(`:${normalizedNodeId}`));
+  const relatedRoutes = routeMatchKey
+    ? signalRoutes.filter((r) => r.target_ref === routeMatchKey || r.topic.includes(routeMatchKey))
+    : [];
+  const incomingCount = routeMatchKey ? signalRoutes.filter((r) => r.target_ref === routeMatchKey).length : 0;
+  const outgoingCount = routeMatchKey ? signalRoutes.filter((r) => r.topic.includes(routeMatchKey)).length : 0;
+
+  return (
+    <div className="min-h-full bg-surface px-5 py-4 md:px-8" data-testid="signal-detail-page">
+      <header className="mb-4">
+        <div className="inline-flex select-none items-center gap-2 text-xs text-muted-foreground">
+          <Link to="/agents" className="inline-flex items-center gap-1 hover:text-foreground">
+            <ArrowLeft size={14} />
+            网络
+          </Link>
+          <span>/</span>
+          <span>信号详情</span>
+        </div>
+      </header>
+
+      <div className="flex flex-col gap-4 text-foreground">
+        <div className="rounded-2xl border border-border-card bg-card p-4">
+          <div className="flex flex-col gap-1">
+            <p className="text-xs font-medium text-muted-foreground">
+              {historyEvent ? '信号 ID' : '节点 ID'}
+            </p>
+            <p className="font-mono text-sm text-foreground">{nodeId || '—'}</p>
+          </div>
+        </div>
+
+        {historyEvent && (
+          <div className="rounded-2xl border border-border-card bg-card p-4">
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center gap-2">
+                <span
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: signalTopicTint(historyEvent.topic) }}
+                />
+                <p className="font-mono text-xs text-foreground">{historyEvent.topic}</p>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="flex flex-col gap-0.5">
+                  <p className="text-[10px] text-muted-foreground">来源</p>
+                  <p className="text-xs text-foreground">{historyEvent.source}</p>
+                </div>
+                <div className="flex flex-col gap-0.5">
+                  <p className="text-[10px] text-muted-foreground">时间</p>
+                  <p className="text-xs text-foreground">{formatSignalTime(historyEvent.ts)}</p>
+                </div>
+                <div className="flex flex-col gap-0.5">
+                  <p className="text-[10px] text-muted-foreground">主机</p>
+                  <p className="text-xs text-foreground">{historyEvent.origin_host_id}</p>
+                </div>
+                <div className="flex flex-col gap-0.5">
+                  <p className="text-[10px] text-muted-foreground">跳数</p>
+                  <p className="text-xs text-foreground">{historyEvent.hop}</p>
+                </div>
+              </div>
+              <div className="flex flex-col gap-1">
+                <p className="text-[10px] text-muted-foreground">Payload</p>
+                <pre className="overflow-x-auto rounded-lg bg-background p-3 text-[10px] text-foreground">
+                  {formatSignalPayload(historyEvent.payload)}
+                </pre>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {node && (
+          <div className="rounded-2xl border border-border-card bg-card p-4">
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center gap-2">
+                <span
+                  className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                    node.type === 'signal-input'
+                      ? 'bg-[#EDE9FE] text-[#7C3AED]'
+                      : node.type === 'agent'
+                        ? 'bg-[#CCFBF1] text-[#0D9488]'
+                        : node.type === 'actor'
+                          ? 'bg-[#FEF3C7] text-[#B45309]'
+                          : node.type === 'topic'
+                            ? 'bg-[#FFEDD5] text-[#EA580C]'
+                            : 'bg-[#DBEAFE] text-[#1D4ED8]'
+                  }`}
+                >
+                  {signalNodeTypeBadgeLabel(node.type)}
+                </span>
+                <span className="text-xs text-muted-foreground">状态：{node.status}</span>
+              </div>
+              <div className="flex gap-4">
+                <div className="flex flex-col gap-0.5">
+                  <p className="text-[10px] text-muted-foreground">接收路由</p>
+                  <p className="text-sm font-medium text-foreground">{incomingCount}</p>
+                </div>
+                <div className="flex flex-col gap-0.5">
+                  <p className="text-[10px] text-muted-foreground">发送路由</p>
+                  <p className="text-sm font-medium text-foreground">{outgoingCount}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="rounded-2xl border border-border-card bg-card p-4">
+          <p className="text-xs font-medium text-muted-foreground">最近信号路由</p>
+          <div className="mt-2 flex flex-col gap-1">
+            {relatedRoutes.slice(0, 10).map((r) => (
+              <div
+                key={r.id}
+                className="flex items-center gap-2 rounded-[6px] border border-border-card bg-background px-3 py-2"
+              >
+                <span className={`h-1.5 w-1.5 rounded-full ${r.enabled ? 'bg-[#22C55E]' : 'bg-[#57534E]'}`} />
+                <span className="flex-1 truncate font-mono text-xs text-foreground">{r.topic}</span>
+                <span className="shrink-0 text-[10px] text-muted-foreground">→ {r.target_type}</span>
+              </div>
+            ))}
+            {relatedRoutes.length === 0 && (
+              <p className="text-xs text-muted-foreground">无关联路由</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/app/pages/task-dag-detail-view.ts
+++ b/src/ui/app/pages/task-dag-detail-view.ts
@@ -1,5 +1,6 @@
 ﻿import { buildTaskGraph, type TaskGraphEdge } from '@/lib/task/task-dag-graph';
 import {
+  calculateTaskDagCollapseScope,
   projectVisibleTaskGraph,
   type TaskDagVisibilityState,
   type VisibleTaskGraphNode,
@@ -22,7 +23,9 @@ const EDGE_TYPE_LABELS: Record<TaskGraphEdge['type'], string> = {
 export interface TaskDagDetailViewNode extends VisibleTaskGraphNode {
   statusLabel: string;
   upstreamNodeCount: number;
+  downstreamNodeCount: number;
   canCollapseUpstream: boolean;
+  canCollapseDownstream: boolean;
   isCurrentTask: boolean;
   isVisibleRoot: boolean;
   isVisibleCurrentRoot: boolean;
@@ -147,6 +150,40 @@ function collectUpstreamNodeIds(nodeId: string, incomingEdgesByTarget: Map<strin
   return upstreamNodeIds;
 }
 
+function buildGraphOutgoingEdgeMap(edges: TaskGraphEdge[]): Map<string, TaskGraphEdge[]> {
+  const outgoingEdgesBySource = new Map<string, TaskGraphEdge[]>();
+
+  for (const edge of edges) {
+    const current = outgoingEdgesBySource.get(edge.source);
+    if (current) {
+      current.push(edge);
+      continue;
+    }
+    outgoingEdgesBySource.set(edge.source, [edge]);
+  }
+
+  return outgoingEdgesBySource;
+}
+
+function collectDownstreamNodeIds(nodeId: string, outgoingEdgesBySource: Map<string, TaskGraphEdge[]>): Set<string> {
+  const downstreamNodeIds = new Set<string>();
+  const pendingNodeIds = (outgoingEdgesBySource.get(nodeId) ?? []).map((edge) => edge.target);
+
+  while (pendingNodeIds.length > 0) {
+    const currentNodeId = pendingNodeIds.pop();
+    if (!currentNodeId || downstreamNodeIds.has(currentNodeId)) {
+      continue;
+    }
+
+    downstreamNodeIds.add(currentNodeId);
+    for (const edge of outgoingEdgesBySource.get(currentNodeId) ?? []) {
+      pendingNodeIds.push(edge.target);
+    }
+  }
+
+  return downstreamNodeIds;
+}
+
 export function buildTaskDagDetailView(
   currentTask: TaskNode,
   allTasks: TaskNode[],
@@ -164,16 +201,22 @@ export function buildTaskDagDetailView(
   const visibleRootNodeIdSet = new Set(visibleGraph.visibleRootNodeIds);
   const sourceRootNodeIdSet = new Set(visibleGraph.sourceRootNodeIds);
   const incomingEdgesByTarget = buildGraphIncomingEdgeMap(taskGraph.edges);
+  const outgoingEdgesBySource = buildGraphOutgoingEdgeMap(taskGraph.edges);
   const graphNodeById = new Map(taskGraph.nodes.map((node) => [node.id, node]));
 
   const nodes = visibleGraph.nodes.map((node) => {
     const upstreamNodeCount = collectUpstreamNodeIds(node.id, incomingEdgesByTarget).size;
+    const downstreamNodeCount = collectDownstreamNodeIds(node.id, outgoingEdgesBySource).size;
+    const upstreamScopeSize = calculateTaskDagCollapseScope(taskGraph, visibilityState, 'upstream', node.id).size;
+    const downstreamScopeSize = calculateTaskDagCollapseScope(taskGraph, visibilityState, 'downstream', node.id).size;
 
     return {
       ...node,
       statusLabel: STATUS_LABELS[node.status],
       upstreamNodeCount,
-      canCollapseUpstream: upstreamNodeCount > 0,
+      downstreamNodeCount,
+      canCollapseUpstream: upstreamScopeSize > 1 || visibilityState.collapsedUpstreamOf.includes(node.id),
+      canCollapseDownstream: downstreamScopeSize > 1 || visibilityState.collapsedDownstreamOf.includes(node.id),
       isCurrentTask: node.id === currentTask.id,
       isVisibleRoot: visibleRootNodeIdSet.has(node.id),
       isVisibleCurrentRoot: node.id === visibleGraph.visibleCurrentRootNodeId,

--- a/src/ui/app/pages/task-dag-flow.ts
+++ b/src/ui/app/pages/task-dag-flow.ts
@@ -24,11 +24,12 @@ const PRIORITY_LABEL: Record<TaskNode['priority'], string> = {
 };
 
 function resolveExecutionLabel(node: TaskGraph['nodes'][number]): string {
+  if (node.status === 'completed') return '已完成';
+  if (node.status === 'cancelled') return '已取消';
   if (node.status === 'in_progress') return '进行中';
   if (node.status === 'suspended') return '已挂起';
-  if (node.isExecutable && node.isBlocked) return '可执行（软阻塞提醒）';
-  if (node.isExecutable) return '可执行';
   if (node.isBlocked) return '受阻';
+  if (node.isExecutable) return '可执行';
   return '待处理';
 }
 

--- a/src/ui/app/pages/task-dag-flow.ts
+++ b/src/ui/app/pages/task-dag-flow.ts
@@ -39,9 +39,13 @@ export type TaskDagFlowNodeData = {
   priorityLabel: string;
   executionLabel: string;
   isCurrentRoot: boolean;
+  isCollapsedTarget: boolean;
+  isCollapsedUpstreamTarget: boolean;
+  isCollapsedDownstreamTarget: boolean;
   isBlocked: boolean;
   isExecutable: boolean;
   hiddenUpstreamCount: number;
+  hiddenDownstreamCount: number;
 };
 
 export type TaskDagFlowNode = Node<TaskDagFlowNodeData, 'taskDag'>;
@@ -95,9 +99,13 @@ export function buildTaskDagFlow(graph: TaskGraph): {
           priorityLabel: PRIORITY_LABEL[node.priority],
           executionLabel: resolveExecutionLabel(node),
           isCurrentRoot: node.id === graph.currentRootNodeId,
+          isCollapsedTarget: false,
+          isCollapsedUpstreamTarget: false,
+          isCollapsedDownstreamTarget: false,
           isBlocked: node.isBlocked,
           isExecutable: node.isExecutable,
           hiddenUpstreamCount: 0,
+          hiddenDownstreamCount: 0,
         },
       } satisfies TaskDagFlowNode;
     });
@@ -173,9 +181,13 @@ export function buildVisibleTaskDagFlow(visibleGraph: VisibleTaskGraph): {
           priorityLabel: PRIORITY_LABEL[node.priority],
           executionLabel: resolveExecutionLabel(node),
           isCurrentRoot: node.id === visibleGraph.visibleCurrentRootNodeId,
+          isCollapsedTarget: node.isCollapsedTarget,
+          isCollapsedUpstreamTarget: node.isCollapsedUpstreamTarget,
+          isCollapsedDownstreamTarget: node.isCollapsedDownstreamTarget,
           isBlocked: node.isBlocked,
           isExecutable: node.isExecutable,
           hiddenUpstreamCount: node.hiddenUpstreamCount,
+          hiddenDownstreamCount: node.hiddenDownstreamCount,
         },
       } satisfies TaskDagFlowNode;
     });

--- a/src/ui/app/pages/task-dag-flow.ts
+++ b/src/ui/app/pages/task-dag-flow.ts
@@ -1,5 +1,6 @@
 ﻿import { MarkerType, Position, type Edge, type Node } from '@xyflow/react';
 import type { TaskGraph } from '@/lib/task/task-dag-graph';
+import type { VisibleTaskGraph } from '@/lib/task/task-dag-visibility';
 import type { TaskNode } from '@/lib/types/task';
 
 export const TASK_DAG_NODE_WIDTH = 256;
@@ -39,6 +40,7 @@ export type TaskDagFlowNodeData = {
   isCurrentRoot: boolean;
   isBlocked: boolean;
   isExecutable: boolean;
+  hiddenUpstreamCount: number;
 };
 
 export type TaskDagFlowNode = Node<TaskDagFlowNodeData, 'taskDag'>;
@@ -94,11 +96,90 @@ export function buildTaskDagFlow(graph: TaskGraph): {
           isCurrentRoot: node.id === graph.currentRootNodeId,
           isBlocked: node.isBlocked,
           isExecutable: node.isExecutable,
+          hiddenUpstreamCount: 0,
         },
       } satisfies TaskDagFlowNode;
     });
 
   const edges = graph.edges.map((edge) => {
+    const hardEdge = edge.type === 'hard';
+    return {
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      type: 'smoothstep',
+      animated: false,
+      selectable: false,
+      style: hardEdge
+        ? { stroke: '#C75B3A', strokeWidth: 2.25 }
+        : { stroke: '#78716C', strokeWidth: 1.75, strokeDasharray: '7 5' },
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        color: hardEdge ? '#C75B3A' : '#78716C',
+      },
+    } satisfies TaskDagFlowEdge;
+  });
+
+  return { nodes, edges };
+}
+
+export function buildVisibleTaskDagFlow(visibleGraph: VisibleTaskGraph): {
+  nodes: TaskDagFlowNode[];
+  edges: TaskDagFlowEdge[];
+} {
+  const nodeById = new Map(visibleGraph.nodes.map((node) => [node.id, node]));
+  const topologicalOrder = visibleGraph.nodes.map((node) => node.id);
+  const incomingByTarget = new Map<string, string[]>();
+  const depthById = new Map<string, number>();
+  const rowsByDepth = new Map<number, string[]>();
+
+  for (const edge of visibleGraph.edges) {
+    const incoming = incomingByTarget.get(edge.target) ?? [];
+    incoming.push(edge.source);
+    incomingByTarget.set(edge.target, incoming);
+  }
+
+  for (const taskId of topologicalOrder) {
+    const incomingDepths = (incomingByTarget.get(taskId) ?? [])
+      .map((sourceId) => depthById.get(sourceId))
+      .filter((depth): depth is number => depth !== undefined);
+    const depth = incomingDepths.length > 0 ? Math.max(...incomingDepths) + 1 : 0;
+    depthById.set(taskId, depth);
+    const rows = rowsByDepth.get(depth) ?? [];
+    rows.push(taskId);
+    rowsByDepth.set(depth, rows);
+  }
+
+  const nodes = topologicalOrder
+    .map((taskId) => nodeById.get(taskId))
+    .filter((node): node is VisibleTaskGraph['nodes'][number] => Boolean(node))
+    .map((node) => {
+      const depth = depthById.get(node.id) ?? 0;
+      const row = rowsByDepth.get(depth)?.indexOf(node.id) ?? 0;
+      return {
+        id: node.id,
+        type: 'taskDag',
+        position: {
+          x: depth * COLUMN_GAP,
+          y: row * ROW_GAP,
+        },
+        sourcePosition: Position.Right,
+        targetPosition: Position.Left,
+        draggable: false,
+        data: {
+          title: node.title,
+          statusLabel: STATUS_LABEL[node.status],
+          priorityLabel: PRIORITY_LABEL[node.priority],
+          executionLabel: resolveExecutionLabel(node),
+          isCurrentRoot: node.id === visibleGraph.visibleCurrentRootNodeId,
+          isBlocked: node.isBlocked,
+          isExecutable: node.isExecutable,
+          hiddenUpstreamCount: node.hiddenUpstreamCount,
+        },
+      } satisfies TaskDagFlowNode;
+    });
+
+  const edges = visibleGraph.edges.map((edge) => {
     const hardEdge = edge.type === 'hard';
     return {
       id: edge.id,

--- a/src/ui/app/pages/task-route-memory.ts
+++ b/src/ui/app/pages/task-route-memory.ts
@@ -1,0 +1,23 @@
+export const TASKS_LAST_PATH_KEY = 'exomind:last-tasks-path';
+export const TASKS_FORCE_MAIN_QUERY_KEY = 'main';
+export const TASKS_FORCE_MAIN_QUERY_VALUE = '1';
+
+export function buildTasksMainSearch(search?: Record<string, string>): Record<string, string> {
+  return {
+    ...(search ?? {}),
+    [TASKS_FORCE_MAIN_QUERY_KEY]: TASKS_FORCE_MAIN_QUERY_VALUE,
+  };
+}
+
+export function shouldForceTasksMain(search: string): boolean {
+  const normalizedSearch = search.startsWith('?') ? search.slice(1) : search;
+  return new URLSearchParams(normalizedSearch).get(TASKS_FORCE_MAIN_QUERY_KEY) === TASKS_FORCE_MAIN_QUERY_VALUE;
+}
+
+export function resolveTasksRestorePath(savedPath: string | null, search: string): string | null {
+  if (shouldForceTasksMain(search)) {
+    return null;
+  }
+
+  return savedPath && savedPath.startsWith('/tasks/') ? savedPath : null;
+}

--- a/src/ui/app/pages/task-tab-filters.ts
+++ b/src/ui/app/pages/task-tab-filters.ts
@@ -1,4 +1,5 @@
-import type { TaskNode } from '@/lib/types/task';
+import { isTerminalTaskStatus } from '@/lib/types/task';
+import type { TaskNode, TaskStatus } from '@/lib/types/task';
 
 /** Sort contract: dueAt asc (tasks with due date first), no-due at bottom, tiebreak by updatedAt desc */
 export function sortByDue(tasks: TaskNode[]): TaskNode[] {
@@ -31,12 +32,27 @@ function excludeCancelled(tasks: TaskNode[]): TaskNode[] {
   return tasks.filter((t) => t.status !== 'cancelled');
 }
 
-/** "当下" tab: show all non-cancelled tasks, in_progress pinned to top, rest sorted by due */
+/** "当下" tab: show all non-terminal tasks, in_progress pinned to top, rest sorted by due */
 export function filterNow(tasks: TaskNode[]): TaskNode[] {
-  const pool = excludeCancelled(tasks);
+  const pool = tasks.filter((t) => !isTerminalTaskStatus(t.status));
   const inProgress = pool.filter((t) => t.status === 'in_progress');
   const rest = pool.filter((t) => t.status !== 'in_progress');
   return [...inProgress, ...sortByDue(rest)];
+}
+
+const STATUS_SORT_ORDER: Record<TaskStatus, number> = {
+  in_progress: 0,
+  pending: 1,
+  suspended: 2,
+  completed: 3,
+  cancelled: 4,
+};
+
+/** Sort by status group (in_progress first), then by updatedAt desc within each group */
+function sortByStatusGroup(tasks: TaskNode[]): TaskNode[] {
+  return [...tasks].sort(
+    (a, b) => STATUS_SORT_ORDER[a.status] - STATUS_SORT_ORDER[b.status] || b.updatedAt - a.updatedAt,
+  );
 }
 
 /** "今日" tab: dueAt today OR in_progress with updatedAt today */
@@ -49,7 +65,7 @@ export function filterToday(tasks: TaskNode[], now: Date): TaskNode[] {
       (t.dueAt !== undefined && t.dueAt >= todayStart && t.dueAt < todayEnd) ||
       (t.status === 'in_progress' && t.updatedAt >= todayStart),
   );
-  return sortByDue(filtered);
+  return sortByStatusGroup(filtered);
 }
 
 /** "一周" tab: dueAt within 7 days OR in_progress */
@@ -59,7 +75,7 @@ export function filterWeek(tasks: TaskNode[], now: Date): TaskNode[] {
   const filtered = pool.filter(
     (t) => t.status === 'in_progress' || (t.dueAt !== undefined && t.dueAt <= weekEnd),
   );
-  return sortByDue(filtered);
+  return sortByStatusGroup(filtered);
 }
 
 /** "月" tab: dueAt in current month OR in_progress */
@@ -72,5 +88,5 @@ export function filterMonth(tasks: TaskNode[], now: Date): TaskNode[] {
       t.status === 'in_progress' ||
       (t.dueAt !== undefined && t.dueAt >= monthStart && t.dueAt < monthEnd),
   );
-  return sortByDue(filtered);
+  return sortByStatusGroup(filtered);
 }

--- a/src/ui/app/pages/task-tab-filters.ts
+++ b/src/ui/app/pages/task-tab-filters.ts
@@ -1,5 +1,6 @@
 import { isTerminalTaskStatus } from '@/lib/types/task';
 import type { TaskNode, TaskStatus } from '@/lib/types/task';
+import type { TaskGraph } from '@/lib/task/task-dag-graph';
 
 /** Sort contract: dueAt asc (tasks with due date first), no-due at bottom, tiebreak by updatedAt desc */
 export function sortByDue(tasks: TaskNode[]): TaskNode[] {
@@ -32,12 +33,26 @@ function excludeCancelled(tasks: TaskNode[]): TaskNode[] {
   return tasks.filter((t) => t.status !== 'cancelled');
 }
 
-/** "当下" tab: show all non-terminal tasks, in_progress pinned to top, rest sorted by due */
-export function filterNow(tasks: TaskNode[]): TaskNode[] {
+/**
+ * "当下" tab: show all non-terminal tasks.
+ * Sort order: in_progress first, then unblocked (BFS order), then blocked.
+ * Within each group, sort by updatedAt desc.
+ */
+export function filterNow(tasks: TaskNode[], graph?: TaskGraph): TaskNode[] {
   const pool = tasks.filter((t) => !isTerminalTaskStatus(t.status));
+  const unblockedSet = new Set(graph?.currentRootCandidateNodeIds ?? []);
+
   const inProgress = pool.filter((t) => t.status === 'in_progress');
   const rest = pool.filter((t) => t.status !== 'in_progress');
-  return [...inProgress, ...sortByDue(rest)];
+  const unblocked = rest.filter((t) => unblockedSet.has(t.id));
+  const blocked = rest.filter((t) => !unblockedSet.has(t.id));
+
+  const byUpdatedDesc = (a: TaskNode, b: TaskNode) => b.updatedAt - a.updatedAt;
+  return [
+    ...inProgress.sort(byUpdatedDesc),
+    ...unblocked.sort(byUpdatedDesc),
+    ...blocked.sort(byUpdatedDesc),
+  ];
 }
 
 const STATUS_SORT_ORDER: Record<TaskStatus, number> = {

--- a/src/ui/app/pages/task-timeblock-detail-view.ts
+++ b/src/ui/app/pages/task-timeblock-detail-view.ts
@@ -366,7 +366,7 @@ function buildPlanActual(task: TaskNode, block: TimeBlock, scheduleBadge: Timebl
 
   return {
     planContent: `计划：${task.title}${planDuration}`,
-    actualContent: `实际：${block.name}（耗时 ${formatMinutes(actualDuration)}）${block.note ? `；备注：${block.note}` : ''}`,
+    actualContent: `实际：${block.name}（耗时 ${formatMinutes(actualDuration)}）`,
     diffReason,
   };
 }

--- a/src/ui/app/pages/task-timeblock-detail-view.ts
+++ b/src/ui/app/pages/task-timeblock-detail-view.ts
@@ -57,7 +57,7 @@ export interface TimeblockAiSummary {
 }
 
 export interface TimeblockActionItem {
-  id: 'open-task' | 'restart' | 'copy-summary';
+  id: 'open-task' | 'copy-summary';
   label: string;
   to?: string;
   search?: Record<string, string>;
@@ -404,7 +404,6 @@ export function buildTaskTimeblockDetailViewModel(input: BuildTaskTimeblockDetai
   ];
   const actions: TimeblockActionItem[] = [
     { id: 'open-task', label: '查看关联任务', to: `/tasks/${input.task.id}` },
-    { id: 'restart', label: '再来一个时间块' },
     { id: 'copy-summary', label: '复制总结' },
   ];
 

--- a/src/ui/app/pages/task-timeblock-detail-view.ts
+++ b/src/ui/app/pages/task-timeblock-detail-view.ts
@@ -57,7 +57,7 @@ export interface TimeblockAiSummary {
 }
 
 export interface TimeblockActionItem {
-  id: 'open-task' | 'open-eventlog' | 'restart' | 'copy-summary';
+  id: 'open-task' | 'restart' | 'copy-summary';
   label: string;
   to?: string;
   search?: Record<string, string>;
@@ -342,7 +342,7 @@ function buildRealTimeline(block: TimeBlock, eventLogs: TimeblockEventLog[]): Ti
           id: `${block.startId}-empty`,
           title: '暂无事件记录',
           timeLabel: formatDateTime(block.startTime),
-          description: '该时间块范围内未检索到 EventLog 事件。',
+          description: '该时间块范围内未检索到事件日志。',
           tone: 'neutral',
         },
       ],
@@ -401,7 +401,6 @@ export function buildTaskTimeblockDetailViewModel(input: BuildTaskTimeblockDetai
   ];
   const actions: TimeblockActionItem[] = [
     { id: 'open-task', label: '查看关联任务', to: `/tasks/${input.task.id}` },
-    { id: 'open-eventlog', label: '打开 EventLog', to: '/eventlog' },
     { id: 'restart', label: '再来一个时间块' },
     { id: 'copy-summary', label: '复制总结' },
   ];

--- a/src/ui/app/pages/task-timeblock-detail-view.ts
+++ b/src/ui/app/pages/task-timeblock-detail-view.ts
@@ -397,7 +397,6 @@ export function buildTaskTimeblockDetailViewModel(input: BuildTaskTimeblockDetai
     { key: 'start', label: '开始', value: formatClock(block.startTime) },
     { key: 'end', label: '结束', value: formatClock(block.endTime) },
     { key: 'duration', label: '时长', value: formatMinutes(actualMinutes) },
-    { key: 'expected', label: '预期', value: input.task.estimatedMinutes ? formatMinutes(input.task.estimatedMinutes) : '未估时' },
     { key: 'event_count', label: '事件数', value: `${timeline.items.length}` },
   ];
   const actions: TimeblockActionItem[] = [

--- a/src/ui/app/pages/task-timeblock-detail-view.ts
+++ b/src/ui/app/pages/task-timeblock-detail-view.ts
@@ -433,6 +433,7 @@ export function buildTaskTimeblockDetailViewModel(input: BuildTaskTimeblockDetai
   const metrics: TimeblockSummaryMetric[] = [
     { key: 'start', label: '开始', value: formatClock(block.startTime) },
     { key: 'end', label: '结束', value: formatClock(block.endTime) },
+    { key: 'expected', label: '预期', value: input.task.estimatedMinutes ? formatMinutes(input.task.estimatedMinutes) : '正计时' },
     { key: 'duration', label: '时长', value: formatMinutes(actualMinutes) },
     { key: 'event_count', label: '事件数', value: `${timeline.items.length}` },
     { key: 'blockCount', label: '时间块数', value: String(blockCount) },

--- a/src/ui/app/pages/task-timeblock-detail-view.ts
+++ b/src/ui/app/pages/task-timeblock-detail-view.ts
@@ -9,7 +9,7 @@ export interface TimeblockBadge {
 }
 
 export interface TimeblockSummaryMetric {
-  key: 'start' | 'end' | 'duration' | 'expected' | 'event_count';
+  key: 'start' | 'end' | 'duration' | 'expected' | 'event_count' | 'blockCount';
   label: string;
   value: string;
 }
@@ -393,11 +393,14 @@ export function buildTaskTimeblockDetailViewModel(input: BuildTaskTimeblockDetai
     : buildRealTimeline(block, input.eventLogs ?? []);
 
   const badges = scheduleBadge ? [statusBadge, scheduleBadge] : [statusBadge];
+  const taskBlockIds = new Set((input.task.timeBlockIds ?? []).map((v) => v.trim()));
+  const blockCount = input.blocks.filter((b) => taskBlockIds.has(b.startId) || taskBlockIds.has(b.id)).length;
   const metrics: TimeblockSummaryMetric[] = [
     { key: 'start', label: '开始', value: formatClock(block.startTime) },
     { key: 'end', label: '结束', value: formatClock(block.endTime) },
     { key: 'duration', label: '时长', value: formatMinutes(actualMinutes) },
     { key: 'event_count', label: '事件数', value: `${timeline.items.length}` },
+    { key: 'blockCount', label: '时间块数', value: String(blockCount) },
   ];
   const actions: TimeblockActionItem[] = [
     { id: 'open-task', label: '查看关联任务', to: `/tasks/${input.task.id}` },

--- a/src/ui/app/pages/task-timeblock-detail-view.ts
+++ b/src/ui/app/pages/task-timeblock-detail-view.ts
@@ -70,6 +70,15 @@ export interface TimeblockEventLog {
   type?: string;
 }
 
+export interface LinkedBlockItem {
+  startId: string;
+  name: string;
+  startLabel: string;
+  endLabel: string;
+  durationLabel: string;
+  isActive: boolean;
+}
+
 export interface TaskTimeblockDetailViewModel {
   summary: TimeblockSummary;
   anchors: TimeblockAnchorItem[];
@@ -77,6 +86,7 @@ export interface TaskTimeblockDetailViewModel {
   timeline: TimeblockTimeline;
   aiSummary: TimeblockAiSummary;
   actions: TimeblockActionItem[];
+  linkedBlocks: LinkedBlockItem[];
 }
 
 export interface BuildTaskTimeblockDetailViewModelInput {
@@ -394,7 +404,32 @@ export function buildTaskTimeblockDetailViewModel(input: BuildTaskTimeblockDetai
 
   const badges = scheduleBadge ? [statusBadge, scheduleBadge] : [statusBadge];
   const taskBlockIds = new Set((input.task.timeBlockIds ?? []).map((v) => v.trim()));
-  const blockCount = input.blocks.filter((b) => taskBlockIds.has(b.startId) || taskBlockIds.has(b.id)).length;
+  const completedLinked = input.blocks
+    .filter((b) => taskBlockIds.has(b.startId) || taskBlockIds.has(b.id))
+    .sort((a, b) => b.endTime - a.endTime);
+  const blockCount = completedLinked.length;
+
+  const linkedBlocks: LinkedBlockItem[] = completedLinked.map((b) => ({
+    startId: b.startId,
+    name: b.name,
+    startLabel: formatDateTime(b.startTime),
+    endLabel: formatDateTime(b.endTime),
+    durationLabel: formatMinutes(resolveDurationMinutes(b)),
+    isActive: false,
+  }));
+
+  if (input.activeBlock && input.activeBlock.taskId === input.task.id) {
+    const ab = input.activeBlock;
+    linkedBlocks.unshift({
+      startId: ab.startId,
+      name: ab.name,
+      startLabel: formatDateTime(ab.startTime),
+      endLabel: '进行中',
+      durationLabel: formatMinutes(Math.max(0, Math.round((nowTs - ab.startTime) / 60_000))),
+      isActive: true,
+    });
+  }
+
   const metrics: TimeblockSummaryMetric[] = [
     { key: 'start', label: '开始', value: formatClock(block.startTime) },
     { key: 'end', label: '结束', value: formatClock(block.endTime) },
@@ -424,5 +459,6 @@ export function buildTaskTimeblockDetailViewModel(input: BuildTaskTimeblockDetai
     timeline,
     aiSummary,
     actions,
+    linkedBlocks,
   };
 }

--- a/src/ui/app/pages/task-timeblock-detail-view.ts
+++ b/src/ui/app/pages/task-timeblock-detail-view.ts
@@ -138,13 +138,13 @@ function resolveBlockForTask(
   activeBlock: ActiveBlockData | null | undefined,
   preferredBlockId: string | undefined,
   nowTs: number,
-): TimeBlock {
+): TimeBlock | null {
   if (preferredBlockId) {
     const preferred = blocks.find((block) => block.id === preferredBlockId || block.startId === preferredBlockId);
     if (preferred) return preferred;
   }
 
-  const taskBlockIds = new Set((task.timeBlockIds ?? []).map((value) => value.trim()));
+  const taskBlockIds = new Set((task.timeBlockIds ?? []).map((value) => value.trim()).filter(Boolean));
   const linkedBlocks = blocks.filter((block) => taskBlockIds.has(block.startId) || taskBlockIds.has(block.id));
   const sortedLinkedBlocks = linkedBlocks.sort((left, right) => right.endTime - left.endTime);
   const latestLinked = sortedLinkedBlocks[0];
@@ -163,20 +163,11 @@ function resolveBlockForTask(
     };
   }
 
-  const fallbackTs = task.updatedAt || nowTs;
-  return {
-    id: `task-${task.id}-fallback`,
-    startId: `task-${task.id}-fallback`,
-    endId: `task-${task.id}-fallback-end`,
-    name: task.title,
-    note: task.description,
-    tags: new Set(['block_feedback']),
-    startTime: fallbackTs,
-    endTime: fallbackTs,
-  };
+  return null;
 }
 
-function resolveDurationMinutes(block: TimeBlock): number {
+function resolveDurationMinutes(block: TimeBlock | null): number {
+  if (!block) return 0;
   return Math.max(0, Math.round((block.endTime - block.startTime) / 60_000));
 }
 
@@ -321,12 +312,21 @@ function resolveEventTone(type: string | undefined): TimeblockEventTone {
   return 'neutral';
 }
 
-function buildRealTimeline(block: TimeBlock, eventLogs: TimeblockEventLog[]): TimeblockTimeline {
+type TimeRange = { startTime: number; endTime: number };
+
+function buildRealTimeline(ranges: TimeRange[], eventLogs: TimeblockEventLog[]): TimeblockTimeline {
+  if (ranges.length === 0) {
+    return {
+      sectionTitle: '事件时间线',
+      items: [],
+    };
+  }
+
   const items = eventLogs
     .map((event) => {
       const timestamp = parseEventTimestamp(event.createdAt);
       if (timestamp === null) return null;
-      if (timestamp < block.startTime || timestamp > block.endTime) return null;
+      if (!ranges.some((range) => timestamp >= range.startTime && timestamp <= range.endTime)) return null;
 
       return {
         id: event.id,
@@ -349,9 +349,9 @@ function buildRealTimeline(block: TimeBlock, eventLogs: TimeblockEventLog[]): Ti
       sectionTitle: '事件时间线',
       items: [
         {
-          id: `${block.startId}-empty`,
+          id: 'timeline-empty',
           title: '暂无事件记录',
-          timeLabel: formatDateTime(block.startTime),
+          timeLabel: '—',
           description: '该时间块范围内未检索到事件日志。',
           tone: 'neutral',
         },
@@ -365,18 +365,20 @@ function buildRealTimeline(block: TimeBlock, eventLogs: TimeblockEventLog[]): Ti
   };
 }
 
-function buildPlanActual(task: TaskNode, block: TimeBlock, scheduleBadge: TimeblockBadge | null): TimeblockPlanActual {
+function buildPlanActual(task: TaskNode, block: TimeBlock | null, scheduleBadge: TimeblockBadge | null): TimeblockPlanActual {
   const planDuration = task.estimatedMinutes ? `（预计 ${formatMinutes(task.estimatedMinutes)}）` : '';
   const actualDuration = resolveDurationMinutes(block);
-  const diffReason = scheduleBadge
-    ? `与计划对比：${scheduleBadge.label}。`
-    : hasBlockerHint(block.note)
-      ? '执行中出现阻塞，已在时间块内处理并恢复。'
-      : '执行与计划基本一致。';
+  const diffReason = block
+    ? scheduleBadge
+      ? `与计划对比：${scheduleBadge.label}。`
+      : hasBlockerHint(block.note)
+        ? '执行中出现阻塞，已在时间块内处理并恢复。'
+        : '执行与计划基本一致。'
+    : '开始时间块后可生成实际记录。';
 
   return {
     planContent: `计划：${task.title}${planDuration}`,
-    actualContent: `实际：${block.name}（耗时 ${formatMinutes(actualDuration)}）`,
+    actualContent: block ? `实际：${block.name}（耗时 ${formatMinutes(actualDuration)}）` : '实际：暂无时间块记录',
     diffReason,
   };
 }
@@ -392,21 +394,43 @@ export function buildTaskTimeblockDetailViewModel(input: BuildTaskTimeblockDetai
     nowTs,
   );
   const actualMinutes = resolveDurationMinutes(block);
-  const scheduleBadge = resolveScheduleBadge(input.task.estimatedMinutes, actualMinutes);
+  const scheduleBadge = block ? resolveScheduleBadge(input.task.estimatedMinutes, actualMinutes) : null;
   const statusBadge: TimeblockBadge = {
     label: STATUS_BADGE_LABEL[input.task.status],
     tone: input.task.status === 'completed' ? 'success' : input.task.status === 'cancelled' ? 'danger' : 'neutral',
   };
-  const aiSummary = buildAiSummary(block.name, input.reviewMarkdown);
-  const timeline = useMockData
-    ? buildMockTimeline(block, aiSummary, nowTs)
-    : buildRealTimeline(block, input.eventLogs ?? []);
+  const summaryBlockName = block?.name ?? input.task.title;
+  const aiSummary = buildAiSummary(summaryBlockName, input.reviewMarkdown);
 
-  const badges = scheduleBadge ? [statusBadge, scheduleBadge] : [statusBadge];
-  const taskBlockIds = new Set((input.task.timeBlockIds ?? []).map((v) => v.trim()));
+  const taskBlockIds = new Set((input.task.timeBlockIds ?? []).map((v) => v.trim()).filter(Boolean));
   const completedLinked = input.blocks
     .filter((b) => taskBlockIds.has(b.startId) || taskBlockIds.has(b.id))
     .sort((a, b) => b.endTime - a.endTime);
+  const timelineRanges: TimeRange[] = completedLinked.map((linked) => ({
+    startTime: linked.startTime,
+    endTime: linked.endTime,
+  }));
+  if (input.activeBlock && input.activeBlock.taskId === input.task.id) {
+    timelineRanges.push({ startTime: input.activeBlock.startTime, endTime: nowTs });
+  }
+
+  const mockBlock: TimeBlock = block ?? {
+    id: `task-${input.task.id}-mock`,
+    startId: `task-${input.task.id}-mock`,
+    endId: `task-${input.task.id}-mock`,
+    name: summaryBlockName,
+    note: input.task.description,
+    tags: new Set(['block_feedback']),
+    startTime: nowTs,
+    endTime: nowTs,
+  };
+  const timeline = useMockData
+    ? timelineRanges.length > 0
+      ? buildMockTimeline(mockBlock, aiSummary, nowTs)
+      : { sectionTitle: '事件时间线', items: [] }
+    : buildRealTimeline(timelineRanges, input.eventLogs ?? []);
+
+  const badges = scheduleBadge ? [statusBadge, scheduleBadge] : [statusBadge];
   const blockCount = completedLinked.length;
 
   const linkedBlocks: LinkedBlockItem[] = completedLinked.map((b) => ({
@@ -431,8 +455,8 @@ export function buildTaskTimeblockDetailViewModel(input: BuildTaskTimeblockDetai
   }
 
   const metrics: TimeblockSummaryMetric[] = [
-    { key: 'start', label: '开始', value: formatClock(block.startTime) },
-    { key: 'end', label: '结束', value: formatClock(block.endTime) },
+    { key: 'start', label: '开始', value: block ? formatClock(block.startTime) : '—' },
+    { key: 'end', label: '结束', value: block ? formatClock(block.endTime) : '—' },
     { key: 'expected', label: '预期', value: input.task.estimatedMinutes ? formatMinutes(input.task.estimatedMinutes) : '正计时' },
     { key: 'duration', label: '时长', value: formatMinutes(actualMinutes) },
     { key: 'event_count', label: '事件数', value: `${timeline.items.length}` },
@@ -445,7 +469,7 @@ export function buildTaskTimeblockDetailViewModel(input: BuildTaskTimeblockDetai
 
   return {
     summary: {
-      blockName: block.name,
+      blockName: summaryBlockName,
       badges,
       taskLinkLabel: input.task.title,
       metrics,

--- a/src/ui/app/pages/task-timeblock-detail-view.ts
+++ b/src/ui/app/pages/task-timeblock-detail-view.ts
@@ -57,7 +57,7 @@ export interface TimeblockAiSummary {
 }
 
 export interface TimeblockActionItem {
-  id: 'back-source' | 'open-task' | 'open-eventlog' | 'restart' | 'copy-summary';
+  id: 'open-task' | 'open-eventlog' | 'restart' | 'copy-summary';
   label: string;
   to?: string;
   search?: Record<string, string>;
@@ -88,11 +88,6 @@ export interface BuildTaskTimeblockDetailViewModelInput {
   reviewMarkdown?: string;
   useMockData?: boolean;
   now?: Date;
-  backAction?: {
-    label: string;
-    to: string;
-    search?: Record<string, string>;
-  };
 }
 
 const STATUS_BADGE_LABEL: Record<TaskNode['status'], string> = {
@@ -406,9 +401,6 @@ export function buildTaskTimeblockDetailViewModel(input: BuildTaskTimeblockDetai
     { key: 'event_count', label: '事件数', value: `${timeline.items.length}` },
   ];
   const actions: TimeblockActionItem[] = [
-    ...(input.backAction
-      ? [{ id: 'back-source', label: input.backAction.label, to: input.backAction.to, search: input.backAction.search } as const]
-      : []),
     { id: 'open-task', label: '查看关联任务', to: `/tasks/${input.task.id}` },
     { id: 'open-eventlog', label: '打开 EventLog', to: '/eventlog' },
     { id: 'restart', label: '再来一个时间块' },

--- a/src/ui/app/pages/task-title-fuzzy-search.ts
+++ b/src/ui/app/pages/task-title-fuzzy-search.ts
@@ -4,14 +4,34 @@ function normalizeFuzzyText(value: string): string {
   return value.toLocaleLowerCase().replace(/\s+/g, '');
 }
 
-function countCharOccurrences(text: string, target: string): number {
-  let count = 0;
+function buildCharCountMap(text: string): Map<string, number> {
+  const countMap = new Map<string, number>();
   for (const char of text) {
-    if (char === target) {
-      count += 1;
+    countMap.set(char, (countMap.get(char) ?? 0) + 1);
+  }
+  return countMap;
+}
+
+function getLongestCommonSubstringLength(left: string, right: string): number {
+  if (!left || !right) {
+    return 0;
+  }
+
+  const dp = new Array<number>(right.length + 1).fill(0);
+  let maxLength = 0;
+
+  for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+    for (let rightIndex = right.length; rightIndex >= 1; rightIndex -= 1) {
+      if (left[leftIndex - 1] === right[rightIndex - 1]) {
+        dp[rightIndex] = dp[rightIndex - 1] + 1;
+        maxLength = Math.max(maxLength, dp[rightIndex]);
+      } else {
+        dp[rightIndex] = 0;
+      }
     }
   }
-  return count;
+
+  return maxLength;
 }
 
 export function extractTaskTitleSearchQuery(inputValue: string): string {
@@ -24,10 +44,12 @@ export function getTaskTitleFuzzyScore(title: string, query: string): number | n
   const normalizedQuery = normalizeFuzzyText(query);
   if (!normalizedQuery) return 0;
 
+  const titleCharCountMap = buildCharCountMap(normalizedTitle);
+  const queryCharCountMap = buildCharCountMap(normalizedQuery);
   let score = 0;
-  for (const queryChar of normalizedQuery) {
-    const occurrences = countCharOccurrences(normalizedTitle, queryChar);
-    if (occurrences === 0) {
+  for (const [queryChar, requiredOccurrences] of queryCharCountMap) {
+    const occurrences = titleCharCountMap.get(queryChar) ?? 0;
+    if (occurrences < requiredOccurrences) {
       return null;
     }
     score += occurrences;
@@ -43,11 +65,19 @@ export function filterTasksByTitleFuzzySearch(tasks: TaskNode[], query: string):
   }
 
   return tasks
-    .map((task) => ({
-      task,
-      score: getTaskTitleFuzzyScore(task.title, normalizedQuery),
-    }))
-    .filter((entry): entry is { task: TaskNode; score: number } => entry.score !== null)
-    .sort((left, right) => right.score - left.score || left.task.title.localeCompare(right.task.title, 'zh-CN'))
+    .map((task) => {
+      const normalizedTitle = normalizeFuzzyText(task.title);
+      return {
+        task,
+        score: getTaskTitleFuzzyScore(normalizedTitle, normalizedQuery),
+        longestSubstringLength: getLongestCommonSubstringLength(normalizedTitle, normalizedQuery),
+      };
+    })
+    .filter((entry): entry is { task: TaskNode; score: number; longestSubstringLength: number } => entry.score !== null)
+    .sort((left, right) => (
+      right.longestSubstringLength - left.longestSubstringLength
+      || right.score - left.score
+      || left.task.title.localeCompare(right.task.title, 'zh-CN')
+    ))
     .map((entry) => entry.task);
 }

--- a/src/ui/app/pages/task-title-fuzzy-search.ts
+++ b/src/ui/app/pages/task-title-fuzzy-search.ts
@@ -1,0 +1,53 @@
+import type { TaskNode } from '@/lib/types/task';
+
+function normalizeFuzzyText(value: string): string {
+  return value.toLocaleLowerCase().replace(/\s+/g, '');
+}
+
+function countCharOccurrences(text: string, target: string): number {
+  let count = 0;
+  for (const char of text) {
+    if (char === target) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+export function extractTaskTitleSearchQuery(inputValue: string): string {
+  const [firstLine = ''] = inputValue.split(/\r?\n/, 1);
+  return normalizeFuzzyText(firstLine.trim());
+}
+
+export function getTaskTitleFuzzyScore(title: string, query: string): number | null {
+  const normalizedTitle = normalizeFuzzyText(title);
+  const normalizedQuery = normalizeFuzzyText(query);
+  if (!normalizedQuery) return 0;
+
+  let score = 0;
+  for (const queryChar of normalizedQuery) {
+    const occurrences = countCharOccurrences(normalizedTitle, queryChar);
+    if (occurrences === 0) {
+      return null;
+    }
+    score += occurrences;
+  }
+
+  return score;
+}
+
+export function filterTasksByTitleFuzzySearch(tasks: TaskNode[], query: string): TaskNode[] {
+  const normalizedQuery = normalizeFuzzyText(query);
+  if (!normalizedQuery) {
+    return tasks;
+  }
+
+  return tasks
+    .map((task) => ({
+      task,
+      score: getTaskTitleFuzzyScore(task.title, normalizedQuery),
+    }))
+    .filter((entry): entry is { task: TaskNode; score: number } => entry.score !== null)
+    .sort((left, right) => right.score - left.score || left.task.title.localeCompare(right.task.title, 'zh-CN'))
+    .map((entry) => entry.task);
+}

--- a/src/ui/hooks/useSignalStream.ts
+++ b/src/ui/hooks/useSignalStream.ts
@@ -168,10 +168,38 @@ export function useSignalStream(): void {
           log.info('[SignalStream] eventlog.replication.appended → EventStorage');
         }
       },
-      onActiveBlockReplicationSnapshot: async (payload: ActiveBlockReplicationSnapshotPayload) => {
-        await projectActiveBlockSnapshot(payload);
-        log.info('[SignalStream] active_block.replication.snapshot → ActiveBlockStorage');
-      },
+      // Throttle: RT dispatches active_block.replication.snapshot at high frequency
+      // (dozens per second), causing UI state overwrites. Cap at 1s. See #554.
+      onActiveBlockReplicationSnapshot: (() => {
+        let lastProcessedAt = 0;
+        let pendingPayload: ActiveBlockReplicationSnapshotPayload | null = null;
+        let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+
+        return async (payload: ActiveBlockReplicationSnapshotPayload) => {
+          const now = Date.now();
+          const elapsed = now - lastProcessedAt;
+
+          if (elapsed >= 1000) {
+            lastProcessedAt = now;
+            await projectActiveBlockSnapshot(payload);
+            return;
+          }
+
+          // Throttle: queue the latest payload and process after cooldown
+          pendingPayload = payload;
+          if (!pendingTimer) {
+            pendingTimer = setTimeout(async () => {
+              pendingTimer = null;
+              if (pendingPayload) {
+                lastProcessedAt = Date.now();
+                const p = pendingPayload;
+                pendingPayload = null;
+                await projectActiveBlockSnapshot(p);
+              }
+            }, 1000 - elapsed);
+          }
+        };
+      })(),
       onReviewCompleted: async (payload) => {
         const content = formatReviewAsMarkdown(payload);
         await appendEventWithEcsReplication({

--- a/src/ui/stores/sync-store.ts
+++ b/src/ui/stores/sync-store.ts
@@ -250,9 +250,17 @@ export const useSyncStore = create<SyncState>()(
       ensureProfileStorageMigrated();
       const initialSession = getProfileSession();
       const initialActiveProfile = getActiveProfile();
+      const initialIsLoggedIn = Boolean(
+        initialSession.activeProfileId
+        && initialSession.unlockedProfileIds.includes(initialSession.activeProfileId)
+        && initialActiveProfile
+      );
       migrateLegacySyncCredentialsToIdentityLink(initialActiveProfile);
-      const initialCredentials = initialActiveProfile
+      const initialCredentials = initialIsLoggedIn && initialActiveProfile
         ? buildCredentialsFromLinkedIdentity(initialActiveProfile.profileId, initialActiveProfile.slug)
+        : null;
+      const initialCurrentUser = initialIsLoggedIn
+        ? initialActiveProfile?.displayName || initialActiveProfile?.slug || null
         : null;
       clearLegacySyncStorePersist();
 
@@ -267,12 +275,9 @@ export const useSyncStore = create<SyncState>()(
         pollInterval: 5,
       },
       credentials: initialCredentials,
-      isLoggedIn: Boolean(
-        initialSession.activeProfileId
-        && initialSession.unlockedProfileIds.includes(initialSession.activeProfileId)
-      ),
-      currentUser: initialActiveProfile?.displayName || initialActiveProfile?.slug || null,
-      activeProfileId: initialSession.activeProfileId,
+      isLoggedIn: initialIsLoggedIn,
+      currentUser: initialCurrentUser,
+      activeProfileId: initialIsLoggedIn ? initialSession.activeProfileId : null,
       conflicts: [],
 
       // 更新状态

--- a/tests/e2e/agent-page-default-enabled.issue551.test.ts
+++ b/tests/e2e/agent-page-default-enabled.issue551.test.ts
@@ -1,0 +1,21 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function setupIssue551AgentDefaultFlags(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('exomind:uiMode', 'new');
+  });
+}
+
+test.describe('Issue #551 agent page default enabled（网络页面默认开启）', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupIssue551AgentDefaultFlags(page);
+  });
+
+  test('mobile bottom nav shows 网络 without explicit localStorage flag（未显式写入开关时底栏默认展示网络）', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/tasks');
+
+    await expect(page.getByTestId('mobile-bottom-tab')).toBeVisible();
+    await expect(page.getByRole('link', { name: '网络' })).toBeVisible();
+  });
+});

--- a/tests/e2e/eventlog-input-multiline.test.ts
+++ b/tests/e2e/eventlog-input-multiline.test.ts
@@ -2,6 +2,9 @@ import { expect, test } from '@playwright/test';
 
 test.describe('事件日志输入框 - 多行与滚动', () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('exomind:inputSendMode', 'ctrl-enter-send');
+    });
     await page.goto('/eventlog');
     await page.waitForLoadState('networkidle');
   });

--- a/tests/e2e/eventlog.test.ts
+++ b/tests/e2e/eventlog.test.ts
@@ -12,6 +12,7 @@ test.describe('EventLog Page', () => {
           localStorage.removeItem(key);
         }
       }
+      localStorage.setItem('exomind:inputSendMode', 'ctrl-enter-send');
     });
     await page.goto('/eventlog');
     await expect(eventInput(page)).toBeVisible();
@@ -31,6 +32,24 @@ test.describe('EventLog Page', () => {
     await input.press('Control+Enter');
 
     await expect(page.getByText(marker)).toBeVisible();
+  });
+
+  test('Enter mode does not send on Ctrl+Enter', async ({ page }) => {
+    await page.evaluate(() => {
+      localStorage.setItem('exomind:inputSendMode', 'enter-send');
+      window.dispatchEvent(new CustomEvent('exomind:input-send-mode-changed', { detail: 'enter-send' }));
+    });
+
+    const marker = `eventlog-enter-mode-${Date.now()}`;
+    const input = eventInput(page);
+    const eventList = page.getByTestId('event-list');
+
+    await input.fill(marker);
+    await expect(eventList.getByTestId('new-mobile-user-message-row')).toHaveCount(0);
+    await input.press('Control+Enter');
+
+    await expect(input).toHaveValue(`${marker}\n`);
+    await expect(eventList.getByTestId('new-mobile-user-message-row')).toHaveCount(0);
   });
 
   test('Shift+Enter inserts newline without sending', async ({ page }) => {

--- a/tests/e2e/me-page-feature-flag.issue551.test.ts
+++ b/tests/e2e/me-page-feature-flag.issue551.test.ts
@@ -1,0 +1,31 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function setupIssue551Flags(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('exomind:uiMode', 'new');
+    localStorage.setItem('exomind:developerMode', 'true');
+    localStorage.setItem('exomind:commandPaletteEnabled', 'true');
+  });
+}
+
+test.describe('Issue #551 me page feature flag（Me 页面功能开关）', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupIssue551Flags(page);
+  });
+
+  test('me entry stays hidden by default and /me redirects to settings（默认隐藏入口且 /me 跳转设置）', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/tasks');
+    await expect(page.getByTestId('mobile-bottom-tab')).toBeVisible();
+
+    await expect(page.getByRole('link', { name: 'Me' })).toHaveCount(0);
+
+    await page.keyboard.press('ControlOrMeta+K');
+    await expect(page.getByTestId('command-palette-overlay')).toBeVisible();
+    await page.getByTestId('command-palette-input').fill('Me');
+    await expect(page.getByTestId('command-palette-item-navigate:me')).toHaveCount(0);
+
+    await page.goto('/me');
+    await expect(page).toHaveURL(/\/settings$/);
+  });
+});

--- a/tests/e2e/me-ui.issue215.test.ts
+++ b/tests/e2e/me-ui.issue215.test.ts
@@ -4,6 +4,7 @@ async function setupIssue215Flags(page: Page) {
   await page.addInitScript(() => {
     localStorage.setItem('exomind:uiMode', 'new');
     localStorage.setItem('exomind:useMockData', 'true');
+    localStorage.setItem('exomind:mePageEnabled', 'true');
   });
 }
 
@@ -14,7 +15,6 @@ test.describe('Issue #215 Me UI（Me 三视图）', () => {
 
   test('默认展示状态视图并可切换学习/内隐（status -> learn -> implicit）', async ({ page }) => {
     await page.goto('/me');
-    await page.waitForLoadState('networkidle');
 
     await expect(page.getByTestId('new-me-page')).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Me' })).toBeVisible();
@@ -33,8 +33,9 @@ test.describe('Issue #215 Me UI（Me 三视图）', () => {
   });
 
   test('底部导航可进入 Me（bottom nav to me）', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
     await page.goto('/tasks');
-    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId('mobile-bottom-tab')).toBeVisible();
 
     await page.getByRole('link', { name: 'Me' }).click();
     await expect(page).toHaveURL(/\/me$/);

--- a/tests/e2e/settings-desktop.issue198.test.ts
+++ b/tests/e2e/settings-desktop.issue198.test.ts
@@ -5,6 +5,7 @@ async function setupIssue198Flags(page: Page) {
     localStorage.setItem('exomind:uiMode', 'new');
     localStorage.setItem('exomind:developerMode', 'true');
     localStorage.setItem('exomind:agentPageEnabled', 'true');
+    localStorage.setItem('exomind:mePageEnabled', 'true');
     localStorage.setItem('exomind:desktopAdaptiveEnabled', 'true');
   });
 }

--- a/tests/e2e/settings-desktop.issue198.test.ts
+++ b/tests/e2e/settings-desktop.issue198.test.ts
@@ -9,6 +9,10 @@ async function setupIssue198Flags(page: Page) {
   });
 }
 
+async function getTestIdWidth(page: Page, testId: string): Promise<number> {
+  return page.getByTestId(testId).evaluate((node) => Math.round(node.getBoundingClientRect().width));
+}
+
 async function seedLoggedInDesktopProfile(page: Page) {
   await page.addInitScript(() => {
     const profileId = 'profile-hailay';
@@ -101,6 +105,45 @@ test.describe('Issue #198 settings desktop shell（设置页桌面壳层）', ()
     await expect(page.getByTestId('desktop-sidebar-item-dashboard')).toHaveCount(0);
     await expect(page.locator('[data-testid^="desktop-sidebar-item-"]')).toHaveCount(5);
     await expect(page.getByTestId('mobile-bottom-tab')).toBeHidden();
+  });
+
+  test('desktop sidebar can collapse and expand with wider content（桌面侧栏可收起展开且内容区变宽）', async ({ page }) => {
+    await page.goto('/settings');
+    await expect(page.getByTestId('desktop-sidebar')).toBeVisible();
+
+    const sidebarWidthExpanded = await getTestIdWidth(page, 'desktop-sidebar');
+    const contentWidthExpanded = await getTestIdWidth(page, 'desktop-settings-content');
+
+    const toggle = page.getByTestId('desktop-sidebar-toggle');
+    await expect(toggle).toHaveAttribute('aria-label', '收起侧边栏');
+    await toggle.click();
+    await expect(page.getByTestId('desktop-sidebar')).toHaveAttribute('data-state', 'collapsed');
+    await expect(toggle).toHaveAttribute('aria-label', '展开侧边栏');
+    await page.waitForTimeout(250);
+
+    const sidebarWidthCollapsed = await getTestIdWidth(page, 'desktop-sidebar');
+    const contentWidthCollapsed = await getTestIdWidth(page, 'desktop-settings-content');
+
+    expect(sidebarWidthCollapsed).toBeLessThan(sidebarWidthExpanded);
+    expect(contentWidthCollapsed).toBeGreaterThan(contentWidthExpanded + 100);
+
+    await toggle.click();
+    await expect(page.getByTestId('desktop-sidebar')).toHaveAttribute('data-state', 'expanded');
+    await expect(toggle).toHaveAttribute('aria-label', '收起侧边栏');
+  });
+
+  test('desktop sidebar collapse persists across desktop routes（桌面侧栏收起状态在桌面路由切换间保持）', async ({ page }) => {
+    await page.goto('/settings');
+    await page.getByTestId('desktop-sidebar-toggle').click();
+    await expect(page.getByTestId('desktop-sidebar')).toHaveAttribute('data-state', 'collapsed');
+
+    await page.getByTestId('desktop-sidebar-item-now').click();
+    await expect(page).toHaveURL(/\/eventlog$/);
+    await expect(page.getByTestId('desktop-sidebar')).toHaveAttribute('data-state', 'collapsed');
+
+    await page.getByTestId('desktop-sidebar-item-settings').click();
+    await expect(page).toHaveURL(/\/settings$/);
+    await expect(page.getByTestId('desktop-sidebar')).toHaveAttribute('data-state', 'collapsed');
   });
 
   test('desktop agents route uses desktop shell（桌面端 Agent 页面走桌面壳层）', async ({ page }) => {

--- a/tests/unit/components/ChatPage.profile-placeholder.test.tsx
+++ b/tests/unit/components/ChatPage.profile-placeholder.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Event } from '@/lib/types/event';
+import { ChatPage } from '@/components/Chat/ChatPage';
+import { useSyncStore } from '@/ui/stores/sync-store';
+import { getEventLogService } from '@/lib/services/eventlog.service';
+
+vi.mock('@/ui/stores/sync-store', () => ({
+  useSyncStore: vi.fn(),
+}));
+
+vi.mock('@/lib/services/eventlog.service', () => ({
+  getEventLogService: vi.fn(),
+}));
+
+vi.mock('@/components/Chat/EventMarkdown', () => ({
+  EventMarkdown: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+vi.mock('@/components/Chat/MessageActions', () => ({
+  MessageActions: () => null,
+}));
+
+vi.mock('@/ui/app/components/NowInputRow', async () => {
+  const React = await import('react');
+  return {
+    NowInputRow: React.forwardRef<HTMLDivElement>((_, ref) => (
+      <div ref={ref} data-testid="now-input-row" />
+    )),
+  };
+});
+
+vi.mock('@/ui/app/components/PageMoreMenu', () => ({
+  PageMoreMenu: () => <div data-testid="page-more-menu" />,
+}));
+
+vi.mock('@/ui/app/components/FocusTimerWidget', async () => {
+  const React = await import('react');
+  return {
+    FocusTimerWidget: React.forwardRef<HTMLDivElement>((_, ref) => (
+      <div ref={ref} data-testid="focus-timer-widget" />
+    )),
+  };
+});
+
+vi.mock('@/components/TimeBlockWidget', () => ({
+  TimeBlockWidget: () => <div data-testid="time-block-widget" />,
+}));
+
+vi.mock('@/components/VoiceMessageInput', () => ({
+  VoiceMessageInput: () => <div data-testid="voice-message-input" />,
+}));
+
+const mockUseSyncStore = vi.mocked(useSyncStore);
+const mockGetEventLogService = vi.mocked(getEventLogService);
+
+const baseEvent: Event = {
+  id: 'event-1',
+  timestamp: new Date('2026-03-17T10:00:00.000Z').getTime(),
+  content: '记录了一条用户事件',
+  tags: new Set(),
+  metadata: {
+    source: {
+      deviceId: 'device-1',
+      deviceName: 'Pixel 9',
+      platform: 'android',
+      app: 'ExoMind',
+    },
+  },
+};
+
+describe('ChatPage profile placeholder', () => {
+  const unsubscribe = vi.fn();
+  const loadEvents = vi.fn<() => Promise<Event[]>>();
+  const onEvent = vi.fn(() => unsubscribe);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
+    loadEvents.mockResolvedValue([baseEvent]);
+    mockGetEventLogService.mockReturnValue({
+      loadEvents,
+      addEvent: vi.fn(),
+      appendEventData: vi.fn(),
+      exportEventsAsJson: vi.fn(),
+      importEventsFromJson: vi.fn(),
+      onEvent,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('shows placeholder name and avatar initial when currentUser is empty', async () => {
+    mockUseSyncStore.mockReturnValue({
+      currentUser: null,
+      isLoggedIn: false,
+      activeProfileId: null,
+    } as never);
+
+    render(<ChatPage variant="new-mobile" />);
+
+    const row = await screen.findByTestId('new-mobile-user-message-row');
+
+    await waitFor(() => {
+      expect(within(row).getByText('未名')).toBeInTheDocument();
+    });
+    expect(within(row).getByText('未')).toBeInTheDocument();
+  });
+
+  it('keeps using current profile name and derived avatar initial when currentUser exists', async () => {
+    mockUseSyncStore.mockReturnValue({
+      currentUser: 'Alice',
+      isLoggedIn: true,
+      activeProfileId: 'profile-alice',
+    } as never);
+
+    render(<ChatPage variant="new-mobile" />);
+
+    const row = await screen.findByTestId('new-mobile-user-message-row');
+
+    await waitFor(() => {
+      expect(within(row).getByText('Alice')).toBeInTheDocument();
+    });
+    expect(within(row).getByText('A')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/settings/DeveloperSection.test.tsx
+++ b/tests/unit/components/settings/DeveloperSection.test.tsx
@@ -9,6 +9,7 @@ import './setup-settings-mocks.tsx';
 import { getDeveloperModeEnabled } from '@/config/developer-mode';
 import { setDevtoolsEnabled } from '@/config/devtools-mode';
 import { setCommandPaletteEnabled } from '@/config/command-palette-enabled';
+import { setMePageEnabled } from '@/config/me-page-enabled';
 import { syncDevtoolsWithSettings } from '@/lib/debug/devtools-runtime';
 import { SettingsPage } from '@/ui/app/pages/SettingsPage';
 
@@ -26,6 +27,7 @@ describe('SettingsPage - Developer Section (developerMode=true)', () => {
     render(<SettingsPage />);
     const row = screen.getByText('功能开关');
     fireEvent.click(row);
+    expect(screen.getByText('Me 页面')).toBeInTheDocument();
     expect(screen.getByText('网络页面')).toBeInTheDocument();
     expect(screen.getByText('命令面板')).toBeInTheDocument();
   });
@@ -56,5 +58,15 @@ describe('SettingsPage - Developer Section (developerMode=true)', () => {
     fireEvent.click(toggle);
 
     expect(vi.mocked(setCommandPaletteEnabled)).toHaveBeenCalledWith(true);
+  });
+
+  it('updates me page state inside feature toggles drawer', () => {
+    render(<SettingsPage />);
+    fireEvent.click(screen.getByText('功能开关'));
+
+    const toggle = screen.getByTestId('feature-toggle-me-page-switch');
+    fireEvent.click(toggle);
+
+    expect(vi.mocked(setMePageEnabled)).toHaveBeenCalledWith(true);
   });
 });

--- a/tests/unit/components/settings/setup-settings-mocks.tsx
+++ b/tests/unit/components/settings/setup-settings-mocks.tsx
@@ -266,6 +266,12 @@ vi.mock('@/config/task-page-fuzzy-search', () => ({
   subscribeTaskPageFuzzySearchChanges: vi.fn(() => () => {}),
 }));
 
+vi.mock('@/config/task-create-success-action', () => ({
+  getTaskCreateSuccessAction: vi.fn(() => 'refocus'),
+  setTaskCreateSuccessAction: vi.fn((value: string) => value),
+  subscribeTaskCreateSuccessActionChanges: vi.fn(() => () => {}),
+}));
+
 vi.mock('@/config/voice-shortcut-send-mode', () => ({
   getVoiceShortcutSendMode: vi.fn(() => 'insert-only'),
   setVoiceShortcutSendMode: vi.fn((value: string) => value),

--- a/tests/unit/components/settings/setup-settings-mocks.tsx
+++ b/tests/unit/components/settings/setup-settings-mocks.tsx
@@ -254,6 +254,12 @@ vi.mock('@/config/voice-transcript-send-mode', () => ({
   subscribeVoiceTranscriptSendModeChanges: vi.fn(() => () => {}),
 }));
 
+vi.mock('@/config/input-send-mode', () => ({
+  getInputSendMode: vi.fn(() => 'ctrl-enter-send'),
+  setInputSendMode: vi.fn((value: string) => value),
+  subscribeInputSendModeChanges: vi.fn(() => () => {}),
+}));
+
 vi.mock('@/config/voice-shortcut-send-mode', () => ({
   getVoiceShortcutSendMode: vi.fn(() => 'insert-only'),
   setVoiceShortcutSendMode: vi.fn((value: string) => value),

--- a/tests/unit/components/settings/setup-settings-mocks.tsx
+++ b/tests/unit/components/settings/setup-settings-mocks.tsx
@@ -95,6 +95,7 @@ export const settingsPageServiceMocks = {
 export const settingsPagePreferenceState = {
   developerMode: false,
   agentPageEnabled: false,
+  mePageEnabled: false,
   desktopAdaptiveEnabled: true,
   voiceShortcutAsrProvider: 'moss' as string,
 };
@@ -177,6 +178,12 @@ vi.mock('@/config/agent-page-enabled', () => ({
   getAgentPageEnabled: vi.fn(() => settingsPagePreferenceState.agentPageEnabled),
   setAgentPageEnabled: vi.fn(),
   subscribeAgentPageEnabledChanges: vi.fn(() => () => {}),
+}));
+
+vi.mock('@/config/me-page-enabled', () => ({
+  getMePageEnabled: vi.fn(() => settingsPagePreferenceState.mePageEnabled),
+  setMePageEnabled: vi.fn(),
+  subscribeMePageEnabledChanges: vi.fn(() => () => {}),
 }));
 
 vi.mock('@/config/desktop-adaptive', () => ({

--- a/tests/unit/components/settings/setup-settings-mocks.tsx
+++ b/tests/unit/components/settings/setup-settings-mocks.tsx
@@ -260,6 +260,12 @@ vi.mock('@/config/input-send-mode', () => ({
   subscribeInputSendModeChanges: vi.fn(() => () => {}),
 }));
 
+vi.mock('@/config/task-page-fuzzy-search', () => ({
+  getTaskPageFuzzySearchEnabled: vi.fn(() => true),
+  setTaskPageFuzzySearchEnabled: vi.fn((value: boolean) => value),
+  subscribeTaskPageFuzzySearchChanges: vi.fn(() => () => {}),
+}));
+
 vi.mock('@/config/voice-shortcut-send-mode', () => ({
   getVoiceShortcutSendMode: vi.fn(() => 'insert-only'),
   setVoiceShortcutSendMode: vi.fn((value: string) => value),

--- a/tests/unit/config/agent-page-enabled.test.ts
+++ b/tests/unit/config/agent-page-enabled.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getAgentPageEnabled,
+  setAgentPageEnabled,
+  subscribeAgentPageEnabledChanges,
+} from '@/config/agent-page-enabled';
+
+describe('agent page flag（网络页面开关）', () => {
+  let storage: Record<string, string>;
+
+  beforeEach(() => {
+    storage = {};
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => (key in storage ? storage[key] : null),
+        setItem: (key: string, value: string) => {
+          storage[key] = value;
+        },
+      },
+    });
+  });
+
+  it('defaults to true when key is missing（缺省时默认开启）', () => {
+    expect(getAgentPageEnabled()).toBe(true);
+  });
+
+  it('returns false when stored value is false（显式 false 时关闭）', () => {
+    storage['exomind:agentPageEnabled'] = 'false';
+    expect(getAgentPageEnabled()).toBe(false);
+  });
+
+  it('persists and emits custom event when toggled（切换时持久化并发事件）', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeAgentPageEnabledChanges(listener);
+
+    setAgentPageEnabled(false);
+
+    expect(storage['exomind:agentPageEnabled']).toBe('false');
+    expect(listener).toHaveBeenCalledWith(false);
+    unsubscribe();
+  });
+
+  it('treats storage key removal as enabled（storage 删除键后恢复默认开启）', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeAgentPageEnabledChanges(listener);
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'exomind:agentPageEnabled',
+      newValue: null,
+    }));
+
+    expect(listener).toHaveBeenCalledWith(true);
+    unsubscribe();
+  });
+});

--- a/tests/unit/config/input-send-mode.test.ts
+++ b/tests/unit/config/input-send-mode.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('input send mode（输入框发送方式）', () => {
+  let storage: Record<string, string>;
+
+  beforeEach(() => {
+    storage = {};
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => (key in storage ? storage[key] : null),
+        setItem: (key: string, value: string) => {
+          storage[key] = value;
+        },
+      },
+    });
+  });
+
+  it('defaults to ctrl-enter-send when missing（未设置时默认 Ctrl+Enter 发送）', async () => {
+    const module = await import('@/config/input-send-mode');
+    expect(module.getInputSendMode()).toBe('ctrl-enter-send');
+  });
+
+  it('persists and emits custom event（保存并广播模式变更）', async () => {
+    const module = await import('@/config/input-send-mode');
+    const listener = vi.fn();
+    const unsubscribe = module.subscribeInputSendModeChanges(listener);
+
+    module.setInputSendMode('enter-send');
+
+    expect(storage['exomind:inputSendMode']).toBe('enter-send');
+    expect(listener).toHaveBeenCalledWith('enter-send');
+    unsubscribe();
+  });
+
+  it('normalizes invalid values and supports storage sync（异常值归一化并支持 storage 同步）', async () => {
+    const module = await import('@/config/input-send-mode');
+    const listener = vi.fn();
+    const unsubscribe = module.subscribeInputSendModeChanges(listener);
+
+    storage['exomind:inputSendMode'] = 'unexpected';
+    expect(module.getInputSendMode()).toBe('ctrl-enter-send');
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'exomind:inputSendMode',
+      newValue: 'enter-send',
+    }));
+
+    expect(listener).toHaveBeenCalledWith('enter-send');
+    unsubscribe();
+  });
+});

--- a/tests/unit/config/task-create-success-action.test.ts
+++ b/tests/unit/config/task-create-success-action.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+describe('task create success action config（任务创建后行为配置）', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults to refocus when missing（未设置时默认回焦）', async () => {
+    const module = await import('@/config/task-create-success-action');
+    expect(module.getTaskCreateSuccessAction()).toBe('refocus');
+  });
+
+  it('normalizes invalid values back to refocus（非法值回退到默认）', async () => {
+    localStorage.setItem('exomind:taskCreateSuccessAction', 'invalid');
+    const module = await import('@/config/task-create-success-action');
+    expect(module.getTaskCreateSuccessAction()).toBe('refocus');
+  });
+
+  it('persists and emits open-detail（支持持久化打开详情）', async () => {
+    const module = await import('@/config/task-create-success-action');
+    const listener = vi.fn();
+    const unsubscribe = module.subscribeTaskCreateSuccessActionChanges(listener);
+
+    expect(module.setTaskCreateSuccessAction('open-detail')).toBe('open-detail');
+    expect(module.getTaskCreateSuccessAction()).toBe('open-detail');
+    expect(localStorage.getItem('exomind:taskCreateSuccessAction')).toBe('open-detail');
+    expect(listener).toHaveBeenCalledWith('open-detail');
+
+    unsubscribe();
+  });
+});

--- a/tests/unit/config/task-page-fuzzy-search.test.ts
+++ b/tests/unit/config/task-page-fuzzy-search.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('task page fuzzy search config（任务页模糊搜索配置）', () => {
+  let storage: Record<string, string>;
+
+  beforeEach(() => {
+    storage = {};
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => (key in storage ? storage[key] : null),
+        setItem: (key: string, value: string) => {
+          storage[key] = value;
+        },
+      },
+    });
+  });
+
+  it('defaults to enabled when missing（未设置时默认开启）', async () => {
+    const module = await import('@/config/task-page-fuzzy-search');
+    expect(module.getTaskPageFuzzySearchEnabled()).toBe(true);
+  });
+
+  it('persists and emits custom event（保存并广播开关变更）', async () => {
+    const module = await import('@/config/task-page-fuzzy-search');
+    const listener = vi.fn();
+    const unsubscribe = module.subscribeTaskPageFuzzySearchChanges(listener);
+
+    module.setTaskPageFuzzySearchEnabled(false);
+
+    expect(storage['exomind:taskPageFuzzySearchEnabled']).toBe('false');
+    expect(listener).toHaveBeenCalledWith(false);
+    unsubscribe();
+  });
+
+  it('normalizes storage values and supports storage sync（异常值归一化并支持 storage 同步）', async () => {
+    const module = await import('@/config/task-page-fuzzy-search');
+    const listener = vi.fn();
+    const unsubscribe = module.subscribeTaskPageFuzzySearchChanges(listener);
+
+    storage['exomind:taskPageFuzzySearchEnabled'] = 'unexpected';
+    expect(module.getTaskPageFuzzySearchEnabled()).toBe(true);
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'exomind:taskPageFuzzySearchEnabled',
+      newValue: 'false',
+    }));
+
+    expect(listener).toHaveBeenCalledWith(false);
+    unsubscribe();
+  });
+});

--- a/tests/unit/hooks/use-tauri-fullscreen-shortcut.issue556.test.tsx
+++ b/tests/unit/hooks/use-tauri-fullscreen-shortcut.issue556.test.tsx
@@ -1,0 +1,114 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  isTauriWindow: vi.fn(),
+  isFullscreen: vi.fn(),
+  setFullscreen: vi.fn(),
+}));
+
+vi.mock('@/config/runtime-target', () => ({
+  isTauriWindow: mocks.isTauriWindow,
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    isFullscreen: mocks.isFullscreen,
+    setFullscreen: mocks.setFullscreen,
+  }),
+}));
+
+describe('useTauriFullscreenShortcut issue-556', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isTauriWindow.mockReturnValue(true);
+    mocks.isFullscreen.mockResolvedValue(false);
+    mocks.setFullscreen.mockResolvedValue(undefined);
+  });
+
+  it('enters fullscreen on F11 in tauri window（Tauri 窗口按 F11 进入全屏）', async () => {
+    const { useTauriFullscreenShortcut } = await import('@/ui/app/hooks/useTauriFullscreenShortcut');
+
+    renderHook(() => useTauriFullscreenShortcut());
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'F11',
+      cancelable: true,
+    });
+
+    window.dispatchEvent(event);
+
+    await waitFor(() => {
+      expect(mocks.isFullscreen).toHaveBeenCalledTimes(1);
+      expect(mocks.setFullscreen).toHaveBeenCalledWith(true);
+    });
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('exits fullscreen on repeated F11 in tauri window（Tauri 窗口再次按 F11 退出全屏）', async () => {
+    const { useTauriFullscreenShortcut } = await import('@/ui/app/hooks/useTauriFullscreenShortcut');
+    mocks.isFullscreen.mockResolvedValue(true);
+
+    renderHook(() => useTauriFullscreenShortcut());
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'F11',
+      cancelable: true,
+    });
+
+    window.dispatchEvent(event);
+
+    await waitFor(() => {
+      expect(mocks.isFullscreen).toHaveBeenCalledTimes(1);
+      expect(mocks.setFullscreen).toHaveBeenCalledWith(false);
+    });
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('does not hijack browser F11 outside tauri（非 Tauri 环境不接管浏览器 F11）', async () => {
+    const { useTauriFullscreenShortcut } = await import('@/ui/app/hooks/useTauriFullscreenShortcut');
+    mocks.isTauriWindow.mockReturnValue(false);
+
+    renderHook(() => useTauriFullscreenShortcut());
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'F11',
+      cancelable: true,
+    });
+
+    window.dispatchEvent(event);
+
+    await waitFor(() => {
+      expect(mocks.isFullscreen).not.toHaveBeenCalled();
+      expect(mocks.setFullscreen).not.toHaveBeenCalled();
+    });
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('ignores existing modified shortcuts like Ctrl/Cmd+K and Alt+Q（不影响现有带修饰键快捷键）', async () => {
+    const { useTauriFullscreenShortcut } = await import('@/ui/app/hooks/useTauriFullscreenShortcut');
+
+    renderHook(() => useTauriFullscreenShortcut());
+
+    const commandPaletteEvent = new KeyboardEvent('keydown', {
+      key: 'k',
+      ctrlKey: true,
+      cancelable: true,
+    });
+    const voiceShortcutEvent = new KeyboardEvent('keydown', {
+      key: 'q',
+      altKey: true,
+      cancelable: true,
+    });
+
+    window.dispatchEvent(commandPaletteEvent);
+    window.dispatchEvent(voiceShortcutEvent);
+
+    await waitFor(() => {
+      expect(mocks.isFullscreen).not.toHaveBeenCalled();
+      expect(mocks.setFullscreen).not.toHaveBeenCalled();
+    });
+    expect(commandPaletteEvent.defaultPrevented).toBe(false);
+    expect(voiceShortcutEvent.defaultPrevented).toBe(false);
+  });
+});

--- a/tests/unit/hooks/use-timer-config.issue400.test.ts
+++ b/tests/unit/hooks/use-timer-config.issue400.test.ts
@@ -3,10 +3,11 @@ import { describe, expect, it } from 'vitest';
 import { useTimerConfig } from '@/ui/app/hooks/useTimerConfig';
 
 describe('useTimerConfig', () => {
-  it('defaults to 25-minute countdown config（默认返回 25 分钟倒计时配置）', () => {
+  it('defaults to countup config without estimated minutes（未传估时时默认返回正计时配置）', () => {
     const { result } = renderHook(() => useTimerConfig());
 
-    expect(result.current.timerConfig).toEqual({ mode: 'countdown', minutes: 25 });
+    expect(result.current.countdownMinutes).toBe(25);
+    expect(result.current.timerConfig).toEqual({ mode: 'countup' });
   });
 
   it('uses provided initial minutes（使用传入的初始分钟数）', () => {
@@ -43,5 +44,24 @@ describe('useTimerConfig', () => {
     expect(result.current.countdownMinutes).toBe(30);
     expect(result.current.customDurationDraft).toBe('30');
     expect(result.current.timerConfig).toEqual({ mode: 'countdown', minutes: 30 });
+  });
+
+  it('syncTimerConfig does not block later estimated-minute sync（自动同步不应阻断后续估时同步）', () => {
+    const { result, rerender } = renderHook(
+      ({ initialMinutes }: { initialMinutes?: number }) => useTimerConfig(initialMinutes, 'task-1'),
+      {
+        initialProps: { initialMinutes: 120 },
+      },
+    );
+
+    act(() => {
+      result.current.syncTimerConfig({ mode: 'countdown', minutes: 30 });
+    });
+
+    rerender({ initialMinutes: 60 });
+
+    expect(result.current.timerMode).toBe('countdown');
+    expect(result.current.countdownMinutes).toBe(60);
+    expect(result.current.timerConfig).toEqual({ mode: 'countdown', minutes: 60 });
   });
 });

--- a/tests/unit/services/command-palette.commands.issue551.test.ts
+++ b/tests/unit/services/command-palette.commands.issue551.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createCoreNavigationCommands } from '@/lib/services/command-palette.commands';
+
+describe('issue-551 me command palette registration（Me 页面命令注册）', () => {
+  it('omits navigate:me when the me page feature flag is disabled（关闭开关时不注册打开 Me）', () => {
+    const commands = createCoreNavigationCommands({
+      navigate: vi.fn(),
+      featureFlags: {
+        mePageEnabled: false,
+      },
+    });
+
+    expect(commands.find((command) => command.id === 'navigate:me')).toBeUndefined();
+  });
+
+  it('registers navigate:me when the me page feature flag is enabled（开启开关时注册打开 Me）', async () => {
+    const navigate = vi.fn();
+    const commands = createCoreNavigationCommands({
+      navigate,
+      featureFlags: {
+        mePageEnabled: true,
+      },
+    });
+
+    const meCommand = commands.find((command) => command.id === 'navigate:me');
+    expect(meCommand).toBeDefined();
+
+    const result = await meCommand?.execute(undefined, {
+      currentPath: '/settings',
+      platform: 'web',
+      developerModeEnabled: true,
+      commandPaletteEnabled: true,
+      featureFlags: {
+        mePageEnabled: true,
+        agentPageEnabled: false,
+        goalsV2Enabled: false,
+      },
+    });
+
+    expect(navigate).toHaveBeenCalledWith('/me');
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/tests/unit/services/command-registry.service.issue243.test.ts
+++ b/tests/unit/services/command-registry.service.issue243.test.ts
@@ -9,6 +9,7 @@ function createContext(overrides: Partial<CommandContext> = {}): CommandContext 
     developerModeEnabled: true,
     commandPaletteEnabled: true,
     featureFlags: {
+      mePageEnabled: false,
       agentPageEnabled: true,
       goalsV2Enabled: false,
       ...overrides.featureFlags,

--- a/tests/unit/settings/settings-input-section.issue199.test.tsx
+++ b/tests/unit/settings/settings-input-section.issue199.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '../components/settings/setup-settings-mocks.tsx';
 import { SettingsPage } from '@/ui/app/pages/SettingsPage';
 import { getDeveloperModeEnabled } from '@/config/developer-mode';
+import { setInputSendMode } from '@/config/input-send-mode';
 import { setVoiceTranscriptSendMode } from '@/config/voice-transcript-send-mode';
 import { setVoiceShortcutSendMode } from '@/config/voice-shortcut-send-mode';
 import { getVoiceShortcutHotkey, setVoiceShortcutHotkey } from '@/config/voice-shortcut-hotkey';
@@ -52,6 +53,7 @@ describe('SettingsPage input section（输入分组语音配置）', () => {
     render(<SettingsPage />);
 
     expect(screen.getByTestId('new-settings-input-section')).toBeInTheDocument();
+    expect(screen.getByText('输入框发送方式')).toBeInTheDocument();
     expect(screen.getByText('语音转写后')).toBeInTheDocument();
     expect(screen.getByText('聊天与外部输入语音完成后')).toBeInTheDocument();
     expect(screen.getByText('全局语音快捷键')).toBeInTheDocument();
@@ -62,6 +64,7 @@ describe('SettingsPage input section（输入分组语音配置）', () => {
     expect(screen.getByText('悬浮窗实时文本行数')).toBeInTheDocument();
     expect(screen.getByText('悬浮窗距任务栏间距')).toBeInTheDocument();
     expect(screen.getByText('MOSS API Token')).toBeInTheDocument();
+    expect(screen.getByText('统一控制「任务 / 当下」输入框使用 Enter 发送还是 Ctrl/Cmd+Enter 发送')).toBeInTheDocument();
     expect(screen.getByText('仅作用于「当下」页面输入框，默认插入输入框')).toBeInTheDocument();
     expect(screen.getByText('Shortcut Voice（快捷键语音）默认 Alt+Q，按一次开始再按一次结束')).toBeInTheDocument();
     expect(screen.queryByText('MOSS 语音测试')).not.toBeInTheDocument();
@@ -140,6 +143,16 @@ describe('SettingsPage input section（输入分组语音配置）', () => {
 
     expect(setModeMock).toHaveBeenCalledWith('auto-enter-send');
     expect(screen.getByTestId('new-settings-voice-shortcut-send-mode-auto-enter-send')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('toggles keyboard input send mode from input section', () => {
+    const setModeMock = vi.mocked(setInputSendMode);
+    render(<SettingsPage />);
+
+    fireEvent.click(screen.getByTestId('new-settings-input-send-mode-enter-send'));
+
+    expect(setModeMock).toHaveBeenCalledWith('enter-send');
+    expect(screen.getByTestId('new-settings-input-send-mode-enter-send')).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('toggles overlay diagnostics visibility from input section', () => {

--- a/tests/unit/settings/settings-input-section.issue199.test.tsx
+++ b/tests/unit/settings/settings-input-section.issue199.test.tsx
@@ -5,6 +5,7 @@ import { SettingsPage } from '@/ui/app/pages/SettingsPage';
 import { getDeveloperModeEnabled } from '@/config/developer-mode';
 import { setInputSendMode } from '@/config/input-send-mode';
 import { setTaskPageFuzzySearchEnabled } from '@/config/task-page-fuzzy-search';
+import { setTaskCreateSuccessAction } from '@/config/task-create-success-action';
 import { setVoiceTranscriptSendMode } from '@/config/voice-transcript-send-mode';
 import { setVoiceShortcutSendMode } from '@/config/voice-shortcut-send-mode';
 import { getVoiceShortcutHotkey, setVoiceShortcutHotkey } from '@/config/voice-shortcut-hotkey';
@@ -56,6 +57,7 @@ describe('SettingsPage input section（输入分组语音配置）', () => {
     expect(screen.getByTestId('new-settings-input-section')).toBeInTheDocument();
     expect(screen.getByText('输入框发送方式')).toBeInTheDocument();
     expect(screen.getByText('任务页输入框模糊搜索')).toBeInTheDocument();
+    expect(screen.getByText('创建任务后')).toBeInTheDocument();
     expect(screen.getByText('语音转写后')).toBeInTheDocument();
     expect(screen.getByText('聊天与外部输入语音完成后')).toBeInTheDocument();
     expect(screen.getByText('全局语音快捷键')).toBeInTheDocument();
@@ -68,6 +70,7 @@ describe('SettingsPage input section（输入分组语音配置）', () => {
     expect(screen.getByText('MOSS API Token')).toBeInTheDocument();
     expect(screen.getByText('统一控制「任务 / 当下」输入框使用 Enter 发送还是 Ctrl/Cmd+Enter 发送')).toBeInTheDocument();
     expect(screen.getByText('仅作用于任务页；开启后会用输入框第一行对任务标题做防抖模糊过滤')).toBeInTheDocument();
+    expect(screen.getByText('仅作用于任务页快速添加；默认继续回焦，也可切换为直接打开新建任务详情')).toBeInTheDocument();
     expect(screen.getByText('仅作用于「当下」页面输入框，默认插入输入框')).toBeInTheDocument();
     expect(screen.getByText('Shortcut Voice（快捷键语音）默认 Alt+Q，按一次开始再按一次结束')).toBeInTheDocument();
     expect(screen.queryByText('MOSS 语音测试')).not.toBeInTheDocument();
@@ -80,8 +83,8 @@ describe('SettingsPage input section（输入分组语音配置）', () => {
     render(<SettingsPage />);
 
     expect(screen.getByText('MOSS 语音测试')).toBeInTheDocument();
-    expect(screen.getByText('火山引擎 ASR 测试')).toBeInTheDocument();
-    expect(screen.getAllByText('可用')).toHaveLength(2);
+    expect(screen.queryByText('火山引擎 ASR 测试')).not.toBeInTheDocument();
+    expect(screen.getAllByText('可用')).toHaveLength(1);
   });
 
   it('switches shortcut voice provider from input section', async () => {
@@ -165,6 +168,16 @@ describe('SettingsPage input section（输入分组语音配置）', () => {
     fireEvent.click(screen.getByTestId('new-settings-task-page-fuzzy-search-switch'));
 
     expect(setEnabledMock).toHaveBeenCalledWith(false);
+  });
+
+  it('switches task create success action from input section', () => {
+    const setActionMock = vi.mocked(setTaskCreateSuccessAction);
+    render(<SettingsPage />);
+
+    fireEvent.click(screen.getByTestId('new-settings-task-create-success-action-open-detail'));
+
+    expect(setActionMock).toHaveBeenCalledWith('open-detail');
+    expect(screen.getByTestId('new-settings-task-create-success-action-open-detail')).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('toggles overlay diagnostics visibility from input section', () => {

--- a/tests/unit/settings/settings-input-section.issue199.test.tsx
+++ b/tests/unit/settings/settings-input-section.issue199.test.tsx
@@ -4,6 +4,7 @@ import '../components/settings/setup-settings-mocks.tsx';
 import { SettingsPage } from '@/ui/app/pages/SettingsPage';
 import { getDeveloperModeEnabled } from '@/config/developer-mode';
 import { setInputSendMode } from '@/config/input-send-mode';
+import { setTaskPageFuzzySearchEnabled } from '@/config/task-page-fuzzy-search';
 import { setVoiceTranscriptSendMode } from '@/config/voice-transcript-send-mode';
 import { setVoiceShortcutSendMode } from '@/config/voice-shortcut-send-mode';
 import { getVoiceShortcutHotkey, setVoiceShortcutHotkey } from '@/config/voice-shortcut-hotkey';
@@ -54,6 +55,7 @@ describe('SettingsPage input section（输入分组语音配置）', () => {
 
     expect(screen.getByTestId('new-settings-input-section')).toBeInTheDocument();
     expect(screen.getByText('输入框发送方式')).toBeInTheDocument();
+    expect(screen.getByText('任务页输入框模糊搜索')).toBeInTheDocument();
     expect(screen.getByText('语音转写后')).toBeInTheDocument();
     expect(screen.getByText('聊天与外部输入语音完成后')).toBeInTheDocument();
     expect(screen.getByText('全局语音快捷键')).toBeInTheDocument();
@@ -65,6 +67,7 @@ describe('SettingsPage input section（输入分组语音配置）', () => {
     expect(screen.getByText('悬浮窗距任务栏间距')).toBeInTheDocument();
     expect(screen.getByText('MOSS API Token')).toBeInTheDocument();
     expect(screen.getByText('统一控制「任务 / 当下」输入框使用 Enter 发送还是 Ctrl/Cmd+Enter 发送')).toBeInTheDocument();
+    expect(screen.getByText('仅作用于任务页；开启后会用输入框第一行对任务标题做防抖模糊过滤')).toBeInTheDocument();
     expect(screen.getByText('仅作用于「当下」页面输入框，默认插入输入框')).toBeInTheDocument();
     expect(screen.getByText('Shortcut Voice（快捷键语音）默认 Alt+Q，按一次开始再按一次结束')).toBeInTheDocument();
     expect(screen.queryByText('MOSS 语音测试')).not.toBeInTheDocument();
@@ -153,6 +156,15 @@ describe('SettingsPage input section（输入分组语音配置）', () => {
 
     expect(setModeMock).toHaveBeenCalledWith('enter-send');
     expect(screen.getByTestId('new-settings-input-send-mode-enter-send')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('toggles task page fuzzy search from input section', () => {
+    const setEnabledMock = vi.mocked(setTaskPageFuzzySearchEnabled);
+    render(<SettingsPage />);
+
+    fireEvent.click(screen.getByTestId('new-settings-task-page-fuzzy-search-switch'));
+
+    expect(setEnabledMock).toHaveBeenCalledWith(false);
   });
 
   it('toggles overlay diagnostics visibility from input section', () => {

--- a/tests/unit/settings/settings-instance-diagnostics.issue514.test.tsx
+++ b/tests/unit/settings/settings-instance-diagnostics.issue514.test.tsx
@@ -145,6 +145,12 @@ vi.mock('@/config/voice-transcript-send-mode', () => ({
   subscribeVoiceTranscriptSendModeChanges: () => () => {},
 }));
 
+vi.mock('@/config/input-send-mode', () => ({
+  getInputSendMode: () => 'ctrl-enter-send',
+  setInputSendMode: vi.fn(),
+  subscribeInputSendModeChanges: () => () => {},
+}));
+
 vi.mock('@/config/voice-shortcut-hotkey', () => ({
   VOICE_SHORTCUT_HOTKEY_VALUES: ['Alt+Q', 'Alt+W'],
   getVoiceShortcutHotkey: () => 'Alt+Q',

--- a/tests/unit/settings/settings-registry-coverage.test.ts
+++ b/tests/unit/settings/settings-registry-coverage.test.ts
@@ -20,6 +20,7 @@ const AUDITED_SETTINGS_IDS = [
   'sound-preset',
   'focus-bgm',
   'feedback-content',
+  'input-send-mode',
   'voice-transcript-send-mode',
   'voice-shortcut-send-mode',
   'voice-shortcut-hotkey',
@@ -64,6 +65,7 @@ const AUDITED_SETTINGS_IDS = [
 
 const INLINE_SINGLE_ENUM_IDS = [
   'theme',
+  'input-send-mode',
   'voice-transcript-send-mode',
   'voice-shortcut-send-mode',
   'voice-shortcut-hotkey',

--- a/tests/unit/settings/settings-registry-coverage.test.ts
+++ b/tests/unit/settings/settings-registry-coverage.test.ts
@@ -21,6 +21,7 @@ const AUDITED_SETTINGS_IDS = [
   'focus-bgm',
   'feedback-content',
   'input-send-mode',
+  'task-page-fuzzy-search',
   'voice-transcript-send-mode',
   'voice-shortcut-send-mode',
   'voice-shortcut-hotkey',
@@ -86,6 +87,7 @@ const MULTI_ENUM_IDS = [
 
 const BOOLEAN_IDS = [
   'voice-shortcut-mic-prewarm',
+  'task-page-fuzzy-search',
   'voice-overlay-show-diagnostics',
   'now-workbench-overlay-enabled',
   'developer-mode',

--- a/tests/unit/settings/settings-registry-coverage.test.ts
+++ b/tests/unit/settings/settings-registry-coverage.test.ts
@@ -22,6 +22,7 @@ const AUDITED_SETTINGS_IDS = [
   'feedback-content',
   'input-send-mode',
   'task-page-fuzzy-search',
+  'task-create-success-action',
   'voice-transcript-send-mode',
   'voice-shortcut-send-mode',
   'voice-shortcut-hotkey',
@@ -67,6 +68,7 @@ const AUDITED_SETTINGS_IDS = [
 const INLINE_SINGLE_ENUM_IDS = [
   'theme',
   'input-send-mode',
+  'task-create-success-action',
   'voice-transcript-send-mode',
   'voice-shortcut-send-mode',
   'voice-shortcut-hotkey',

--- a/tests/unit/settings/settings-registry-coverage.test.ts
+++ b/tests/unit/settings/settings-registry-coverage.test.ts
@@ -243,6 +243,7 @@ describe('settings registry coverage audit', () => {
     const featureToggles = getItem('feature-toggles', 'group');
     expect(featureToggles.groupStyle).toBe('adaptive-overlay');
     expect(featureToggles.children.map((child) => child.id)).toEqual([
+      'me-page-enabled',
       'agent-page-enabled',
       'desktop-adaptive',
       'command-palette-enabled',
@@ -318,6 +319,7 @@ describe('settings registry coverage audit', () => {
 
   it('keeps the feature toggles drawer checklist in sync with its audited child settings', () => {
     expect(FEATURE_TOGGLE_SETTING_IDS).toEqual([
+      'me-page-enabled',
       'agent-page-enabled',
       'desktop-adaptive',
       'command-palette-enabled',

--- a/tests/unit/settings/settings-renderers.test.tsx
+++ b/tests/unit/settings/settings-renderers.test.tsx
@@ -286,9 +286,13 @@ describe('SettingsItemRenderer', () => {
       </SettingsToneProvider>,
     );
 
-    expect(screen.getByRole('slider').getAttribute('style') ?? '').toContain(
+    const slider = screen.getByRole('slider');
+
+    expect(slider.className).toContain('settings-range');
+    expect(slider.getAttribute('style') ?? '').toContain(
       'accent-color: var(--settings-tone-color, var(--settings-tone-default))',
     );
+    expect(slider.getAttribute('style') ?? '').toContain('--settings-range-progress: 53.85%');
   });
 
   it('renders dialog string items and saves edited values', () => {

--- a/tests/unit/settings/settings-renderers.test.tsx
+++ b/tests/unit/settings/settings-renderers.test.tsx
@@ -290,9 +290,10 @@ describe('SettingsItemRenderer', () => {
 
     expect(slider.className).toContain('settings-range');
     expect(slider.getAttribute('style') ?? '').toContain(
-      'accent-color: var(--settings-tone-color, var(--settings-tone-default))',
+      '--settings-tone-color: var(--settings-tone-developer)',
     );
     expect(slider.getAttribute('style') ?? '').toContain('--settings-range-progress: 53.85%');
+    expect(slider.getAttribute('style') ?? '').toContain('--settings-range-progress-ratio: 0.5385');
   });
 
   it('renders dialog string items and saves edited values', () => {

--- a/tests/unit/sync-store.test.ts
+++ b/tests/unit/sync-store.test.ts
@@ -69,6 +69,28 @@ describe('SyncStore', () => {
       expect((store as typeof store & { activeProfileId?: string | null }).activeProfileId).toBeNull();
       expect(store.conflicts).toEqual([]);
     });
+
+    it('没有激活档案 session 时不应保留旧 currentUser', async () => {
+      const profileModule = await import('@/lib/profile/profile-storage');
+      profileModule.createLocalProfile({
+        slug: 'hailay',
+        displayName: 'Hailay',
+      });
+      profileModule.setProfileSession({
+        version: 1,
+        activeProfileId: null,
+        unlockedProfileIds: [],
+      });
+
+      vi.resetModules();
+      const module = await import('@/ui/stores/sync-store');
+      const store = module.useSyncStore.getState();
+
+      expect(store.isLoggedIn).toBe(false);
+      expect(store.currentUser).toBeNull();
+      expect((store as typeof store & { activeProfileId?: string | null }).activeProfileId).toBeNull();
+      expect(store.credentials).toBeNull();
+    });
   });
 
   describe('setStatus', () => {

--- a/tests/unit/tauri/fullscreen-capability.issue556.test.ts
+++ b/tests/unit/tauri/fullscreen-capability.issue556.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('fullscreen capability issue-556（主窗口全屏权限）', () => {
+  it('allows the main window to toggle native fullscreen（主窗口允许切换原生全屏）', () => {
+    const filePath = resolve(process.cwd(), 'src-tauri/capabilities/default.json');
+    const capability = JSON.parse(readFileSync(filePath, 'utf8')) as {
+      permissions: string[];
+    };
+
+    expect(capability.permissions).toContain('core:window:allow-set-fullscreen');
+  });
+});

--- a/tests/unit/ui/command-palette-scroll.issue243.test.tsx
+++ b/tests/unit/ui/command-palette-scroll.issue243.test.tsx
@@ -135,6 +135,7 @@ describe('command palette scroll sync issue-243（高亮项滚动同步）', () 
     developerModeEnabled: true,
     commandPaletteEnabled: true,
     featureFlags: {
+      mePageEnabled: false,
       agentPageEnabled: true,
       goalsV2Enabled: false,
     },

--- a/tests/unit/ui/desktop-settings-shell.issue198.test.ts
+++ b/tests/unit/ui/desktop-settings-shell.issue198.test.ts
@@ -61,6 +61,14 @@ describe('issue-198 desktop settings shell（桌面设置壳层）', () => {
     expect(source).toContain('desktopAdaptiveEnabled');
   });
 
+  it('adds collapsible desktop sidebar state and toggle（桌面侧栏支持收起状态与切换按钮）', () => {
+    expect(source).toContain('desktopSidebarCollapsed');
+    expect(source).toContain('setDesktopSidebarCollapsed');
+    expect(source).toContain('data-testid="desktop-sidebar-toggle"');
+    expect(source).toContain('收起侧边栏');
+    expect(source).toContain('展开侧边栏');
+  });
+
   it('uses settings content area marker（设置内容区标识）', () => {
     expect(source).toContain('data-testid="desktop-settings-content"');
     expect(source).not.toContain('data-testid="desktop-settings-nav"');

--- a/tests/unit/ui/desktop-settings-shell.issue198.test.ts
+++ b/tests/unit/ui/desktop-settings-shell.issue198.test.ts
@@ -27,10 +27,12 @@ describe('issue-198 desktop settings shell（桌面设置壳层）', () => {
     expect(source).toContain("location.pathname === '/agents'");
   });
 
-  it('uses five desktop nav items including me entry（桌面导航5项且包含 Me 入口）', () => {
+  it('keeps me entry behind feature flag in desktop nav（桌面导航中的 Me 入口受功能开关控制）', () => {
     expect(desktopNavBlock).toContain("title: '当下', path: '/eventlog'");
     expect(desktopNavBlock).toContain("title: '任务', path: '/tasks'");
-    expect(desktopNavBlock).toContain("title: 'Me', path: '/me'");
+    expect(desktopNavBlock).toContain('...(mePageEnabled ? [{');
+    expect(desktopNavBlock).toContain("title: 'Me'");
+    expect(desktopNavBlock).toContain("path: '/me'");
     expect(desktopNavBlock).toContain("icon: UserRound");
     expect(desktopNavBlock).toContain("key: 'agents'");
     expect(desktopNavBlock).toContain("title: '网络'");

--- a/tests/unit/ui/estimated-time-editor.issue384.test.tsx
+++ b/tests/unit/ui/estimated-time-editor.issue384.test.tsx
@@ -34,7 +34,6 @@ describe('EstimatedTimeEditor issue #384', () => {
   it('renders current estimatedMinutes and highlights current preset（显示当前估时并高亮预设）', () => {
     render(<EstimatedTimeEditor taskId="task-1" currentMinutes={25} />);
 
-    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：25 分钟');
     expect(screen.getByTestId('estimated-time-preset-25')).toHaveAttribute('aria-pressed', 'true');
   });
 
@@ -47,7 +46,6 @@ describe('EstimatedTimeEditor issue #384', () => {
       expect(updateTaskMock).toHaveBeenCalledWith('task-1', { estimatedMinutes: 45 });
     });
 
-    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：45 分钟');
     expect(screen.getByTestId('estimated-time-preset-45')).toHaveAttribute('aria-pressed', 'true');
   });
 
@@ -62,21 +60,19 @@ describe('EstimatedTimeEditor issue #384', () => {
       expect(updateTaskMock).toHaveBeenCalledWith('task-1', { estimatedMinutes: 90 });
     });
 
-    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：90 分钟');
     expect(screen.getByTestId('estimated-time-custom-trigger')).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('clear resets the value to undefined（清空估时）', async () => {
+  it('"无" preset resets the value to undefined（选择"无"清空估时）', async () => {
     render(<EstimatedTimeEditor taskId="task-1" currentMinutes={60} />);
 
-    fireEvent.click(screen.getByTestId('estimated-time-clear'));
+    fireEvent.click(screen.getByTestId('estimated-time-preset-none'));
 
     await waitFor(() => {
       expect(updateTaskMock).toHaveBeenCalledWith('task-1', { estimatedMinutes: undefined });
     });
 
-    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：未估时');
-    expect(screen.getByTestId('estimated-time-clear')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('estimated-time-preset-none')).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('calls onUpdate after successful save（保存成功后回调 onUpdate）', async () => {

--- a/tests/unit/ui/fullscreen-shortcut-routing.issue556.test.ts
+++ b/tests/unit/ui/fullscreen-shortcut-routing.issue556.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('fullscreen shortcut routing issue-556', () => {
+  it('wires useTauriFullscreenShortcut into NewLayout', () => {
+    const sourcePath = path.resolve('src/routes.tsx');
+    const source = readFileSync(sourcePath, 'utf-8');
+
+    expect(source).toContain("import { useTauriFullscreenShortcut } from '@/ui/app/hooks/useTauriFullscreenShortcut';");
+
+    const newLayoutStart = source.indexOf('function NewLayout() {');
+    expect(newLayoutStart).toBeGreaterThanOrEqual(0);
+
+    const newLayoutSlice = source.slice(newLayoutStart, newLayoutStart + 500);
+    expect(newLayoutSlice).toContain('useTauriFullscreenShortcut();');
+  });
+});

--- a/tests/unit/ui/me-routing.issue551.test.ts
+++ b/tests/unit/ui/me-routing.issue551.test.ts
@@ -1,0 +1,25 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('issue-551 me page feature guard（Me 页面功能开关接线）', () => {
+  const sourcePath = path.resolve('src/routes.tsx');
+  const source = readFileSync(sourcePath, 'utf-8');
+
+  it('wires me-page-enabled state into layout subscriptions（路由壳层订阅 Me 页面开关）', () => {
+    expect(source).toContain('getMePageEnabled');
+    expect(source).toContain('subscribeMePageEnabledChanges');
+    expect(source).toContain('const [mePageEnabled, setMePageEnabled] = useState(() => getMePageEnabled())');
+  });
+
+  it('gates mobile/desktop navigation and command context with the me flag（导航与命令上下文受 Me 开关控制）', () => {
+    expect(source).toContain("...(mePageEnabled ? [{ title: 'Me', path: '/me', icon: UserRound }] : [])");
+    expect(source).toContain("featureFlags: {");
+    expect(source).toContain('mePageEnabled');
+  });
+
+  it('redirects /me to settings when the me page is disabled（关闭开关时访问 /me 跳转到设置）', () => {
+    expect(source).toContain("path: '/me'");
+    expect(source).toContain("void navigate({ to: '/settings', replace: true })");
+  });
+});

--- a/tests/unit/ui/now-input-row.issue546-draft.test.tsx
+++ b/tests/unit/ui/now-input-row.issue546-draft.test.tsx
@@ -1,0 +1,208 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { NowInputRow } from '@/ui/app/components/NowInputRow';
+
+const {
+  mockReadClipboardText,
+  mockToast,
+  startVoiceSpy,
+  setLatestVoiceProps,
+  getVoiceTranscriptSendMode,
+  subscribeVoiceTranscriptSendModeChanges,
+  getInputSendMode,
+  subscribeInputSendModeChanges,
+  resetVoiceTranscriptMode,
+  resetInputSendMode,
+  mockPublishVoiceTranscriptSignal,
+} = vi.hoisted(() => {
+  let latestVoiceProps: any = null;
+  let transcriptMode: 'insert' | 'direct-send' = 'insert';
+  let transcriptListeners: Array<(nextMode: 'insert' | 'direct-send') => void> = [];
+  let inputSendMode: 'enter-send' | 'ctrl-enter-send' = 'ctrl-enter-send';
+  let inputSendListeners: Array<(nextMode: 'enter-send' | 'ctrl-enter-send') => void> = [];
+  return {
+    mockReadClipboardText: vi.fn(),
+    mockToast: vi.fn(),
+    startVoiceSpy: vi.fn(),
+    setLatestVoiceProps: (props: any) => {
+      latestVoiceProps = props;
+    },
+    getVoiceTranscriptSendMode: vi.fn(() => transcriptMode),
+    subscribeVoiceTranscriptSendModeChanges: vi.fn((listener: (nextMode: 'insert' | 'direct-send') => void) => {
+      transcriptListeners.push(listener);
+      return () => {
+        transcriptListeners = transcriptListeners.filter((item) => item !== listener);
+      };
+    }),
+    getInputSendMode: vi.fn(() => inputSendMode),
+    subscribeInputSendModeChanges: vi.fn((listener: (nextMode: 'enter-send' | 'ctrl-enter-send') => void) => {
+      inputSendListeners.push(listener);
+      return () => {
+        inputSendListeners = inputSendListeners.filter((item) => item !== listener);
+      };
+    }),
+    mockPublishVoiceTranscriptSignal: vi.fn(),
+    resetVoiceTranscriptMode: () => {
+      latestVoiceProps = null;
+      transcriptMode = 'insert';
+      transcriptListeners = [];
+    },
+    resetInputSendMode: () => {
+      inputSendMode = 'ctrl-enter-send';
+      inputSendListeners = [];
+    },
+  };
+});
+
+vi.mock('@/components/VoiceInputButton', async () => {
+  const React = await import('react');
+  return {
+    VoiceInputButton: React.forwardRef((props: any, ref: any) => {
+      setLatestVoiceProps(props);
+      React.useImperativeHandle(ref, () => ({
+        start: () => startVoiceSpy(),
+      }));
+      return <button type="button" data-testid="new-now-voice-button-mock">voice</button>;
+    }),
+  };
+});
+
+vi.mock('@/lib/services', () => ({
+  getClipboardService: () => ({
+    readText: mockReadClipboardText,
+    isAvailable: () => true,
+  }),
+}));
+
+vi.mock('@/components/ui/toast-hook', () => ({
+  toast: mockToast,
+}));
+
+vi.mock('@/config/voice-transcript-send-mode', () => ({
+  getVoiceTranscriptSendMode,
+  subscribeVoiceTranscriptSendModeChanges,
+}));
+
+vi.mock('@/config/input-send-mode', () => ({
+  getInputSendMode,
+  subscribeInputSendModeChanges,
+}));
+
+vi.mock('@/lib/services/voice-signal.service', () => ({
+  publishVoiceTranscriptSignal: mockPublishVoiceTranscriptSignal,
+}));
+
+describe('NowInputRow issue-546 draft cache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+    mockReadClipboardText.mockReset();
+    mockToast.mockReset();
+    startVoiceSpy.mockReset();
+    mockPublishVoiceTranscriptSignal.mockReset();
+    mockPublishVoiceTranscriptSignal.mockResolvedValue(undefined);
+    resetVoiceTranscriptMode();
+    resetInputSendMode();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('restores persisted draft when draftStorageKey is provided', () => {
+    localStorage.setItem('exomind:draft:test-now-input', '未提交草稿');
+
+    render(
+      <NowInputRow
+        onSend={vi.fn()}
+        placeholder="输入内容记录事件..."
+        draftStorageKey="exomind:draft:test-now-input"
+      />,
+    );
+
+    expect(screen.getByTestId('new-now-input-textarea')).toHaveValue('未提交草稿');
+  });
+
+  it('persists draft after debounce and clears it after successful submit', async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(
+      <NowInputRow
+        onSend={onSend}
+        placeholder="输入内容记录事件..."
+        draftStorageKey="exomind:draft:test-now-input"
+      />,
+    );
+
+    const textarea = screen.getByTestId('new-now-input-textarea');
+    fireEvent.change(textarea, { target: { value: '等待提交的任务草稿' } });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(localStorage.getItem('exomind:draft:test-now-input')).toBe('等待提交的任务草稿');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('new-now-send-button'));
+    });
+
+    expect(onSend).toHaveBeenCalledWith('等待提交的任务草稿');
+    expect(textarea).toHaveValue('');
+    expect(localStorage.getItem('exomind:draft:test-now-input')).toBeNull();
+  });
+
+  it('keeps draft cache when submit fails', async () => {
+    const onSend = vi.fn().mockRejectedValue(new Error('network down'));
+    render(
+      <NowInputRow
+        onSend={onSend}
+        placeholder="输入内容记录事件..."
+        draftStorageKey="exomind:draft:test-now-input"
+      />,
+    );
+
+    const textarea = screen.getByTestId('new-now-input-textarea');
+    fireEvent.change(textarea, { target: { value: '失败后保留的草稿' } });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('new-now-send-button'));
+    });
+
+    expect(textarea).toHaveValue('失败后保留的草稿');
+    expect(localStorage.getItem('exomind:draft:test-now-input')).toBe('失败后保留的草稿');
+  });
+
+  it('does not touch storage when draftStorageKey is omitted', () => {
+    render(<NowInputRow onSend={vi.fn()} placeholder="输入内容记录事件..." />);
+
+    fireEvent.change(screen.getByTestId('new-now-input-textarea'), { target: { value: '纯内存输入' } });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    const autoKey = localStorage.key(0);
+    expect(autoKey).toContain('exomind:draft:now-input:');
+    expect(localStorage.getItem(autoKey!)).toBe('纯内存输入');
+  });
+
+  it('skips storage when draftStorageKey is explicitly null', () => {
+    const setItemSpy = vi.spyOn(window.localStorage, 'setItem');
+    render(<NowInputRow onSend={vi.fn()} placeholder="输入内容记录事件..." draftStorageKey={null} />);
+
+    fireEvent.change(screen.getByTestId('new-now-input-textarea'), { target: { value: '禁用缓存' } });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(setItemSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/ui/now-input-row.test.tsx
+++ b/tests/unit/ui/now-input-row.test.tsx
@@ -11,13 +11,19 @@ const {
   getLatestVoiceProps,
   getVoiceTranscriptSendMode,
   subscribeVoiceTranscriptSendModeChanges,
+  getInputSendMode,
+  subscribeInputSendModeChanges,
   resetVoiceTranscriptMode,
   emitVoiceTranscriptMode,
+  resetInputSendMode,
+  emitInputSendMode,
   mockPublishVoiceTranscriptSignal,
 } = vi.hoisted(() => {
   let latestVoiceProps: any = null;
-  let mode: 'insert' | 'direct-send' = 'insert';
-  let listeners: Array<(nextMode: 'insert' | 'direct-send') => void> = [];
+  let transcriptMode: 'insert' | 'direct-send' = 'insert';
+  let transcriptListeners: Array<(nextMode: 'insert' | 'direct-send') => void> = [];
+  let inputSendMode: 'enter-send' | 'ctrl-enter-send' = 'ctrl-enter-send';
+  let inputSendListeners: Array<(nextMode: 'enter-send' | 'ctrl-enter-send') => void> = [];
   return {
     mockReadClipboardText: vi.fn(),
     mockToast: vi.fn(),
@@ -26,21 +32,36 @@ const {
       latestVoiceProps = props;
     },
     getLatestVoiceProps: () => latestVoiceProps,
-    getVoiceTranscriptSendMode: vi.fn(() => mode),
+    getVoiceTranscriptSendMode: vi.fn(() => transcriptMode),
     subscribeVoiceTranscriptSendModeChanges: vi.fn((listener: (nextMode: 'insert' | 'direct-send') => void) => {
-      listeners.push(listener);
+      transcriptListeners.push(listener);
       return () => {
-        listeners = listeners.filter((item) => item !== listener);
+        transcriptListeners = transcriptListeners.filter((item) => item !== listener);
+      };
+    }),
+    getInputSendMode: vi.fn(() => inputSendMode),
+    subscribeInputSendModeChanges: vi.fn((listener: (nextMode: 'enter-send' | 'ctrl-enter-send') => void) => {
+      inputSendListeners.push(listener);
+      return () => {
+        inputSendListeners = inputSendListeners.filter((item) => item !== listener);
       };
     }),
     mockPublishVoiceTranscriptSignal: vi.fn(),
     resetVoiceTranscriptMode: () => {
-      mode = 'insert';
-      listeners = [];
+      transcriptMode = 'insert';
+      transcriptListeners = [];
+    },
+    resetInputSendMode: () => {
+      inputSendMode = 'ctrl-enter-send';
+      inputSendListeners = [];
     },
     emitVoiceTranscriptMode: (nextMode: 'insert' | 'direct-send') => {
-      mode = nextMode;
-      listeners.forEach((listener) => listener(nextMode));
+      transcriptMode = nextMode;
+      transcriptListeners.forEach((listener) => listener(nextMode));
+    },
+    emitInputSendMode: (nextMode: 'enter-send' | 'ctrl-enter-send') => {
+      inputSendMode = nextMode;
+      inputSendListeners.forEach((listener) => listener(nextMode));
     },
   };
 });
@@ -74,6 +95,11 @@ vi.mock('@/config/voice-transcript-send-mode', () => ({
   subscribeVoiceTranscriptSendModeChanges,
 }));
 
+vi.mock('@/config/input-send-mode', () => ({
+  getInputSendMode,
+  subscribeInputSendModeChanges,
+}));
+
 vi.mock('@/lib/services/voice-signal.service', () => ({
   publishVoiceTranscriptSignal: mockPublishVoiceTranscriptSignal,
 }));
@@ -81,14 +107,18 @@ vi.mock('@/lib/services/voice-signal.service', () => ({
 describe('NowInputRow', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    localStorage.clear();
     mockReadClipboardText.mockReset();
     mockToast.mockReset();
     startVoiceSpy.mockReset();
     getVoiceTranscriptSendMode.mockClear();
     subscribeVoiceTranscriptSendModeChanges.mockClear();
+    getInputSendMode.mockClear();
+    subscribeInputSendModeChanges.mockClear();
     mockPublishVoiceTranscriptSignal.mockReset();
     mockPublishVoiceTranscriptSignal.mockResolvedValue(undefined);
     resetVoiceTranscriptMode();
+    resetInputSendMode();
     setLatestVoiceProps(null);
   });
 
@@ -170,6 +200,30 @@ describe('NowInputRow', () => {
     expect(startVoiceSpy).not.toHaveBeenCalled();
   });
 
+  it('submits text when pressing Enter in auto-enter-send mode', () => {
+    const onSend = vi.fn();
+    emitInputSendMode('enter-send');
+    render(<NowInputRow onSend={onSend} placeholder="输入内容记录事件..." />);
+
+    const textarea = screen.getByTestId('new-now-input-textarea');
+    fireEvent.change(textarea, { target: { value: '直接回车发送' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' });
+
+    expect(onSend).toHaveBeenCalledWith('直接回车发送');
+  });
+
+  it('keeps Shift+Enter as newline in auto-enter-send mode', () => {
+    const onSend = vi.fn();
+    emitInputSendMode('enter-send');
+    render(<NowInputRow onSend={onSend} placeholder="输入内容记录事件..." />);
+
+    const textarea = screen.getByTestId('new-now-input-textarea');
+    fireEvent.change(textarea, { target: { value: '保留换行' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', shiftKey: true });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
   it('inserts voice transcript into textarea', () => {
     render(<NowInputRow onSend={vi.fn()} placeholder="输入内容记录事件..." />);
     const textarea = screen.getByTestId('new-now-input-textarea');
@@ -192,8 +246,28 @@ describe('NowInputRow', () => {
       getLatestVoiceProps()?.onResult?.('  直接发送内容  ');
     });
 
-    expect(onSend).toHaveBeenCalledWith('直接发送内容');
+    expect(onSend).toHaveBeenCalledWith('直接发送内容', ['voice']);
     expect((textarea as HTMLTextAreaElement).value).toBe('');
+  });
+
+  it('refocuses textarea after clicking send', async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined);
+    render(<NowInputRow onSend={onSend} placeholder="输入内容记录事件..." />);
+
+    const textarea = screen.getByTestId('new-now-input-textarea');
+    const sendButton = screen.getByTestId('new-now-send-button');
+    fireEvent.change(textarea, { target: { value: '发送后回焦' } });
+
+    sendButton.focus();
+    expect(sendButton).toHaveFocus();
+
+    await act(async () => {
+      fireEvent.click(sendButton);
+      vi.advanceTimersByTime(20);
+    });
+
+    expect(onSend).toHaveBeenCalledWith('发送后回焦');
+    expect(textarea).toHaveFocus();
   });
 
   it('publishes voice transcript signal when ASR returns text（语音结果会发布信号）', () => {

--- a/tests/unit/ui/now-input-row.test.tsx
+++ b/tests/unit/ui/now-input-row.test.tsx
@@ -143,6 +143,16 @@ describe('NowInputRow', () => {
     expect((textarea as HTMLTextAreaElement).value).toBe('');
   });
 
+  it('reports value changes through optional callback', () => {
+    const onValueChange = vi.fn();
+    render(<NowInputRow onSend={vi.fn()} onValueChange={onValueChange} placeholder="输入内容记录事件..." />);
+
+    const textarea = screen.getByTestId('new-now-input-textarea');
+    fireEvent.change(textarea, { target: { value: '同步外部搜索态' } });
+
+    expect(onValueChange).toHaveBeenLastCalledWith('同步外部搜索态');
+  });
+
   it('renders voice button and starts voice recording by ref handle', () => {
     const ref = React.createRef<{ startVoiceRecording: () => void }>();
     render(<NowInputRow ref={ref} onSend={vi.fn()} placeholder="输入内容记录事件..." />);

--- a/tests/unit/ui/now-input-row.test.tsx
+++ b/tests/unit/ui/now-input-row.test.tsx
@@ -188,7 +188,7 @@ describe('NowInputRow', () => {
     expect(onSend).toHaveBeenCalledWith('Ctrl+Enter 发送');
   });
 
-  it('does not submit when pressing Enter without Ctrl', () => {
+  it('inserts newline when pressing Enter without Ctrl', () => {
     const onSend = vi.fn();
     render(<NowInputRow onSend={onSend} placeholder="输入内容记录事件..." />);
 
@@ -198,6 +198,7 @@ describe('NowInputRow', () => {
 
     expect(onSend).not.toHaveBeenCalled();
     expect(startVoiceSpy).not.toHaveBeenCalled();
+    expect(textarea).toHaveValue('仅回车不发送\n');
   });
 
   it('submits text when pressing Enter in auto-enter-send mode', () => {
@@ -222,6 +223,35 @@ describe('NowInputRow', () => {
     fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', shiftKey: true });
 
     expect(onSend).not.toHaveBeenCalled();
+    expect(textarea).toHaveValue('保留换行\n');
+  });
+
+  it('inserts newline on Ctrl+Enter in auto-enter-send mode', () => {
+    const onSend = vi.fn();
+    emitInputSendMode('enter-send');
+    render(<NowInputRow onSend={onSend} placeholder="输入内容记录事件..." />);
+
+    const textarea = screen.getByTestId('new-now-input-textarea');
+    fireEvent.change(textarea, { target: { value: 'Enter 模式不认 Ctrl+Enter' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', ctrlKey: true });
+
+    expect(onSend).not.toHaveBeenCalled();
+    expect(startVoiceSpy).not.toHaveBeenCalled();
+    expect(textarea).toHaveValue('Enter 模式不认 Ctrl+Enter\n');
+  });
+
+  it('does not submit on Cmd+Enter in auto-enter-send mode', () => {
+    const onSend = vi.fn();
+    emitInputSendMode('enter-send');
+    render(<NowInputRow onSend={onSend} placeholder="输入内容记录事件..." />);
+
+    const textarea = screen.getByTestId('new-now-input-textarea');
+    fireEvent.change(textarea, { target: { value: 'Enter 模式不认 Cmd+Enter' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', metaKey: true });
+
+    expect(onSend).not.toHaveBeenCalled();
+    expect(startVoiceSpy).not.toHaveBeenCalled();
+    expect(textarea).toHaveValue('Enter 模式不认 Cmd+Enter\n');
   });
 
   it('inserts voice transcript into textarea', () => {

--- a/tests/unit/ui/task-breadcrumb.return-main.test.tsx
+++ b/tests/unit/ui/task-breadcrumb.return-main.test.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskBreadcrumb } from '@/ui/app/components/TaskBreadcrumb';
+import { TASKS_LAST_PATH_KEY } from '@/ui/app/pages/task-route-memory';
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    to,
+    search,
+    onClick,
+  }: {
+    children?: ReactNode;
+    to: string;
+    search?: Record<string, string>;
+    onClick?: () => void;
+  }) => (
+    <button type="button" data-testid={`breadcrumb-link-${to}`} data-search={JSON.stringify(search ?? null)} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+describe('TaskBreadcrumb return to task root', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('adds the force-main search flag and clears remembered task sub-routes', () => {
+    sessionStorage.setItem(TASKS_LAST_PATH_KEY, '/tasks/dag');
+
+    render(<TaskBreadcrumb segments={[{ label: '任务', to: '/tasks' }]} current={{ label: 'DAG 视图' }} />);
+
+    const link = screen.getByTestId('breadcrumb-link-/tasks');
+    expect(link.getAttribute('data-search')).toBe(JSON.stringify({ main: '1' }));
+
+    fireEvent.click(link);
+    expect(sessionStorage.getItem(TASKS_LAST_PATH_KEY)).toBeNull();
+  });
+});

--- a/tests/unit/ui/task-command-palette.issue243.test.tsx
+++ b/tests/unit/ui/task-command-palette.issue243.test.tsx
@@ -13,6 +13,7 @@ const runtimeFlags = vi.hoisted(() => ({
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children, ...props }: { children?: ReactNode }) => <a {...props}>{children}</a>,
+  useNavigate: () => vi.fn(),
 }));
 
 vi.mock('@/lib/services', () => ({
@@ -60,6 +61,12 @@ vi.mock('@/config/developer-mode', () => ({
 vi.mock('@/config/command-palette-enabled', () => ({
   getCommandPaletteEnabled: () => runtimeFlags.commandPaletteEnabled,
   subscribeCommandPaletteEnabledChanges: () => () => {},
+}));
+
+vi.mock('@/config/task-create-success-action', () => ({
+  getTaskCreateSuccessAction: vi.fn(() => 'refocus'),
+  setTaskCreateSuccessAction: vi.fn((value: string) => value),
+  subscribeTaskCreateSuccessActionChanges: vi.fn(() => () => {}),
 }));
 
 describe('new tasks page command palette entry issue-243（任务页命令面板入口）', () => {

--- a/tests/unit/ui/task-current-root-card.issue411.test.tsx
+++ b/tests/unit/ui/task-current-root-card.issue411.test.tsx
@@ -55,9 +55,7 @@ describe('TaskCurrentRootCard issue-411（当前根节点按未阻塞判定）',
     expect(graph.currentRootNodeId).toBe('downstream-open');
     expect(screen.getByTestId('task-current-root-card')).toHaveTextContent('下游可执行节点');
     expect(screen.queryByText('暂无未阻塞节点')).not.toBeInTheDocument();
-    expect(screen.getByTestId('task-current-root-card')).toHaveTextContent(
-      '共 1 个未阻塞节点 · 当前按稳定顺序排第 1 个',
-    );
+    expect(screen.getByTestId('task-current-root-card')).toHaveTextContent('未阻塞节点 · 1');
   });
 
   it('does not pick a node whose hard dependency is unfinished', () => {

--- a/tests/unit/ui/task-current-root-card.issue546-filter.test.tsx
+++ b/tests/unit/ui/task-current-root-card.issue546-filter.test.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { buildTaskGraph } from '@/lib/task/task-dag-graph';
+import type { TaskNode } from '@/lib/types/task';
+import { TaskCurrentRootCard } from '@/ui/app/components/TaskCurrentRootCard';
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+function makeTask(overrides: Partial<TaskNode> & { id: string; title: string; updatedAt: number }): TaskNode {
+  return {
+    id: overrides.id,
+    title: overrides.title,
+    description: undefined,
+    status: 'pending',
+    priority: 'medium',
+    dependsOn: [],
+    tags: [],
+    createdAt: overrides.updatedAt,
+    updatedAt: overrides.updatedAt,
+    ...overrides,
+  };
+}
+
+function renderCard(tasks: TaskNode[], searchQuery = ''): void {
+  const graph = buildTaskGraph(tasks);
+  const taskById = new Map(tasks.map((task) => [task.id, task]));
+  render(
+    <TaskCurrentRootCard
+      graph={graph}
+      taskById={taskById}
+      searchQuery={searchQuery}
+      collapsible={true}
+    />,
+  );
+}
+
+describe('TaskCurrentRootCard issue-546 filter and collapse', () => {
+  it('filters unblocked tasks by the same fuzzy title rule', () => {
+    renderCard([
+      makeTask({ id: 'task-1', title: 'aba', updatedAt: 10 }),
+      makeTask({ id: 'task-2', title: 'baaab', updatedAt: 20 }),
+      makeTask({ id: 'task-3', title: 'delta', updatedAt: 30 }),
+      makeTask({ id: 'task-4', title: 'abacus', updatedAt: 40 }),
+    ], 'ab');
+
+    expect(screen.getByTestId('task-current-root-card')).toHaveTextContent('未阻塞节点 · 3');
+    expect(screen.getByTestId('task-current-root-card-link-task-2')).toBeInTheDocument();
+    expect(screen.getByTestId('task-current-root-card-link-task-1')).toBeInTheDocument();
+    expect(screen.getByTestId('task-current-root-card-link-task-4')).toBeInTheDocument();
+    expect(screen.queryByTestId('task-current-root-card-link-task-3')).toBeNull();
+  });
+
+  it('collapses to at most 3 tasks and expands from the header button', () => {
+    renderCard([
+      makeTask({ id: 'task-1', title: 'Task 1', updatedAt: 10 }),
+      makeTask({ id: 'task-2', title: 'Task 2', updatedAt: 20 }),
+      makeTask({ id: 'task-3', title: 'Task 3', updatedAt: 30 }),
+      makeTask({ id: 'task-4', title: 'Task 4', updatedAt: 40 }),
+    ]);
+
+    expect(screen.getByTestId('task-current-root-card-link-task-1')).toBeInTheDocument();
+    expect(screen.getByTestId('task-current-root-card-link-task-2')).toBeInTheDocument();
+    expect(screen.getByTestId('task-current-root-card-link-task-3')).toBeInTheDocument();
+    expect(screen.queryByTestId('task-current-root-card-link-task-4')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('task-current-root-card-collapse-toggle'));
+
+    expect(screen.getByTestId('task-current-root-card-link-task-4')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/ui/task-dag-detail-view.issue395.test.ts
+++ b/tests/unit/ui/task-dag-detail-view.issue395.test.ts
@@ -35,7 +35,7 @@ describe('buildTaskDagDetailView issue #395', () => {
       dependsOn: [{ taskId: 'a', type: 'hard' }],
     });
 
-    const view = buildTaskDagDetailView(taskA, [taskA, taskB], { collapsedUpstreamOf: ['a'] });
+    const view = buildTaskDagDetailView(taskA, [taskA, taskB], { collapsedUpstreamOf: ['a'], collapsedDownstreamOf: [] });
 
     expect(view).not.toBeNull();
     expect(view).toMatchObject({
@@ -48,5 +48,38 @@ describe('buildTaskDagDetailView issue #395', () => {
       isSourceCurrentRootVisible: false,
     });
     expect(view?.nodes.every((node) => node.isVisibleCurrentRoot === false)).toBe(true);
+  });
+
+  it('disables upstream collapse when external descendants would leak semantics', () => {
+    const taskRoot = makeTask({ id: 'root', title: 'Root', createdAt: 10, updatedAt: 10 });
+    const taskCurrent = makeTask({
+      id: 'current',
+      title: 'Current',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [{ taskId: 'root', type: 'hard' }],
+    });
+    const externalParent = makeTask({ id: 'external', title: 'External', createdAt: 15, updatedAt: 15 });
+    const externalChild = makeTask({
+      id: 'external-child',
+      title: 'External Child',
+      createdAt: 30,
+      updatedAt: 30,
+      dependsOn: [
+        { taskId: 'root', type: 'hard' },
+        { taskId: 'external', type: 'hard' },
+      ],
+    });
+
+    const view = buildTaskDagDetailView(taskCurrent, [taskRoot, taskCurrent, externalParent, externalChild], {
+      collapsedUpstreamOf: [],
+      collapsedDownstreamOf: [],
+    });
+
+    expect(view).not.toBeNull();
+    expect(view?.nodes.find((node) => node.id === 'current')).toMatchObject({
+      upstreamNodeCount: 1,
+      canCollapseUpstream: false,
+    });
   });
 });

--- a/tests/unit/ui/task-dag-page.issue394.test.tsx
+++ b/tests/unit/ui/task-dag-page.issue394.test.tsx
@@ -33,6 +33,7 @@ vi.mock('@xyflow/react', () => ({
     edges,
     children,
     onNodeClick,
+    onNodeContextMenu,
     nodeTypes,
     onInit,
     ...props
@@ -41,6 +42,7 @@ vi.mock('@xyflow/react', () => ({
     edges?: Array<{ id: string }>;
     children?: ReactNode;
     onNodeClick?: (_event: unknown, node: { id: string; data?: Record<string, unknown> }) => void;
+    onNodeContextMenu?: (_event: { preventDefault: () => void; clientX: number; clientY: number }, node: { id: string; data?: Record<string, unknown> }) => void;
     nodeTypes?: Record<string, (props: { id: string; data: Record<string, unknown> }) => JSX.Element>;
     onInit?: (instance: {
       setCenter: typeof flowApiMocks.setCenter;
@@ -62,6 +64,10 @@ vi.mock('@xyflow/react', () => ({
               type="button"
               data-testid={`mock-react-flow-node-${node.id}`}
               onClick={() => onNodeClick?.({}, node)}
+              onContextMenu={(event) => {
+                event.preventDefault();
+                onNodeContextMenu?.({ preventDefault: () => {}, clientX: 32, clientY: 48 }, node);
+              }}
             >
               {NodeComponent ? <NodeComponent id={node.id} data={node.data ?? {}} /> : node.id}
             </button>
@@ -205,7 +211,86 @@ describe('TaskDagPage issue-394（任务 DAG 只读视图）', () => {
 
     fireEvent.click(screen.getByTestId('mock-react-flow-node-task-b'));
 
-    expect(await screen.findByTestId('task-dag-selected-panel')).toHaveTextContent('接入任务列表引导');
+    await waitFor(() => {
+      expect(screen.getByTestId('task-dag-selected-panel')).toHaveTextContent('接入任务列表引导');
+    });
     expect(screen.getByTestId('task-dag-selected-link')).toBeInTheDocument();
+  });
+
+  it('supports collapse downstream from the selected inspect panel', async () => {
+    listTasksMock.mockResolvedValue([
+      makeTask({ id: 'task-a', title: 'A', createdAt: 10, updatedAt: 10 }),
+      makeTask({
+        id: 'task-b',
+        title: 'B',
+        createdAt: 20,
+        updatedAt: 20,
+        dependsOn: [{ taskId: 'task-a', type: 'hard' }],
+      }),
+      makeTask({
+        id: 'task-c',
+        title: 'C',
+        createdAt: 30,
+        updatedAt: 30,
+        dependsOn: [{ taskId: 'task-b', type: 'hard' }],
+      }),
+    ]);
+
+    render(<TaskDagPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-react-flow-node-task-b')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('mock-react-flow-node-task-b'));
+    fireEvent.click(screen.getByTestId('task-dag-selected-toggle-downstream'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mock-react-flow-node-task-c')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('task-dag-selected-toggle-downstream')).toHaveTextContent('展开下游');
+  });
+
+  it('shows disabled upstream/downstream actions in the context menu when a node cannot be safely folded', async () => {
+    listTasksMock.mockResolvedValue([
+      makeTask({ id: 'task-a', title: 'A', createdAt: 10, updatedAt: 10 }),
+      makeTask({
+        id: 'task-b',
+        title: 'B',
+        createdAt: 20,
+        updatedAt: 20,
+        dependsOn: [{ taskId: 'task-a', type: 'hard' }],
+      }),
+      makeTask({
+        id: 'task-y',
+        title: 'Y',
+        createdAt: 25,
+        updatedAt: 25,
+        dependsOn: [{ taskId: 'task-a', type: 'hard' }],
+      }),
+      makeTask({ id: 'task-x', title: 'X', createdAt: 15, updatedAt: 15 }),
+      makeTask({
+        id: 'task-c',
+        title: 'C',
+        createdAt: 30,
+        updatedAt: 30,
+        dependsOn: [
+          { taskId: 'task-b', type: 'hard' },
+          { taskId: 'task-x', type: 'hard' },
+        ],
+      }),
+    ]);
+
+    render(<TaskDagPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-react-flow-node-task-b')).toBeInTheDocument();
+    });
+
+    fireEvent.contextMenu(screen.getByTestId('mock-react-flow-node-task-b'));
+
+    expect(await screen.findByTestId('task-dag-context-toggle-upstream')).toBeDisabled();
+    expect(screen.getByTestId('task-dag-context-toggle-downstream')).toBeDisabled();
   });
 });

--- a/tests/unit/ui/task-dag-page.issue394.test.tsx
+++ b/tests/unit/ui/task-dag-page.issue394.test.tsx
@@ -10,10 +10,14 @@ const onTaskChangeMock = vi.fn(() => () => {});
 const flowApiMocks = vi.hoisted(() => ({
   setCenter: vi.fn(),
   fitView: vi.fn(),
+  getViewport: vi.fn(() => ({ x: 0, y: 0, zoom: 0.12 })),
+  getNode: vi.fn(),
+  lastProps: null as null | Record<string, unknown>,
 }));
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+  useLocation: () => ({ pathname: '/tasks/dag', searchStr: '' }),
 }));
 
 vi.mock('@/lib/services', () => ({
@@ -31,14 +35,22 @@ vi.mock('@xyflow/react', () => ({
     onNodeClick,
     nodeTypes,
     onInit,
+    ...props
   }: {
     nodes?: Array<{ id: string; type?: string; data?: Record<string, unknown> }>;
     edges?: Array<{ id: string }>;
     children?: ReactNode;
     onNodeClick?: (_event: unknown, node: { id: string; data?: Record<string, unknown> }) => void;
     nodeTypes?: Record<string, (props: { id: string; data: Record<string, unknown> }) => JSX.Element>;
-    onInit?: (instance: { setCenter: typeof flowApiMocks.setCenter; fitView: typeof flowApiMocks.fitView }) => void;
+    onInit?: (instance: {
+      setCenter: typeof flowApiMocks.setCenter;
+      fitView: typeof flowApiMocks.fitView;
+      getViewport: typeof flowApiMocks.getViewport;
+      getNode: typeof flowApiMocks.getNode;
+    }) => void;
+    [key: string]: unknown;
   }) => {
+    flowApiMocks.lastProps = props;
     onInit?.(flowApiMocks);
     return (
       <div data-testid="mock-react-flow">
@@ -88,6 +100,10 @@ describe('TaskDagPage issue-394（任务 DAG 只读视图）', () => {
   beforeEach(() => {
     flowApiMocks.setCenter.mockReset();
     flowApiMocks.fitView.mockReset();
+    flowApiMocks.getViewport.mockClear();
+    flowApiMocks.getViewport.mockReturnValue({ x: 0, y: 0, zoom: 0.12 });
+    flowApiMocks.getNode.mockReset();
+    flowApiMocks.lastProps = null;
     listTasksMock.mockReset();
     onTaskChangeMock.mockClear();
 
@@ -124,7 +140,31 @@ describe('TaskDagPage issue-394（任务 DAG 只读视图）', () => {
     expect(screen.getByTestId('task-dag-legend-soft')).toHaveTextContent('软依赖');
 
     fireEvent.click(screen.getByTestId('task-dag-current-root-jump'));
-    expect(flowApiMocks.setCenter).toHaveBeenCalled();
+    expect(flowApiMocks.setCenter).toHaveBeenCalledWith(expect.any(Number), expect.any(Number), {
+      duration: 250,
+      zoom: 0.12,
+    });
+  });
+
+  it('allows fit view to zoom out below the old lower bound', async () => {
+    render(<TaskDagPage />);
+
+    await waitFor(() => {
+      expect(listTasksMock).toHaveBeenCalledWith(true);
+    });
+
+    expect(flowApiMocks.lastProps).toMatchObject({
+      fitView: true,
+      minZoom: 0.01,
+      fitViewOptions: {
+        padding: 0.2,
+        minZoom: 0.01,
+      },
+    });
+    expect(flowApiMocks.fitView).toHaveBeenCalledWith({
+      padding: 0.2,
+      minZoom: 0.01,
+    });
   });
 
   it('uses unblocked unfinished node as current root when structural roots are terminal', async () => {

--- a/tests/unit/ui/task-dag-visibility.issue395.test.ts
+++ b/tests/unit/ui/task-dag-visibility.issue395.test.ts
@@ -36,9 +36,10 @@ describe('projectVisibleTaskGraph issue-395（任务 DAG 折叠投影第一阶�
     })
 
     const graph = buildTaskGraph([taskC, taskA, taskB])
-    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['c'] })
+    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['c'], collapsedDownstreamOf: [] })
 
     expect(visible.state.collapsedUpstreamOf).toEqual(['c'])
+    expect(visible.state.collapsedDownstreamOf).toEqual([])
     expect(visible.hiddenNodeIds).toEqual(['a', 'b'])
     expect(visible.nodes).toEqual([
       expect.objectContaining({
@@ -64,7 +65,7 @@ describe('projectVisibleTaskGraph issue-395（任务 DAG 折叠投影第一阶�
     const sideRoot = makeTask({ id: 'side', title: 'Side', createdAt: 15, updatedAt: 15 })
 
     const graph = buildTaskGraph([child, sideRoot, root])
-    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: [] })
+    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: [], collapsedDownstreamOf: [] })
 
     expect(visible.hiddenNodeIds).toEqual([])
     expect(visible.nodes.map((node) => node.id)).toEqual(graph.nodes.map((node) => node.id))
@@ -100,7 +101,7 @@ describe('projectVisibleTaskGraph issue-395（任务 DAG 折叠投影第一阶�
     })
 
     const graph = buildTaskGraph([taskD, taskB, taskA, taskC])
-    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['c'] })
+    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['c'], collapsedDownstreamOf: [] })
 
     expect(visible.hiddenNodeIds).toEqual(['a', 'b'])
     expect(visible.nodes.map((node) => ({ id: node.id, hidden: node.hiddenUpstreamCount }))).toEqual([
@@ -136,8 +137,8 @@ describe('projectVisibleTaskGraph issue-395（任务 DAG 折叠投影第一阶�
     })
 
     const graph = buildTaskGraph([taskY, taskB, taskA, taskX])
-    const first = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['y', 'b', 'y'] })
-    const second = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['b', 'y'] })
+    const first = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['y', 'b', 'y'], collapsedDownstreamOf: [] })
+    const second = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['b', 'y'], collapsedDownstreamOf: [] })
 
     expect(first).toEqual(second)
     expect(first.hiddenNodeIds).toEqual(['a', 'x'])
@@ -174,7 +175,7 @@ describe('projectVisibleTaskGraph issue-395（任务 DAG 折叠投影第一阶�
 
     const graph = buildTaskGraph([target, softSource, hardSource])
     const snapshot = JSON.parse(JSON.stringify(graph))
-    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['target'] })
+    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['target'], collapsedDownstreamOf: [] })
     const visibleTarget = visible.nodes.find((node) => node.id === 'target')
     const graphTarget = graph.nodes.find((node) => node.id === 'target')
 
@@ -197,7 +198,7 @@ describe('projectVisibleTaskGraph issue-395（任务 DAG 折叠投影第一阶�
     })
 
     const graph = buildTaskGraph([taskB, rootX, rootA])
-    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['b'] })
+    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['b'], collapsedDownstreamOf: [] })
 
     expect(graph.rootNodeIds).toEqual(['a', 'x'])
     expect(graph.currentRootNodeId).toBe('a')
@@ -223,8 +224,8 @@ describe('projectVisibleTaskGraph issue-395（任务 DAG 折叠投影第一阶�
     })
 
     const graph = buildTaskGraph([leaf, root, middle])
-    const first = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['leaf'] })
-    const second = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['leaf'] })
+    const first = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['leaf'], collapsedDownstreamOf: [] })
+    const second = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['leaf'], collapsedDownstreamOf: [] })
 
     expect(second).toEqual(first)
   })
@@ -246,7 +247,7 @@ describe('projectVisibleTaskGraph issue-395（任务 DAG 折叠投影第一阶�
     })
 
     const graph = buildTaskGraph([taskA, taskB])
-    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['a'] })
+    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: ['a'], collapsedDownstreamOf: [] })
 
     expect(graph.hasCycle).toBe(true)
     expect(graph.rootNodeIds).toEqual([])
@@ -255,5 +256,56 @@ describe('projectVisibleTaskGraph issue-395（任务 DAG 折叠投影第一阶�
     expect(visible.visibleRootNodeIds).toEqual(['a'])
     expect(visible.visibleCurrentRootNodeId).toBeNull()
     expect(visible.sourceCurrentRootNodeId).toBeNull()
+  })
+
+  it('collapses downstream while preserving external incoming edges via remapped anchor output', () => {
+    const taskA = makeTask({ id: 'a', title: 'A', createdAt: 10, updatedAt: 10 })
+    const taskB = makeTask({
+      id: 'b',
+      title: 'B',
+      createdAt: 20,
+      updatedAt: 20,
+      dependsOn: [{ taskId: 'a', type: 'hard' }],
+    })
+    const taskX = makeTask({ id: 'x', title: 'X', createdAt: 15, updatedAt: 15 })
+    const taskTarget = makeTask({
+      id: 'target',
+      title: 'Target',
+      createdAt: 30,
+      updatedAt: 30,
+      dependsOn: [
+        { taskId: 'b', type: 'hard' },
+        { taskId: 'x', type: 'hard' },
+      ],
+    })
+
+    const graph = buildTaskGraph([taskTarget, taskX, taskB, taskA])
+    const visible = projectVisibleTaskGraph(graph, { collapsedUpstreamOf: [], collapsedDownstreamOf: ['a'] })
+
+    expect(visible.hiddenNodeIds).toEqual(['b'])
+    expect(visible.nodes.map((node) => ({
+      id: node.id,
+      hiddenDownstreamCount: node.hiddenDownstreamCount,
+      isCollapsedDownstreamTarget: node.isCollapsedDownstreamTarget,
+    }))).toEqual([
+      { id: 'a', hiddenDownstreamCount: 1, isCollapsedDownstreamTarget: true },
+      { id: 'x', hiddenDownstreamCount: 0, isCollapsedDownstreamTarget: false },
+      { id: 'target', hiddenDownstreamCount: 0, isCollapsedDownstreamTarget: false },
+    ])
+    expect(visible.edges).toEqual([
+      {
+        id: 'edge:a->target:hard:collapsed-downstream',
+        source: 'a',
+        target: 'target',
+        type: 'hard',
+      },
+      {
+        id: 'edge:x->target:hard',
+        source: 'x',
+        target: 'target',
+        type: 'hard',
+      },
+    ])
+    expect(visible.visibleRootNodeIds).toEqual(['a', 'x'])
   })
 })

--- a/tests/unit/ui/task-detail-page.dag-visibility.issue395.test.tsx
+++ b/tests/unit/ui/task-detail-page.dag-visibility.issue395.test.tsx
@@ -56,12 +56,15 @@ const loadActiveBlockMock = vi.fn<() => Promise<ActiveBlockData | null>>();
 const onBlockChangeMock = vi.fn(() => () => {});
 const pauseBlockMock = vi.fn<() => Promise<void>>();
 const calculateSpentMinutesMock = vi.fn<(taskId: string) => Promise<number>>();
-const getEventsMock = vi.fn<() => Promise<Array<{ id: string; content: string; createdAt: string; type?: string }>>>();
+const loadEventsMock = vi.fn<
+  () => Promise<Array<{ id: string; timestamp?: number | string | Date; content: string; tags?: Set<string> }>>
+>();
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
   useParams: () => ({ taskId: 'task-1' }),
   useNavigate: () => navigateMock,
+  useLocation: () => ({ pathname: '/tasks/task-1', searchStr: '' }),
 }));
 
 vi.mock('@/lib/services', () => ({
@@ -88,11 +91,8 @@ vi.mock('@/lib/services', () => ({
     calculateSpentMinutes: calculateSpentMinutesMock,
     startBlockForTask: vi.fn(),
   }),
-}));
-
-vi.mock('@/lib/storage/event-storage', () => ({
-  getEventStorage: () => ({
-    getEvents: getEventsMock,
+  getEventLogService: () => ({
+    loadEvents: loadEventsMock,
   }),
 }));
 
@@ -189,8 +189,8 @@ describe('TaskDetailPage DAG visibility issue #395', () => {
 
     calculateSpentMinutesMock.mockReset();
     calculateSpentMinutesMock.mockResolvedValue(15);
-    getEventsMock.mockReset();
-    getEventsMock.mockResolvedValue([]);
+    loadEventsMock.mockReset();
+    loadEventsMock.mockResolvedValue([]);
   });
 
   it('renders dependency graph and supports collapse / expand upstream from current task', async () => {
@@ -238,6 +238,54 @@ describe('TaskDetailPage DAG visibility issue #395', () => {
     expect(screen.getByTestId('task-dag-node-task-2')).toHaveTextContent('已隐藏 1 项');
     expect(screen.getByTestId('task-dag-node-task-1')).toHaveTextContent('已隐藏 1 项');
     expect(screen.getByTestId('task-dag-node-task-3')).toHaveTextContent('已隐藏 1 项');
+  });
+
+  it('supports collapse downstream from the dependency inspect card', async () => {
+    renderPage();
+
+    expect(await screen.findByText('依赖图')).toBeInTheDocument();
+    expect(screen.getByTestId('task-dag-toggle-downstream-task-1')).toBeEnabled();
+
+    fireEvent.click(screen.getByTestId('task-dag-toggle-downstream-task-1'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('task-dag-node-task-3')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('task-dag-node-task-1')).toHaveTextContent('下游已隐藏 1 项');
+    expect(screen.getByTestId('task-dag-toggle-downstream-task-1')).toHaveTextContent('展开下游');
+  });
+
+  it('disables unsafe upstream collapse just like downstream（不安全的上游折叠同样禁用）', async () => {
+    tasksState = [
+      makeTask({
+        id: 'task-1',
+        title: '当前任务',
+        dependsOn: [{ taskId: 'task-2', type: 'hard' }],
+      }),
+      makeTask({
+        id: 'task-2',
+        title: '共享前置',
+      }),
+      makeTask({
+        id: 'task-3',
+        title: '范围外分支',
+        dependsOn: [
+          { taskId: 'task-2', type: 'hard' },
+          { taskId: 'task-4', type: 'hard' },
+        ],
+      }),
+      makeTask({
+        id: 'task-4',
+        title: '范围外前置',
+      }),
+    ];
+
+    renderPage();
+
+    expect(await screen.findByText('依赖图')).toBeInTheDocument();
+    expect(screen.getByTestId('task-dag-toggle-upstream-task-1')).toBeDisabled();
+    expect(screen.getByTestId('task-dag-toggle-downstream-task-1')).toBeDisabled();
   });
 
   it('disables current-root guidance in the detail panel when the source graph is cyclic', async () => {

--- a/tests/unit/ui/task-detail-page.estimated-time-race.issue384.test.tsx
+++ b/tests/unit/ui/task-detail-page.estimated-time-race.issue384.test.tsx
@@ -146,7 +146,7 @@ describe('TaskDetailPage estimated minutes race issue #384', () => {
     const view = render(<TaskDetailPage />);
 
     await screen.findByText('关联任务：任务 A');
-    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：60 分钟');
+    expect(screen.getByTestId('estimated-time-preset-60')).toHaveAttribute('aria-pressed', 'true');
 
     fireEvent.click(screen.getByTestId('estimated-time-preset-45'));
 
@@ -158,13 +158,15 @@ describe('TaskDetailPage estimated minutes race issue #384', () => {
     view.rerender(<TaskDetailPage />);
 
     await screen.findByText('关联任务：任务 B');
-    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：30 分钟');
+    // Task B has estimatedMinutes=30 which is not a preset, so custom trigger should show
+    expect(screen.getByTestId('estimated-time-custom-trigger')).toHaveAttribute('aria-pressed', 'true');
 
     await act(async () => {
       pendingSave.resolve(makeTask({ id: 'task-1', title: '任务 A', estimatedMinutes: 45, updatedAt: 999 }));
       await pendingSave.promise;
     });
 
-    expect(screen.getByTestId('estimated-time-current')).toHaveTextContent('当前：30 分钟');
+    // Stale save for task-1 should not affect task-2's display
+    expect(screen.getByTestId('estimated-time-custom-trigger')).toHaveAttribute('aria-pressed', 'true');
   });
 });

--- a/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
+++ b/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
@@ -6,6 +6,7 @@ import type { TaskNode } from '@/lib/types/task';
 import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
 
 const navigateMock = vi.fn();
+const scrollIntoViewMock = vi.fn();
 
 const getTaskMock = vi.fn<(id: string) => Promise<TaskNode | null>>();
 const listTasksMock = vi.fn<(includeCancelled?: boolean) => Promise<TaskNode[]>>();
@@ -24,8 +25,8 @@ const pauseBlockMock = vi.fn<() => Promise<void>>();
 const calculateSpentMinutesMock = vi.fn<(taskId: string) => Promise<number>>();
 const startBlockForTaskMock = vi.fn();
 
-const getEventsMock = vi.fn<
-  () => Promise<Array<{ id: string; content: string; createdAt: string; type?: string }>>
+const loadEventsMock = vi.fn<
+  () => Promise<Array<{ id: string; content: string; timestamp: number; tags: Set<string> }>>
 >();
 let currentTaskId = 'task-1';
 
@@ -33,6 +34,7 @@ vi.mock('@tanstack/react-router', () => ({
   Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
   useParams: () => ({ taskId: currentTaskId }),
   useNavigate: () => navigateMock,
+  useLocation: () => ({ pathname: window.location.pathname, searchStr: window.location.search }),
 }));
 
 vi.mock('@/lib/services', () => ({
@@ -55,15 +57,12 @@ vi.mock('@/lib/services', () => ({
     onBlockChange: onBlockChangeMock,
     pauseBlock: pauseBlockMock,
   }),
+  getEventLogService: () => ({
+    loadEvents: loadEventsMock,
+  }),
   getTaskTimerService: () => ({
     calculateSpentMinutes: calculateSpentMinutesMock,
     startBlockForTask: startBlockForTaskMock,
-  }),
-}));
-
-vi.mock('@/lib/storage/event-storage', () => ({
-  getEventStorage: () => ({
-    getEvents: getEventsMock,
   }),
 }));
 
@@ -119,7 +118,13 @@ function makeBlock(overrides: Partial<TimeBlock> = {}): TimeBlock {
 describe('TaskDetailPage timeblock detail layout（任务详情布局）', () => {
   beforeEach(() => {
     currentTaskId = 'task-1';
+    window.history.replaceState({}, '', '/tasks/task-1');
     navigateMock.mockReset();
+    scrollIntoViewMock.mockReset();
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoViewMock,
+    });
     startBlockForTaskMock.mockReset();
     startBlockForTaskMock.mockResolvedValue(null);
     getTaskMock.mockImplementation(async (id: string) => {
@@ -168,12 +173,12 @@ describe('TaskDetailPage timeblock detail layout（任务详情布局）', () =>
     loadTimeBlocksMock.mockResolvedValue([makeBlock()]);
     loadActiveBlockMock.mockResolvedValue(null);
     calculateSpentMinutesMock.mockResolvedValue(90);
-    getEventsMock.mockResolvedValue([
+    loadEventsMock.mockResolvedValue([
       {
         id: 'event-1',
-        createdAt: new Date('2026-03-06T10:31:00+08:00').toISOString(),
-        type: 'agent_feedback',
+        timestamp: new Date('2026-03-06T10:31:00+08:00').getTime(),
         content: '## AI 反馈：深度工作：EventLog 模块实现\n\n**做得好的** 主流程完成清晰\n\n**卡住的地方** 依赖冲突\n\n**建议** 拆分组件并补测试',
+        tags: new Set(['agent_feedback']),
       },
     ]);
   });
@@ -188,13 +193,63 @@ describe('TaskDetailPage timeblock detail layout（任务详情布局）', () =>
 
     expect(await screen.findByText('任务详情')).toBeInTheDocument();
     expect(screen.getByText('概览')).toBeInTheDocument();
-    expect(screen.getByText('时间线')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '信息面板' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '计时控制' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '事件时间线' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '依赖关系' })).toBeInTheDocument();
     expect(screen.getAllByText('AI 总结').length).toBeGreaterThan(0);
-    expect(screen.getByText('计划 vs 实际')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '计划 vs 实际' })).toBeInTheDocument();
     expect(screen.getByTestId('task-timer-card')).toBeInTheDocument();
     expect(screen.getByTestId('task-mode-countup')).toBeInTheDocument();
     expect(screen.getByTestId('task-mode-countdown')).toBeInTheDocument();
     expect(screen.getByTestId('task-pause-button')).toBeInTheDocument();
+  });
+
+  it('orders portrait cards with info and timer before linked content（竖屏卡片顺序正确）', async () => {
+    mockMatchMedia(false);
+    render(<TaskDetailPage />);
+
+    await screen.findByText('任务详情');
+
+    const infoTitle = screen.getByRole('heading', { name: '信息面板' });
+    const timerTitle = screen.getByRole('heading', { name: '计时控制' });
+    const rootGuidance = screen.getByTestId('task-current-root-card');
+    const linkedTitle = screen.getByRole('heading', { name: '关联时间块' });
+    const timelineTitle = screen.getByRole('heading', { name: '事件时间线' });
+    const aiSummaryTitle = screen.getByRole('heading', { name: 'AI 总结' });
+    const actionsTitle = screen.getByRole('heading', { name: '其他操作' });
+
+    expect(infoTitle.compareDocumentPosition(timerTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(timerTitle.compareDocumentPosition(rootGuidance) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(rootGuidance.compareDocumentPosition(linkedTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(linkedTitle.compareDocumentPosition(timelineTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(timelineTitle.compareDocumentPosition(aiSummaryTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(aiSummaryTitle.compareDocumentPosition(actionsTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('scrolls to anchored mobile sections from top tabs（移动端顶部 tab 导航可滚动到分区）', async () => {
+    mockMatchMedia(false);
+    render(<TaskDetailPage />);
+
+    await screen.findByText('任务详情');
+
+    expect(screen.getByTestId('task-mobile-section-tabs')).toBeInTheDocument();
+    expect(screen.getAllByRole('tab')).toHaveLength(10);
+
+    fireEvent.click(screen.getByRole('tab', { name: '依赖关系' }));
+
+    expect(document.getElementById('task-detail-dependency')).not.toBeNull();
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+  });
+
+  it('hides task detail scrollbars while preserving scroll containers（任务详情隐藏滚动条）', async () => {
+    mockMatchMedia(false);
+    render(<TaskDetailPage />);
+
+    await screen.findByText('任务详情');
+
+    expect(screen.getByTestId('new-task-detail-page')).toHaveClass('scrollbar-none');
+    expect(screen.getByTestId('task-mobile-section-tabs').firstElementChild).toHaveClass('scrollbar-none');
   });
 
   it('renders desktop two-column timeblock detail（桌面端双列任务详情）', async () => {
@@ -206,11 +261,40 @@ describe('TaskDetailPage timeblock detail layout（任务详情布局）', () =>
       expect(loadTimeBlocksMock).toHaveBeenCalled();
     });
 
-    expect(await screen.findByText('任务 > 今日 > 任务详情')).toBeInTheDocument();
+    expect(await screen.findByText('任务')).toBeInTheDocument();
+    expect(screen.getByText('任务详情')).toBeInTheDocument();
     expect(screen.getAllByText('深度工作：EventLog 模块实现').length).toBeGreaterThan(0);
     expect(screen.getByText('事件时间线')).toBeInTheDocument();
-    expect(screen.getByText('洞察')).toBeInTheDocument();
-    expect(screen.getByText('操作')).toBeInTheDocument();
+    expect(screen.getByText('AI 总结')).toBeInTheDocument();
+    expect(screen.getByText('其他操作')).toBeInTheDocument();
+  });
+
+  it('places linked blocks above timeline on desktop（关联时间块在事件时间线上方）', async () => {
+    window.history.replaceState({}, '', '/tasks/block/block-1?from=today');
+    mockMatchMedia(true);
+    render(<TaskDetailPage />);
+
+    await waitFor(() => {
+      expect(loadTimeBlocksMock).toHaveBeenCalled();
+    });
+
+    const linkedTitle = await screen.findByText('关联时间块');
+    const timelineTitle = screen.getByText('事件时间线');
+    expect(linkedTitle.compareDocumentPosition(timelineTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('shows empty timeline hint when no linked blocks（无关联时间块时显示空态提示）', async () => {
+    mockMatchMedia(false);
+    const emptyTask = makeTask({ timeBlockIds: [] });
+    getTaskMock.mockResolvedValue(emptyTask);
+    listTasksMock.mockResolvedValue([emptyTask]);
+    loadTimeBlocksMock.mockResolvedValue([]);
+    loadEventsMock.mockResolvedValue([]);
+
+    render(<TaskDetailPage />);
+
+    await screen.findByText('任务详情');
+    expect(screen.getByText('暂无关联时间块，开始一个时间块后即可在此查看事件。')).toBeInTheDocument();
   });
 
   it('renders current root guidance without DAG link（详情页复用当前根节点规则，#496 移除 DAG 链接）', async () => {
@@ -222,7 +306,7 @@ describe('TaskDetailPage timeblock detail layout（任务详情布局）', () =>
     });
 
     expect(await screen.findByTestId('task-current-root-card')).toHaveTextContent('优先收口 DAG 根节点');
-    expect(screen.getByTestId('task-current-root-link')).toBeInTheDocument();
+    expect(screen.getByText('优先收口 DAG 根节点')).toBeInTheDocument();
     expect(screen.queryByTestId('task-current-root-dag-link')).toBeNull();
   });
 

--- a/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
+++ b/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
@@ -120,6 +120,7 @@ describe('TaskDetailPage timeblock detail layout（任务详情布局）', () =>
   beforeEach(() => {
     currentTaskId = 'task-1';
     window.history.replaceState({}, '', '/tasks/task-1');
+    window.localStorage.clear();
     navigateMock.mockReset();
     scrollIntoViewMock.mockReset();
     Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
@@ -346,9 +347,7 @@ describe('TaskDetailPage timeblock detail layout（任务详情布局）', () =>
       expect(updateTaskMock).toHaveBeenCalledWith('task-1', expect.objectContaining({ estimatedMinutes: 60 }));
     });
 
-    await waitFor(() => {
-      expect(screen.queryByTestId('task-countdown-auto-remaining')).toBeNull();
-    });
+    expect(screen.getByTestId('task-countdown-auto-fill-switch')).toHaveAttribute('aria-checked', 'false');
 
     fireEvent.click(screen.getByText('开始计时'));
 
@@ -357,18 +356,59 @@ describe('TaskDetailPage timeblock detail layout（任务详情布局）', () =>
     });
   });
 
-  it('shows remaining-time shortcut from estimated and spent minutes（展示基于任务估时与已耗时的剩余时长快捷按钮）', async () => {
+  it('persists auto-fill switch and reapplies remaining minutes after remount（自动补全开关持久化并在回页后重新应用）', async () => {
+    mockMatchMedia(false);
+    const view = render(<TaskDetailPage />);
+
+    await screen.findByText('任务详情');
+
+    expect(screen.getByTestId('task-countdown-auto-fill-status')).toHaveTextContent('剩余 30min');
+    fireEvent.click(screen.getByTestId('task-countdown-auto-fill-switch'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('task-countdown-auto-fill-switch')).toHaveAttribute('aria-checked', 'true');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('task-countdown-custom-trigger')).toHaveTextContent('30m');
+    });
+
+    view.unmount();
+    render(<TaskDetailPage />);
+
+    await screen.findByText('任务详情');
+    expect(screen.getByTestId('task-countdown-auto-fill-switch')).toHaveAttribute('aria-checked', 'true');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('task-countdown-custom-trigger')).toHaveTextContent('30m');
+    });
+  });
+
+  it('routes estimated-time changes through remaining time while auto-fill is enabled（自动补全开启时按剩余时长路由任务估时变化）', async () => {
     mockMatchMedia(false);
     render(<TaskDetailPage />);
 
     await screen.findByText('任务详情');
 
-    expect(await screen.findByTestId('task-countdown-auto-remaining')).toHaveTextContent('自动：剩余 30min');
+    fireEvent.click(screen.getByTestId('task-countdown-auto-fill-switch'));
+    await waitFor(() => {
+      expect(screen.getByTestId('task-countdown-auto-fill-switch')).toHaveAttribute('aria-checked', 'true');
+    });
 
-    fireEvent.click(screen.getByTestId('task-countdown-auto-remaining'));
+    fireEvent.click(screen.getByTestId('estimated-time-preset-60'));
 
     await waitFor(() => {
-      expect(screen.getByTestId('task-countdown-custom-trigger')).toHaveTextContent('30m');
+      expect(updateTaskMock).toHaveBeenCalledWith('task-1', expect.objectContaining({ estimatedMinutes: 60 }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('task-mode-countup')).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    fireEvent.click(screen.getByText('开始计时'));
+
+    await waitFor(() => {
+      expect(startBlockForTaskMock).toHaveBeenCalledWith('task-1', { mode: 'countup' });
     });
   });
 

--- a/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
+++ b/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
@@ -213,7 +213,7 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
     expect(screen.getByText('操作')).toBeInTheDocument();
   });
 
-  it('renders current root guidance with DAG link（详情页复用当前根节点规则）', async () => {
+  it('renders current root guidance without DAG link（详情页复用当前根节点规则，#496 移除 DAG 链接）', async () => {
     mockMatchMedia(true);
     render(<TaskDetailPage />);
 
@@ -223,7 +223,7 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
 
     expect(await screen.findByTestId('task-current-root-card')).toHaveTextContent('优先收口 DAG 根节点');
     expect(screen.getByTestId('task-current-root-link')).toBeInTheDocument();
-    expect(screen.getByTestId('task-current-root-dag-link')).toBeInTheDocument();
+    expect(screen.queryByTestId('task-current-root-dag-link')).toBeNull();
   });
 
   it('starts countdown with task estimated minutes instead of hardcoded 25（开始计时时使用任务预估分钟数）', async () => {

--- a/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
+++ b/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
@@ -87,7 +87,7 @@ function makeTask(overrides: Partial<TaskNode> = {}): TaskNode {
   return {
     id: 'task-1',
     title: '深度工作：EventLog 模块实现',
-    description: '实现时间块详情页首版',
+    description: '实现任务详情页首版',
     status: 'completed',
     priority: 'high',
     dependsOn: [],
@@ -116,7 +116,7 @@ function makeBlock(overrides: Partial<TimeBlock> = {}): TimeBlock {
   };
 }
 
-describe('TaskDetailPage timeblock detail layout（时间块详情布局）', () => {
+describe('TaskDetailPage timeblock detail layout（任务详情布局）', () => {
   beforeEach(() => {
     currentTaskId = 'task-1';
     navigateMock.mockReset();
@@ -186,7 +186,7 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
       expect(getTaskMock).toHaveBeenCalledWith('task-1');
     });
 
-    expect(await screen.findByText('时间块详情')).toBeInTheDocument();
+    expect(await screen.findByText('任务详情')).toBeInTheDocument();
     expect(screen.getByText('概览')).toBeInTheDocument();
     expect(screen.getByText('时间线')).toBeInTheDocument();
     expect(screen.getAllByText('AI 总结').length).toBeGreaterThan(0);
@@ -197,7 +197,7 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
     expect(screen.getByTestId('task-pause-button')).toBeInTheDocument();
   });
 
-  it('renders desktop two-column timeblock detail（桌面端双列时间块详情）', async () => {
+  it('renders desktop two-column timeblock detail（桌面端双列任务详情）', async () => {
     window.history.replaceState({}, '', '/tasks/block/block-1?from=today');
     mockMatchMedia(true);
     render(<TaskDetailPage />);
@@ -206,7 +206,7 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
       expect(loadTimeBlocksMock).toHaveBeenCalled();
     });
 
-    expect(await screen.findByText('任务 > 今日 > 时间块详情')).toBeInTheDocument();
+    expect(await screen.findByText('任务 > 今日 > 任务详情')).toBeInTheDocument();
     expect(screen.getAllByText('深度工作：EventLog 模块实现').length).toBeGreaterThan(0);
     expect(screen.getByText('事件时间线')).toBeInTheDocument();
     expect(screen.getByText('洞察')).toBeInTheDocument();
@@ -230,7 +230,7 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
     mockMatchMedia(false);
     render(<TaskDetailPage />);
 
-    await screen.findByText('时间块详情');
+    await screen.findByText('任务详情');
 
     await waitFor(() => {
       expect(screen.getByTestId('task-countdown-custom-trigger')).toHaveTextContent('120m');
@@ -247,7 +247,7 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
     mockMatchMedia(false);
     const { rerender } = render(<TaskDetailPage />);
 
-    await screen.findByText('时间块详情');
+    await screen.findByText('任务详情');
 
     fireEvent.click(screen.getByTestId('task-mode-countup'));
     expect(screen.getByTestId('task-mode-countup')).toHaveAttribute('aria-pressed', 'true');
@@ -292,7 +292,7 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
 
     const { rerender } = render(<TaskDetailPage />);
 
-    await screen.findByText('时间块详情');
+    await screen.findByText('任务详情');
     fireEvent.click(screen.getByTestId('task-mode-countup'));
 
     currentTaskId = 'task-2';

--- a/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
+++ b/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
@@ -307,6 +307,44 @@ describe('TaskDetailPage timeblock detail layout（任务详情布局）', () =>
 
   it('renders current root guidance without DAG link（详情页复用当前根节点规则，#496 移除 DAG 链接）', async () => {
     mockMatchMedia(true);
+    listTasksMock.mockResolvedValue([
+      makeTask({
+        id: 'task-root',
+        title: '优先收口 DAG 根节点',
+        status: 'pending',
+        createdAt: 10,
+        updatedAt: 10,
+      }),
+      makeTask({
+        id: 'task-3',
+        title: '并行任务 A',
+        status: 'pending',
+        createdAt: 15,
+        updatedAt: 15,
+      }),
+      makeTask({
+        id: 'task-4',
+        title: '并行任务 B',
+        status: 'pending',
+        createdAt: 18,
+        updatedAt: 18,
+      }),
+      makeTask({
+        id: 'task-1',
+        title: '深度工作：EventLog 模块实现',
+        status: 'in_progress',
+        createdAt: 20,
+        updatedAt: 20,
+      }),
+      makeTask({
+        id: 'task-2',
+        title: '切换后的任务 B',
+        estimatedMinutes: 30,
+        status: 'pending',
+        createdAt: 30,
+        updatedAt: 30,
+      }),
+    ]);
     render(<TaskDetailPage />);
 
     await waitFor(() => {
@@ -315,6 +353,7 @@ describe('TaskDetailPage timeblock detail layout（任务详情布局）', () =>
 
     expect(await screen.findByTestId('task-current-root-card')).toHaveTextContent('优先收口 DAG 根节点');
     expect(screen.getByText('优先收口 DAG 根节点')).toBeInTheDocument();
+    expect(screen.getByTestId('task-current-root-card-collapse-toggle')).toBeInTheDocument();
     expect(screen.queryByTestId('task-current-root-dag-link')).toBeNull();
   });
 

--- a/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
+++ b/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
@@ -10,6 +10,7 @@ const scrollIntoViewMock = vi.fn();
 
 const getTaskMock = vi.fn<(id: string) => Promise<TaskNode | null>>();
 const listTasksMock = vi.fn<(includeCancelled?: boolean) => Promise<TaskNode[]>>();
+const updateTaskMock = vi.fn<(id: string, input: Partial<TaskNode>) => Promise<TaskNode | null>>();
 const addDependencyMock = vi.fn<(taskId: string, depTaskId: string, type: 'soft' | 'hard') => Promise<TaskNode | null>>();
 const removeDependencyMock = vi.fn<(taskId: string, depTaskId: string) => Promise<TaskNode | null>>();
 const getAvailableTransitionsMock = vi.fn<(id: string) => Promise<Array<TaskNode['status']>>>();
@@ -48,7 +49,7 @@ vi.mock('@/lib/services', () => ({
     checkDependenciesMet: checkDependenciesMetMock,
     onTaskChange: onTaskChangeMock,
     transitionTask: vi.fn(),
-    updateTask: vi.fn(),
+    updateTask: updateTaskMock,
     cancelTask: vi.fn(),
   }),
   getTimeBlockService: () => ({
@@ -127,6 +128,12 @@ describe('TaskDetailPage timeblock detail layout（任务详情布局）', () =>
     });
     startBlockForTaskMock.mockReset();
     startBlockForTaskMock.mockResolvedValue(null);
+    updateTaskMock.mockReset();
+    updateTaskMock.mockImplementation(async (id, input) => makeTask({
+      id,
+      ...input,
+      updatedAt: Date.now(),
+    }));
     getTaskMock.mockImplementation(async (id: string) => {
       if (id === 'task-2') {
         return makeTask({
@@ -324,6 +331,44 @@ describe('TaskDetailPage timeblock detail layout（任务详情布局）', () =>
 
     await waitFor(() => {
       expect(startBlockForTaskMock).toHaveBeenCalledWith('task-1', { mode: 'countdown', minutes: 120 });
+    });
+  });
+
+  it('syncs task estimated minutes into expected duration before manual timer override（任务估时会同步到预期时长）', async () => {
+    mockMatchMedia(false);
+    render(<TaskDetailPage />);
+
+    await screen.findByText('任务详情');
+
+    fireEvent.click(screen.getByTestId('estimated-time-preset-60'));
+
+    await waitFor(() => {
+      expect(updateTaskMock).toHaveBeenCalledWith('task-1', expect.objectContaining({ estimatedMinutes: 60 }));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('task-countdown-auto-remaining')).toBeNull();
+    });
+
+    fireEvent.click(screen.getByText('开始计时'));
+
+    await waitFor(() => {
+      expect(startBlockForTaskMock).toHaveBeenCalledWith('task-1', { mode: 'countdown', minutes: 60 });
+    });
+  });
+
+  it('shows remaining-time shortcut from estimated and spent minutes（展示基于任务估时与已耗时的剩余时长快捷按钮）', async () => {
+    mockMatchMedia(false);
+    render(<TaskDetailPage />);
+
+    await screen.findByText('任务详情');
+
+    expect(await screen.findByTestId('task-countdown-auto-remaining')).toHaveTextContent('自动：剩余 30min');
+
+    fireEvent.click(screen.getByTestId('task-countdown-auto-remaining'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('task-countdown-custom-trigger')).toHaveTextContent('30m');
     });
   });
 

--- a/tests/unit/ui/task-route-memory.test.ts
+++ b/tests/unit/ui/task-route-memory.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { buildTasksMainSearch, resolveTasksRestorePath, shouldForceTasksMain } from '@/ui/app/pages/task-route-memory';
+
+describe('task route memory helpers', () => {
+  it('marks explicit task-root returns with a force-main search flag', () => {
+    expect(buildTasksMainSearch()).toEqual({ main: '1' });
+    expect(buildTasksMainSearch({ from: 'dag' })).toEqual({ from: 'dag', main: '1' });
+  });
+
+  it('skips restore when the search explicitly requests the tasks root', () => {
+    expect(shouldForceTasksMain('?main=1')).toBe(true);
+    expect(resolveTasksRestorePath('/tasks/dag', '?main=1')).toBeNull();
+  });
+
+  it('restores the saved sub-route when no force-main flag is present', () => {
+    expect(shouldForceTasksMain('')).toBe(false);
+    expect(resolveTasksRestorePath('/tasks/dag', '')).toBe('/tasks/dag');
+    expect(resolveTasksRestorePath('/agents', '')).toBeNull();
+  });
+});

--- a/tests/unit/ui/task-status-selector.issue493.test.tsx
+++ b/tests/unit/ui/task-status-selector.issue493.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TaskStatusSelector } from '@/ui/app/components/TaskStatusSelector';
+
+describe('TaskStatusSelector issue-493（关联任务名过长）', () => {
+  it('keeps long linked task title wrappable inside the dialog（较长任务名应允许换行）', () => {
+    const linkedTaskTitle = '我们现在弄一个非常长的专注名称，这个时间块会是非常长的，所以我们需要测试换行是否能在反馈弹窗里正确生效，并且不要把弹窗撑破';
+
+    render(
+      <TaskStatusSelector
+        value="continue"
+        onChange={vi.fn()}
+        linkedTaskTitle={linkedTaskTitle}
+      />,
+    );
+
+    const linkedTitle = screen.getByTestId('feedback-task-linked-title');
+    expect(linkedTitle).toHaveTextContent(linkedTaskTitle);
+    expect(linkedTitle).toHaveClass('min-w-0');
+    expect(linkedTitle).toHaveClass('flex-1');
+    expect(linkedTitle).toHaveClass('whitespace-normal');
+    expect(linkedTitle).toHaveClass('break-all');
+    expect(linkedTitle).not.toHaveClass('truncate');
+  });
+
+  it('truncates linked task title after 100 characters with ellipsis（超过100字符后省略号截断）', () => {
+    const linkedTaskTitle = `任务-${'超'.repeat(110)}-结尾`;
+    const expectedTitle = `${Array.from(linkedTaskTitle).slice(0, 100).join('')}...`;
+
+    render(
+      <TaskStatusSelector
+        value="continue"
+        onChange={vi.fn()}
+        linkedTaskTitle={linkedTaskTitle}
+      />,
+    );
+
+    const linkedTitle = screen.getByTestId('feedback-task-linked-title');
+    expect(linkedTitle).toHaveTextContent(expectedTitle);
+    expect(linkedTitle).toHaveAttribute('title', linkedTaskTitle);
+  });
+});

--- a/tests/unit/ui/task-tab-filters.issue338.test.ts
+++ b/tests/unit/ui/task-tab-filters.issue338.test.ts
@@ -170,12 +170,12 @@ describe('filterToday（"今日" tab）', () => {
     expect(filterToday([task], today)).toEqual([]);
   });
 
-  it('sorts results by due date', () => {
-    const late = makeTask({ id: 'late', dueAt: todayStart + 50_000, updatedAt: todayStart });
-    const early = makeTask({ id: 'early', dueAt: todayStart + 10_000, updatedAt: todayStart });
+  it('sorts results by status group (in_progress first, then by updatedAt desc)', () => {
+    const late = makeTask({ id: 'late', dueAt: todayStart + 50_000, updatedAt: todayStart + 2000 });
+    const early = makeTask({ id: 'early', dueAt: todayStart + 10_000, updatedAt: todayStart + 1000 });
     const noDue = makeTask({ id: 'noDue', status: 'in_progress', updatedAt: todayStart + 1000 });
     const result = filterToday([late, noDue, early], today);
-    expect(result.map((t) => t.id)).toEqual(['early', 'late', 'noDue']);
+    expect(result.map((t) => t.id)).toEqual(['noDue', 'late', 'early']);
   });
 });
 
@@ -205,12 +205,12 @@ describe('filterWeek（"一周" tab）', () => {
     expect(filterWeek([task], now)).toEqual([]);
   });
 
-  it('sorts: dueAt asc, no-due at bottom', () => {
-    const far = makeTask({ id: 'far', dueAt: nowMs + 5 * 86_400_000, updatedAt: nowMs });
-    const near = makeTask({ id: 'near', dueAt: nowMs + 1 * 86_400_000, updatedAt: nowMs });
+  it('sorts by status group (in_progress first, then by updatedAt desc)', () => {
+    const far = makeTask({ id: 'far', dueAt: nowMs + 5 * 86_400_000, updatedAt: nowMs + 2000 });
+    const near = makeTask({ id: 'near', dueAt: nowMs + 1 * 86_400_000, updatedAt: nowMs + 1000 });
     const noDue = makeTask({ id: 'noDue', status: 'in_progress', updatedAt: nowMs });
     const result = filterWeek([far, noDue, near], now);
-    expect(result.map((t) => t.id)).toEqual(['near', 'far', 'noDue']);
+    expect(result.map((t) => t.id)).toEqual(['noDue', 'far', 'near']);
   });
 });
 

--- a/tests/unit/ui/task-timeblock-detail-view.test.ts
+++ b/tests/unit/ui/task-timeblock-detail-view.test.ts
@@ -194,4 +194,104 @@ describe('buildTaskTimeblockDetailViewModel（时间块详情视图模型）', (
     expect(model.timeline.items.map((item) => item.title)).toEqual(['开始时间块', '事件记录', '结束时间块']);
     expect(model.timeline.items[1].description).toContain('处理中途阻塞');
   });
+
+  it('linkedBlocks contains all blocks matched by task.timeBlockIds（linkedBlocks 包含任务关联的所有已完成时间块）', () => {
+    const task = makeTask({
+      id: 'task-linked',
+      title: '关联时间块展示',
+      estimatedMinutes: 60,
+      timeBlockIds: ['block-a', 'block-b'],
+    });
+    const blockA = makeBlock({
+      id: 'block-a',
+      name: '上午块',
+      startTime: start,
+      endTime: start + 30 * 60_000,
+    });
+    const blockB = makeBlock({
+      id: 'block-b',
+      name: '下午块',
+      startTime: start + 4 * 60 * 60_000,
+      endTime: start + 5 * 60 * 60_000,
+    });
+    const unrelated = makeBlock({
+      id: 'block-other',
+      name: '无关块',
+      startTime: start,
+      endTime: end,
+    });
+
+    const model = buildTaskTimeblockDetailViewModel({
+      task,
+      blocks: [blockA, blockB, unrelated],
+      reviewMarkdown: '',
+      useMockData: true,
+    });
+
+    expect(model.linkedBlocks).toHaveLength(2);
+    expect(model.linkedBlocks.map((b) => b.name)).toEqual(['下午块', '上午块']);
+    expect(model.linkedBlocks.every((b) => !b.isActive)).toBe(true);
+    expect(model.linkedBlocks[0].durationLabel).toBe('1h');
+    expect(model.linkedBlocks[1].durationLabel).toBe('30m');
+  });
+
+  it('linkedBlocks includes active block when present（进行中的活跃时间块出现在 linkedBlocks 列表开头）', () => {
+    const task = makeTask({
+      id: 'task-active',
+      title: '活跃块测试',
+      status: 'in_progress',
+      estimatedMinutes: 60,
+      timeBlockIds: ['block-done'],
+    });
+    const doneBlock = makeBlock({
+      id: 'block-done',
+      name: '已完成块',
+      startTime: start,
+      endTime: start + 45 * 60_000,
+    });
+
+    const now = new Date(start + 2 * 60 * 60_000);
+    const model = buildTaskTimeblockDetailViewModel({
+      task,
+      blocks: [doneBlock],
+      activeBlock: {
+        startId: 'block-active',
+        name: '当前块',
+        startTime: start + 60 * 60_000,
+        taskId: 'task-active',
+        mode: 'countup',
+        phase: 'focus',
+        paused: false,
+        elapsed: 0,
+      },
+      reviewMarkdown: '',
+      useMockData: true,
+      now,
+    });
+
+    expect(model.linkedBlocks).toHaveLength(2);
+    expect(model.linkedBlocks[0].isActive).toBe(true);
+    expect(model.linkedBlocks[0].name).toBe('当前块');
+    expect(model.linkedBlocks[0].endLabel).toBe('进行中');
+    expect(model.linkedBlocks[1].isActive).toBe(false);
+    expect(model.linkedBlocks[1].name).toBe('已完成块');
+  });
+
+  it('linkedBlocks is empty when task has no timeBlockIds（无关联时间块 ID 时返回空列表）', () => {
+    const task = makeTask({
+      id: 'task-empty',
+      title: '空时间块任务',
+      estimatedMinutes: 60,
+      timeBlockIds: [],
+    });
+
+    const model = buildTaskTimeblockDetailViewModel({
+      task,
+      blocks: [],
+      reviewMarkdown: '',
+      useMockData: true,
+    });
+
+    expect(model.linkedBlocks).toHaveLength(0);
+  });
 });

--- a/tests/unit/ui/task-title-fuzzy-search.issue546.test.ts
+++ b/tests/unit/ui/task-title-fuzzy-search.issue546.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import type { TaskNode } from '@/lib/types/task';
+import {
+  extractTaskTitleSearchQuery,
+  filterTasksByTitleFuzzySearch,
+  getTaskTitleFuzzyScore,
+} from '@/ui/app/pages/task-title-fuzzy-search';
+
+function makeTask(id: string, title: string): TaskNode {
+  return {
+    id,
+    title,
+    description: undefined,
+    status: 'pending',
+    priority: 'medium',
+    dependsOn: [],
+    tags: [],
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+describe('task title fuzzy search issue-546（任务页标题模糊搜索）', () => {
+  it('extracts only the first line from the input', () => {
+    expect(extractTaskTitleSearchQuery(' Alpha Beta \n第二行不参与匹配')).toBe('alphabeta');
+  });
+
+  it('scores by total character occurrences and filters titles missing any query char', () => {
+    const tasks = [
+      makeTask('task-1', 'aba'),
+      makeTask('task-2', 'baaab'),
+      makeTask('task-3', 'delta'),
+      makeTask('task-4', 'abacus'),
+    ];
+
+    expect(getTaskTitleFuzzyScore('baaab', 'ab')).toBe(5);
+    expect(getTaskTitleFuzzyScore('delta', 'ab')).toBeNull();
+    expect(filterTasksByTitleFuzzySearch(tasks, 'ab').map((task) => task.id)).toEqual([
+      'task-2',
+      'task-1',
+      'task-4',
+    ]);
+  });
+});

--- a/tests/unit/ui/task-title-fuzzy-search.issue546.test.ts
+++ b/tests/unit/ui/task-title-fuzzy-search.issue546.test.ts
@@ -41,4 +41,32 @@ describe('task title fuzzy search issue-546（任务页标题模糊搜索）', (
       'task-4',
     ]);
   });
+
+  it('requires repeated query characters to appear at least as many times in the title', () => {
+    const tasks = [
+      makeTask('task-1', '55'),
+      makeTask('task-2', '1555 bug'),
+      makeTask('task-3', '50505'),
+    ];
+
+    expect(getTaskTitleFuzzyScore('55', '555')).toBeNull();
+    expect(filterTasksByTitleFuzzySearch(tasks, '555').map((task) => task.id)).toEqual([
+      'task-2',
+      'task-3',
+    ]);
+  });
+
+  it('prioritizes longer continuous matches before total character frequency', () => {
+    const tasks = [
+      makeTask('task-1', 'Hub 123 Git'),
+      makeTask('task-2', 'GitHub issue#455'),
+      makeTask('task-3', 'Git-X-Hub notes'),
+    ];
+
+    expect(filterTasksByTitleFuzzySearch(tasks, 'GitHub').map((task) => task.id)).toEqual([
+      'task-2',
+      'task-3',
+      'task-1',
+    ]);
+  });
 });

--- a/tests/unit/ui/tasks-page-today-view.test.tsx
+++ b/tests/unit/ui/tasks-page-today-view.test.tsx
@@ -11,6 +11,13 @@ const loadActiveBlockMock = vi.fn<() => Promise<ActiveBlockData | null>>();
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/config/task-create-success-action', () => ({
+  getTaskCreateSuccessAction: vi.fn(() => 'refocus'),
+  setTaskCreateSuccessAction: vi.fn((value: string) => value),
+  subscribeTaskCreateSuccessActionChanges: vi.fn(() => () => {}),
 }));
 
 vi.mock('@/lib/services', () => ({
@@ -65,7 +72,7 @@ function makeBlock(overrides: { id: string; name: string; startTime: number; end
   };
 }
 
-describe('TasksPage today view（任务页今日时间块视图）', () => {
+describe('TasksPage current layout（任务页当前布局）', () => {
   const morning = new Date('2026-03-06T09:00:00.000+08:00').getTime();
   const afternoon = new Date('2026-03-06T15:00:00.000+08:00').getTime();
 
@@ -123,47 +130,38 @@ describe('TasksPage today view（任务页今日时间块视图）', () => {
 
     expect(await screen.findByTestId('task-current-root-card')).toHaveTextContent('实现下午编码任务');
     expect(screen.getByTestId('task-current-root-badge-task-2')).toBeInTheDocument();
-    expect(screen.getByTestId('task-current-root-dag-link')).toBeInTheDocument();
   });
 
-  it('renders today timeblock layout when 今日 tab is active', async () => {
+  it('renders top navigation links for timeblocks and dag', async () => {
     render(<TasksPage />);
 
     await waitFor(() => {
       expect(listTasksMock).toHaveBeenCalled();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: '今日' }));
-
-    expect(await screen.findByText('进行中')).toBeInTheDocument();
-    expect(screen.getByText('上午')).toBeInTheDocument();
-    expect(screen.getByText('下午')).toBeInTheDocument();
-    expect(screen.getAllByText('完成 Task List 视图设计').length).toBeGreaterThan(0);
+    expect(screen.getByText('时间块').closest('a')).toHaveAttribute('to', '/tasks/timeblocks');
+    expect(screen.getByText('DAG').closest('a')).toHaveAttribute('to', '/tasks/dag');
   });
 
-  it('keeps quick add input visible in today view', async () => {
+  it('keeps quick add input visible on the tasks page', async () => {
     render(<TasksPage />);
 
     await waitFor(() => {
       expect(listTasksMock).toHaveBeenCalled();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: '今日' }));
-
-    expect(screen.getByPlaceholderText('快速添加任务...')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('添加任务与描述...')).toBeInTheDocument();
   });
 
-  it('renders clickable links for each historical timeblock card', async () => {
+  it('renders clickable links for current visible tasks', async () => {
     render(<TasksPage />);
 
     await waitFor(() => {
       expect(listTasksMock).toHaveBeenCalled();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: '今日' }));
-
-    expect(await screen.findByTestId('tasks-today-block-link-block-1')).toBeInTheDocument();
-    expect(screen.getByTestId('tasks-today-block-link-block-2')).toBeInTheDocument();
+    expect(await screen.findByTestId('tasks-page-task-link-task-1')).toBeInTheDocument();
+    expect(screen.getByTestId('tasks-page-task-link-task-2')).toBeInTheDocument();
   });
 
   afterEach(() => {

--- a/tests/unit/ui/tasks-page.issue546-draft.test.tsx
+++ b/tests/unit/ui/tasks-page.issue546-draft.test.tsx
@@ -1,0 +1,96 @@
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { TasksPage, TASKS_QUICK_ADD_DRAFT_KEY } from '@/ui/app/pages/TasksPage';
+import type { TaskNode } from '@/lib/types/task';
+
+const listTasksMock = vi.fn<() => Promise<TaskNode[]>>();
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children?: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+vi.mock('@/lib/services', () => ({
+  getTaskService: () => ({
+    listTasks: listTasksMock,
+    createTask: vi.fn(async ({ title, description, estimatedMinutes }: { title: string; description?: string; estimatedMinutes?: number }) => ({
+      id: 'created-task',
+      title,
+      description,
+      estimatedMinutes,
+      status: 'pending',
+      priority: 'medium',
+      dependsOn: [],
+      tags: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    })),
+    getTask: vi.fn(),
+    updateTask: vi.fn(),
+    cancelTask: vi.fn(),
+    transitionTask: vi.fn(),
+    getAvailableTransitions: vi.fn(async () => []),
+    getChildTasks: vi.fn(async () => []),
+    addDependency: vi.fn(),
+    removeDependency: vi.fn(),
+    checkDependenciesMet: vi.fn(async () => ({ met: true, blocking: [] })),
+    startSync: vi.fn(async () => {}),
+    stopSync: vi.fn(async () => {}),
+    onTaskChange: vi.fn(() => () => {}),
+  }),
+}));
+
+describe('TasksPage issue-546 draft cache wiring', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    listTasksMock.mockReset();
+    listTasksMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('restores quick-add draft from the task-specific storage key', async () => {
+    localStorage.setItem(TASKS_QUICK_ADD_DRAFT_KEY, '恢复未提交任务');
+
+    render(<TasksPage />);
+
+    await waitFor(() => {
+      expect(listTasksMock).toHaveBeenCalledWith(true);
+    });
+
+    expect(screen.getByTestId('new-now-input-textarea')).toHaveValue('恢复未提交任务');
+  });
+
+  it('persists quick-add draft across remounts and clears it after submit', async () => {
+    const { unmount } = render(<TasksPage />);
+
+    await waitFor(() => {
+      expect(listTasksMock).toHaveBeenCalledWith(true);
+    });
+
+    const textarea = screen.getByTestId('new-now-input-textarea');
+    fireEvent.change(textarea, { target: { value: '跨页面保留的任务草稿' } });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 350));
+    });
+
+    expect(localStorage.getItem(TASKS_QUICK_ADD_DRAFT_KEY)).toBe('跨页面保留的任务草稿');
+
+    unmount();
+    render(<TasksPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('new-now-input-textarea')).toHaveValue('跨页面保留的任务草稿');
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('new-now-send-button'));
+    });
+
+    expect(screen.getByTestId('new-now-input-textarea')).toHaveValue('');
+    expect(localStorage.getItem(TASKS_QUICK_ADD_DRAFT_KEY)).toBeNull();
+  });
+});

--- a/tests/unit/ui/tasks-page.issue546-draft.test.tsx
+++ b/tests/unit/ui/tasks-page.issue546-draft.test.tsx
@@ -8,6 +8,13 @@ const listTasksMock = vi.fn<() => Promise<TaskNode[]>>();
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children, ...props }: { children?: ReactNode }) => <a {...props}>{children}</a>,
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/config/task-create-success-action', () => ({
+  getTaskCreateSuccessAction: vi.fn(() => 'refocus'),
+  setTaskCreateSuccessAction: vi.fn((value: string) => value),
+  subscribeTaskCreateSuccessActionChanges: vi.fn(() => () => {}),
 }));
 
 vi.mock('@/lib/services', () => ({

--- a/tests/unit/ui/tasks-page.issue546-fuzzy-search.test.tsx
+++ b/tests/unit/ui/tasks-page.issue546-fuzzy-search.test.tsx
@@ -1,0 +1,223 @@
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { TasksPage } from '@/ui/app/pages/TasksPage';
+import type { TaskNode } from '@/lib/types/task';
+
+const listTasksMock = vi.fn<() => Promise<TaskNode[]>>();
+
+const fuzzySearchState = vi.hoisted(() => {
+  let enabled = true;
+  let listeners: Array<(value: boolean) => void> = [];
+  return {
+    reset: () => {
+      enabled = true;
+      listeners = [];
+    },
+    getEnabled: () => enabled,
+    subscribe: (listener: (value: boolean) => void) => {
+      listeners.push(listener);
+      return () => {
+        listeners = listeners.filter((item) => item !== listener);
+      };
+    },
+    emit: (value: boolean) => {
+      enabled = value;
+      listeners.forEach((listener) => listener(value));
+      return value;
+    },
+  };
+});
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children?: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+vi.mock('@/lib/services', () => ({
+  getTaskService: () => ({
+    listTasks: listTasksMock,
+    createTask: vi.fn(),
+    getTask: vi.fn(),
+    updateTask: vi.fn(),
+    cancelTask: vi.fn(),
+    transitionTask: vi.fn(async () => null),
+    getAvailableTransitions: vi.fn(async () => []),
+    getChildTasks: vi.fn(async () => []),
+    addDependency: vi.fn(),
+    removeDependency: vi.fn(),
+    checkDependenciesMet: vi.fn(async () => ({ met: true, blocking: [] })),
+    startSync: vi.fn(async () => {}),
+    stopSync: vi.fn(async () => {}),
+    onTaskChange: vi.fn(() => () => {}),
+  }),
+}));
+
+vi.mock('@/config/task-page-fuzzy-search', () => ({
+  getTaskPageFuzzySearchEnabled: vi.fn(() => fuzzySearchState.getEnabled()),
+  setTaskPageFuzzySearchEnabled: vi.fn((value: boolean) => fuzzySearchState.emit(value)),
+  subscribeTaskPageFuzzySearchChanges: vi.fn((listener: (value: boolean) => void) => fuzzySearchState.subscribe(listener)),
+}));
+
+vi.mock('@/ui/app/components/PageMoreMenu', () => ({
+  PageMoreMenu: () => <div data-testid="page-more-menu" />,
+}));
+
+vi.mock('@/ui/app/components/TaskCurrentRootCard', () => ({
+  TaskCurrentRootCard: () => <div data-testid="task-current-root-card" />,
+}));
+
+vi.mock('@/ui/app/components/NowInputRow', async () => {
+  const React = await import('react');
+  return {
+    NowInputRow: React.forwardRef(function MockNowInputRow(props: any, ref: any) {
+      const [value, setValue] = React.useState('');
+      React.useImperativeHandle(ref, () => ({
+        focusText: vi.fn(),
+        startVoiceRecording: vi.fn(),
+      }));
+
+      return (
+        <div data-testid="task-search-input-row">
+          <textarea
+            data-testid="task-search-input"
+            value={value}
+            onChange={(event) => {
+              setValue(event.target.value);
+              props.onValueChange?.(event.target.value);
+            }}
+          />
+          <button
+            type="button"
+            data-testid="task-search-send"
+            onClick={() => {
+              void props.onSend(value);
+              setValue('');
+              props.onValueChange?.('');
+            }}
+          >
+            send
+          </button>
+        </div>
+      );
+    }),
+  };
+});
+
+function makeTask(overrides: Partial<TaskNode> & { id: string; title: string; updatedAt: number }): TaskNode {
+  return {
+    id: overrides.id,
+    title: overrides.title,
+    description: undefined,
+    status: 'pending',
+    priority: 'medium',
+    dependsOn: [],
+    tags: [],
+    createdAt: overrides.updatedAt,
+    updatedAt: overrides.updatedAt,
+    ...overrides,
+  };
+}
+
+function visibleTaskOrder(): string[] {
+  return screen
+    .queryAllByTestId(/tasks-page-task-link-/)
+    .map((node) => node.getAttribute('data-testid') ?? '');
+}
+
+async function flushLoad(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe('TasksPage issue-546 fuzzy search', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fuzzySearchState.reset();
+    listTasksMock.mockReset();
+    listTasksMock.mockResolvedValue([
+      makeTask({ id: 'task-1', title: 'aba', updatedAt: 10 }),
+      makeTask({ id: 'task-2', title: 'baaab', updatedAt: 20 }),
+      makeTask({ id: 'task-3', title: 'delta', updatedAt: 30 }),
+      makeTask({ id: 'task-4', title: 'abacus', updatedAt: 40 }),
+    ]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('debounces search, matches only the first line, and sorts by fuzzy score', async () => {
+    render(<TasksPage />);
+
+    await flushLoad();
+    expect(listTasksMock).toHaveBeenCalledWith(true);
+
+    expect(visibleTaskOrder()).toEqual([
+      'tasks-page-task-link-task-4',
+      'tasks-page-task-link-task-3',
+      'tasks-page-task-link-task-2',
+      'tasks-page-task-link-task-1',
+    ]);
+
+    fireEvent.change(screen.getByTestId('task-search-input'), {
+      target: { value: 'ab\nzzz' },
+    });
+
+    expect(visibleTaskOrder()).toEqual([
+      'tasks-page-task-link-task-4',
+      'tasks-page-task-link-task-3',
+      'tasks-page-task-link-task-2',
+      'tasks-page-task-link-task-1',
+    ]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(179);
+    });
+
+    expect(visibleTaskOrder()).toHaveLength(4);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(visibleTaskOrder()).toEqual([
+      'tasks-page-task-link-task-2',
+      'tasks-page-task-link-task-1',
+      'tasks-page-task-link-task-4',
+    ]);
+    expect(screen.queryByTestId('tasks-page-task-link-task-3')).not.toBeInTheDocument();
+  });
+
+  it('restores the full list immediately when fuzzy search is turned off', async () => {
+    render(<TasksPage />);
+
+    await flushLoad();
+    expect(listTasksMock).toHaveBeenCalledWith(true);
+
+    fireEvent.change(screen.getByTestId('task-search-input'), {
+      target: { value: 'ab' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(180);
+    });
+
+    expect(visibleTaskOrder()).toEqual([
+      'tasks-page-task-link-task-2',
+      'tasks-page-task-link-task-1',
+      'tasks-page-task-link-task-4',
+    ]);
+
+    await act(async () => {
+      fuzzySearchState.emit(false);
+    });
+
+    expect(visibleTaskOrder()).toEqual([
+      'tasks-page-task-link-task-4',
+      'tasks-page-task-link-task-3',
+      'tasks-page-task-link-task-2',
+      'tasks-page-task-link-task-1',
+    ]);
+  });
+});

--- a/tests/unit/ui/tasks-page.issue546-fuzzy-search.test.tsx
+++ b/tests/unit/ui/tasks-page.issue546-fuzzy-search.test.tsx
@@ -232,4 +232,48 @@ describe('TasksPage issue-546 fuzzy search', () => {
     ]);
     expect(screen.getByTestId('task-current-root-card')).toHaveAttribute('data-search-query', '');
   });
+
+  it('includes terminal tasks in results while an active title search is running', async () => {
+    listTasksMock.mockResolvedValue([
+      makeTask({ id: 'task-1', title: 'Active alpha', updatedAt: 10, status: 'pending' }),
+      makeTask({ id: 'task-2', title: 'Archived alpha', updatedAt: 20, status: 'completed' }),
+      makeTask({ id: 'task-3', title: 'Cancelled alpha', updatedAt: 30, status: 'cancelled' }),
+      makeTask({ id: 'task-4', title: 'delta', updatedAt: 40, status: 'pending' }),
+    ]);
+
+    render(<TasksPage />);
+
+    await flushLoad();
+
+    expect(visibleTaskOrder()).toEqual([
+      'tasks-page-task-link-task-4',
+      'tasks-page-task-link-task-1',
+    ]);
+
+    fireEvent.change(screen.getByTestId('task-search-input'), {
+      target: { value: 'alpha' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(180);
+    });
+
+    expect(screen.getByTestId('tasks-page-task-link-task-1')).toBeInTheDocument();
+    expect(screen.getByTestId('tasks-page-task-link-task-2')).toBeInTheDocument();
+    expect(screen.getByTestId('tasks-page-task-link-task-3')).toBeInTheDocument();
+    expect(screen.queryByTestId('tasks-page-task-link-task-4')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('task-search-input'), {
+      target: { value: '' },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(180);
+    });
+
+    expect(visibleTaskOrder()).toEqual([
+      'tasks-page-task-link-task-4',
+      'tasks-page-task-link-task-1',
+    ]);
+  });
 });

--- a/tests/unit/ui/tasks-page.issue546-fuzzy-search.test.tsx
+++ b/tests/unit/ui/tasks-page.issue546-fuzzy-search.test.tsx
@@ -5,6 +5,8 @@ import { TasksPage } from '@/ui/app/pages/TasksPage';
 import type { TaskNode } from '@/lib/types/task';
 
 const listTasksMock = vi.fn<() => Promise<TaskNode[]>>();
+const navigateMock = vi.fn();
+const createTaskMock = vi.fn();
 const taskCurrentRootCardMock = vi.fn((props: Record<string, unknown>) => (
   <div
     data-testid="task-current-root-card"
@@ -36,14 +38,25 @@ const fuzzySearchState = vi.hoisted(() => {
   };
 });
 
+const taskCreateSuccessActionState = vi.hoisted(() => {
+  let value: 'refocus' | 'open-detail' = 'refocus';
+  return {
+    reset: () => {
+      value = 'refocus';
+    },
+    get: () => value,
+  };
+});
+
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children, ...props }: { children?: ReactNode }) => <a {...props}>{children}</a>,
+  useNavigate: () => navigateMock,
 }));
 
 vi.mock('@/lib/services', () => ({
   getTaskService: () => ({
     listTasks: listTasksMock,
-    createTask: vi.fn(),
+    createTask: createTaskMock,
     getTask: vi.fn(),
     updateTask: vi.fn(),
     cancelTask: vi.fn(),
@@ -63,6 +76,12 @@ vi.mock('@/config/task-page-fuzzy-search', () => ({
   getTaskPageFuzzySearchEnabled: vi.fn(() => fuzzySearchState.getEnabled()),
   setTaskPageFuzzySearchEnabled: vi.fn((value: boolean) => fuzzySearchState.emit(value)),
   subscribeTaskPageFuzzySearchChanges: vi.fn((listener: (value: boolean) => void) => fuzzySearchState.subscribe(listener)),
+}));
+
+vi.mock('@/config/task-create-success-action', () => ({
+  getTaskCreateSuccessAction: vi.fn(() => taskCreateSuccessActionState.get()),
+  setTaskCreateSuccessAction: vi.fn((value: 'refocus' | 'open-detail') => value),
+  subscribeTaskCreateSuccessActionChanges: vi.fn(() => () => {}),
 }));
 
 vi.mock('@/ui/app/components/PageMoreMenu', () => ({
@@ -141,7 +160,10 @@ describe('TasksPage issue-546 fuzzy search', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     fuzzySearchState.reset();
+    taskCreateSuccessActionState.reset();
     listTasksMock.mockReset();
+    createTaskMock.mockReset();
+    navigateMock.mockReset();
     taskCurrentRootCardMock.mockClear();
     listTasksMock.mockResolvedValue([
       makeTask({ id: 'task-1', title: 'aba', updatedAt: 10 }),

--- a/tests/unit/ui/tasks-page.issue546-fuzzy-search.test.tsx
+++ b/tests/unit/ui/tasks-page.issue546-fuzzy-search.test.tsx
@@ -5,6 +5,13 @@ import { TasksPage } from '@/ui/app/pages/TasksPage';
 import type { TaskNode } from '@/lib/types/task';
 
 const listTasksMock = vi.fn<() => Promise<TaskNode[]>>();
+const taskCurrentRootCardMock = vi.fn((props: Record<string, unknown>) => (
+  <div
+    data-testid="task-current-root-card"
+    data-search-query={String(props.searchQuery ?? '')}
+    data-collapsible={String(Boolean(props.collapsible))}
+  />
+));
 
 const fuzzySearchState = vi.hoisted(() => {
   let enabled = true;
@@ -63,7 +70,7 @@ vi.mock('@/ui/app/components/PageMoreMenu', () => ({
 }));
 
 vi.mock('@/ui/app/components/TaskCurrentRootCard', () => ({
-  TaskCurrentRootCard: () => <div data-testid="task-current-root-card" />,
+  TaskCurrentRootCard: (props: Record<string, unknown>) => taskCurrentRootCardMock(props),
 }));
 
 vi.mock('@/ui/app/components/NowInputRow', async () => {
@@ -135,6 +142,7 @@ describe('TasksPage issue-546 fuzzy search', () => {
     vi.useFakeTimers();
     fuzzySearchState.reset();
     listTasksMock.mockReset();
+    taskCurrentRootCardMock.mockClear();
     listTasksMock.mockResolvedValue([
       makeTask({ id: 'task-1', title: 'aba', updatedAt: 10 }),
       makeTask({ id: 'task-2', title: 'baaab', updatedAt: 20 }),
@@ -159,6 +167,8 @@ describe('TasksPage issue-546 fuzzy search', () => {
       'tasks-page-task-link-task-2',
       'tasks-page-task-link-task-1',
     ]);
+    expect(screen.getByTestId('task-current-root-card')).toHaveAttribute('data-search-query', '');
+    expect(screen.getByTestId('task-current-root-card')).toHaveAttribute('data-collapsible', 'true');
 
     fireEvent.change(screen.getByTestId('task-search-input'), {
       target: { value: 'ab\nzzz' },
@@ -187,6 +197,7 @@ describe('TasksPage issue-546 fuzzy search', () => {
       'tasks-page-task-link-task-4',
     ]);
     expect(screen.queryByTestId('tasks-page-task-link-task-3')).not.toBeInTheDocument();
+    expect(screen.getByTestId('task-current-root-card')).toHaveAttribute('data-search-query', 'ab');
   });
 
   it('restores the full list immediately when fuzzy search is turned off', async () => {
@@ -219,5 +230,6 @@ describe('TasksPage issue-546 fuzzy search', () => {
       'tasks-page-task-link-task-2',
       'tasks-page-task-link-task-1',
     ]);
+    expect(screen.getByTestId('task-current-root-card')).toHaveAttribute('data-search-query', '');
   });
 });

--- a/tests/unit/ui/tasks-page.quick-add-estimate.test.tsx
+++ b/tests/unit/ui/tasks-page.quick-add-estimate.test.tsx
@@ -8,9 +8,21 @@ const listTasksMock = vi.fn<() => Promise<TaskNode[]>>();
 const createTaskMock = vi.fn<
   (input: { title: string; description?: string; estimatedMinutes?: number }) => Promise<TaskNode>
 >();
+const navigateMock = vi.fn();
+
+const taskCreateSuccessActionState = vi.hoisted(() => {
+  let value: 'refocus' | 'open-detail' = 'refocus';
+  return {
+    get: () => value,
+    set: (next: 'refocus' | 'open-detail') => {
+      value = next;
+    },
+  };
+});
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children, ...props }: { children?: ReactNode }) => <a {...props}>{children}</a>,
+  useNavigate: vi.fn(() => navigateMock),
 }));
 
 vi.mock('@/lib/services', () => ({
@@ -32,10 +44,18 @@ vi.mock('@/lib/services', () => ({
   }),
 }));
 
+vi.mock('@/config/task-create-success-action', () => ({
+  getTaskCreateSuccessAction: vi.fn(() => taskCreateSuccessActionState.get()),
+  setTaskCreateSuccessAction: vi.fn((value: 'refocus' | 'open-detail') => value),
+  subscribeTaskCreateSuccessActionChanges: vi.fn(() => () => {}),
+}));
+
 describe('TasksPage quick add estimate default', () => {
   beforeEach(() => {
     listTasksMock.mockReset();
     createTaskMock.mockReset();
+    navigateMock.mockReset();
+    taskCreateSuccessActionState.set('refocus');
 
     listTasksMock.mockResolvedValue([]);
     createTaskMock.mockImplementation(async (input) => ({
@@ -76,5 +96,30 @@ describe('TasksPage quick add estimate default', () => {
     expect(createInput.estimatedMinutes).toBeUndefined();
     expect(Object.prototype.hasOwnProperty.call(createInput, 'estimatedMinutes')).toBe(false);
     expect(await screen.findByText('未估时')).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('opens task detail after quick add when action is open-detail', async () => {
+    taskCreateSuccessActionState.set('open-detail');
+    render(<TasksPage />);
+
+    await waitFor(() => {
+      expect(listTasksMock).toHaveBeenCalledWith(true);
+    });
+
+    fireEvent.change(screen.getByTestId('new-now-input-textarea'), {
+      target: { value: '跳详情任务' },
+    });
+    fireEvent.click(screen.getByTestId('new-now-send-button'));
+
+    await waitFor(() => {
+      expect(createTaskMock).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith({
+        to: '/tasks/$taskId',
+        params: { taskId: 'created-task' },
+      });
+    });
   });
 });

--- a/tests/unit/ui/tasks-page.quick-add-estimate.test.tsx
+++ b/tests/unit/ui/tasks-page.quick-add-estimate.test.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { TasksPage } from '@/ui/app/pages/TasksPage';
+import type { TaskNode } from '@/lib/types/task';
+
+const listTasksMock = vi.fn<() => Promise<TaskNode[]>>();
+const createTaskMock = vi.fn<
+  (input: { title: string; description?: string; estimatedMinutes?: number }) => Promise<TaskNode>
+>();
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children?: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+vi.mock('@/lib/services', () => ({
+  getTaskService: () => ({
+    listTasks: listTasksMock,
+    createTask: createTaskMock,
+    getTask: vi.fn(),
+    updateTask: vi.fn(),
+    cancelTask: vi.fn(),
+    transitionTask: vi.fn(),
+    getAvailableTransitions: vi.fn(async () => []),
+    getChildTasks: vi.fn(async () => []),
+    addDependency: vi.fn(),
+    removeDependency: vi.fn(),
+    checkDependenciesMet: vi.fn(async () => ({ met: true, blocking: [] })),
+    startSync: vi.fn(async () => {}),
+    stopSync: vi.fn(async () => {}),
+    onTaskChange: vi.fn(() => () => {}),
+  }),
+}));
+
+describe('TasksPage quick add estimate default', () => {
+  beforeEach(() => {
+    listTasksMock.mockReset();
+    createTaskMock.mockReset();
+
+    listTasksMock.mockResolvedValue([]);
+    createTaskMock.mockImplementation(async (input) => ({
+      id: 'created-task',
+      title: input.title,
+      description: input.description,
+      estimatedMinutes: input.estimatedMinutes,
+      status: 'pending',
+      priority: 'medium',
+      dependsOn: [],
+      tags: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }));
+  });
+
+  it('quick add does not force a default 25min estimate', async () => {
+    render(<TasksPage />);
+
+    await waitFor(() => {
+      expect(listTasksMock).toHaveBeenCalledWith(true);
+    });
+
+    fireEvent.change(screen.getByTestId('new-now-input-textarea'), {
+      target: { value: '新任务\n补充描述' },
+    });
+    fireEvent.click(screen.getByTestId('new-now-send-button'));
+
+    await waitFor(() => {
+      expect(createTaskMock).toHaveBeenCalledTimes(1);
+    });
+
+    const createInput = createTaskMock.mock.calls[0][0];
+    expect(createInput).toMatchObject({
+      title: '新任务',
+      description: '补充描述',
+    });
+    expect(createInput.estimatedMinutes).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(createInput, 'estimatedMinutes')).toBe(false);
+    expect(await screen.findByText('未估时')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/ui/timeblock-detail-back-link.issue406.test.tsx
+++ b/tests/unit/ui/timeblock-detail-back-link.issue406.test.tsx
@@ -172,7 +172,7 @@ describe('timeblock detail back link issue #406', () => {
     });
 
     const backLink = await screen.findByTestId('timeblock-back-link-mobile');
-    expect(backLink).toHaveTextContent(`← 返回${label}`);
+    expect(backLink).toHaveAttribute('aria-label', `返回${label}`);
     expect(backLink).toHaveAttribute('href', `/tasks?tab=${from}`);
   });
 
@@ -184,7 +184,7 @@ describe('timeblock detail back link issue #406', () => {
     });
 
     const backLink = await screen.findByTestId('timeblock-back-link-mobile');
-    expect(backLink).toHaveTextContent('← 返回任务');
+    expect(backLink).toHaveAttribute('aria-label', '返回任务');
     expect(backLink).toHaveAttribute('href', '/tasks');
   });
 
@@ -196,7 +196,7 @@ describe('timeblock detail back link issue #406', () => {
     });
 
     const backLink = await screen.findByTestId('timeblock-back-link-mobile');
-    expect(backLink).toHaveTextContent('← 返回任务');
+    expect(backLink).toHaveAttribute('aria-label', '返回任务');
     expect(backLink).toHaveAttribute('href', '/tasks');
   });
 
@@ -207,7 +207,7 @@ describe('timeblock detail back link issue #406', () => {
       expect(loadTimeBlocksMock).toHaveBeenCalled();
     });
 
-    expect(await screen.findByText('任务 > 今日 > 时间块详情')).toBeInTheDocument();
+    expect(await screen.findByText('任务 > 今日 > 任务详情')).toBeInTheDocument();
     const backLink = screen.getByTestId('timeblock-back-link-desktop');
     expect(backLink).toHaveTextContent('← 返回今日');
     expect(backLink).toHaveAttribute('href', '/tasks?tab=today');

--- a/tests/unit/ui/timeblock-detail-back-link.issue406.test.tsx
+++ b/tests/unit/ui/timeblock-detail-back-link.issue406.test.tsx
@@ -213,23 +213,13 @@ describe('timeblock detail back link issue #406', () => {
     expect(backLink).toHaveAttribute('href', '/tasks?tab=today');
   });
 
-  it('adds a back action into the view model actions list', () => {
+  it('does not include a back-source action in the view model (navigation via breadcrumb)', () => {
     const model = buildTaskTimeblockDetailViewModel({
       task: makeTask(),
       blocks: [makeBlock()],
       useMockData: true,
-      backAction: {
-        label: '← 返回今日',
-        to: '/tasks',
-        search: { tab: 'today' },
-      },
     });
 
-    expect(model.actions[0]).toEqual({
-      id: 'back-source',
-      label: '← 返回今日',
-      to: '/tasks',
-      search: { tab: 'today' },
-    });
+    expect(model.actions.every((a) => a.id !== 'back-source')).toBe(true);
   });
 });

--- a/tests/unit/ui/timeblock-detail-back-link.issue406.test.tsx
+++ b/tests/unit/ui/timeblock-detail-back-link.issue406.test.tsx
@@ -207,7 +207,10 @@ describe('timeblock detail back link issue #406', () => {
       expect(loadTimeBlocksMock).toHaveBeenCalled();
     });
 
-    expect(await screen.findByText('任务 > 今日 > 任务详情')).toBeInTheDocument();
+    const breadcrumb = await screen.findByText((_content, element) =>
+      element?.tagName === 'P' && element.textContent === '任务 > 今日 > 任务详情',
+    );
+    expect(breadcrumb).toBeInTheDocument();
     const backLink = screen.getByTestId('timeblock-back-link-desktop');
     expect(backLink).toHaveTextContent('← 返回今日');
     expect(backLink).toHaveAttribute('href', '/tasks?tab=today');


### PR DESCRIPTION
## 概要

这条 PR 已经从最初的“任务系统批量优化”扩大为一组跨页面、跨交互层的集中收口，覆盖：

- 任务系统主链路优化（详情页、计时控制、DAG、时间块反馈、输入体验）
- 悬浮窗完成反馈与状态选择复用
- 浅色主题与设置页 slider / 任务页局部组件视觉一致性修正
- Me 页面入口 gating 与功能开关默认值调整
- 桌面端 F11 / 侧边栏 / 路由返回语义收口
- EventLog / Agent 拓扑等相邻页面问题修正
- RT 任务字段闭口与依赖图一致性约束补齐

## 已完成并已关闭的 Issue

- #410 `feat(task): 完成任务不应显示在当下，日期视图按状态后按更新时间分组排序`
- #413 `bug(task-dag): 左下角控制按钮需与网络页面 ReactFlow 控件保持一致`
- #422 `feat(task): 已完成/已取消任务禁止修改估时与依赖关系`
- #423 `feat(task-ui): 任务时间块详情页将关键信息卡片移至左上并与计时控制并排`
- #424 `feat(task-dag): 支持「折叠上下游」并定义可折叠范围与外部依赖保持规则`
- #430 `bug(task-detail): 清理“操作”卡片冗余动作并统一文案（返回任务/EventLog/再来一个时间块）`
- #467 `feat(task): 任务页面默认视图可配置（DAG/列表）`
- #492 `feat(task-timer): 计时控制支持「自动补全」——快速设置剩余预期时间`
- #493 `bug(focus): 「结束专注并记录反馈」对话框任务名过长时宽度溢出（手机端明显）`
- #495 `feat(task-timer): 统一任务估时“无”与正计时语义（任务估时/计时控制/当下配置对齐）`
- #496 `bug(task-ui): 当前根节点卡片在窄屏挤压正文，且任务页内 DAG 入口重复`
- #508 `bug(eventlog-profile): 未打开档案时当下页用户消息仍显示 Hailay，应使用占位符（建议『未名』）`
- #509 `bug(settings-slider): 浅色模式下滑动条未滑动轨道颜色错误，应为浅灰而非深灰`
- #528 `feat(desktop-sidebar): PC 端菜单侧边栏支持收回与重新展开，提供更沉浸的内容区`
- #550 `bug(tauri-overlay): 悬浮窗任务完成对话框缺少任务状态选择且未与当下页面复用`
- #551 `bug(ui): 未完成 Me 页面应隐藏并改为开发者功能开关`
- #556 `feat(tauri): PC端支持 F11 切换全屏`
- #561 `feat(agent-topology): 竖屏选中节点用独立导航展示详情（含 Signal 节点）`

## 已推进但需要完成的 Issue

- #546 `feat(task-input): 任务输入框体验优化 — 聚焦·缓存·搜索·键位·回焦`
  - 已完成回焦、草稿缓存、发送键位设置、任务页面模糊搜索及相关测试；若后续继续在本分支推进，将优先围绕这一条做最终收口

## 关联但不纳入本 PR 完成条件的 Issue

- #418 `tracking: 任务与时间块解耦、关联语义与反馈联动状态更新`
  - 本 PR 仅推进了其中“时间块反馈联动任务状态”“任务-时间块关联展示”的局部能力；该 tracking 范围远超本次 PR，不作为本 PR 的完成判定条件
- #563 `spec(task-dag): 默认全画布主视图展示原则（图布优先、选中式详情）`
  - 本 PR 仅在 DAG 缩放能力与总览体验上做了局部推进；距离“默认全画布主视图”的目标仍有明显差距，因此不作为本 PR 的完成判定条件

## 本 PR 内的额外收口

- 功能开关「网络页面」默认开启，仅显式设为 `false` 时关闭
- 结束专注反馈弹窗的确认按钮、状态选择器、浅色主题视觉与滑动动画收口
- 「任务详情 / 计时控制 / 任务估时」的 active indicator 与计时时长主题色对齐
- 当下页专注卡片运行态“结束”按钮在浅色模式下恢复为红底白图标
- DAG 视图允许进一步缩小，`适配视口` 更易总览全局；跳到当前根节点时保留当前缩放倍数
- 任务详情页计时语义进一步统一：`预期时长` 文案收敛为 `计时时长`，并同步估时/计时控制状态
- 任务返回主列表的路由语义进一步收口，显式回到 `/tasks` 根列表而不是隐式沿用旧记忆
- 输入框发送键位行为继续修正，确保 Enter / Ctrl+Enter 模式与设置一致
- DAG 折叠支持对称的「折叠下游」，并在 DAG 页面与任务详情依赖面板同步提供禁用态与隐藏摘要
- RT 侧补齐终态任务字段级闭口：禁止修改估时与依赖关系，并返回明确 `409`
- RT 侧补齐任务依赖成环拒绝：阻止直接自环与间接环，避免把 DAG 写坏

## 关键提交摘录

- `d1df9ca` 悬浮窗完成对话框加入状态选择
- `c896722` Me 页面入口 gating；并调整网络页面功能开关默认值
- `966acfb` `1fd0b3b` Tauri PC 端 F11 全屏支持与 wiring 修复
- `ee55645` 未打开档案时 EventLog 用户占位名修正
- `28e9a89` `47e1412` 设置页 slider 浅色轨道与样式收口
- `03efd2f` DAG 缩放下限放开，支持更大范围总览
- `fccb8f8` `e4a0825` 输入框草稿缓存、发送键位设置与快捷键行为修正
- `07816b3` `5fd3278` `a1a7468` `5291af6` 一组浅色主题与状态选择器视觉一致性修正
- `4d4ecaf` Agent 拓扑移动端 Signal 独立详情页
- `a808e00` 计时控制自动补全收尾与持久化行为补齐
- `9920386` DAG 折叠下游、禁用态与单测覆盖收口
- `8f1ab52` RT 终态任务字段级闭口：禁止修改估时与依赖关系并返回 `409`
- `120a9d7` RT 任务依赖成环拒绝：阻止自环与间接环

## 测试与验证

- 已补多组单测覆盖：
  - settings slider
  - ChatPage profile placeholder
  - DAG 缩放/跳转行为
  - task route memory / breadcrumb return
  - now input row 草稿缓存 / 发送键位 / shortcut 行为
  - tasks quick add 默认估时行为
  - task DAG 折叠上下游算法 / DAG 页交互 / 详情依赖面板交互
  - RT 终态任务字段闭口（memory / sqlite / HTTP route）
  - RT 依赖成环拒绝（self-cycle / indirect cycle / sqlite / HTTP route）
- 本 PR 的问题收口过程已在 PR 评论中持续补充验证结果与 issue 状态同步
- 已补 RT 实机 curl 验证（1949）：
  - 终态任务允许更新 `title`，但修改 `estimated_minutes` 返回 `409`
  - `A -> B -> C` 后再尝试 `C -> A` 返回 `409`

## 说明

- 本 PR 不再把“已推进”与“已完成”混写
- #418 与 #563 仅作为关联背景与局部推进记录，不纳入本 PR 完成条件
- #424 已按当前代码与聚焦验证结果收口，E2E / 可视化回归作为后续测试债单独跟踪，不再作为继续保持 open 的理由
- 若后续继续在本分支上推进，将优先按 `#546` 继续收口

Claude Code 生成，Codex 整合。