### PR TITLE
fix(eventlog-profile): 未打开档案时当下页使用占位名

### DIFF
--- a/src/components/Chat/ChatPage.tsx
+++ b/src/components/Chat/ChatPage.tsx
@@ -47,6 +47,7 @@ interface ChatPageProps {
 
 const UNKNOWN_DEVICE_LABEL = '未知设备';
 const UNKNOWN_PLATFORM_LABEL = '未知平台';
+const CLOSED_PROFILE_EVENTLOG_NAME = '未名';
 
 function resolvePlatformLabel(platform?: string): string {
   if (!platform) {
@@ -66,6 +67,15 @@ function resolveAvatarInitial(name: string): string {
   const trimmed = name.trim();
   if (!trimmed) return '我';
   return trimmed.charAt(0).toUpperCase();
+}
+
+function resolveEventLogUserDisplayName(currentUser?: string | null): string {
+  if (typeof currentUser !== 'string') {
+    return CLOSED_PROFILE_EVENTLOG_NAME;
+  }
+
+  const trimmed = currentUser.trim();
+  return trimmed.length > 0 ? trimmed : CLOSED_PROFILE_EVENTLOG_NAME;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -124,7 +134,7 @@ export function ChatPage({ variant = 'default', hideHeader = false }: ChatPagePr
   const voiceMessageInputRef = useRef<VoiceMessageInputHandle | null>(null);
   const timeBlockWidgetRef = useRef<TimeBlockWidgetHandle | null>(null);
   const focusTimerWidgetRef = useRef<FocusTimerWidgetHandle | null>(null);
-  const userDisplayName = currentUser || 'Hailay';
+  const userDisplayName = useMemo(() => resolveEventLogUserDisplayName(currentUser), [currentUser]);
   const userAvatarInitial = useMemo(() => resolveAvatarInitial(userDisplayName), [userDisplayName]);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {

--- a/tests/unit/components/ChatPage.profile-placeholder.test.tsx
+++ b/tests/unit/components/ChatPage.profile-placeholder.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Event } from '@/lib/types/event';
+import { ChatPage } from '@/components/Chat/ChatPage';
+import { useSyncStore } from '@/ui/stores/sync-store';
+import { getEventLogService } from '@/lib/services/eventlog.service';
+
+vi.mock('@/ui/stores/sync-store', () => ({
+  useSyncStore: vi.fn(),
+}));
+
+vi.mock('@/lib/services/eventlog.service', () => ({
+  getEventLogService: vi.fn(),
+}));
+
+vi.mock('@/components/Chat/EventMarkdown', () => ({
+  EventMarkdown: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+vi.mock('@/components/Chat/MessageActions', () => ({
+  MessageActions: () => null,
+}));
+
+vi.mock('@/ui/app/components/NowInputRow', async () => {
+  const React = await import('react');
+  return {
+    NowInputRow: React.forwardRef<HTMLDivElement>((_, ref) => (
+      <div ref={ref} data-testid="now-input-row" />
+    )),
+  };
+});
+
+vi.mock('@/ui/app/components/PageMoreMenu', () => ({
+  PageMoreMenu: () => <div data-testid="page-more-menu" />,
+}));
+
+vi.mock('@/ui/app/components/FocusTimerWidget', async () => {
+  const React = await import('react');
+  return {
+    FocusTimerWidget: React.forwardRef<HTMLDivElement>((_, ref) => (
+      <div ref={ref} data-testid="focus-timer-widget" />
+    )),
+  };
+});
+
+vi.mock('@/components/TimeBlockWidget', () => ({
+  TimeBlockWidget: () => <div data-testid="time-block-widget" />,
+}));
+
+vi.mock('@/components/VoiceMessageInput', () => ({
+  VoiceMessageInput: () => <div data-testid="voice-message-input" />,
+}));
+
+const mockUseSyncStore = vi.mocked(useSyncStore);
+const mockGetEventLogService = vi.mocked(getEventLogService);
+
+const baseEvent: Event = {
+  id: 'event-1',
+  timestamp: new Date('2026-03-17T10:00:00.000Z').getTime(),
+  content: '记录了一条用户事件',
+  tags: new Set(),
+  metadata: {
+    source: {
+      deviceId: 'device-1',
+      deviceName: 'Pixel 9',
+      platform: 'android',
+      app: 'ExoMind',
+    },
+  },
+};
+
+describe('ChatPage profile placeholder', () => {
+  const unsubscribe = vi.fn();
+  const loadEvents = vi.fn<() => Promise<Event[]>>();
+  const onEvent = vi.fn(() => unsubscribe);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
+    loadEvents.mockResolvedValue([baseEvent]);
+    mockGetEventLogService.mockReturnValue({
+      loadEvents,
+      addEvent: vi.fn(),
+      appendEventData: vi.fn(),
+      exportEventsAsJson: vi.fn(),
+      importEventsFromJson: vi.fn(),
+      onEvent,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('shows placeholder name and avatar initial when currentUser is empty', async () => {
+    mockUseSyncStore.mockReturnValue({
+      currentUser: null,
+      isLoggedIn: false,
+      activeProfileId: null,
+    } as never);
+
+    render(<ChatPage variant="new-mobile" />);
+
+    const row = await screen.findByTestId('new-mobile-user-message-row');
+
+    await waitFor(() => {
+      expect(within(row).getByText('未名')).toBeInTheDocument();
+    });
+    expect(within(row).getByText('未')).toBeInTheDocument();
+  });
+
+  it('keeps using current profile name and derived avatar initial when currentUser exists', async () => {
+    mockUseSyncStore.mockReturnValue({
+      currentUser: 'Alice',
+      isLoggedIn: true,
+      activeProfileId: 'profile-alice',
+    } as never);
+
+    render(<ChatPage variant="new-mobile" />);
+
+    const row = await screen.findByTestId('new-mobile-user-message-row');
+
+    await waitFor(() => {
+      expect(within(row).getByText('Alice')).toBeInTheDocument();
+    });
+    expect(within(row).getByText('A')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 摘要
- 将 ChatPage 在未打开档案时使用的真实姓名字面量替换为具名的「已关闭档案」占位符
- 头像首字母改为从解析后的展示名推导，保证用户名与头像保持一致
- 补充 UI 测试，覆盖关闭档案与已打开档案两种渲染场景

## 测试
- `bunx tsc --noEmit`
- `npx vitest run tests/unit/components/ChatPage.profile-placeholder.test.tsx tests/components/ChatPage.test.tsx`

## 备注
- 按当前要求，本 PR 未包含真实 Web / Sync 集成联调。

Closes #508
