### PR TITLE
feat: 解耦时间块与单任务绑定，并新增当下工作台 Tab（#418 #516）

### DIFF
--- a/Scripts/dev/tauri-dev-manager-lib.ts
+++ b/Scripts/dev/tauri-dev-manager-lib.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { appendFile, mkdir } from 'node:fs/promises';
 import { resolveTauriDevInstanceName } from './tauri-dev-target-dir-lib';
 
 export type ManagedTauriInstancePaths = {
@@ -21,6 +22,29 @@ export type ManagedTauriInstanceRecord = {
   startedAt: string;
   enableWatch: boolean;
   target: TauriDevTarget;
+};
+
+export type ManagedTauriLogSessionStart = {
+  name: string;
+  target: TauriDevTarget;
+  webPort: number;
+  hmrPort: number;
+  startedAt: string;
+};
+
+export type ManagedTauriInstanceHealthSnapshot = {
+  rootPidAlive: boolean;
+  webPortListening: boolean;
+  hmrPortListening: boolean;
+  appProcessAlive?: boolean;
+  webPortPids?: number[];
+  hmrPortPids?: number[];
+  appPids?: number[];
+};
+
+export type ManagedTauriInstanceHealth = {
+  status: 'running' | 'degraded' | 'stale';
+  detail: string;
 };
 
 export type BuildManagedTauriCommandInput = {
@@ -70,4 +94,109 @@ export function buildManagedTauriCommand(input: BuildManagedTauriCommandInput): 
   );
 
   return commands.join(' && ');
+}
+
+function collectListeningPortLabels(
+  record: ManagedTauriInstanceRecord,
+  snapshot: ManagedTauriInstanceHealthSnapshot,
+): string[] {
+  const labels: string[] = [];
+  if (snapshot.webPortListening) {
+    labels.push(`web=${record.webPort}`);
+  }
+  if (snapshot.hmrPortListening) {
+    labels.push(`hmr=${record.hmrPort}`);
+  }
+  return labels;
+}
+
+function uniquePositivePids(values: Array<number | undefined>): number[] {
+  return [...new Set(values.filter((value): value is number => Number.isInteger(value) && value > 0))];
+}
+
+export function formatManagedTauriLogSessionStart(input: ManagedTauriLogSessionStart): string {
+  const timestamp = input.startedAt.trim();
+  return [
+    '',
+    `===== manager session start [${timestamp}] name=${input.name} target=${input.target} web=${input.webPort} hmr=${input.hmrPort} =====`,
+    '',
+  ].join('\n');
+}
+
+export async function appendManagedTauriLogSessionStart(
+  logPath: string,
+  input: ManagedTauriLogSessionStart,
+): Promise<void> {
+  await mkdir(path.dirname(logPath), { recursive: true });
+  await appendFile(logPath, formatManagedTauriLogSessionStart(input), 'utf8');
+}
+
+export function evaluateManagedTauriInstanceHealth(
+  record: ManagedTauriInstanceRecord,
+  snapshot: ManagedTauriInstanceHealthSnapshot,
+): ManagedTauriInstanceHealth {
+  const listeningLabels = collectListeningPortLabels(record, snapshot);
+
+  if (!snapshot.rootPidAlive) {
+    if (listeningLabels.length > 0) {
+      return {
+        status: 'stale',
+        detail: `root pid exited; lingering listeners: ${listeningLabels.join(', ')}`,
+      };
+    }
+
+    return {
+      status: 'stale',
+      detail: 'root pid exited',
+    };
+  }
+
+  if (record.target === 'desktop' && snapshot.appProcessAlive === false) {
+    if (listeningLabels.length > 0) {
+      return {
+        status: 'stale',
+        detail: `desktop app process missing; lingering listeners: ${listeningLabels.join(', ')}`,
+      };
+    }
+
+    return {
+      status: 'stale',
+      detail: 'desktop app process missing',
+    };
+  }
+
+  const missingLabels: string[] = [];
+  if (!snapshot.webPortListening) {
+    missingLabels.push(`web=${record.webPort}`);
+  }
+  if (!snapshot.hmrPortListening) {
+    missingLabels.push(`hmr=${record.hmrPort}`);
+  }
+
+  if (missingLabels.length > 0) {
+    return {
+      status: 'degraded',
+      detail: `missing listeners: ${missingLabels.join(', ')}`,
+    };
+  }
+
+  return {
+    status: 'running',
+    detail: 'ok',
+  };
+}
+
+export function collectManagedTauriCleanupPids(
+  record: ManagedTauriInstanceRecord,
+  snapshot: ManagedTauriInstanceHealthSnapshot,
+): number[] {
+  if (snapshot.rootPidAlive) {
+    return uniquePositivePids([record.rootPid]);
+  }
+
+  return uniquePositivePids([
+    ...(snapshot.webPortPids ?? []),
+    ...(snapshot.hmrPortPids ?? []),
+    ...(snapshot.appPids ?? []),
+  ]);
 }

--- a/Scripts/dev/tauri-dev-manager.ts
+++ b/Scripts/dev/tauri-dev-manager.ts
@@ -5,7 +5,11 @@ import { createServer } from 'node:net';
 import { access, mkdir, open, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import {
+  appendManagedTauriLogSessionStart,
+  collectManagedTauriCleanupPids,
+  evaluateManagedTauriInstanceHealth,
   resolveManagedTauriInstancePaths,
+  type ManagedTauriInstanceHealthSnapshot,
   type ManagedTauriInstanceRecord,
   type TauriDevTarget,
 } from './tauri-dev-manager-lib';
@@ -19,6 +23,19 @@ type ParsedArgs = {
 
 const PROJECT_ROOT = process.cwd();
 const DEFAULT_WEB_PORT = 1420;
+const WINDOWS_TOOL_PROCESS_NAMES = new Set(['bun.exe', 'cargo.exe', 'node.exe', 'vite.exe']);
+const desktopProcessNameCache = new Map<string, Promise<string | null>>();
+
+type WindowsProcessInfo = {
+  ProcessId: number;
+  ParentProcessId: number;
+  Name: string;
+};
+
+type PortListenerInfo = {
+  LocalPort: number;
+  OwningProcess: number;
+};
 
 function printUsage(): never {
   console.log(`Usage:
@@ -171,6 +188,171 @@ function escapePowerShellLiteral(value: string): string {
   return value.replaceAll("'", "''");
 }
 
+function normalizeJsonArray<T>(value: T | T[] | null | undefined): T[] {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function runPowerShellJson<T>(script: string): T[] {
+  const result = spawnSync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-Command',
+      script,
+    ],
+    {
+      cwd: PROJECT_ROOT,
+      encoding: 'utf8',
+      windowsHide: true,
+    },
+  );
+
+  if (result.status !== 0) {
+    const stderr = result.stderr?.trim();
+    const stdout = result.stdout?.trim();
+    throw new Error(stderr || stdout || 'powershell health probe failed');
+  }
+
+  const raw = result.stdout.trim();
+  if (!raw) {
+    return [];
+  }
+
+  return normalizeJsonArray(JSON.parse(raw) as T | T[] | null);
+}
+
+function getDescendantProcesses(processes: WindowsProcessInfo[], rootPid: number): WindowsProcessInfo[] {
+  const childrenByParent = new Map<number, WindowsProcessInfo[]>();
+  for (const processInfo of processes) {
+    const siblings = childrenByParent.get(processInfo.ParentProcessId) ?? [];
+    siblings.push(processInfo);
+    childrenByParent.set(processInfo.ParentProcessId, siblings);
+  }
+
+  const descendants: WindowsProcessInfo[] = [];
+  const queue = [...(childrenByParent.get(rootPid) ?? [])];
+  const seen = new Set<number>();
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || seen.has(current.ProcessId)) {
+      continue;
+    }
+
+    seen.add(current.ProcessId);
+    descendants.push(current);
+    queue.push(...(childrenByParent.get(current.ProcessId) ?? []));
+  }
+
+  return descendants;
+}
+
+async function resolveDesktopProcessBaseName(projectRoot: string): Promise<string | null> {
+  const cached = desktopProcessNameCache.get(projectRoot);
+  if (cached) {
+    return await cached;
+  }
+
+  const pending = (async () => {
+    try {
+      const cargoTomlPath = path.join(projectRoot, 'src-tauri', 'Cargo.toml');
+      const cargoToml = await readFile(cargoTomlPath, 'utf8');
+      const packageSectionMatch = cargoToml.match(/\[package\][\s\S]*?^name\s*=\s*"([^"]+)"/m);
+      return packageSectionMatch?.[1]?.trim() || null;
+    } catch {
+      return null;
+    }
+  })();
+
+  desktopProcessNameCache.set(projectRoot, pending);
+  return await pending;
+}
+
+function matchesDesktopProcessName(name: string, expectedBaseName: string | null): boolean {
+  const normalized = name.trim().toLowerCase();
+  if (expectedBaseName) {
+    const expected = expectedBaseName.trim().toLowerCase();
+    return normalized === expected || normalized === `${expected}.exe`;
+  }
+
+  return !WINDOWS_TOOL_PROCESS_NAMES.has(normalized);
+}
+
+function groupListenerPidsByPort(portListeners: PortListenerInfo[], port: number): number[] {
+  return [...new Set(
+    portListeners
+      .filter((listener) => listener.LocalPort === port)
+      .map((listener) => listener.OwningProcess)
+      .filter((pid) => Number.isInteger(pid) && pid > 0),
+  )];
+}
+
+async function collectManagedTauriHealthSnapshot(
+  record: ManagedTauriInstanceRecord,
+): Promise<ManagedTauriInstanceHealthSnapshot> {
+  const rootPidAlive = isPidAlive(record.rootPid);
+  const portProbeScript = [
+    `$ports = @(${record.webPort}, ${record.hmrPort})`,
+    "Get-NetTCPConnection -State Listen -ErrorAction SilentlyContinue | Where-Object { $ports -contains $_.LocalPort } | Select-Object LocalPort, OwningProcess | ConvertTo-Json -Compress",
+  ].join('; ');
+  const portListeners = runPowerShellJson<PortListenerInfo>(portProbeScript);
+  const webPortPids = groupListenerPidsByPort(portListeners, record.webPort);
+  const hmrPortPids = groupListenerPidsByPort(portListeners, record.hmrPort);
+
+  if (record.target !== 'desktop') {
+    return {
+      rootPidAlive,
+      webPortListening: webPortPids.length > 0,
+      hmrPortListening: hmrPortPids.length > 0,
+      webPortPids,
+      hmrPortPids,
+    };
+  }
+
+  if (!rootPidAlive) {
+    return {
+      rootPidAlive,
+      webPortListening: webPortPids.length > 0,
+      hmrPortListening: hmrPortPids.length > 0,
+      appProcessAlive: false,
+      webPortPids,
+      hmrPortPids,
+      appPids: [],
+    };
+  }
+
+  const expectedDesktopProcess = await resolveDesktopProcessBaseName(record.projectRoot);
+  const processes = runPowerShellJson<WindowsProcessInfo>(
+    'Get-CimInstance Win32_Process | Select-Object ProcessId, ParentProcessId, Name | ConvertTo-Json -Compress',
+  );
+  const descendants = getDescendantProcesses(processes, record.rootPid);
+  const appPids = descendants
+    .filter((processInfo) => matchesDesktopProcessName(processInfo.Name, expectedDesktopProcess))
+    .map((processInfo) => processInfo.ProcessId);
+
+  return {
+    rootPidAlive,
+    webPortListening: webPortPids.length > 0,
+    hmrPortListening: hmrPortPids.length > 0,
+    appProcessAlive: appPids.length > 0,
+    webPortPids,
+    hmrPortPids,
+    appPids,
+  };
+}
+
+function stopWindowsProcess(pid: number): void {
+  const result = spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], {
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+
+  if (result.status !== 0 && isPidAlive(pid)) {
+    throw new Error(result.stderr || result.stdout || `failed to stop PID ${pid}`);
+  }
+}
+
 function parseTarget(flags: Map<string, string | true>): TauriDevTarget {
   const raw = getFlagValue(flags, '--target');
   if (!raw) return 'desktop';
@@ -194,10 +376,6 @@ async function startCommand(flags: Map<string, string | true>): Promise<void> {
     throw new Error(`instance already running: ${paths.name} (PID ${existing.rootPid})`);
   }
 
-  if (await fileExists(paths.logPath)) {
-    await rm(paths.logPath, { force: true });
-  }
-
   const env = {
     ...process.env,
     EXOMIND_WEB_PORT: String(webPort),
@@ -205,6 +383,15 @@ async function startCommand(flags: Map<string, string | true>): Promise<void> {
     EXOMIND_TAURI_INSTANCE_NAME: paths.name,
     ...(enableWatch ? { EXOMIND_TAURI_ENABLE_WATCH: '1' } : {}),
   };
+  const startedAt = new Date().toISOString();
+
+  await appendManagedTauriLogSessionStart(paths.logPath, {
+    name: paths.name,
+    target,
+    webPort,
+    hmrPort,
+    startedAt,
+  });
 
   const logHandle = await open(paths.logPath, 'a');
   const tauriArgs = target === 'android'
@@ -228,7 +415,7 @@ async function startCommand(flags: Map<string, string | true>): Promise<void> {
     hmrPort,
     logPath: paths.logPath,
     metaPath: paths.metaPath,
-    startedAt: new Date().toISOString(),
+    startedAt,
     enableWatch,
     target,
   };
@@ -257,14 +444,19 @@ async function listCommand(): Promise<void> {
     return;
   }
 
-  const rows = records.map((record) => ({
-    name: record.name,
-    target: record.target ?? 'desktop',
-    pid: record.rootPid,
-    status: isPidAlive(record.rootPid) ? 'running' : 'stale',
-    web: `http://localhost:${record.webPort}`,
-    hmr: record.hmrPort,
-    log: path.relative(PROJECT_ROOT, record.logPath),
+  const rows = await Promise.all(records.map(async (record) => {
+    const snapshot = await collectManagedTauriHealthSnapshot(record);
+    const health = evaluateManagedTauriInstanceHealth(record, snapshot);
+    return {
+      name: record.name,
+      target: record.target ?? 'desktop',
+      pid: record.rootPid,
+      status: health.status,
+      detail: health.detail,
+      web: `http://localhost:${record.webPort}`,
+      hmr: record.hmrPort,
+      log: path.relative(PROJECT_ROOT, record.logPath),
+    };
   }));
 
   console.table(rows);
@@ -282,15 +474,11 @@ async function stopCommand(flags: Map<string, string | true>): Promise<void> {
     throw new Error(`instance not found: ${paths.name}`);
   }
 
-  if (isPidAlive(record.rootPid)) {
-    const result = spawnSync('taskkill', ['/PID', String(record.rootPid), '/T', '/F'], {
-      encoding: 'utf8',
-      windowsHide: true,
-    });
+  const snapshot = await collectManagedTauriHealthSnapshot(record);
+  const cleanupPids = collectManagedTauriCleanupPids(record, snapshot);
 
-    if (result.status !== 0) {
-      throw new Error(result.stderr || result.stdout || `failed to stop PID ${record.rootPid}`);
-    }
+  for (const pid of cleanupPids) {
+    stopWindowsProcess(pid);
   }
 
   await rm(paths.metaPath, { force: true });
@@ -339,7 +527,10 @@ async function pruneCommand(): Promise<void> {
   let removed = 0;
 
   for (const record of records) {
-    if (isPidAlive(record.rootPid)) {
+    const snapshot = await collectManagedTauriHealthSnapshot(record);
+    const cleanupPids = collectManagedTauriCleanupPids(record, snapshot);
+
+    if (snapshot.rootPidAlive || cleanupPids.length > 0) {
       continue;
     }
 

--- a/Scripts/lib/pr-lock.ts
+++ b/Scripts/lib/pr-lock.ts
@@ -144,9 +144,10 @@ export class PRLockManager {
     const lockFile = '.exomind/lock-state.json';
     const contextDir = '.exomind';
 
-    // 确保目录存在
+    // 确保目录存在（Windows/Unix 通用）
     try {
-      execSync(`mkdir -p ${contextDir}`, { stdio: 'ignore' });
+      const fs = await import('fs');
+      fs.mkdirSync(contextDir, { recursive: true });
     } catch (e) {
       console.warn('[PRLock] Failed to create .exomind directory:', e);
       return;
@@ -201,7 +202,8 @@ export class PRLockManager {
     const lockFile = '.exomind/lock-state.json';
 
     try {
-      execSync(`rm -f ${lockFile}`, { stdio: 'ignore' });
+      const fs = await import('fs');
+      fs.rmSync(lockFile, { force: true });
       console.log('[PRLock] Lock state deleted');
     } catch (e) {
       console.warn('[PRLock] Failed to delete lock state:', e);

--- a/crates/exomind-runtime/src/routes/timeblocks.rs
+++ b/crates/exomind-runtime/src/routes/timeblocks.rs
@@ -454,6 +454,9 @@ mod tests {
                             tags: vec!["focus".to_string()],
                             start_time: 1_700_000_000_000,
                             end_time: 1_700_000_060_000,
+                            task_ids: vec![],
+                            task_status_outcomes: None,
+                            task_association_log: vec![],
                         }])
                         .unwrap(),
                     ))
@@ -480,6 +483,18 @@ mod tests {
                             tags: vec!["focus".to_string()],
                             start_time: 1_700_000_100_000,
                             end_time: 1_700_000_160_000,
+                            task_ids: vec!["task-profile-a".to_string()],
+                            task_status_outcomes: Some(std::collections::HashMap::from([(
+                                "task-profile-a".to_string(),
+                                "continue".to_string(),
+                            )])),
+                            task_association_log: vec![crate::timeblock::BlockTaskAssociationEvent {
+                                block_id: "tb-profile-a".to_string(),
+                                task_id: "task-profile-a".to_string(),
+                                action: "associated".to_string(),
+                                timestamp: 1_700_000_100_000,
+                                source: "block_start".to_string(),
+                            }],
                         }])
                         .unwrap(),
                     ))
@@ -517,6 +532,14 @@ mod tests {
                             pause_accumulated_ms: Some(0),
                             paused: false,
                             paused_at: None,
+                            task_ids: vec!["task-profile-a".to_string()],
+                            task_association_log: vec![crate::timeblock::BlockTaskAssociationEvent {
+                                block_id: "active-profile-a".to_string(),
+                                task_id: "task-profile-a".to_string(),
+                                action: "associated".to_string(),
+                                timestamp: 1_700_000_100_000,
+                                source: "block_start".to_string(),
+                            }],
                             task_id: Some("task-profile-a".to_string()),
                         })
                         .unwrap(),
@@ -572,7 +595,9 @@ mod tests {
         assert_eq!(anonymous_blocks[0]["id"], "tb-anonymous");
         assert_eq!(profile_a_blocks.len(), 1);
         assert_eq!(profile_a_blocks[0]["id"], "tb-profile-a");
-        assert_eq!(profile_a_active["taskId"], "task-profile-a");
+        assert_eq!(profile_a_blocks[0]["taskIds"], serde_json::json!(["task-profile-a"]));
+        assert_eq!(profile_a_active["taskIds"], serde_json::json!(["task-profile-a"]));
+        assert!(profile_a_active.get("taskId").is_none());
         assert_eq!(timeblock_store.list_completed().unwrap().len(), 1);
         assert_eq!(timeblock_store.list_completed_in_scope(Some("profile-a")).unwrap().len(), 1);
     }
@@ -601,6 +626,18 @@ mod tests {
                             tags: vec!["focus".to_string()],
                             start_time: 1_700_000_100_000,
                             end_time: 1_700_000_160_000,
+                            task_ids: vec!["task-user-a".to_string()],
+                            task_status_outcomes: Some(std::collections::HashMap::from([(
+                                "task-user-a".to_string(),
+                                "continue".to_string(),
+                            )])),
+                            task_association_log: vec![crate::timeblock::BlockTaskAssociationEvent {
+                                block_id: "tb-user-a".to_string(),
+                                task_id: "task-user-a".to_string(),
+                                action: "associated".to_string(),
+                                timestamp: 1_700_000_100_000,
+                                source: "block_start".to_string(),
+                            }],
                         }])
                         .unwrap(),
                     ))
@@ -638,6 +675,14 @@ mod tests {
                             pause_accumulated_ms: Some(0),
                             paused: false,
                             paused_at: None,
+                            task_ids: vec!["task-user-a".to_string()],
+                            task_association_log: vec![crate::timeblock::BlockTaskAssociationEvent {
+                                block_id: "active-user-a".to_string(),
+                                task_id: "task-user-a".to_string(),
+                                action: "associated".to_string(),
+                                timestamp: 1_700_000_100_000,
+                                source: "block_start".to_string(),
+                            }],
                             task_id: Some("task-user-a".to_string()),
                         })
                         .unwrap(),
@@ -677,7 +722,9 @@ mod tests {
 
         assert_eq!(scoped_blocks.len(), 1);
         assert_eq!(scoped_blocks[0]["id"], "tb-user-a");
-        assert_eq!(scoped_active["taskId"], "task-user-a");
+        assert_eq!(scoped_blocks[0]["taskIds"], serde_json::json!(["task-user-a"]));
+        assert_eq!(scoped_active["taskIds"], serde_json::json!(["task-user-a"]));
+        assert!(scoped_active.get("taskId").is_none());
         assert!(timeblock_store.list_completed().unwrap().is_empty(), "default anonymous scope should stay isolated");
         assert_eq!(timeblock_store.list_completed_in_scope(Some("user-a")).unwrap().len(), 1);
     }

--- a/crates/exomind-runtime/src/timeblock.rs
+++ b/crates/exomind-runtime/src/timeblock.rs
@@ -18,6 +18,22 @@ pub struct TimeBlockData {
     pub tags: Vec<String>,
     pub start_time: u64,
     pub end_time: u64,
+    #[serde(default)]
+    pub task_ids: Vec<String>,
+    #[serde(default)]
+    pub task_status_outcomes: Option<HashMap<String, String>>,
+    #[serde(default)]
+    pub task_association_log: Vec<BlockTaskAssociationEvent>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockTaskAssociationEvent {
+    pub block_id: String,
+    pub task_id: String,
+    pub action: String,
+    pub timestamp: u64,
+    pub source: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -42,7 +58,29 @@ pub struct ActiveBlockData {
     pub pause_accumulated_ms: Option<u64>,
     pub paused: bool,
     pub paused_at: Option<u64>,
+    #[serde(default)]
+    pub task_ids: Vec<String>,
+    #[serde(default)]
+    pub task_association_log: Vec<BlockTaskAssociationEvent>,
+    /// Deprecated: legacy single-task field. Read for compat, never written.
+    #[serde(default, skip_serializing)]
     pub task_id: Option<String>,
+}
+
+impl ActiveBlockData {
+    pub fn normalize_task_ids(mut self) -> Self {
+        if self.task_ids.is_empty() {
+            if let Some(task_id) = self
+                .task_id
+                .clone()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+            {
+                self.task_ids = vec![task_id];
+            }
+        }
+        self
+    }
 }
 
 #[derive(Debug, Error)]
@@ -151,7 +189,7 @@ impl TimeBlockStore {
                 .read()
                 .unwrap()
                 .get(normalize_scope_key(scope_key))
-                .and_then(|scope| scope.active.clone())),
+                .and_then(|scope| scope.active.clone().map(ActiveBlockData::normalize_task_ids))),
             TimeBlockStoreBackend::Sqlite(store) => store.get_active_scoped(normalize_scope_key(scope_key)),
         }
     }
@@ -172,7 +210,7 @@ impl TimeBlockStore {
                     .unwrap()
                     .entry(normalize_scope_key(scope_key).to_string())
                     .or_default()
-                    .active = Some(block);
+                    .active = Some(block.normalize_task_ids());
                 Ok(())
             }
             TimeBlockStoreBackend::Sqlite(store) => store.put_active_scoped(normalize_scope_key(scope_key), &block),
@@ -247,6 +285,7 @@ impl Default for TimeBlockStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
     use tempfile::tempdir;
 
     #[test]
@@ -264,6 +303,15 @@ mod tests {
             tags: vec!["block_feedback".to_string()],
             start_time: 1,
             end_time: 2,
+            task_ids: vec!["task-a".to_string()],
+            task_status_outcomes: Some(HashMap::from([("task-a".to_string(), "continue".to_string())])),
+            task_association_log: vec![BlockTaskAssociationEvent {
+                block_id: "tb-a".to_string(),
+                task_id: "task-a".to_string(),
+                action: "associated".to_string(),
+                timestamp: 1,
+                source: "block_start".to_string(),
+            }],
         }]).unwrap();
         store.replace_completed_scoped(Some("profile-b"), &[TimeBlockData {
             id: "tb-b".to_string(),
@@ -274,6 +322,9 @@ mod tests {
             tags: vec!["block_feedback".to_string()],
             start_time: 3,
             end_time: 4,
+            task_ids: vec![],
+            task_status_outcomes: None,
+            task_association_log: vec![],
         }]).unwrap();
 
         store.put_active_scoped(Some("profile-a"), ActiveBlockData {
@@ -296,6 +347,14 @@ mod tests {
             pause_accumulated_ms: None,
             paused: false,
             paused_at: None,
+            task_ids: vec!["task-a".to_string()],
+            task_association_log: vec![BlockTaskAssociationEvent {
+                block_id: "active-a".to_string(),
+                task_id: "task-a".to_string(),
+                action: "associated".to_string(),
+                timestamp: 10,
+                source: "block_start".to_string(),
+            }],
             task_id: None,
         }).unwrap();
 
@@ -306,9 +365,32 @@ mod tests {
 
         assert_eq!(completed_a.len(), 1);
         assert_eq!(completed_a[0].id, "tb-a");
+        assert_eq!(completed_a[0].task_ids, vec!["task-a".to_string()]);
         assert_eq!(completed_b.len(), 1);
         assert_eq!(completed_b[0].id, "tb-b");
         assert_eq!(active_a.as_ref().map(|block| block.start_id.as_str()), Some("active-a"));
+        assert_eq!(active_a.as_ref().map(|block| block.task_ids.clone()), Some(vec!["task-a".to_string()]));
         assert!(active_b.is_none());
+    }
+
+    #[test]
+    fn active_block_promotes_legacy_task_id_to_task_ids() {
+        let block: ActiveBlockData = serde_json::from_value(json!({
+            "startId": "legacy-active",
+            "name": "Legacy active",
+            "mode": "countup",
+            "elapsed": 10,
+            "paused": false,
+            "startTime": 123,
+            "taskId": "legacy-task",
+        }))
+        .unwrap();
+
+        let normalized = block.normalize_task_ids();
+        let serialized = serde_json::to_value(&normalized).unwrap();
+
+        assert_eq!(normalized.task_ids, vec!["legacy-task".to_string()]);
+        assert_eq!(serialized["taskIds"], json!(["legacy-task"]));
+        assert!(serialized.get("taskId").is_none());
     }
 }

--- a/crates/exomind-runtime/src/timeblock_sqlite.rs
+++ b/crates/exomind-runtime/src/timeblock_sqlite.rs
@@ -35,7 +35,8 @@ impl SqliteTimeBlockStore {
     pub fn list_completed_scoped(&self, scope_key: &str) -> Result<Vec<TimeBlockData>, TimeBlockStoreError> {
         let connection = self.connection();
         let mut statement = connection.prepare(
-            "SELECT id, name, start_id, end_id, note, tags_json, start_time, end_time
+            "SELECT id, name, start_id, end_id, note, tags_json, start_time, end_time,
+                    task_ids_json, task_status_outcomes_json, task_association_log_json
              FROM completed_timeblocks
              WHERE scope_key = ?1
              ORDER BY end_time DESC, id DESC",
@@ -52,6 +53,14 @@ impl SqliteTimeBlockStore {
                     .map_err(to_sqlite_conversion_error)?,
                 start_time: row.get(6)?,
                 end_time: row.get(7)?,
+                task_ids: serde_json::from_str::<Vec<String>>(&row.get::<_, String>(8)?)
+                    .map_err(to_sqlite_conversion_error)?,
+                task_status_outcomes: row
+                    .get::<_, Option<String>>(9)?
+                    .map(|value| serde_json::from_str(&value).map_err(to_sqlite_conversion_error))
+                    .transpose()?,
+                task_association_log: serde_json::from_str(&row.get::<_, String>(10)?)
+                    .map_err(to_sqlite_conversion_error)?,
             })
         })?;
 
@@ -72,8 +81,9 @@ impl SqliteTimeBlockStore {
         for block in blocks {
             tx.execute(
                 "INSERT INTO completed_timeblocks (
-                    scope_key, id, name, start_id, end_id, note, tags_json, start_time, end_time
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                    scope_key, id, name, start_id, end_id, note, tags_json, start_time, end_time,
+                    task_ids_json, task_status_outcomes_json, task_association_log_json
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
                 params![
                     normalize_scope_key(scope_key),
                     block.id,
@@ -84,6 +94,12 @@ impl SqliteTimeBlockStore {
                     serde_json::to_string(&block.tags)?,
                     block.start_time,
                     block.end_time,
+                    serde_json::to_string(&block.task_ids)?,
+                    block.task_status_outcomes
+                        .as_ref()
+                        .map(serde_json::to_string)
+                        .transpose()?,
+                    serde_json::to_string(&block.task_association_log)?,
                 ],
             )?;
         }
@@ -106,7 +122,10 @@ impl SqliteTimeBlockStore {
             .optional()?;
 
         payload
-            .map(|json| serde_json::from_str::<ActiveBlockData>(&json))
+            .map(|json| {
+                serde_json::from_str::<ActiveBlockData>(&json)
+                    .map(ActiveBlockData::normalize_task_ids)
+            })
             .transpose()
             .map_err(TimeBlockStoreError::from)
     }
@@ -124,7 +143,7 @@ impl SqliteTimeBlockStore {
             params![
                 normalize_scope_key(scope_key),
                 ACTIVE_BLOCK_SINGLETON_KEY,
-                serde_json::to_string(block)?,
+                serde_json::to_string(&block.clone().normalize_task_ids())?,
             ],
         )?;
         Ok(())
@@ -183,10 +202,7 @@ impl SqliteTimeBlockStore {
         )?;
 
         if has_completed_table {
-            let mut statement = connection.prepare("PRAGMA table_info(completed_timeblocks)")?;
-            let columns = statement
-                .query_map([], |row| row.get::<_, String>(1))?
-                .collect::<Result<Vec<_>, _>>()?;
+            let columns = completed_timeblock_columns(&connection)?;
             if !columns.iter().any(|column| column == "scope_key") {
                 connection.execute_batch(
                     "ALTER TABLE completed_timeblocks RENAME TO completed_timeblocks_legacy;
@@ -200,15 +216,42 @@ impl SqliteTimeBlockStore {
                         tags_json TEXT NOT NULL,
                         start_time INTEGER NOT NULL,
                         end_time INTEGER NOT NULL,
+                        task_ids_json TEXT NOT NULL DEFAULT '[]',
+                        task_status_outcomes_json TEXT NULL,
+                        task_association_log_json TEXT NOT NULL DEFAULT '[]',
                         PRIMARY KEY (scope_key, id)
                      );
                      INSERT INTO completed_timeblocks (
-                        scope_key, id, name, start_id, end_id, note, tags_json, start_time, end_time
+                        scope_key, id, name, start_id, end_id, note, tags_json, start_time, end_time,
+                        task_ids_json, task_status_outcomes_json, task_association_log_json
                      )
                      SELECT
-                        'anonymous', id, name, start_id, end_id, note, tags_json, start_time, end_time
-                     FROM completed_timeblocks_legacy;
-                     DROP TABLE completed_timeblocks_legacy;",
+                        'anonymous', id, name, start_id, end_id, note, tags_json, start_time, end_time,
+                        '[]', NULL, '[]'
+                      FROM completed_timeblocks_legacy;
+                      DROP TABLE completed_timeblocks_legacy;",
+                )?;
+            }
+
+            let columns = completed_timeblock_columns(&connection)?;
+            if !columns.iter().any(|column| column == "task_ids_json") {
+                connection.execute(
+                    "ALTER TABLE completed_timeblocks ADD COLUMN task_ids_json TEXT NOT NULL DEFAULT '[]'",
+                    [],
+                )?;
+            }
+
+            if !columns.iter().any(|column| column == "task_status_outcomes_json") {
+                connection.execute(
+                    "ALTER TABLE completed_timeblocks ADD COLUMN task_status_outcomes_json TEXT NULL",
+                    [],
+                )?;
+            }
+
+            if !columns.iter().any(|column| column == "task_association_log_json") {
+                connection.execute(
+                    "ALTER TABLE completed_timeblocks ADD COLUMN task_association_log_json TEXT NOT NULL DEFAULT '[]'",
+                    [],
                 )?;
             }
         }
@@ -253,6 +296,9 @@ impl SqliteTimeBlockStore {
                 tags_json TEXT NOT NULL,
                 start_time INTEGER NOT NULL,
                 end_time INTEGER NOT NULL,
+                task_ids_json TEXT NOT NULL DEFAULT '[]',
+                task_status_outcomes_json TEXT NULL,
+                task_association_log_json TEXT NOT NULL DEFAULT '[]',
                 PRIMARY KEY (scope_key, id)
              );
              CREATE TABLE IF NOT EXISTS active_timeblock (
@@ -277,6 +323,14 @@ fn normalize_scope_key(scope_key: &str) -> &str {
     } else {
         normalized
     }
+}
+
+fn completed_timeblock_columns(connection: &Connection) -> Result<Vec<String>, TimeBlockStoreError> {
+    let mut statement = connection.prepare("PRAGMA table_info(completed_timeblocks)")?;
+    statement
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(TimeBlockStoreError::from)
 }
 
 fn to_sqlite_conversion_error(error: serde_json::Error) -> rusqlite::Error {

--- a/crates/exomind-runtime/tests/timeblock_routes.rs
+++ b/crates/exomind-runtime/tests/timeblock_routes.rs
@@ -74,7 +74,15 @@ async fn put_and_get_active_timeblock() {
         "accumulatedRunMs": 0,
         "startTime": 1700000000000u64,
         "pauseAccumulatedMs": 0,
-        "paused": false
+        "paused": false,
+        "taskIds": ["task-1"],
+        "taskAssociationLog": [{
+            "blockId": "active-1",
+            "taskId": "task-1",
+            "action": "associated",
+            "timestamp": 1700000000000u64,
+            "source": "block_start",
+        }]
     });
 
     let put_response = app
@@ -102,6 +110,8 @@ async fn put_and_get_active_timeblock() {
     let parsed: Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(parsed["startId"], "active-1");
     assert_eq!(parsed["mode"], "countdown");
+    assert_eq!(parsed["taskIds"], json!(["task-1"]));
+    assert!(parsed.get("taskId").is_none(), "legacy taskId should not be serialized");
 }
 
 #[tokio::test]
@@ -119,6 +129,15 @@ async fn exports_sqlite_snapshot_and_backend_status() {
             tags: vec!["block_feedback".to_string()],
             start_time: 1700000000000,
             end_time: 1700000060000,
+            task_ids: vec!["task-1".to_string()],
+            task_status_outcomes: Some(std::collections::HashMap::from([("task-1".to_string(), "completed".to_string())])),
+            task_association_log: vec![exomind_runtime::timeblock::BlockTaskAssociationEvent {
+                block_id: "tb-1".to_string(),
+                task_id: "task-1".to_string(),
+                action: "associated".to_string(),
+                timestamp: 1700000000000,
+                source: "block_start".to_string(),
+            }],
         }])
         .unwrap();
     let app = test_router(test_state_with_timeblock_store(store));
@@ -166,6 +185,9 @@ async fn imports_json_backup_with_overwrite() {
             tags: vec!["block_feedback".to_string()],
             start_time: 1700000000000,
             end_time: 1700000060000,
+            task_ids: vec![],
+            task_status_outcomes: None,
+            task_association_log: vec![],
         }])
         .unwrap();
 
@@ -180,7 +202,16 @@ async fn imports_json_backup_with_overwrite() {
                 "endId": "end-new",
                 "tags": ["block_feedback"],
                 "startTime": 1700000100000u64,
-                "endTime": 1700000160000u64
+                "endTime": 1700000160000u64,
+                "taskIds": ["task-new"],
+                "taskStatusOutcomes": { "task-new": "continue" },
+                "taskAssociationLog": [{
+                    "blockId": "new-block",
+                    "taskId": "task-new",
+                    "action": "associated",
+                    "timestamp": 1700000100000u64,
+                    "source": "block_start"
+                }]
             }
         ],
         "active_block": {
@@ -189,7 +220,16 @@ async fn imports_json_backup_with_overwrite() {
             "mode": "countup",
             "elapsed": 30000,
             "paused": false,
-            "startTime": 1700000200000u64
+            "startTime": 1700000200000u64,
+            "taskId": "task-legacy",
+            "taskIds": ["task-new"],
+            "taskAssociationLog": [{
+                "blockId": "active-new",
+                "taskId": "task-new",
+                "action": "associated",
+                "timestamp": 1700000200000u64,
+                "source": "block_start"
+            }]
         }
     });
 
@@ -225,4 +265,6 @@ async fn imports_json_backup_with_overwrite() {
     let active_body = active_response.into_body().collect().await.unwrap().to_bytes();
     let active_payload: Value = serde_json::from_slice(&active_body).unwrap();
     assert_eq!(active_payload["startId"], "active-new");
+    assert_eq!(active_payload["taskIds"], json!(["task-new"]));
+    assert!(active_payload.get("taskId").is_none());
 }

--- a/crates/exomind-runtime/tests/timeblock_runtime_sqlite_persistence.rs
+++ b/crates/exomind-runtime/tests/timeblock_runtime_sqlite_persistence.rs
@@ -1,9 +1,10 @@
 use exomind_runtime::{
     AppState,
-    timeblock::{ActiveBlockData, TimeBlockData, TimeBlockStore},
+    timeblock::{ActiveBlockData, BlockTaskAssociationEvent, TimeBlockData, TimeBlockStore},
 };
 use tempfile::tempdir;
 use std::sync::Mutex;
+use std::collections::HashMap;
 
 static TIMEBLOCK_SQLITE_ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -38,6 +39,15 @@ fn app_state_runtime_reuses_timeblock_sqlite_storage_for_completed_and_active() 
             tags: vec!["block_feedback".to_string()],
             start_time: 1_700_000_000_000,
             end_time: 1_700_000_060_000,
+            task_ids: vec!["task-1".to_string()],
+            task_status_outcomes: Some(HashMap::from([("task-1".to_string(), "continue".to_string())])),
+            task_association_log: vec![BlockTaskAssociationEvent {
+                block_id: "tb-1".to_string(),
+                task_id: "task-1".to_string(),
+                action: "associated".to_string(),
+                timestamp: 1_700_000_000_000,
+                source: "block_start".to_string(),
+            }],
         }])
         .unwrap();
 
@@ -63,6 +73,14 @@ fn app_state_runtime_reuses_timeblock_sqlite_storage_for_completed_and_active() 
             pause_accumulated_ms: Some(0),
             paused: false,
             paused_at: None,
+            task_ids: vec!["task-1".to_string()],
+            task_association_log: vec![BlockTaskAssociationEvent {
+                block_id: "start-active".to_string(),
+                task_id: "task-1".to_string(),
+                action: "associated".to_string(),
+                timestamp: 1_700_000_000_000,
+                source: "block_start".to_string(),
+            }],
             task_id: Some("task-1".to_string()),
         })
         .unwrap();
@@ -86,8 +104,9 @@ fn app_state_runtime_reuses_timeblock_sqlite_storage_for_completed_and_active() 
 
     assert_eq!(completed.len(), 1, "completed blocks should persist across runtime restarts");
     assert_eq!(completed[0].id, "tb-1");
+    assert_eq!(completed[0].task_ids, vec!["task-1".to_string()]);
     assert_eq!(active.as_ref().map(|block| block.start_id.as_str()), Some("start-active"));
-    assert_eq!(active.as_ref().and_then(|block| block.task_id.as_deref()), Some("task-1"));
+    assert_eq!(active.as_ref().map(|block| block.task_ids.clone()), Some(vec!["task-1".to_string()]));
 }
 
 #[test]
@@ -121,6 +140,9 @@ fn app_state_runtime_reuses_timeblock_sqlite_storage_with_profile_scope() {
             tags: vec!["block_feedback".to_string()],
             start_time: 1_700_000_000_000,
             end_time: 1_700_000_030_000,
+            task_ids: vec![],
+            task_status_outcomes: None,
+            task_association_log: vec![],
         }])
         .unwrap();
 
@@ -137,6 +159,15 @@ fn app_state_runtime_reuses_timeblock_sqlite_storage_with_profile_scope() {
                 tags: vec!["block_feedback".to_string()],
                 start_time: 1_700_000_100_000,
                 end_time: 1_700_000_160_000,
+                task_ids: vec!["task-profile-a".to_string()],
+                task_status_outcomes: Some(HashMap::from([("task-profile-a".to_string(), "completed".to_string())])),
+                task_association_log: vec![BlockTaskAssociationEvent {
+                    block_id: "tb-profile-a".to_string(),
+                    task_id: "task-profile-a".to_string(),
+                    action: "associated".to_string(),
+                    timestamp: 1_700_000_100_000,
+                    source: "block_start".to_string(),
+                }],
             }],
         )
         .unwrap();
@@ -165,6 +196,14 @@ fn app_state_runtime_reuses_timeblock_sqlite_storage_with_profile_scope() {
                 pause_accumulated_ms: Some(0),
                 paused: false,
                 paused_at: None,
+                task_ids: vec!["task-profile-a".to_string()],
+                task_association_log: vec![BlockTaskAssociationEvent {
+                    block_id: "active-profile-a".to_string(),
+                    task_id: "task-profile-a".to_string(),
+                    action: "associated".to_string(),
+                    timestamp: 1_700_000_100_000,
+                    source: "block_start".to_string(),
+                }],
                 task_id: Some("task-profile-a".to_string()),
             },
         )
@@ -202,9 +241,10 @@ fn app_state_runtime_reuses_timeblock_sqlite_storage_with_profile_scope() {
     assert_eq!(anonymous_completed[0].id, "tb-anonymous");
     assert_eq!(profile_a_completed.len(), 1, "profile scope should persist its own completed blocks");
     assert_eq!(profile_a_completed[0].id, "tb-profile-a");
+    assert_eq!(profile_a_completed[0].task_ids, vec!["task-profile-a".to_string()]);
     assert_eq!(
-        profile_a_active.as_ref().and_then(|block| block.task_id.as_deref()),
-        Some("task-profile-a"),
+        profile_a_active.as_ref().map(|block| block.task_ids.clone()),
+        Some(vec!["task-profile-a".to_string()]),
         "profile scope should persist its own active block",
     );
     assert!(profile_b_completed.is_empty(), "other profiles should not see scoped blocks");
@@ -226,6 +266,9 @@ fn timeblock_store_clearing_active_block_preserves_completed_blocks() {
             tags: vec!["block_feedback".to_string()],
             start_time: 1_700_000_100_000,
             end_time: 1_700_000_160_000,
+            task_ids: vec![],
+            task_status_outcomes: None,
+            task_association_log: vec![],
         }])
         .unwrap();
 
@@ -250,6 +293,8 @@ fn timeblock_store_clearing_active_block_preserves_completed_blocks() {
             pause_accumulated_ms: Some(5_000),
             paused: true,
             paused_at: Some(1_700_000_120_000),
+            task_ids: vec![],
+            task_association_log: vec![],
             task_id: None,
         })
         .unwrap();

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:e2e:issue201": "node Scripts/test/playwright-runner.cjs test tests/e2e/agents-page.issue201.test.ts --config tests/e2e/playwright.issue201.config.ts",
     "test:e2e:issue245f": "node Scripts/test/playwright-runner.cjs test tests/e2e/agent-hub.signal-routes.issue245f.test.ts --config tests/e2e/playwright.issue245f.config.ts",
     "test:e2e:issue243": "node Scripts/test/playwright-runner.cjs test tests/e2e/command-palette.issue243.test.ts --config tests/e2e/playwright.issue243.config.ts",
+    "test:e2e:issue418-516": "node Scripts/test/playwright-runner.cjs test tests/e2e/now-tabs-timeblock-detail.issue418-516.test.ts --config tests/e2e/playwright.issue418-516.config.ts",
     "test:e2e:report": "node Scripts/test/playwright-runner.cjs test --reporter=html",
     "test:e2e:website": "node Scripts/test/playwright-runner.cjs test tests/e2e/website.dark-mode.test.ts tests/e2e/website.smoke.test.ts --config tests/e2e/playwright.website.config.ts",
     "test:e2e:website:prod": "node Scripts/test/playwright-runner.cjs test tests/e2e/website.smoke.test.ts --config tests/e2e/playwright.website.prod.config.ts",

--- a/src/components/Chat/ChatPage.tsx
+++ b/src/components/Chat/ChatPage.tsx
@@ -43,6 +43,7 @@ function sortEventsAscending(events: Event[]): Event[] {
 interface ChatPageProps {
   variant?: 'default' | 'new-mobile'; // new-mobile（新移动端外观）用于 v0.3.0 UI 重构
   hideHeader?: boolean;
+  showTimerWidget?: boolean;
 }
 
 const UNKNOWN_DEVICE_LABEL = '未知设备';
@@ -102,7 +103,11 @@ function formatEventSourceLabel(event: Event): string {
   return `${resolvedDeviceName} · ${platformLabel}`;
 }
 
-export function ChatPage({ variant = 'default', hideHeader = false }: ChatPageProps = {}) {
+export function ChatPage({
+  variant = 'default',
+  hideHeader = false,
+  showTimerWidget = true,
+}: ChatPageProps = {}) {
   const [events, setEvents] = useState<Event[]>([]);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [isInitialLoading, setIsInitialLoading] = useState(true);
@@ -475,11 +480,11 @@ export function ChatPage({ variant = 'default', hideHeader = false }: ChatPagePr
       )}
 
       {/* TimeBlock 控件栏 */}
-      {variant === 'new-mobile' ? (
+      {variant === 'new-mobile' && showTimerWidget ? (
         <FocusTimerWidget ref={focusTimerWidgetRef} />
-      ) : (
+      ) : variant === 'default' ? (
         <TimeBlockWidget ref={timeBlockWidgetRef} variant="default" />
-      )}
+      ) : null}
 
       {/* 事件列表 */}
       <div

--- a/src/config/runtime-target.ts
+++ b/src/config/runtime-target.ts
@@ -97,7 +97,7 @@ export function isTauriWindow(): boolean {
     return false;
   }
 
-  return '__TAURI_INTERNALS__' in window;
+  return '__TAURI_INTERNALS__' in window || '__TAURI__' in window;
 }
 
 function resolveEmbeddedHost(): string {

--- a/src/lib/services/task-timer.service.ts
+++ b/src/lib/services/task-timer.service.ts
@@ -10,16 +10,29 @@
  * - 关联查询与动态时长计算（spentMinutes 不持久化）
  */
 
-import type { ActiveBlockData, TimerConfig } from '@/lib/types/event'
+import type { ActiveBlockData, BlockTaskAssociationEvent, TimerConfig } from '@/lib/types/event'
 import { getTaskService, type TaskService } from './task.service'
 import { getTimeBlockService, type TimeBlockService } from './timeblock.service'
+import type { TaskNode, TaskStatus } from '@/lib/types/task'
 
 export interface TaskTimerService {
   /** 从任务快速启动一个时间块，自动关联 */
   startBlockForTask(taskId: string, config?: TimerConfig): Promise<ActiveBlockData | null>
 
+  /** 从多个任务启动一个时间块，建立多任务关联 */
+  startBlockForTasks(taskIds: string[], config?: TimerConfig): Promise<ActiveBlockData | null>
+
+  /** 运行中追加一个关联任务 */
+  addTaskToBlock(taskId: string): Promise<void>
+
+  /** 运行中移除一个关联任务 */
+  removeTaskFromBlock(taskId: string): Promise<void>
+
   /** 时间块结束时回调：记录 blockId 关联（spentMinutes 动态计算，不持久化） */
   onBlockEndForTask(taskId: string, blockId: string): Promise<void>
+
+  /** 时间块结束时回调：只为结束时仍关联的任务记录 blockId */
+  onBlockEndForTasks(taskIds: string[], blockId: string): Promise<void>
 
   /** 获取任务关联的所有时间块 ID */
   getBlockIdsForTask(taskId: string): Promise<string[]>
@@ -41,46 +54,102 @@ export class TaskTimerServiceImpl implements TaskTimerService {
     taskId: string,
     config: TimerConfig = { mode: 'countup' },
   ): Promise<ActiveBlockData | null> {
-    const task = await this.taskSvc.getTask(taskId)
-    if (!task) return null
+    return this.startBlockForTasks([taskId], config)
+  }
 
-    // 终态任务不允许启动计时
-    if (task.status === 'completed' || task.status === 'cancelled') return null
+  async startBlockForTasks(
+    taskIds: string[],
+    config: TimerConfig = { mode: 'countup' },
+  ): Promise<ActiveBlockData | null> {
+    const normalizedTaskIds = Array.from(new Set(taskIds.map((taskId) => taskId.trim()).filter(Boolean)))
+    if (normalizedTaskIds.length === 0) return null
 
-    // 如果任务非 in_progress，先转换状态
-    if (task.status === 'pending') {
-      await this.taskSvc.transitionTask(taskId, 'in_progress')
-    } else if (task.status === 'suspended') {
-      await this.taskSvc.transitionTask(taskId, 'in_progress')
+    const tasks = await this.loadTasks(normalizedTaskIds)
+    if (!tasks) return null
+
+    for (const task of tasks) {
+      const nextStatus = this.resolveAutoProgressStatus(task.status)
+      if (nextStatus) {
+        await this.taskSvc.transitionTask(task.id, nextStatus)
+      }
     }
 
-    // 启动时间块，使用任务标题作为名称，传入 taskId 标记关联
-    const block = await this.tbSvc.startBlock(task.title, config, undefined, taskId)
+    const [primaryTask] = tasks
+    if (!primaryTask) return null
 
-    // 将 blockId 追加到 task.timeBlockIds
-    const existingIds = task.timeBlockIds ?? []
-    if (!existingIds.includes(block.startId)) {
-      await this.taskSvc.updateTask(taskId, {
-        timeBlockIds: [...existingIds, block.startId],
-      })
+    return this.tbSvc.startBlock(primaryTask.title, config, undefined, { taskIds: normalizedTaskIds })
+  }
+
+  async addTaskToBlock(taskId: string): Promise<void> {
+    const normalizedTaskId = taskId.trim()
+    if (!normalizedTaskId) return
+
+    const activeBlock = await this.tbSvc.loadActiveBlock()
+    if (!activeBlock) return
+
+    const task = await this.taskSvc.getTask(normalizedTaskId)
+    if (!task) return
+    if (task.status === 'completed' || task.status === 'cancelled') return
+
+    const existingTaskIds = activeBlock.taskIds ?? []
+    if (existingTaskIds.includes(normalizedTaskId)) return
+
+    const nextStatus = this.resolveAutoProgressStatus(task.status)
+    if (nextStatus) {
+      await this.taskSvc.transitionTask(task.id, nextStatus)
     }
 
-    return block
+    await this.tbSvc.updateActiveBlock({
+      taskIds: [...existingTaskIds, normalizedTaskId],
+      taskAssociationLog: this.appendAssociationEvent(
+        activeBlock.taskAssociationLog ?? [],
+        activeBlock.startId,
+        normalizedTaskId,
+        'associated',
+      ),
+    })
+  }
+
+  async removeTaskFromBlock(taskId: string): Promise<void> {
+    const normalizedTaskId = taskId.trim()
+    if (!normalizedTaskId) return
+
+    const activeBlock = await this.tbSvc.loadActiveBlock()
+    if (!activeBlock) return
+
+    const existingTaskIds = activeBlock.taskIds ?? []
+    if (!existingTaskIds.includes(normalizedTaskId)) return
+
+    await this.tbSvc.updateActiveBlock({
+      taskIds: existingTaskIds.filter((existingTaskId) => existingTaskId !== normalizedTaskId),
+      taskAssociationLog: this.appendAssociationEvent(
+        activeBlock.taskAssociationLog ?? [],
+        activeBlock.startId,
+        normalizedTaskId,
+        'disassociated',
+      ),
+    })
   }
 
   async onBlockEndForTask(
     taskId: string,
     blockId: string,
   ): Promise<void> {
-    const task = await this.taskSvc.getTask(taskId)
-    if (!task) return
+    await this.onBlockEndForTasks([taskId], blockId)
+  }
 
-    // 追加 blockId（避免重复）
-    const existingIds = task.timeBlockIds ?? []
-    if (!existingIds.includes(blockId)) {
-      await this.taskSvc.updateTask(taskId, {
-        timeBlockIds: [...existingIds, blockId],
-      })
+  async onBlockEndForTasks(taskIds: string[], blockId: string): Promise<void> {
+    const normalizedTaskIds = Array.from(new Set(taskIds.map((taskId) => taskId.trim()).filter(Boolean)))
+    for (const taskId of normalizedTaskIds) {
+      const task = await this.taskSvc.getTask(taskId)
+      if (!task) continue
+
+      const existingIds = task.timeBlockIds ?? []
+      if (!existingIds.includes(blockId)) {
+        await this.taskSvc.updateTask(taskId, {
+          timeBlockIds: [...existingIds, blockId],
+        })
+      }
     }
   }
 
@@ -107,6 +176,43 @@ export class TaskTimerServiceImpl implements TaskTimerService {
     }
 
     return Math.round(totalMs / 60_000)
+  }
+
+  private async loadTasks(taskIds: string[]): Promise<TaskNode[] | null> {
+    const tasks = await Promise.all(taskIds.map((taskId) => this.taskSvc.getTask(taskId)))
+    if (tasks.some((task) => !task)) return null
+
+    const resolvedTasks = tasks.filter((task): task is TaskNode => task !== null)
+    if (resolvedTasks.some((task) => task.status === 'completed' || task.status === 'cancelled')) {
+      return null
+    }
+
+    return resolvedTasks
+  }
+
+  private resolveAutoProgressStatus(status: TaskStatus): TaskStatus | null {
+    if (status === 'pending' || status === 'suspended') {
+      return 'in_progress'
+    }
+    return null
+  }
+
+  private appendAssociationEvent(
+    existing: BlockTaskAssociationEvent[],
+    blockId: string,
+    taskId: string,
+    action: BlockTaskAssociationEvent['action'],
+  ): BlockTaskAssociationEvent[] {
+    return [
+      ...existing,
+      {
+        blockId,
+        taskId,
+        action,
+        timestamp: Date.now(),
+        source: 'manual',
+      },
+    ]
   }
 }
 

--- a/src/lib/services/timeblock.service.ts
+++ b/src/lib/services/timeblock.service.ts
@@ -18,11 +18,16 @@ import {
 } from '../storage/active-block-storage';
 import { getTimeblockBackendMode, type DomainBackendMode } from '@/config/domain-backend-mode';
 import { TimeBlockRtAdapter } from '@/lib/adapters/timeblock-rt-adapter';
+import {
+  normalizeActiveBlockTaskIds,
+  normalizeTimeBlockTaskIds,
+} from '../types/event';
 import type {
   TimeBlock,
   TimeBlockData,
   ActiveBlockData,
   ActiveBlockPhase,
+  BlockTaskAssociationEvent,
   TimerConfig,
 } from '../types/event';
 import { getFeedbackPreferences, type FeedbackPreferences } from '../../config/feedback-preferences';
@@ -70,7 +75,17 @@ export interface TimeBlockService {
   loadActiveBlock(): Promise<ActiveBlockData | null>;
 
   /** 开始时间块 */
-  startBlock(name: string, config: TimerConfig, description?: string, taskId?: string): Promise<ActiveBlockData>;
+  startBlock(
+    name: string,
+    config: TimerConfig,
+    description?: string,
+    taskBinding?: string | { taskIds: string[] },
+  ): Promise<ActiveBlockData>;
+
+  /** 更新当前进行中时间块的任务关联 */
+  updateActiveBlock(
+    patch: Partial<Pick<ActiveBlockData, 'taskIds' | 'taskAssociationLog'>>,
+  ): Promise<ActiveBlockData | null>;
 
   /** 标记“行动结束/开始填写反馈”（点击结束时刻） */
   markEnding(): Promise<void>;
@@ -82,7 +97,13 @@ export interface TimeBlockService {
   resumeBlock(): Promise<void>;
 
   /** 结束时间块 */
-  endBlock(feedback?: string): Promise<TimeBlock | null>;
+  endBlock(
+    feedback?: string,
+    options?: {
+      taskStatusOutcomes?: Record<string, string>;
+      taskTitles?: Record<string, string>;
+    },
+  ): Promise<TimeBlock | null>;
 
   /** 更新已计时时长（由 UI 定时调用） */
   updateElapsed(elapsed: number): Promise<void>;
@@ -141,10 +162,40 @@ export class TimeBlockServiceImpl implements TimeBlockService {
     const data = await this.readCompletedBlockData();
     if (!data) return [];
 
-    return data.map(d => ({
-      ...d,
-      tags: new Set(d.tags),
-    }));
+    return data.map((block) => {
+      const normalized = normalizeTimeBlockTaskIds(block);
+      return {
+        ...normalized,
+        tags: new Set(normalized.tags),
+      };
+    });
+  }
+
+  async updateActiveBlock(
+    patch: Partial<Pick<ActiveBlockData, 'taskIds' | 'taskAssociationLog'>>,
+  ): Promise<ActiveBlockData | null> {
+    const existing = await this.readActiveBlock();
+    if (!existing) return null;
+
+    const now = Date.now();
+    const normalizedExisting = this.normalizeActiveBlock(existing, now);
+    if (this.isCompletedBlock(normalizedExisting)) {
+      this.rememberAcceptedBlock(normalizedExisting);
+      return null;
+    }
+
+    const updated = this.normalizeActiveBlock({
+      ...normalizedExisting,
+      ...patch,
+      version: this.nextVersion(normalizedExisting),
+      actorId: this.actorId,
+      updatedAt: now,
+    }, now);
+
+    await this.saveActiveBlock(updated);
+    this.rememberAcceptedBlock(updated);
+    this.notifyChange(updated);
+    return updated;
   }
 
   async loadActiveBlock(): Promise<ActiveBlockData | null> {
@@ -164,7 +215,12 @@ export class TimeBlockServiceImpl implements TimeBlockService {
     return normalized;
   }
 
-  async startBlock(name: string, config: TimerConfig, description?: string, taskId?: string): Promise<ActiveBlockData> {
+  async startBlock(
+    name: string,
+    config: TimerConfig,
+    description?: string,
+    taskBinding?: string | { taskIds: string[] },
+  ): Promise<ActiveBlockData> {
     // 不允许在已有活跃块（运行中/已暂停）时开启新块
     const existing = await this.readActiveBlock();
     if (existing) {
@@ -182,6 +238,16 @@ export class TimeBlockServiceImpl implements TimeBlockService {
     const initialElapsed = config.mode === 'countdown'
       ? (config.minutes ?? 25) * 60 * 1000
       : 0;
+    const resolvedTaskIds = typeof taskBinding === 'string'
+      ? [taskBinding]
+      : taskBinding?.taskIds ?? [];
+    const taskAssociationLog: BlockTaskAssociationEvent[] = resolvedTaskIds.map((linkedTaskId) => ({
+      blockId: startId,
+      taskId: linkedTaskId,
+      action: 'associated',
+      timestamp: now,
+      source: 'block_start',
+    }));
 
     // 创建开始事件
     const normalizedDescription = description?.trim();
@@ -209,7 +275,9 @@ export class TimeBlockServiceImpl implements TimeBlockService {
       actionEndedAt: undefined,
       feedbackStartedAt: undefined,
       feedbackSubmittedAt: undefined,
-      taskId,
+      taskIds: resolvedTaskIds,
+      taskAssociationLog,
+      taskId: undefined,
     };
     const normalizedActiveBlock = this.normalizeActiveBlock(activeBlock, now);
 
@@ -347,7 +415,13 @@ export class TimeBlockServiceImpl implements TimeBlockService {
     log.info(`[TB-SVC] markEnding done ${JSON.stringify({ startId: endedBlock.startId, saveMs, eventMs, totalMs: Math.round(perfNow() - opStart) })}`);
   }
 
-  async endBlock(feedback?: string): Promise<TimeBlock | null> {
+  async endBlock(
+    feedback?: string,
+    options?: {
+      taskStatusOutcomes?: Record<string, string>;
+      taskTitles?: Record<string, string>;
+    },
+  ): Promise<TimeBlock | null> {
     const opStart = perfNow();
     const rawActiveData = await this.readActiveBlock();
     if (!rawActiveData) return null;
@@ -399,6 +473,8 @@ export class TimeBlockServiceImpl implements TimeBlockService {
       actionStartAt,
       actionEndedAt,
       submittedAt,
+      taskStatusOutcomes: options?.taskStatusOutcomes,
+      taskTitles: options?.taskTitles,
     });
 
     const feedbackEventStart = perfNow();
@@ -433,6 +509,9 @@ export class TimeBlockServiceImpl implements TimeBlockService {
       tags: ['block_feedback'],
       startTime: activeData.startTime,
       endTime: submittedAt,
+      taskIds: activeData.taskIds ?? [],
+      taskStatusOutcomes: options?.taskStatusOutcomes,
+      taskAssociationLog: activeData.taskAssociationLog ?? [],
     };
 
     // 追加到已完成列表
@@ -745,11 +824,12 @@ export class TimeBlockServiceImpl implements TimeBlockService {
   }
 
   private async readCompletedBlockData(): Promise<TimeBlockData[]> {
+    const normalizeBlocks = (blocks: TimeBlockData[]) => blocks.map((block) => normalizeTimeBlockTaskIds(block));
     if (this.backendMode === 'rt-sqlite') {
-      return await this.rtAdapter?.listCompletedBlocks() ?? [];
+      return normalizeBlocks(await this.rtAdapter?.listCompletedBlocks() ?? []);
     }
 
-    return await this.env.storage.read<TimeBlockData[]>(TIME_BLOCKS_KEY) || [];
+    return normalizeBlocks(await this.env.storage.read<TimeBlockData[]>(TIME_BLOCKS_KEY) || []);
   }
 
   private async writeCompletedBlockData(blocks: TimeBlockData[]): Promise<void> {
@@ -822,6 +902,8 @@ export class TimeBlockServiceImpl implements TimeBlockService {
   }
 
   private normalizeActiveBlock(data: ActiveBlockData, now: number = Date.now()): ActiveBlockData {
+    const normalizedTaskData = normalizeActiveBlockTaskIds(data);
+    const taskAssociationLog = normalizedTaskData.taskAssociationLog ?? [];
     const phase = this.resolvePhase(data);
     const effectiveNow = this.getPhaseEffectiveNow(data, phase, now);
     const accumulatedRunMs = this.resolveAccumulatedRunMs(data);
@@ -839,7 +921,7 @@ export class TimeBlockServiceImpl implements TimeBlockService {
     const lastTransitionAt = this.resolveLastTransitionAt(data, phase, effectiveNow);
 
     return {
-      ...data,
+      ...normalizedTaskData,
       phase,
       version: data.version ?? this.defaultVersionByPhase(phase),
       lastTransitionAt,
@@ -850,6 +932,9 @@ export class TimeBlockServiceImpl implements TimeBlockService {
       pauseAccumulatedMs: data.pauseAccumulatedMs ?? 0,
       elapsed,
       updatedAt: lastTransitionAt,
+      taskIds: normalizedTaskData.taskIds,
+      taskAssociationLog,
+      taskId: undefined,
     };
   }
 
@@ -865,7 +950,9 @@ export class TimeBlockServiceImpl implements TimeBlockService {
       || prev.actionEndedAt !== next.actionEndedAt
       || prev.feedbackStartedAt !== next.feedbackStartedAt
       || prev.feedbackSubmittedAt !== next.feedbackSubmittedAt
-      || prev.pauseAccumulatedMs !== next.pauseAccumulatedMs;
+      || prev.pauseAccumulatedMs !== next.pauseAccumulatedMs
+      || JSON.stringify(prev.taskIds ?? []) !== JSON.stringify(next.taskIds ?? [])
+      || JSON.stringify(prev.taskAssociationLog ?? []) !== JSON.stringify(next.taskAssociationLog ?? []);
   }
 
   private getBlockPhase(block: ActiveBlockData): number {
@@ -980,7 +1067,9 @@ export class TimeBlockServiceImpl implements TimeBlockService {
       && a.feedbackSubmittedAt === b.feedbackSubmittedAt
       && a.pauseAccumulatedMs === b.pauseAccumulatedMs
       && a.paused === b.paused
-      && a.pausedAt === b.pausedAt;
+      && a.pausedAt === b.pausedAt
+      && JSON.stringify(a.taskIds ?? []) === JSON.stringify(b.taskIds ?? [])
+      && JSON.stringify(a.taskAssociationLog ?? []) === JSON.stringify(b.taskAssociationLog ?? []);
   }
 
   private resolvePhase(block: ActiveBlockData): ActiveBlockPhase {
@@ -1168,6 +1257,8 @@ export class TimeBlockServiceImpl implements TimeBlockService {
         pauseAccumulatedMs: block.pauseAccumulatedMs,
         paused: block.paused,
         pausedAt: block.pausedAt,
+        taskIds: block.taskIds ?? [],
+        taskAssociationLog: block.taskAssociationLog ?? [],
       },
     });
   }
@@ -1224,6 +1315,8 @@ export class TimeBlockServiceImpl implements TimeBlockService {
     actionStartAt: number;
     actionEndedAt: number;
     submittedAt: number;
+    taskStatusOutcomes?: Record<string, string>;
+    taskTitles?: Record<string, string>;
   }): string {
     const hasExpectedDuration = input.expectedDurationMs !== null;
     const expectedDurationMs = input.expectedDurationMs ?? 0;
@@ -1297,6 +1390,22 @@ export class TimeBlockServiceImpl implements TimeBlockService {
         `${input.feedbackText}`,
       );
     }
+
+    if (input.taskStatusOutcomes && Object.keys(input.taskStatusOutcomes).length > 0) {
+      const statusLabels: Record<string, string> = {
+        continue: '将继续',
+        suspended: '已挂起',
+        completed: '已完成',
+        cancelled: '已取消',
+      };
+      print(``, `### 任务状态`);
+      for (const [taskId, status] of Object.entries(input.taskStatusOutcomes)) {
+        const title = input.taskTitles?.[taskId] ?? taskId;
+        const label = statusLabels[status] ?? status;
+        print(`- ${title}：${label}`);
+      }
+    }
+
     return result.trimEnd()
   }
 }

--- a/src/lib/types/event.ts
+++ b/src/lib/types/event.ts
@@ -51,6 +51,14 @@ export interface Event {
   metadata?: EventMetadata;
 }
 
+export interface BlockTaskAssociationEvent {
+  blockId: UUID;
+  taskId: UUID;
+  action: 'associated' | 'disassociated';
+  timestamp: Timestamp;
+  source: 'block_start' | 'manual';
+}
+
 // 时间块数据类型（存储用）
 export interface TimeBlockData {
   id: UUID;
@@ -61,6 +69,9 @@ export interface TimeBlockData {
   tags: string[];
   startTime: Timestamp;
   endTime: Timestamp;
+  taskIds?: UUID[];
+  taskStatusOutcomes?: Record<string, string>;
+  taskAssociationLog?: BlockTaskAssociationEvent[];
 }
 
 // 时间块类型（UI 使用）
@@ -73,6 +84,9 @@ export interface TimeBlock {
   tags: Set<Tag>;
   startTime: Timestamp;
   endTime: Timestamp;
+  taskIds?: UUID[];
+  taskStatusOutcomes?: Record<string, string>;
+  taskAssociationLog?: BlockTaskAssociationEvent[];
 }
 
 // 活跃时间块（进行中）
@@ -116,7 +130,10 @@ export interface ActiveBlockData {
   pauseAccumulatedMs?: number;
   paused: boolean;
   pausedAt?: Timestamp;
-  taskId?: string;  // Phase4: 关联任务 ID
+  taskIds: UUID[];
+  taskAssociationLog: BlockTaskAssociationEvent[];
+  /** @deprecated Use taskIds. Kept for deserialization compat only. */
+  taskId?: UUID;
 }
 
 // 计时器配置
@@ -131,4 +148,29 @@ export interface TimerConfig {
 export interface CreateEventOptions {
   content: NoteContent;
   tags?: Set<Tag>;
+}
+
+export function normalizeActiveBlockTaskIds<T extends { taskId?: UUID; taskIds?: UUID[] }>(
+  block: T,
+): Omit<T, 'taskId' | 'taskIds'> & { taskIds: UUID[]; taskId?: undefined } {
+  const taskIds = block.taskIds?.length
+    ? block.taskIds
+    : block.taskId
+      ? [block.taskId]
+      : [];
+
+  const { taskId: _legacyTaskId, taskIds: _taskIds, ...rest } = block;
+  return {
+    ...rest,
+    taskIds,
+  };
+}
+
+export function normalizeTimeBlockTaskIds<T extends { taskIds?: UUID[] }>(
+  block: T,
+): T & { taskIds: UUID[] } {
+  return {
+    ...block,
+    taskIds: block.taskIds ?? [],
+  };
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -51,6 +51,11 @@ const TaskDetailPage = lazy(async () => {
   return { default: module.TaskDetailPage };
 });
 
+const TimeBlockDetailPage = lazy(async () => {
+  const module = await import('@/ui/app/pages/TimeBlockDetailPage');
+  return { default: module.TimeBlockDetailPage };
+});
+
 const MePage = lazy(async () => {
   const module = await import('@/ui/app/pages/MePage');
   return { default: module.MePage };
@@ -568,7 +573,7 @@ const newTimeblockDetailRoute = createRoute({
   component: function NewTimeblockDetail() {
     return (
       <LazyPage>
-        <TaskDetailPage />
+        <TimeBlockDetailPage />
       </LazyPage>
     );
   },

--- a/src/services/runtime-manager.ts
+++ b/src/services/runtime-manager.ts
@@ -37,7 +37,8 @@ export interface RuntimeManagerSnapshot {
 export interface RuntimeManagerOptions {
   hostService?: Pick<RuntimeHostService, 'listHosts' | 'addHost' | 'removeHost'>
     & Partial<Pick<RuntimeHostService, 'mergeHostMetadata'>>;
-  runtimeClient?: Pick<RuntimeClient, 'getAgents' | 'getTopology' | 'getAllEnergy'>;
+  runtimeClient?: Pick<RuntimeClient, 'getAgents' | 'getTopology'>
+    & Partial<Pick<RuntimeClient, 'getAllEnergy'>>;
   runtimeMeshSyncService?: Pick<RuntimeMeshSyncService, 'ensurePeerPair'>;
   now?: () => Date;
 }
@@ -117,7 +118,8 @@ function parseHostAddress(hostAddress: string): { host: string; port: number } {
 export class RuntimeManager {
   private readonly hostService: Pick<RuntimeHostService, 'listHosts' | 'addHost' | 'removeHost'>
     & Partial<Pick<RuntimeHostService, 'mergeHostMetadata'>>;
-  private readonly runtimeClient: Pick<RuntimeClient, 'getAgents' | 'getTopology' | 'getAllEnergy'>;
+  private readonly runtimeClient: Pick<RuntimeClient, 'getAgents' | 'getTopology'>
+    & Partial<Pick<RuntimeClient, 'getAllEnergy'>>;
   private readonly runtimeMeshSyncService: Pick<RuntimeMeshSyncService, 'ensurePeerPair'>;
   private readonly now: () => Date;
 
@@ -166,13 +168,22 @@ export class RuntimeManager {
 
   private async buildHostSnapshot(host: RuntimeHostRecord): Promise<RuntimeHostSnapshot> {
     const topologyStartedAtMs = Date.now();
+    const energyRequest = this.runtimeClient.getAllEnergy
+      ? this.runtimeClient.getAllEnergy(host).catch(() => ({
+        ok: false as const,
+        error: { code: 'network' as const, message: 'energy fetch failed' },
+      }))
+      : Promise.resolve({
+        ok: false as const,
+        error: { code: 'invalid_payload' as const, message: 'energy endpoint unavailable' },
+      });
     const [agentsResult, topologyEnvelope, energyResult] = await Promise.all([
       this.runtimeClient.getAgents(host),
       this.runtimeClient.getTopology(host).then((result) => ({
         result,
         latencyMs: Math.max(1, Date.now() - topologyStartedAtMs),
       })),
-      this.runtimeClient.getAllEnergy(host).catch(() => ({ ok: false as const, error: { code: 'network' as const, message: 'energy fetch failed' } })),
+      energyRequest,
     ]);
     const topologyResult = topologyEnvelope.result;
 

--- a/src/services/voice-shortcut.service.ts
+++ b/src/services/voice-shortcut.service.ts
@@ -26,7 +26,7 @@ import {
 } from '../lib/media/microphone-capture';
 import { convertWebmBlobToWav } from '../lib/media/wav-audio';
 import type { ASRResult } from '../lib/ports/asr-port';
-import { log } from '@/lib/logger';
+import { log, setConsoleMinLevel } from '@/lib/logger';
 import {
   getVoiceShortcutAsrProvider,
   subscribeVoiceShortcutAsrProviderChanges,
@@ -160,6 +160,7 @@ export class VoiceShortcutService {
   private frozenForegroundWindowContext: ForegroundWindowContext | null = null;
   private frozenForegroundWindowContextPromise: Promise<ForegroundWindowContext | null> | null = null;
   private foregroundWindowCaptureToken = 0;
+  private destroyed = false;
 
   constructor(livePreviewSource: VoiceLivePreviewSource = createDefaultVoiceLivePreviewSource()) {
     this.adapter = new MOSSASRAdapter();
@@ -190,13 +191,19 @@ export class VoiceShortcutService {
     }
   }
 
+  private syncDeveloperConsoleLevel(): void {
+    setConsoleMinLevel(this.developerModeEnabled ? 'DEBUG' : 'INFO');
+  }
+
   async init(): Promise<void> {
     if (this.unlisten || this.initializing) return;
     if (!isTauri()) {
       this.debugWarn(LOG_TAG, 'not in Tauri environment, service disabled');
       return;
     }
+    this.destroyed = false;
     this.initializing = true;
+    this.syncDeveloperConsoleLevel();
 
     try {
       await this.applyShortcut(getVoiceShortcutHotkey());
@@ -221,6 +228,7 @@ export class VoiceShortcutService {
 
       this.unlistenDeveloperMode = subscribeDeveloperModeChanges((enabled) => {
         this.developerModeEnabled = enabled;
+        this.syncDeveloperConsoleLevel();
       });
 
       this.unlistenOverlayBottomOffset = subscribeVoiceOverlayBottomOffsetChanges((offset) => {
@@ -253,6 +261,10 @@ export class VoiceShortcutService {
   }
 
   destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
     this.unlisten?.();
     this.unlisten = null;
     this.unlistenVolcanoStream?.();
@@ -282,6 +294,7 @@ export class VoiceShortcutService {
     this.releaseResources();
     this.clearFrozenForegroundWindowContext();
     this.clearAutoHide();
+    setConsoleMinLevel('INFO');
   }
 
   getState(): VoiceShortcutState {
@@ -289,6 +302,9 @@ export class VoiceShortcutService {
   }
 
   private readonly handleAppForeground = (): void => {
+    if (this.destroyed) {
+      return;
+    }
     if (this.startPending || this.state === 'recording' || this.state === 'recognizing') {
       return;
     }
@@ -296,6 +312,9 @@ export class VoiceShortcutService {
   };
 
   private readonly handleVisibilityChange = (): void => {
+    if (this.destroyed) {
+      return;
+    }
     if (typeof document !== 'undefined' && document.visibilityState !== 'visible') {
       return;
     }
@@ -418,7 +437,7 @@ export class VoiceShortcutService {
     this.clearWarmRotateTimer();
     this.warmRotateTimer = setTimeout(() => {
       void (async () => {
-        if (this.warmVolcanoSessionId !== sessionId || this.startPending) {
+        if (this.destroyed || this.warmVolcanoSessionId !== sessionId || this.startPending) {
           return;
         }
         const warmAgeMs = Math.max(0, Date.now() - createdAtMs);
@@ -440,7 +459,7 @@ export class VoiceShortcutService {
 
     this.warmMaintenanceTimer = setInterval(() => {
       void (async () => {
-        if (this.startPending || this.state === 'recording' || this.state === 'recognizing') {
+        if (this.destroyed || this.startPending || this.state === 'recording' || this.state === 'recognizing') {
           return;
         }
         await this.prewarmVolcanoSessionIfPossible();
@@ -455,6 +474,9 @@ export class VoiceShortcutService {
   }
 
   private async prewarmResourcesForProvider(): Promise<void> {
+    if (this.destroyed) {
+      return;
+    }
     if (!this.micPrewarmEnabled) {
       await this.cancelWarmVolcanoSession();
       this.releaseWarmStream();
@@ -498,6 +520,10 @@ export class VoiceShortcutService {
           (constraints) => navigator.mediaDevices.getUserMedia(constraints),
           { audio: DEFAULT_RECORDING_AUDIO_CONSTRAINTS },
         );
+        if (this.destroyed) {
+          stream.getTracks().forEach((track) => track.stop());
+          return null;
+        }
         this.warmStream = stream;
         return stream;
       } catch (error) {
@@ -631,6 +657,9 @@ export class VoiceShortcutService {
   }
 
   private async prewarmVolcanoSessionIfPossible(): Promise<string | null> {
+    if (this.destroyed) {
+      return null;
+    }
     let config: VolcanoRuntimeConfig;
     try {
       config = this.getVolcanoRuntimeConfigOrThrow();
@@ -665,7 +694,7 @@ export class VoiceShortcutService {
     this.warmVolcanoSessionPromise = (async () => {
       try {
         const sessionId = await invoke<string>('volcano_asr_stream_start', { config });
-        if (this.warmVolcanoSessionKey !== warmKey) {
+        if (this.destroyed || this.warmVolcanoSessionKey !== warmKey) {
           invoke('volcano_asr_stream_cancel', { sessionId }).catch(() => {});
           return null;
         }
@@ -1221,7 +1250,7 @@ export class VoiceShortcutService {
         sessionWarmReason: sessionResult.value.warmReason,
         activationMs: this.completeActivationTracking(),
       });
-      if (this.micPrewarmEnabled) {
+      if (this.micPrewarmEnabled && !this.destroyed) {
         void this.prewarmVolcanoSessionIfPossible();
       }
       void this.syncRecordingActive(true);
@@ -1266,7 +1295,9 @@ export class VoiceShortcutService {
       this.handleError(`识别失败: ${error}`);
     } finally {
       this.cleanupVolcanoStreamingState();
-      void this.prewarmVolcanoSessionIfPossible();
+      if (!this.destroyed) {
+        void this.prewarmVolcanoSessionIfPossible();
+      }
     }
   }
 
@@ -1285,7 +1316,9 @@ export class VoiceShortcutService {
     } finally {
       this.cleanupVolcanoStreamingState();
       this.releaseResources();
-      void this.prewarmVolcanoSessionIfPossible();
+      if (!this.destroyed) {
+        void this.prewarmVolcanoSessionIfPossible();
+      }
     }
   }
 
@@ -1316,7 +1349,7 @@ export class VoiceShortcutService {
       if (payload.errorMessage) {
         this.debugInfo(LOG_TAG, `[warm] standby volcano session closed, replenishing: ${payload.errorMessage}`);
         this.logWarmSessionClosed(this.clearWarmVolcanoSessionState(), payload.errorMessage);
-        if (this.micPrewarmEnabled && this.asrProvider === 'volcano' && !this.startPending) {
+        if (this.micPrewarmEnabled && this.asrProvider === 'volcano' && !this.startPending && !this.destroyed) {
           void this.prewarmVolcanoSessionIfPossible();
         }
       }

--- a/src/ui/app/components/BlockTaskAssociationList.tsx
+++ b/src/ui/app/components/BlockTaskAssociationList.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useMemo, useState } from 'react';
+import { getTaskService, getTaskTimerService, getTimeBlockService } from '@/lib/services';
+import type { ActiveBlockData } from '@/lib/types/event';
+import type { TaskNode } from '@/lib/types/task';
+
+function resolveActiveTaskIds(block: ActiveBlockData | null): string[] {
+  if (!block) return [];
+  if (block.taskIds?.length) return block.taskIds;
+  return block.taskId ? [block.taskId] : [];
+}
+
+export function BlockTaskAssociationList() {
+  const [activeBlock, setActiveBlock] = useState<ActiveBlockData | null>(null);
+  const [tasksById, setTasksById] = useState<Map<string, TaskNode>>(new Map());
+  const [selectedTaskId, setSelectedTaskId] = useState('');
+
+  useEffect(() => {
+    let disposed = false;
+    const taskService = getTaskService();
+    const timeBlockService = getTimeBlockService();
+
+    const load = async () => {
+      const [nextBlock, tasks] = await Promise.all([
+        timeBlockService.loadActiveBlock(),
+        taskService.listTasks(true),
+      ]);
+      if (disposed) return;
+      setActiveBlock(nextBlock);
+      setTasksById(new Map(tasks.map((task) => [task.id, task])));
+    };
+
+    void load();
+    const unsubscribeTasks = taskService.onTaskChange(() => {
+      void load();
+    });
+    const unsubscribeBlocks = timeBlockService.onBlockChange((block) => {
+      setActiveBlock(block);
+      void load();
+    });
+
+    return () => {
+      disposed = true;
+      unsubscribeTasks();
+      unsubscribeBlocks();
+    };
+  }, []);
+
+  const activeTaskIds = resolveActiveTaskIds(activeBlock);
+  const linkedTasks = activeTaskIds
+    .map((taskId) => tasksById.get(taskId))
+    .filter((task): task is TaskNode => Boolean(task));
+
+  const availableTasks = useMemo(() => (
+    [...tasksById.values()].filter((task) => (
+      task.status !== 'completed'
+      && task.status !== 'cancelled'
+      && !activeTaskIds.includes(task.id)
+    ))
+  ), [activeTaskIds, tasksById]);
+
+  useEffect(() => {
+    if (!selectedTaskId && availableTasks[0]) {
+      setSelectedTaskId(availableTasks[0].id);
+    }
+    if (selectedTaskId && !availableTasks.some((task) => task.id === selectedTaskId)) {
+      setSelectedTaskId(availableTasks[0]?.id ?? '');
+    }
+  }, [availableTasks, selectedTaskId]);
+
+  if (!activeBlock) {
+    return (
+      <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
+        <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">任务关联</h3>
+        <p className="mt-2 text-sm text-[#78716C] dark:text-[#A8A29E]">开始时间块后可在这里增删关联任务。</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-2xl border border-[#E7E5E4] bg-white p-4 dark:border-[#292524] dark:bg-[#1C1917]">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">任务关联</h3>
+          <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">运行中可追加或移除关联任务。</p>
+        </div>
+        <span className="rounded-full bg-[#F5F0ED] px-2 py-1 text-xs text-[#78716C] dark:bg-[#292524] dark:text-[#D6D3D1]">
+          {linkedTasks.length} 个任务
+        </span>
+      </div>
+
+      <div className="mt-3 space-y-2">
+        {linkedTasks.length > 0 ? linkedTasks.map((task) => (
+          <div
+            key={task.id}
+            className="flex items-center justify-between rounded-xl border border-[#E7E5E4] px-3 py-2 dark:border-[#3F3F46]"
+          >
+            <div className="min-w-0">
+              <p className="truncate text-sm text-[#1C1917] dark:text-[#FAFAF9]">{task.title}</p>
+              <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">{task.status}</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                void getTaskTimerService().removeTaskFromBlock(task.id);
+              }}
+              className="rounded-lg border border-[#E7E5E4] px-2.5 py-1 text-xs text-[#57534E] dark:border-[#3F3F46] dark:text-[#D6D3D1]"
+            >
+              移除
+            </button>
+          </div>
+        )) : (
+          <p className="text-sm text-[#78716C] dark:text-[#A8A29E]">当前还没有关联任务。</p>
+        )}
+      </div>
+
+      <div className="mt-4 flex gap-2">
+        <select
+          value={selectedTaskId}
+          onChange={(event) => setSelectedTaskId(event.target.value)}
+          className="flex-1 rounded-xl border border-[#E7E5E4] bg-white px-3 py-2 text-sm text-[#44403C] dark:border-[#3F3F46] dark:bg-[#1C1917] dark:text-[#E7E5E4]"
+        >
+          <option value="">选择任务</option>
+          {availableTasks.map((task) => (
+            <option key={task.id} value={task.id}>
+              {task.title}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          disabled={!selectedTaskId}
+          onClick={() => {
+            if (!selectedTaskId) return;
+            void getTaskTimerService().addTaskToBlock(selectedTaskId);
+          }}
+          className="rounded-xl bg-[#C75B3A] px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-[#D6D3D1]"
+        >
+          关联任务
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/ui/app/components/FocusTimerWidget.tsx
+++ b/src/ui/app/components/FocusTimerWidget.tsx
@@ -103,6 +103,29 @@ function resolveExpectedOptionIndex(mode: TimerMode, minutes: number): number {
   return presetIndex >= 0 ? presetIndex + 1 : 4;
 }
 
+function resolveActiveTaskIds(block: ActiveBlockData | null): string[] {
+  if (!block) return [];
+  if (block.taskIds?.length) return block.taskIds;
+  return block.taskId ? [block.taskId] : [];
+}
+
+function buildTaskStatusChoices(
+  taskIds: string[],
+  previousChoices: Record<string, TaskStatusChoice> = {},
+): Record<string, TaskStatusChoice> {
+  return taskIds.reduce<Record<string, TaskStatusChoice>>((nextChoices, taskId) => {
+    nextChoices[taskId] = previousChoices[taskId] ?? 'continue';
+    return nextChoices;
+  }, {});
+}
+
+const TASK_STATUS_OPTIONS = [
+  { key: 'suspended' as const, label: '挂起' },
+  { key: 'continue' as const, label: '继续' },
+  { key: 'completed' as const, label: '完成' },
+  { key: 'cancelled' as const, label: '取消' },
+];
+
 export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWidgetProps>(function FocusTimerWidget(
   { surface = 'default' },
   ref,
@@ -115,6 +138,7 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
   const countdownEndedRef = useRef(false);
   const countdownOverrunRef = useRef(false);
   const hardEndTriggeredRef = useRef(false);
+  const linkedTasksLoadRequestRef = useRef(0);
 
   const [uiState, setUiState] = useState<FocusUiState>('idle');
   const [runningSubState, setRunningSubState] = useState<RunningSubState>('running');
@@ -142,8 +166,8 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
   // Task status selector in feedback dialog
   const activeBlockDataRef = useRef<ActiveBlockData | null>(null);
   const taskStatusChoiceBlockRef = useRef<string | null>(null);
-  const [linkedTask, setLinkedTask] = useState<TaskNode | null>(null);
-  const [taskStatusChoice, setTaskStatusChoice] = useState<TaskStatusChoice>('continue');
+  const [linkedTasks, setLinkedTasks] = useState<TaskNode[]>([]);
+  const [taskStatusChoices, setTaskStatusChoices] = useState<Record<string, TaskStatusChoice>>({});
 
   const isRunningUi = uiState === 'running';
   const isPaused = isRunningUi && runningSubState === 'paused';
@@ -250,6 +274,7 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
   const applyActiveBlock = useCallback((block: ActiveBlockData | null) => {
     activeBlockDataRef.current = block;
     if (!block) {
+      linkedTasksLoadRequestRef.current += 1;
       taskStatusChoiceBlockRef.current = null;
       setUiState('idle');
       setRunningSubState('running');
@@ -264,23 +289,39 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
       hardEndTriggeredRef.current = false;
       setCountdownOvertimeMs(0);
       syncIdleElapsedFromMode(timerMode, countdownMinutes);
-      setLinkedTask(null);
-      setTaskStatusChoice('continue');
+      setLinkedTasks([]);
+      setTaskStatusChoices({});
       return;
     }
 
-    // Fetch linked task if taskId exists
-    if (block.taskId) {
-      void getTaskService().getTask(block.taskId).then((task) => {
-        setLinkedTask(task);
-      });
+    const resolvedTaskIds = resolveActiveTaskIds(block);
+    const taskLoadRequestId = linkedTasksLoadRequestRef.current + 1;
+    linkedTasksLoadRequestRef.current = taskLoadRequestId;
+
+    if (resolvedTaskIds.length > 0) {
+      void Promise.all(resolvedTaskIds.map((taskId) => getTaskService().getTask(taskId)))
+        .then((tasks) => {
+          if (linkedTasksLoadRequestRef.current !== taskLoadRequestId) {
+            return;
+          }
+          setLinkedTasks(tasks.filter((task): task is TaskNode => task !== null));
+        })
+        .catch(() => {
+          if (linkedTasksLoadRequestRef.current !== taskLoadRequestId) {
+            return;
+          }
+          setLinkedTasks([]);
+        });
     } else {
-      setLinkedTask(null);
+      setLinkedTasks([]);
     }
-    if (taskStatusChoiceBlockRef.current !== block.startId) {
-      taskStatusChoiceBlockRef.current = block.startId;
-      setTaskStatusChoice('continue');
-    }
+    setTaskStatusChoices((previousChoices) => {
+      if (taskStatusChoiceBlockRef.current !== block.startId) {
+        taskStatusChoiceBlockRef.current = block.startId;
+        return buildTaskStatusChoices(resolvedTaskIds);
+      }
+      return buildTaskStatusChoices(resolvedTaskIds, previousChoices);
+    });
 
     setTaskName(block.name);
     setTaskNameDraft(block.name);
@@ -545,7 +586,20 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
     if (feedbackSubmitting) return;
     const trimmedFeedback = feedbackText?.trim() ?? '';
     const blockDataSnapshot = activeBlockDataRef.current;
-    const taskStatusChoiceSnapshot = taskStatusChoice;
+    const taskIdsSnapshot = resolveActiveTaskIds(blockDataSnapshot);
+    const linkedTasksSnapshot = linkedTasks;
+    const taskStatusChoicesSnapshot = { ...taskStatusChoices };
+    const taskTitles = linkedTasksSnapshot.reduce<Record<string, string>>((titles, task) => {
+      titles[task.id] = task.title;
+      return titles;
+    }, {});
+    const taskStatusOutcomes = taskIdsSnapshot.reduce<Record<string, string>>((outcomes, taskId) => {
+      const statusChoice = taskStatusChoicesSnapshot[taskId] ?? 'continue';
+      if (statusChoice !== 'continue') {
+        outcomes[taskId] = statusChoice;
+      }
+      return outcomes;
+    }, {});
     if (trimmedFeedback.length === 0) {
       if (skipFeedbackConfirmState === 'idle') {
         startSkipFeedbackConfirmCooldown();
@@ -564,7 +618,14 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
 
     try {
       await mutationQueueRef.current;
-      await timeBlockServiceRef.current.endBlock(trimmedFeedback || undefined);
+      if (taskIdsSnapshot.length > 0) {
+        await timeBlockServiceRef.current.endBlock(trimmedFeedback || undefined, {
+          taskStatusOutcomes: Object.keys(taskStatusOutcomes).length > 0 ? taskStatusOutcomes : undefined,
+          taskTitles: Object.keys(taskTitles).length > 0 ? taskTitles : undefined,
+        });
+      } else {
+        await timeBlockServiceRef.current.endBlock(trimmedFeedback || undefined);
+      }
     } catch (error) {
       log.error(`[TB-UI] endBlock failed ${error instanceof Error ? error.message : String(error)}`);
       try {
@@ -580,11 +641,14 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
     log.info(`[TB-UI] click submit-end -> endBlock done ${JSON.stringify({ elapsedMs: Math.round(perfNow() - t0) })}`);
 
     // Record block association and apply task status transition
-    if (blockDataSnapshot?.taskId) {
+    if (blockDataSnapshot && taskIdsSnapshot.length > 0) {
       try {
-        await getTaskTimerService().onBlockEndForTask(blockDataSnapshot.taskId, blockDataSnapshot.startId);
-        if (taskStatusChoiceSnapshot !== 'continue') {
-          await getTaskService().transitionTask(blockDataSnapshot.taskId, taskStatusChoiceSnapshot as TaskStatus);
+        await getTaskTimerService().onBlockEndForTasks(taskIdsSnapshot, blockDataSnapshot.startId);
+        for (const taskId of taskIdsSnapshot) {
+          const taskStatusChoice = taskStatusChoicesSnapshot[taskId] ?? 'continue';
+          if (taskStatusChoice !== 'continue') {
+            await getTaskService().transitionTask(taskId, taskStatusChoice as TaskStatus);
+          }
         }
       } catch (error) {
         log.error(`[TB-UI] task status update failed ${error instanceof Error ? error.message : String(error)}`);
@@ -599,9 +663,9 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
     setRunningSubState('running');
     setTaskName('');
     setTaskNameDraft('');
-    setLinkedTask(null);
+    setLinkedTasks([]);
     taskStatusChoiceBlockRef.current = null;
-    setTaskStatusChoice('continue');
+    setTaskStatusChoices({});
     countdownEndedRef.current = false;
     countdownOverrunRef.current = false;
     hardEndTriggeredRef.current = false;
@@ -615,7 +679,8 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
     skipFeedbackConfirmState,
     startSkipFeedbackConfirmCooldown,
     syncIdleElapsedFromMode,
-    taskStatusChoice,
+    linkedTasks,
+    taskStatusChoices,
     timerMode,
   ]);
 
@@ -974,38 +1039,52 @@ export const FocusTimerWidget = forwardRef<FocusTimerWidgetHandle, FocusTimerWid
             placeholder="记录本次专注的反馈..."
             className="min-h-[96px] resize-none dark:bg-[rgba(255,255,255,0.06)] dark:border-[#FFFFFF15] dark:text-[#FAFAF9] dark:placeholder:text-[#78716C]"
           />
-          {linkedTask && (
+          {linkedTasks.length > 0 && (
             <div data-testid="feedback-task-status-section" className="flex flex-col gap-1.5">
               <div className="flex items-center gap-2">
-                <span className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">关联任务</span>
-                <span className="truncate text-[12px] text-[#1C1917] dark:text-[#FAFAF9]">{linkedTask.title}</span>
+                <span className="text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">关联任务状态</span>
+                <span className="text-[12px] text-[#78716C] dark:text-[#A8A29E]">可分别设置结束后的任务状态</span>
               </div>
-              <div
-                className="relative overflow-hidden rounded-[10px] border border-[#E7E5E4] bg-[#F5F0ED]/50 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]"
-                data-testid="feedback-task-status-selector"
-              >
-                <div className="relative z-10 grid grid-cols-4 gap-0">
-                  {([
-                    { key: 'suspended' as TaskStatusChoice, label: '挂起' },
-                    { key: 'continue' as TaskStatusChoice, label: '继续' },
-                    { key: 'completed' as TaskStatusChoice, label: '完成' },
-                    { key: 'cancelled' as TaskStatusChoice, label: '取消' },
-                  ] as const).map(({ key, label }) => (
-                    <button
-                      key={key}
-                      type="button"
-                      data-testid={`feedback-task-status-${key}`}
-                      onClick={() => setTaskStatusChoice(key)}
-                      className={`relative z-10 h-8 w-full whitespace-nowrap rounded-[8px] px-[8px] text-center text-[12px] transition-colors duration-200 ${
-                        taskStatusChoice === key
-                          ? 'font-semibold text-[#1C1917] dark:text-[#FAFAF9] bg-white/55 dark:bg-[#FFFFFF14] border border-[#FFFFFFCC] dark:border-[#FFFFFF66] shadow-[0_1px_2px_rgba(0,0,0,0.05)]'
-                          : 'text-[#78716C] hover:text-[#57534E] dark:hover:text-[#D6D3D1]'
-                      }`}
+              <div className="flex flex-col gap-2">
+                {linkedTasks.map((task) => (
+                  <div
+                    key={task.id}
+                    data-testid={`feedback-task-status-row-${task.id}`}
+                    className="rounded-[12px] border border-[#E7E5E4] bg-[#F5F0ED]/50 p-2.5 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]"
+                  >
+                    <div className="mb-2 flex items-center justify-between gap-2">
+                      <span className="truncate text-[12px] font-medium text-[#1C1917] dark:text-[#FAFAF9]">{task.title}</span>
+                      <span className="text-[11px] text-[#78716C] dark:text-[#A8A29E]">{task.status}</span>
+                    </div>
+                    <div
+                      className="relative overflow-hidden rounded-[10px] border border-[#E7E5E4] bg-white/70 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]"
+                      data-testid={`feedback-task-status-selector-${task.id}`}
                     >
-                      {label}
-                    </button>
-                  ))}
-                </div>
+                      <div className="relative z-10 grid grid-cols-4 gap-0">
+                        {TASK_STATUS_OPTIONS.map(({ key, label }) => (
+                          <button
+                            key={key}
+                            type="button"
+                            data-testid={`feedback-task-status-${task.id}-${key}`}
+                            onClick={() => {
+                              setTaskStatusChoices((previousChoices) => ({
+                                ...previousChoices,
+                                [task.id]: key,
+                              }));
+                            }}
+                            className={`relative z-10 h-8 w-full whitespace-nowrap rounded-[8px] px-[8px] text-center text-[12px] transition-colors duration-200 ${
+                              (taskStatusChoices[task.id] ?? 'continue') === key
+                                ? 'font-semibold text-[#1C1917] dark:text-[#FAFAF9] bg-white/55 dark:bg-[#FFFFFF14] border border-[#FFFFFFCC] dark:border-[#FFFFFF66] shadow-[0_1px_2px_rgba(0,0,0,0.05)]'
+                                : 'text-[#78716C] hover:text-[#57534E] dark:hover:text-[#D6D3D1]'
+                            }`}
+                          >
+                            {label}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
           )}

--- a/src/ui/app/components/NowInputRow.tsx
+++ b/src/ui/app/components/NowInputRow.tsx
@@ -11,12 +11,18 @@ import { Clipboard, Image, Mic, SendHorizontal, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from '@/components/ui/toast-hook';
+import {
+  getVoiceTranscriptSendMode,
+  subscribeVoiceTranscriptSendModeChanges,
+  type VoiceTranscriptSendMode,
+} from '@/config/voice-transcript-send-mode';
 import { getClipboardService } from '@/lib/services';
 import type { ClipboardFailureReason } from '@/lib/services';
 import { VoiceInputButton, type VoiceInputButtonHandle } from '@/components/VoiceInputButton';
 import type { VoiceMessageInputHandle } from '@/components/VoiceMessageInput';
 import { publishVoiceTranscriptSignal } from '@/lib/services/voice-signal.service';
 import { log } from '@/lib/logger';
+import { normalizeRecognitionText } from '@/lib/voice/recognition-text';
 
 interface NowInputRowProps {
   onSend: (content: string, tags?: string[]) => void | Promise<void>;
@@ -45,6 +51,9 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
   placeholder = '记录当下的事实...',
 }, ref) {
   const [value, setValue] = useState('');
+  const [voiceTranscriptSendMode, setVoiceTranscriptSendMode] = useState<VoiceTranscriptSendMode>(() =>
+    getVoiceTranscriptSendMode(),
+  );
   const [pasteFeedback, setPasteFeedback] = useState<'idle' | 'success' | 'error'>('idle');
   const [attachmentFeedback, setAttachmentFeedback] = useState<'idle' | 'pending'>('idle');
   const [pasteFailureLabel, setPasteFailureLabel] = useState('未粘贴');
@@ -68,6 +77,8 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
   useEffect(() => {
     resizeTextarea();
   }, [value, resizeTextarea]);
+
+  useEffect(() => subscribeVoiceTranscriptSendModeChanges(setVoiceTranscriptSendMode), []);
 
   useEffect(() => () => {
     if (pasteFeedbackTimerRef.current) {
@@ -142,7 +153,7 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
   }, [insertClipboardText]);
 
   const handleVoiceResult = useCallback((text: string) => {
-    const normalized = text.trim();
+    const normalized = normalizeRecognitionText(text);
     if (!normalized) return;
 
     void publishVoiceTranscriptSignal({ text: normalized }, {
@@ -151,9 +162,16 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
       log.warn(`[new-now-input][voice-signal] ${publishError instanceof Error ? publishError.message : String(publishError)}`);
     });
 
-    // 语音输入始终直接发送到事件日志——语音是即时事件，应该立即入库
-    onSend(normalized, ['voice']);
-  }, [onSend]);
+    if (voiceTranscriptSendMode === 'direct-send') {
+      void onSend(normalized, ['voice']);
+      return;
+    }
+
+    setValue((prev) => {
+      const trimmedPrev = prev.trim();
+      return trimmedPrev ? `${trimmedPrev} ${normalized}` : normalized;
+    });
+  }, [onSend, voiceTranscriptSendMode]);
 
   const handleVoiceError = useCallback((error: string) => {
     log.error(`[new-now-input][voice] ${error}`);

--- a/src/ui/app/components/NowTodayTab.tsx
+++ b/src/ui/app/components/NowTodayTab.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from '@tanstack/react-router';
+import { getTaskService, getTimeBlockService } from '@/lib/services';
+import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
+import type { TaskNode } from '@/lib/types/task';
+import { buildNowTodayBlocksView } from '@/ui/app/pages/now-today-blocks-view';
+
+function isToday(timestamp: number, now: Date): boolean {
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  return timestamp >= start && timestamp < start + 86_400_000;
+}
+
+function resolveActiveTaskIds(block: ActiveBlockData): string[] {
+  if (block.taskIds?.length) return block.taskIds;
+  return block.taskId ? [block.taskId] : [];
+}
+
+function buildRunningTimeBlock(block: ActiveBlockData, now: number): TimeBlock {
+  return {
+    id: block.startId,
+    startId: block.startId,
+    endId: `${block.startId}-active`,
+    name: block.name,
+    note: '进行中',
+    tags: new Set(['block_feedback']),
+    startTime: block.startTime,
+    endTime: now,
+    taskIds: resolveActiveTaskIds(block),
+    taskAssociationLog: block.taskAssociationLog ?? [],
+  };
+}
+
+export function NowTodayTab() {
+  const [blocks, setBlocks] = useState<TimeBlock[]>([]);
+  const [tasksById, setTasksById] = useState<Map<string, TaskNode>>(new Map());
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let disposed = false;
+    const taskService = getTaskService();
+    const timeBlockService = getTimeBlockService();
+
+    const load = async () => {
+      setLoading(true);
+      const now = new Date();
+      const [completedBlocks, activeBlock] = await Promise.all([
+        timeBlockService.loadTimeBlocks(),
+        timeBlockService.loadActiveBlock(),
+      ]);
+
+      const nextBlocks = [...completedBlocks];
+      if (activeBlock && isToday(activeBlock.startTime, now)) {
+        nextBlocks.push(buildRunningTimeBlock(activeBlock, now.getTime()));
+      }
+
+      const taskIds = Array.from(new Set(
+        nextBlocks.flatMap((block) => block.taskIds ?? []).filter(Boolean),
+      ));
+      const tasks = await Promise.all(taskIds.map((taskId) => taskService.getTask(taskId)));
+
+      if (disposed) return;
+      setBlocks(nextBlocks);
+      setTasksById(new Map(tasks.filter((task): task is TaskNode => Boolean(task)).map((task) => [task.id, task])));
+      setLoading(false);
+    };
+
+    void load();
+    const unsubscribeTasks = taskService.onTaskChange(() => {
+      void load();
+    });
+    const unsubscribeBlocks = timeBlockService.onBlockChange(() => {
+      void load();
+    });
+
+    return () => {
+      disposed = true;
+      unsubscribeTasks();
+      unsubscribeBlocks();
+    };
+  }, []);
+
+  const view = useMemo(() => buildNowTodayBlocksView({
+    blocks,
+    tasksById,
+    now: new Date(),
+  }), [blocks, tasksById]);
+
+  if (loading) {
+    return <p className="px-1 py-4 text-sm text-[#78716C] dark:text-[#A8A29E]">加载今日时间块...</p>;
+  }
+
+  if (view.items.length === 0) {
+    return <p className="px-1 py-4 text-sm text-[#78716C] dark:text-[#A8A29E]">今天还没有时间块记录。</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {view.items.map((item) => (
+        <Link
+          key={item.blockId}
+          to="/tasks/block/$blockId"
+          params={{ blockId: item.blockId }}
+          className="block rounded-2xl border border-[#E7E5E4] bg-white p-4 transition-colors hover:bg-[#FAF7F5] dark:border-[#292524] dark:bg-[#1C1917] dark:hover:bg-[#292524]"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{item.title}</p>
+              <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">{item.timeLabel}</p>
+            </div>
+            <span className="rounded-full bg-[#F5F0ED] px-2 py-1 text-[11px] text-[#78716C] dark:bg-[#292524] dark:text-[#D6D3D1]">
+              {item.linkedTasks.length} 个任务
+            </span>
+          </div>
+
+          {item.linkedTasks.length > 0 ? (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {item.linkedTasks.map((task) => (
+                <span
+                  key={`${item.blockId}-${task.taskId}`}
+                  className="rounded-full bg-[#FFF7ED] px-2 py-1 text-[11px] text-[#C75B3A] dark:bg-[#2A231B] dark:text-[#FDBA74]"
+                >
+                  {task.title}{task.outcome ? ` · ${task.outcome}` : ''}
+                </span>
+              ))}
+            </div>
+          ) : null}
+
+          {item.note ? (
+            <p className="mt-3 text-xs text-[#78716C] dark:text-[#A8A29E]">{item.note}</p>
+          ) : null}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/src/ui/app/pages/AgentsPage.tsx
+++ b/src/ui/app/pages/AgentsPage.tsx
@@ -135,6 +135,12 @@ import { RoutesTabView } from './agents/RoutesTabView';
 import { ListTabView, type NodeFilterType } from './agents/NodesTabView';
 import { SignalHistoryTabView } from './agents/SignalHistoryTabView';
 
+export {
+  buildListSectionsFromRuntimeAgents,
+  ENERGY_PHASE_COLORS,
+  mapRuntimeStatusToNodeStatus,
+} from './agents/agents-utils';
+
 function TabBar({
   value,
   onChange,

--- a/src/ui/app/pages/FocusPage.tsx
+++ b/src/ui/app/pages/FocusPage.tsx
@@ -1,11 +1,5 @@
-import { ChatPage } from '@/components/Chat/ChatPage';
+import { NowPage } from './NowPage';
 
 export function FocusPage() {
-  return (
-    <div className="flex h-full min-h-0 flex-col">
-      <section className="min-h-0 flex-1" data-testid="new-now-chat-section">
-        <ChatPage variant="new-mobile" hideHeader />
-      </section>
-    </div>
-  );
+  return <NowPage />;
 }

--- a/src/ui/app/pages/NowPage.tsx
+++ b/src/ui/app/pages/NowPage.tsx
@@ -1,0 +1,38 @@
+import { ChatPage } from '@/components/Chat/ChatPage';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { BlockTaskAssociationList } from '@/ui/app/components/BlockTaskAssociationList';
+import { FocusTimerWidget } from '@/ui/app/components/FocusTimerWidget';
+import { NowTodayTab } from '@/ui/app/components/NowTodayTab';
+
+export function NowPage() {
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-[#FAF7F5] dark:bg-[#0C0A09]">
+      <Tabs defaultValue="focus" className="flex h-full min-h-0 flex-col">
+        <div className="border-b border-[#E7E5E4] px-4 py-3 dark:border-[#292524] md:px-6">
+          <TabsList className="grid h-auto w-full grid-cols-3 rounded-2xl border border-[#E7E5E4] bg-white p-1 dark:border-[#292524] dark:bg-[#1C1917]">
+            <TabsTrigger value="focus" className="rounded-xl text-sm">专注</TabsTrigger>
+            <TabsTrigger value="record" className="rounded-xl text-sm">记录</TabsTrigger>
+            <TabsTrigger value="today" className="rounded-xl text-sm">今日</TabsTrigger>
+          </TabsList>
+        </div>
+
+        <TabsContent value="focus" className="mt-0 min-h-0 flex-1 overflow-y-auto px-4 py-4 md:px-6">
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
+            <FocusTimerWidget />
+            <BlockTaskAssociationList />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="record" className="mt-0 min-h-0 flex-1">
+          <ChatPage variant="new-mobile" hideHeader showTimerWidget={false} />
+        </TabsContent>
+
+        <TabsContent value="today" className="mt-0 min-h-0 flex-1 overflow-y-auto px-4 py-4 md:px-6">
+          <div className="mx-auto w-full max-w-3xl">
+            <NowTodayTab />
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/ui/app/pages/SettingsPage.tsx
+++ b/src/ui/app/pages/SettingsPage.tsx
@@ -50,10 +50,23 @@ export function SettingsPage() {
   const items = useMemo(() => getVisibleSettings(ctx), [ctx]);
 
   useEffect(() => {
-    if (!isTauri()) return;
-    invoke<string>('voice_shortcut_get')
-      .then((hotkey) => { if (hotkey) setVoiceShortcutHotkey(hotkey); })
-      .catch(() => {});
+    let cancelled = false;
+
+    void (async () => {
+      if (!(await isTauri())) return;
+
+      invoke<string>('voice_shortcut_get')
+        .then((hotkey) => {
+          if (!cancelled && hotkey) {
+            setVoiceShortcutHotkey(hotkey);
+          }
+        })
+        .catch(() => {});
+    })();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   if (isDesktopVcLayout) {

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -140,6 +140,12 @@ function buildVirtualTaskFromBlock(block: TimeBlock): TaskNode {
   };
 }
 
+function isTaskLinkedToActiveBlock(block: ActiveBlockData | null, taskId: string | undefined): boolean {
+  if (!block || !taskId) return false;
+  const taskIds = block.taskIds ?? [];
+  return taskIds.includes(taskId) || block.taskId === taskId;
+}
+
 function DetailActionsCard({
   model,
   onRestart,
@@ -1000,8 +1006,8 @@ export function TaskDetailPage() {
       setTask(nextTask);
       setAllTasks(listedTasks);
       setTimeBlocks(blocks);
-      setActiveBlock(nextTask && currentBlock?.taskId === nextTask.id ? currentBlock : null);
-      setHasOtherActiveBlock(Boolean(currentBlock && nextTask && currentBlock.taskId !== nextTask.id));
+      setActiveBlock(nextTask && isTaskLinkedToActiveBlock(currentBlock, nextTask.id) ? currentBlock : null);
+      setHasOtherActiveBlock(Boolean(currentBlock && nextTask && !isTaskLinkedToActiveBlock(currentBlock, nextTask.id)));
 
       if (nextTask) {
         const events = await getEventStorage().getEvents();

--- a/src/ui/app/pages/TimeBlockDetailPage.tsx
+++ b/src/ui/app/pages/TimeBlockDetailPage.tsx
@@ -1,0 +1,143 @@
+import { Link, useParams } from '@tanstack/react-router';
+import { useEffect, useMemo, useState } from 'react';
+import { getTaskService, getTimeBlockService } from '@/lib/services';
+import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
+import type { TaskNode } from '@/lib/types/task';
+import { buildTimeBlockDetailView } from './timeblock-detail-view';
+
+function resolveActiveTaskIds(block: ActiveBlockData): string[] {
+  if (block.taskIds?.length) return block.taskIds;
+  return block.taskId ? [block.taskId] : [];
+}
+
+function buildRunningTimeBlock(block: ActiveBlockData, now: number): TimeBlock {
+  return {
+    id: block.startId,
+    startId: block.startId,
+    endId: `${block.startId}-active`,
+    name: block.name,
+    note: '进行中',
+    tags: new Set(['block_feedback']),
+    startTime: block.startTime,
+    endTime: now,
+    taskIds: resolveActiveTaskIds(block),
+    taskAssociationLog: block.taskAssociationLog ?? [],
+  };
+}
+
+export function TimeBlockDetailPage() {
+  const { blockId } = useParams({ strict: false }) as { blockId?: string };
+  const [block, setBlock] = useState<TimeBlock | null>(null);
+  const [tasksById, setTasksById] = useState<Map<string, TaskNode>>(new Map());
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let disposed = false;
+    const load = async () => {
+      setLoading(true);
+      const timeBlockService = getTimeBlockService();
+      const taskService = getTaskService();
+      const [blocks, activeBlock] = await Promise.all([
+        timeBlockService.loadTimeBlocks(),
+        timeBlockService.loadActiveBlock(),
+      ]);
+
+      let matchedBlock = blocks.find((item) => item.id === blockId || item.startId === blockId) ?? null;
+      if (!matchedBlock && activeBlock && activeBlock.startId === blockId) {
+        matchedBlock = buildRunningTimeBlock(activeBlock, Date.now());
+      }
+
+      const taskIds = matchedBlock?.taskIds ?? [];
+      const tasks = await Promise.all(taskIds.map((taskId) => taskService.getTask(taskId)));
+
+      if (disposed) return;
+      setBlock(matchedBlock);
+      setTasksById(new Map(tasks.filter((task): task is TaskNode => Boolean(task)).map((task) => [task.id, task])));
+      setLoading(false);
+    };
+
+    void load();
+    return () => {
+      disposed = true;
+    };
+  }, [blockId]);
+
+  const view = useMemo(() => (
+    block ? buildTimeBlockDetailView({ block, tasksById }) : null
+  ), [block, tasksById]);
+
+  if (loading) {
+    return <div className="px-6 py-6 text-sm text-[#78716C] dark:text-[#A8A29E]">加载时间块详情...</div>;
+  }
+
+  if (!block || !view) {
+    return (
+      <div className="px-6 py-6">
+        <Link to="/tasks" className="text-sm text-[#78716C] dark:text-[#A8A29E]">← 返回任务</Link>
+        <p className="mt-4 text-sm text-[#78716C] dark:text-[#A8A29E]">未找到对应时间块。</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-full bg-[#FAF7F5] px-6 py-6 dark:bg-[#0C0A09]">
+      <div className="mx-auto max-w-4xl space-y-4">
+        <Link to="/tasks" className="text-sm text-[#78716C] dark:text-[#A8A29E]">← 返回任务</Link>
+
+        <section className="rounded-2xl border border-[#E7E5E4] bg-white p-5 dark:border-[#292524] dark:bg-[#1C1917]">
+          <h1 className="text-lg font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{view.summary.title}</h1>
+          <div className="mt-3 grid gap-3 text-sm text-[#57534E] dark:text-[#D6D3D1] md:grid-cols-3">
+            <div>
+              <p className="text-xs text-[#A8A29E]">开始</p>
+              <p>{view.summary.startLabel}</p>
+            </div>
+            <div>
+              <p className="text-xs text-[#A8A29E]">结束</p>
+              <p>{view.summary.endLabel}</p>
+            </div>
+            <div>
+              <p className="text-xs text-[#A8A29E]">时长</p>
+              <p>{view.summary.durationLabel}</p>
+            </div>
+          </div>
+          {view.summary.feedback ? (
+            <p className="mt-4 rounded-xl bg-[#F5F0ED] px-3 py-3 text-sm text-[#57534E] dark:bg-[#292524] dark:text-[#D6D3D1]">
+              {view.summary.feedback}
+            </p>
+          ) : null}
+        </section>
+
+        <section className="rounded-2xl border border-[#E7E5E4] bg-white p-5 dark:border-[#292524] dark:bg-[#1C1917]">
+          <h2 className="text-base font-semibold text-[#1C1917] dark:text-[#FAFAF9]">关联任务</h2>
+          <div className="mt-3 space-y-2">
+            {view.linkedTasks.length > 0 ? view.linkedTasks.map((task) => (
+              <div key={task.taskId} className="rounded-xl border border-[#E7E5E4] px-3 py-2 dark:border-[#3F3F46]">
+                <p className="text-sm text-[#1C1917] dark:text-[#FAFAF9]">{task.title}</p>
+                <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">{task.outcome ?? '未记录结果'}</p>
+              </div>
+            )) : (
+              <p className="text-sm text-[#78716C] dark:text-[#A8A29E]">这个时间块没有关联任务。</p>
+            )}
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-[#E7E5E4] bg-white p-5 dark:border-[#292524] dark:bg-[#1C1917]">
+          <h2 className="text-base font-semibold text-[#1C1917] dark:text-[#FAFAF9]">关联日志</h2>
+          <div className="mt-3 space-y-2">
+            {view.associationTimeline.length > 0 ? view.associationTimeline.map((item) => (
+              <div key={item.id} className="rounded-xl border border-[#E7E5E4] px-3 py-2 dark:border-[#3F3F46]">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-sm text-[#1C1917] dark:text-[#FAFAF9]">{item.title}</p>
+                  <p className="text-xs text-[#A8A29E]">{item.timestampLabel}</p>
+                </div>
+                <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">{item.action} · {item.source}</p>
+              </div>
+            )) : (
+              <p className="text-sm text-[#78716C] dark:text-[#A8A29E]">暂无关联日志。</p>
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/app/pages/now-today-blocks-view.ts
+++ b/src/ui/app/pages/now-today-blocks-view.ts
@@ -1,0 +1,66 @@
+import type { TimeBlock } from '@/lib/types/event';
+import type { TaskNode } from '@/lib/types/task';
+
+export interface NowTodayLinkedTask {
+  taskId: string;
+  title: string;
+  outcome?: string;
+}
+
+export interface NowTodayBlockItem {
+  blockId: string;
+  title: string;
+  timeLabel: string;
+  linkedTasks: NowTodayLinkedTask[];
+  href: string;
+  note?: string;
+}
+
+export interface NowTodayBlocksView {
+  items: NowTodayBlockItem[];
+}
+
+export interface BuildNowTodayBlocksViewInput {
+  blocks: TimeBlock[];
+  tasksById: Map<string, TaskNode>;
+  now: Date;
+}
+
+function startOfDay(now: Date): number {
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+}
+
+function formatClock(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString('zh-CN', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+function buildLinkedTasks(block: TimeBlock, tasksById: Map<string, TaskNode>): NowTodayLinkedTask[] {
+  return (block.taskIds ?? []).map((taskId) => ({
+    taskId,
+    title: tasksById.get(taskId)?.title ?? taskId,
+    outcome: block.taskStatusOutcomes?.[taskId],
+  }));
+}
+
+export function buildNowTodayBlocksView(input: BuildNowTodayBlocksViewInput): NowTodayBlocksView {
+  const dayStart = startOfDay(input.now);
+  const dayEnd = dayStart + 86_400_000;
+
+  const items = input.blocks
+    .filter((block) => block.startTime >= dayStart && block.startTime < dayEnd)
+    .sort((left, right) => right.startTime - left.startTime)
+    .map((block) => ({
+      blockId: block.id,
+      title: block.name,
+      timeLabel: `${formatClock(block.startTime)} - ${formatClock(block.endTime)}`,
+      linkedTasks: buildLinkedTasks(block, input.tasksById),
+      href: `/tasks/block/${block.id}`,
+      note: block.note,
+    }));
+
+  return { items };
+}

--- a/src/ui/app/pages/task-timeblock-detail-view.ts
+++ b/src/ui/app/pages/task-timeblock-detail-view.ts
@@ -145,7 +145,12 @@ function resolveBlockForTask(
   const latestLinked = sortedLinkedBlocks[0];
   if (latestLinked) return latestLinked;
 
-  if (activeBlock && activeBlock.taskId === task.id) {
+  const activeTaskIds = activeBlock?.taskIds ?? [];
+  const isLinkedActiveBlock = activeBlock
+    ? activeTaskIds.includes(task.id) || activeBlock.taskId === task.id
+    : false;
+
+  if (activeBlock && isLinkedActiveBlock) {
     return {
       id: activeBlock.startId,
       startId: activeBlock.startId,

--- a/src/ui/app/pages/tasks-today-view.ts
+++ b/src/ui/app/pages/tasks-today-view.ts
@@ -124,6 +124,20 @@ function buildTaskLookup(tasks: TaskNode[]): Map<string, TaskNode> {
   return lookup;
 }
 
+function resolveActiveBlockTask(activeBlock: ActiveBlockData, tasks: TaskNode[]): TaskNode | undefined {
+  const activeTaskIds = activeBlock.taskIds ?? [];
+  if (activeTaskIds.length === 0) {
+    return activeBlock.taskId ? tasks.find((item) => item.id === activeBlock.taskId) : undefined;
+  }
+
+  for (const taskId of activeTaskIds) {
+    const matchedTask = tasks.find((item) => item.id === taskId);
+    if (matchedTask) return matchedTask;
+  }
+
+  return undefined;
+}
+
 export function buildTasksTodayViewModel(input: BuildTasksTodayViewModelInput): TasksTodayViewModel {
   const { tasks, blocks, now, activeBlock } = input;
   const todayRange = getTodayRange(now);
@@ -163,13 +177,13 @@ export function buildTasksTodayViewModel(input: BuildTasksTodayViewModelInput): 
   }
 
   if (activeBlock && activeBlock.startTime >= todayRange.start && activeBlock.startTime < todayRange.end) {
-    const task = activeBlock.taskId ? tasks.find((item) => item.id === activeBlock.taskId) : undefined;
+    const task = resolveActiveBlockTask(activeBlock, tasks);
     const bucketId = resolveBucketId(activeBlock.startTime);
     const bucketSpec = SECTION_SPECS.find((section) => section.id === bucketId)!;
     sectionItems.get(bucketId)!.push({
       id: `active-${activeBlock.startId}`,
       blockId: activeBlock.startId,
-      taskId: activeBlock.taskId,
+      taskId: task?.id ?? activeBlock.taskIds?.[0] ?? activeBlock.taskId,
       title: task?.title ?? activeBlock.name,
       bucketId,
       bucketLabel: bucketSpec.label,

--- a/src/ui/app/pages/timeblock-detail-view.ts
+++ b/src/ui/app/pages/timeblock-detail-view.ts
@@ -1,0 +1,85 @@
+import type { TimeBlock } from '@/lib/types/event';
+import type { TaskNode } from '@/lib/types/task';
+
+export interface TimeBlockDetailSummary {
+  title: string;
+  startLabel: string;
+  endLabel: string;
+  durationLabel: string;
+  feedback?: string;
+}
+
+export interface TimeBlockDetailLinkedTask {
+  taskId: string;
+  title: string;
+  outcome?: string;
+}
+
+export interface TimeBlockDetailAssociationItem {
+  id: string;
+  taskId: string;
+  title: string;
+  action: string;
+  source: string;
+  timestampLabel: string;
+}
+
+export interface TimeBlockDetailView {
+  summary: TimeBlockDetailSummary;
+  linkedTasks: TimeBlockDetailLinkedTask[];
+  associationTimeline: TimeBlockDetailAssociationItem[];
+}
+
+export interface BuildTimeBlockDetailViewInput {
+  block: TimeBlock;
+  tasksById: Map<string, TaskNode>;
+}
+
+function formatDateTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleString('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+function formatDuration(startTime: number, endTime: number): string {
+  const totalMinutes = Math.max(0, Math.round((endTime - startTime) / 60_000));
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours > 0 && minutes > 0) return `${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h`;
+  return `${minutes}m`;
+}
+
+export function buildTimeBlockDetailView(input: BuildTimeBlockDetailViewInput): TimeBlockDetailView {
+  const { block, tasksById } = input;
+
+  return {
+    summary: {
+      title: block.name,
+      startLabel: formatDateTime(block.startTime),
+      endLabel: formatDateTime(block.endTime),
+      durationLabel: formatDuration(block.startTime, block.endTime),
+      feedback: block.note,
+    },
+    linkedTasks: (block.taskIds ?? []).map((taskId) => ({
+      taskId,
+      title: tasksById.get(taskId)?.title ?? taskId,
+      outcome: block.taskStatusOutcomes?.[taskId],
+    })),
+    associationTimeline: [...(block.taskAssociationLog ?? [])]
+      .sort((left, right) => left.timestamp - right.timestamp)
+      .map((item) => ({
+        id: `${item.taskId}-${item.action}-${item.timestamp}`,
+        taskId: item.taskId,
+        title: tasksById.get(item.taskId)?.title ?? item.taskId,
+        action: item.action,
+        source: item.source,
+        timestampLabel: formatDateTime(item.timestamp),
+      })),
+  };
+}

--- a/tests/components/ChatPage.test.tsx
+++ b/tests/components/ChatPage.test.tsx
@@ -227,6 +227,14 @@ describe('ChatPage 架构边界', () => {
     expect(source).not.toContain('getEventStorage(currentUser || undefined)');
     expect(source).toContain('activeProfileId');
   });
+
+  it('记录 Tab 复用时可显式关闭内置专注计时器（showTimerWidget）', () => {
+    const source = readFileSync('src/components/Chat/ChatPage.tsx', 'utf-8');
+
+    expect(source).toContain('showTimerWidget?: boolean');
+    expect(source).toContain('showTimerWidget = true');
+    expect(source).toContain("variant === 'new-mobile' && showTimerWidget ? (");
+  });
 });
 
 describe('ChatPage 消息发送逻辑', () => {

--- a/tests/e2e/now-tabs-timeblock-detail.issue418-516.test.ts
+++ b/tests/e2e/now-tabs-timeblock-detail.issue418-516.test.ts
@@ -1,0 +1,107 @@
+import { expect, test, type Page } from '@playwright/test';
+
+function buildCompletedBlock() {
+  const today = new Date();
+  const startTime = new Date(today.getFullYear(), today.getMonth(), today.getDate(), 9, 15, 0).getTime();
+  const endTime = startTime + 50 * 60 * 1000;
+
+  return {
+    id: 'issue418516-block-1',
+    startId: 'issue418516-block-1',
+    endId: 'issue418516-block-1-end',
+    name: 'Issue 418/516 联调时间块',
+    note: '完成多任务收尾与详情验证',
+    tags: ['block_feedback'],
+    startTime,
+    endTime,
+    taskIds: ['node-001', 'node-002'],
+    taskStatusOutcomes: {
+      'node-001': 'completed',
+      'node-002': 'continue',
+    },
+    taskAssociationLog: [
+      {
+        blockId: 'issue418516-block-1',
+        taskId: 'node-001',
+        action: 'associated',
+        timestamp: startTime,
+        source: 'block_start',
+      },
+      {
+        blockId: 'issue418516-block-1',
+        taskId: 'node-002',
+        action: 'associated',
+        timestamp: startTime + 60_000,
+        source: 'block_start',
+      },
+      {
+        blockId: 'issue418516-block-1',
+        taskId: 'node-002',
+        action: 'disassociated',
+        timestamp: startTime + 20 * 60 * 1000,
+        source: 'manual',
+      },
+    ],
+  };
+}
+
+async function setupIssue418516State(page: Page) {
+  const completedBlock = buildCompletedBlock();
+  await page.addInitScript((seedBlock) => {
+    const keysToDelete: string[] = [];
+    for (let index = 0; index < localStorage.length; index += 1) {
+      const key = localStorage.key(index);
+      if (key && (key.startsWith('exomind_') || key.startsWith('exomind:'))) {
+        keysToDelete.push(key);
+      }
+    }
+    keysToDelete.forEach((key) => localStorage.removeItem(key));
+
+    localStorage.setItem('exomind:uiMode', 'new');
+    localStorage.setItem('exomind:useMockData', 'true');
+    localStorage.setItem('exomind_time_blocks', JSON.stringify([seedBlock]));
+    localStorage.removeItem('exomind_active_block');
+  }, completedBlock);
+}
+
+test.describe('Issue #418/#516 Now tabs + timeblock detail（当下三 Tab 与时间块详情）', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupIssue418516State(page);
+  });
+
+  test('record tab hides timer widget and today/detail stay timeblock-first（记录页隐藏计时器，今日/详情按时间块展示）', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('tab', { name: '专注' })).toBeVisible();
+
+    await expect(page.locator('[data-state="active"] [data-testid="new-focus-timer-widget"]')).toHaveCount(1);
+
+    await page.getByRole('tab', { name: '记录' }).click();
+    await expect(page.locator('[data-state="active"] [data-testid="event-list"]')).toHaveCount(1);
+    await expect(page.locator('[data-state="active"] [data-testid="new-focus-timer-widget"]')).toHaveCount(0);
+
+    await page.getByRole('tab', { name: '今日' }).click();
+    await expect(page.getByText('Issue 418/516 联调时间块')).toBeVisible();
+    await expect(page.getByText('完成 TaskNode 数据模型 · completed')).toBeVisible();
+    await expect(page.getByText('实现 CRUD 服务层 · continue')).toBeVisible();
+
+    await page.getByRole('link', { name: /Issue 418\/516 联调时间块/ }).click();
+    await expect(page).toHaveURL(/\/tasks\/block\/issue418516-block-1$/);
+
+    const linkedTasksSection = page.locator('section').filter({
+      has: page.getByRole('heading', { name: '关联任务' }),
+    });
+    const associationSection = page.locator('section').filter({
+      has: page.getByRole('heading', { name: '关联日志' }),
+    });
+
+    await expect(page.getByRole('heading', { name: 'Issue 418/516 联调时间块' })).toBeVisible();
+    await expect(linkedTasksSection).toBeVisible();
+    await expect(linkedTasksSection.getByText('完成 TaskNode 数据模型')).toBeVisible();
+    await expect(linkedTasksSection.getByText('实现 CRUD 服务层')).toBeVisible();
+    await expect(linkedTasksSection.getByText('completed')).toBeVisible();
+    await expect(linkedTasksSection.getByText('continue')).toBeVisible();
+    await expect(associationSection).toBeVisible();
+    await expect(associationSection.getByText('associated · block_start').first()).toBeVisible();
+    await expect(associationSection.getByText('disassociated · manual')).toBeVisible();
+  });
+});

--- a/tests/e2e/playwright.issue418-516.config.ts
+++ b/tests/e2e/playwright.issue418-516.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from '@playwright/test';
+import {
+  getBaseUse,
+  getChromiumProject,
+  withPlaywrightEnv,
+} from './playwright.termux';
+
+const WEB_PORT = 1580;
+const HMR_PORT = 1581;
+const POUCHDB_PORT = 7580;
+const ASR_PORT = 2580;
+const BASE_URL = `http://localhost:${WEB_PORT}`;
+
+export default defineConfig({
+  testDir: '.',
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: 'list',
+  use: getBaseUse(BASE_URL),
+  projects: [getChromiumProject()],
+  webServer: {
+    command: 'node Scripts/test/runtime-dispatch.cjs vite-dev',
+    cwd: '../..',
+    url: BASE_URL,
+    reuseExistingServer: false,
+    timeout: 180000,
+    env: withPlaywrightEnv({
+      ...process.env,
+      EXOMIND_WEB_PORT: String(WEB_PORT),
+      EXOMIND_HMR_PORT: String(HMR_PORT),
+      EXOMIND_POUCHDB_PORT: String(POUCHDB_PORT),
+      EXOMIND_ASR_PORT: String(ASR_PORT),
+      VITE_SYNC_SERVER_URL: `http://localhost:${POUCHDB_PORT}`,
+      VITE_ASR_SERVER_URL: `http://localhost:${ASR_PORT}`,
+    }),
+  },
+});

--- a/tests/integration/timeblock-multi-task-association.issue418.test.ts
+++ b/tests/integration/timeblock-multi-task-association.issue418.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskServiceImpl } from '@/lib/services/task.service';
+import { TaskTimerServiceImpl } from '@/lib/services/task-timer.service';
+import { TimeBlockServiceImpl } from '@/lib/services/timeblock.service';
+import type { ITaskPort, UpdateTaskInput } from '@/lib/environment/interfaces/task.port';
+import type { TaskNode, TaskStatus } from '@/lib/types/task';
+
+const {
+  getEventStorageMock,
+  addEventMock,
+  getFeedbackPreferencesMock,
+} = vi.hoisted(() => ({
+  getEventStorageMock: vi.fn(),
+  addEventMock: vi.fn(),
+  getFeedbackPreferencesMock: vi.fn(),
+}));
+
+vi.mock('@/lib/storage/event-storage', () => ({
+  getEventStorage: getEventStorageMock,
+}));
+
+vi.mock('@/config/feedback-preferences', () => ({
+  getFeedbackPreferences: getFeedbackPreferencesMock,
+}));
+
+type MemoryEnv = {
+  storage: {
+    read: <T>(key: string) => Promise<T | null>;
+    write: (key: string, value: unknown) => Promise<void>;
+    delete: (key: string) => Promise<void>;
+  };
+};
+
+function createMemoryEnv(): MemoryEnv {
+  const data = new Map<string, unknown>();
+  return {
+    storage: {
+      async read<T>(key: string) {
+        return (data.has(key) ? data.get(key) : null) as T | null;
+      },
+      async write(key: string, value: unknown) {
+        data.set(key, value);
+      },
+      async delete(key: string) {
+        data.delete(key);
+      },
+    },
+  };
+}
+
+function createStorage(addEventImpl = addEventMock) {
+  return {
+    addEvent: addEventImpl,
+    getEvents: vi.fn().mockResolvedValue([]),
+  };
+}
+
+function makeTask(overrides: Partial<TaskNode>): TaskNode {
+  const now = Date.now();
+  return {
+    id: overrides.id ?? `task-${now}`,
+    title: overrides.title ?? '测试任务',
+    status: overrides.status ?? 'pending',
+    priority: overrides.priority ?? 'medium',
+    dependsOn: overrides.dependsOn ?? [],
+    tags: overrides.tags ?? [],
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    description: overrides.description,
+    doneCondition: overrides.doneCondition,
+    dueAt: overrides.dueAt,
+    source: overrides.source,
+    parentId: overrides.parentId,
+    estimatedMinutes: overrides.estimatedMinutes,
+    timeBlockIds: overrides.timeBlockIds,
+    completedAt: overrides.completedAt,
+  };
+}
+
+function createMemoryTaskPort(tasks: TaskNode[]): ITaskPort {
+  const store = new Map(tasks.map((task) => [task.id, { ...task }]));
+
+  const applyUpdate = (task: TaskNode, updates: UpdateTaskInput): TaskNode => ({
+    ...task,
+    ...updates,
+    updatedAt: Date.now(),
+  });
+
+  return {
+    listTasks: vi.fn(async (includeCancelled = false) => (
+      [...store.values()].filter((task) => includeCancelled || task.status !== 'cancelled')
+    )),
+    getTaskById: vi.fn(async (id: string) => store.get(id) ?? null),
+    createTask: vi.fn(async (input) => {
+      const created = makeTask({
+        id: `task-${store.size + 1}`,
+        title: input.title,
+        description: input.description,
+        doneCondition: input.doneCondition,
+        priority: input.priority ?? 'medium',
+        dueAt: input.dueAt,
+        source: input.source,
+        parentId: input.parentId,
+        tags: input.tags ?? [],
+        estimatedMinutes: input.estimatedMinutes,
+      });
+      store.set(created.id, created);
+      return created;
+    }),
+    updateTask: vi.fn(async (id: string, updates: UpdateTaskInput) => {
+      const existing = store.get(id);
+      if (!existing) return null;
+      const updated = applyUpdate(existing, updates);
+      store.set(id, updated);
+      return updated;
+    }),
+    cancelTask: vi.fn(async (id: string) => {
+      const existing = store.get(id);
+      if (!existing) return null;
+      const cancelled = {
+        ...existing,
+        status: 'cancelled' as const,
+        updatedAt: Date.now(),
+        completedAt: Date.now(),
+      };
+      store.set(id, cancelled);
+      return cancelled;
+    }),
+    transitionTask: vi.fn(async (id: string, to: TaskStatus) => {
+      const existing = store.get(id);
+      if (!existing) return null;
+      const transitioned = {
+        ...existing,
+        status: to,
+        updatedAt: Date.now(),
+        completedAt: to === 'completed' || to === 'cancelled' ? Date.now() : existing.completedAt,
+      };
+      store.set(id, transitioned);
+      return transitioned;
+    }),
+    getAvailableTransitions: vi.fn(async () => []),
+  };
+}
+
+describe('TimeBlock multi-task association integration（#418 多任务时间块集成）', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    addEventMock.mockReset();
+    getEventStorageMock.mockReset();
+    getFeedbackPreferencesMock.mockReset();
+    getEventStorageMock.mockReturnValue(createStorage());
+    getFeedbackPreferencesMock.mockReturnValue({
+      timingInfoEnabled: true,
+      statisticsEnabled: true,
+      quickFeedbackEnabled: true,
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ accepted: true, event_id: 'evt-integration' }),
+    }) as unknown as typeof fetch);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps only final associated tasks in completed block and task timeBlockIds（只为结束时仍关联的任务回写）', async () => {
+    const taskPort = createMemoryTaskPort([
+      makeTask({ id: 'task-1', title: '任务一', status: 'pending' }),
+      makeTask({ id: 'task-2', title: '任务二', status: 'suspended' }),
+      makeTask({ id: 'task-3', title: '任务三', status: 'pending' }),
+    ]);
+    const taskService = new TaskServiceImpl({ task: taskPort });
+    const timeBlockService = new TimeBlockServiceImpl(createMemoryEnv() as never);
+    const taskTimerService = new TaskTimerServiceImpl(taskService, timeBlockService);
+
+    const block = await taskTimerService.startBlockForTasks(['task-1', 'task-2'], { mode: 'countup' });
+    expect(block).not.toBeNull();
+    expect(block?.taskIds).toEqual(['task-1', 'task-2']);
+    expect((await taskService.getTask('task-1'))?.status).toBe('in_progress');
+    expect((await taskService.getTask('task-2'))?.status).toBe('in_progress');
+
+    await taskTimerService.removeTaskFromBlock('task-2');
+    await taskTimerService.addTaskToBlock('task-3');
+
+    const activeBlock = await timeBlockService.loadActiveBlock();
+    expect(activeBlock?.taskIds).toEqual(['task-1', 'task-3']);
+    expect(activeBlock?.taskAssociationLog).toEqual(expect.arrayContaining([
+      expect.objectContaining({ taskId: 'task-1', action: 'associated', source: 'block_start' }),
+      expect.objectContaining({ taskId: 'task-2', action: 'associated', source: 'block_start' }),
+      expect.objectContaining({ taskId: 'task-2', action: 'disassociated', source: 'manual' }),
+      expect.objectContaining({ taskId: 'task-3', action: 'associated', source: 'manual' }),
+    ]));
+
+    await timeBlockService.markEnding();
+    const completedBlock = await timeBlockService.endBlock('完成多任务专注', {
+      taskStatusOutcomes: {
+        'task-1': 'completed',
+        'task-3': 'suspended',
+      },
+      taskTitles: {
+        'task-1': '任务一',
+        'task-3': '任务三',
+      },
+    });
+
+    expect(completedBlock?.taskIds).toEqual(['task-1', 'task-3']);
+    expect(completedBlock?.taskStatusOutcomes).toEqual({
+      'task-1': 'completed',
+      'task-3': 'suspended',
+    });
+    expect(completedBlock?.taskAssociationLog).toEqual(expect.arrayContaining([
+      expect.objectContaining({ taskId: 'task-2', action: 'disassociated' }),
+      expect.objectContaining({ taskId: 'task-3', action: 'associated' }),
+    ]));
+
+    await taskTimerService.onBlockEndForTasks(['task-1', 'task-3'], block!.startId);
+    await taskService.transitionTask('task-1', 'completed');
+    await taskService.transitionTask('task-3', 'suspended');
+
+    expect((await taskService.getTask('task-1'))?.timeBlockIds).toEqual([block!.startId]);
+    expect((await taskService.getTask('task-3'))?.timeBlockIds).toEqual([block!.startId]);
+    expect((await taskService.getTask('task-2'))?.timeBlockIds ?? []).toEqual([]);
+    expect((await taskService.getTask('task-1'))?.status).toBe('completed');
+    expect((await taskService.getTask('task-3'))?.status).toBe('suspended');
+    expect((await taskService.getTask('task-2'))?.status).toBe('in_progress');
+  });
+});

--- a/tests/unit/adapters/timeblock-rt-adapter.test.ts
+++ b/tests/unit/adapters/timeblock-rt-adapter.test.ts
@@ -35,6 +35,8 @@ describe('TimeBlockRtAdapter（RT 时间块适配器）', () => {
           tags: ['block_feedback'],
           startTime: 1700000000000,
           endTime: 1700000060000,
+          taskIds: [],
+          taskAssociationLog: [],
         },
       ]),
     }));
@@ -56,6 +58,8 @@ describe('TimeBlockRtAdapter（RT 时间块适配器）', () => {
         tags: ['block_feedback'],
         startTime: 1700000000000,
         endTime: 1700000060000,
+        taskIds: [],
+        taskAssociationLog: [],
       },
     ]);
     const [requestUrl] = fetchImpl.mock.calls[0] as [string, RequestInit];
@@ -92,6 +96,8 @@ describe('TimeBlockRtAdapter（RT 时间块适配器）', () => {
       elapsed: 300000,
       paused: false,
       startTime: 1700000000000,
+      taskIds: [],
+      taskAssociationLog: [],
     });
     await adapter.deleteActiveBlock();
 
@@ -108,6 +114,8 @@ describe('TimeBlockRtAdapter（RT 时间块适配器）', () => {
       elapsed: 300000,
       paused: false,
       startTime: 1700000000000,
+      taskIds: [],
+      taskAssociationLog: [],
     });
 
     const [deleteUrl, deleteInit] = fetchImpl.mock.calls[1] as [string, RequestInit];

--- a/tests/unit/app/now-workbench-overlay-main.transparent.test.tsx
+++ b/tests/unit/app/now-workbench-overlay-main.transparent.test.tsx
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const renderMock = vi.fn();
+const nowWorkbenchOverlayPageMock = vi.fn(() => null);
 const createRootMock = vi.fn(() => ({
   render: renderMock,
 }));
@@ -14,12 +15,17 @@ vi.mock('react-dom/client', () => ({
   createRoot: createRootMock,
 }));
 
+vi.mock('@/pages/NowWorkbenchOverlayPage', () => ({
+  NowWorkbenchOverlayPage: nowWorkbenchOverlayPageMock,
+}));
+
 describe('now-workbench-overlay main entry（当下工作台悬浮窗入口）', () => {
   beforeEach(() => {
     document.documentElement.removeAttribute('style');
     document.body.removeAttribute('style');
     document.body.innerHTML = '<div id="root"></div>';
     renderMock.mockReset();
+    nowWorkbenchOverlayPageMock.mockClear();
     createRootMock.mockClear();
   });
 
@@ -35,7 +41,7 @@ describe('now-workbench-overlay main entry（当下工作台悬浮窗入口）',
     expect(document.body.style.overflow).toBe('hidden');
     expect(createRootMock).toHaveBeenCalledTimes(1);
     expect(renderMock).toHaveBeenCalledTimes(1);
-  });
+  }, 15000);
 
   it('renders runtime overlay page instead of static preview props（入口不应写死静态预览数据）', async () => {
     await import('@/now-workbench-overlay-main');
@@ -49,7 +55,7 @@ describe('now-workbench-overlay main entry（当下工作台悬浮窗入口）',
     };
 
     expect(rootElement?.props?.children?.props).toEqual({});
-  });
+  }, 15000);
 
   it('keeps a tracked html entry for the overlay window（悬浮窗必须有独立 HTML 入口且不可被忽略）', () => {
     const htmlEntryPath = resolve(process.cwd(), 'now-workbench-overlay.html');

--- a/tests/unit/components/FocusTimerWidget.state-machine.issue175.test.tsx
+++ b/tests/unit/components/FocusTimerWidget.state-machine.issue175.test.tsx
@@ -1,6 +1,7 @@
 import React, { createRef } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { BlockTaskAssociationList } from '@/ui/app/components/BlockTaskAssociationList';
 import { FocusTimerWidget, type FocusTimerWidgetHandle } from '@/ui/app/components/FocusTimerWidget';
 
 function formatMinuteLabel(timestamp: number): string {
@@ -22,8 +23,11 @@ const onBlockChangeMock = vi.fn(() => () => {});
 const startSyncMock = vi.fn().mockResolvedValue(undefined);
 const stopSyncMock = vi.fn().mockResolvedValue(undefined);
 const getTaskMock = vi.fn();
+const listTasksMock = vi.fn();
 const transitionTaskMock = vi.fn();
-const onBlockEndForTaskMock = vi.fn();
+const addTaskToBlockMock = vi.fn();
+const removeTaskToBlockMock = vi.fn();
+const onBlockEndForTasksMock = vi.fn();
 let onBlockChangeHandler: ((block: unknown) => void) | null = null;
 let originalRequestAnimationFrame: typeof globalThis.requestAnimationFrame | undefined;
 let originalCancelAnimationFrame: typeof globalThis.cancelAnimationFrame | undefined;
@@ -43,10 +47,13 @@ vi.mock('@/lib/services', () => ({
   }),
   getTaskService: () => ({
     getTask: getTaskMock,
+    listTasks: listTasksMock,
     transitionTask: transitionTaskMock,
   }),
   getTaskTimerService: () => ({
-    onBlockEndForTask: onBlockEndForTaskMock,
+    addTaskToBlock: addTaskToBlockMock,
+    removeTaskFromBlock: removeTaskToBlockMock,
+    onBlockEndForTasks: onBlockEndForTasksMock,
   }),
 }));
 
@@ -73,11 +80,17 @@ describe('FocusTimerWidget state machine（新专注计时组件状态机）', (
     markEndingMock.mockResolvedValue(undefined);
     updateElapsedMock.mockResolvedValue(undefined);
     getTaskMock.mockReset();
+    listTasksMock.mockReset();
     transitionTaskMock.mockReset();
-    onBlockEndForTaskMock.mockReset();
+    addTaskToBlockMock.mockReset();
+    removeTaskToBlockMock.mockReset();
+    onBlockEndForTasksMock.mockReset();
     getTaskMock.mockResolvedValue(null);
+    listTasksMock.mockResolvedValue([]);
     transitionTaskMock.mockResolvedValue(null);
-    onBlockEndForTaskMock.mockResolvedValue(undefined);
+    addTaskToBlockMock.mockResolvedValue(undefined);
+    removeTaskToBlockMock.mockResolvedValue(undefined);
+    onBlockEndForTasksMock.mockResolvedValue(undefined);
     onBlockChangeHandler = null;
     onBlockChangeMock.mockReset();
     onBlockChangeMock.mockImplementation((handler: (block: unknown) => void) => {
@@ -463,18 +476,19 @@ describe('FocusTimerWidget state machine（新专注计时组件状态机）', (
       mode: 'countup',
       paused: false,
       phase: 'running',
-      taskId: 'task-1',
+      taskIds: ['task-1', 'task-2'],
+      taskAssociationLog: [],
     });
-    getTaskMock.mockResolvedValue({
-      id: 'task-1',
-      title: '关联任务',
+    getTaskMock.mockImplementation(async (taskId: string) => ({
+      id: taskId,
+      title: taskId === 'task-1' ? '关联任务一' : '关联任务二',
       status: 'in_progress',
       priority: 'medium',
       dependsOn: [],
       tags: [],
       createdAt: now - 20_000,
       updatedAt: now - 5_000,
-    });
+    }));
     endBlockMock.mockImplementation(async () => {
       onBlockChangeHandler?.(null);
       return null;
@@ -485,23 +499,28 @@ describe('FocusTimerWidget state machine（新专注计时组件状态机）', (
     await waitFor(() => {
       expect(screen.getByTestId('new-focus-state-running')).toBeInTheDocument();
       expect(getTaskMock).toHaveBeenCalledWith('task-1');
+      expect(getTaskMock).toHaveBeenCalledWith('task-2');
     });
 
     fireEvent.click(screen.getByTestId('new-focus-end-button'));
     await screen.findByTestId('new-focus-feedback-textarea');
     await waitFor(() => {
       expect(screen.getByTestId('feedback-task-status-section')).toBeInTheDocument();
+      expect(screen.getByTestId('feedback-task-status-row-task-1')).toBeInTheDocument();
+      expect(screen.getByTestId('feedback-task-status-row-task-2')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByTestId('feedback-task-status-completed'));
+    fireEvent.click(screen.getByTestId('feedback-task-status-task-1-completed'));
+    fireEvent.click(screen.getByTestId('feedback-task-status-task-2-cancelled'));
     fireEvent.change(screen.getByTestId('new-focus-feedback-textarea'), {
       target: { value: '结束并完成任务' },
     });
     fireEvent.click(screen.getByTestId('new-focus-feedback-confirm'));
 
     await waitFor(() => {
-      expect(onBlockEndForTaskMock).toHaveBeenCalledWith('task-1', 'block-task-1');
+      expect(onBlockEndForTasksMock).toHaveBeenCalledWith(['task-1', 'task-2'], 'block-task-1');
       expect(transitionTaskMock).toHaveBeenCalledWith('task-1', 'completed');
+      expect(transitionTaskMock).toHaveBeenCalledWith('task-2', 'cancelled');
     });
   });
 
@@ -515,7 +534,8 @@ describe('FocusTimerWidget state machine（新专注计时组件状态机）', (
       mode: 'countup' as const,
       paused: false,
       phase: 'running' as const,
-      taskId: 'task-async',
+      taskIds: ['task-async'],
+      taskAssociationLog: [],
     };
 
     loadActiveBlockMock.mockResolvedValueOnce(runningBlock);
@@ -556,7 +576,7 @@ describe('FocusTimerWidget state machine（新专注计时组件状态机）', (
       expect(screen.getByTestId('feedback-task-status-section')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByTestId('feedback-task-status-completed'));
+    fireEvent.click(screen.getByTestId('feedback-task-status-task-async-completed'));
 
     await act(async () => {
       resolveMarkEnding?.();
@@ -569,7 +589,7 @@ describe('FocusTimerWidget state machine（新专注计时组件状态机）', (
     fireEvent.click(screen.getByTestId('new-focus-feedback-confirm'));
 
     await waitFor(() => {
-      expect(onBlockEndForTaskMock).toHaveBeenCalledWith('task-async', 'block-task-async');
+      expect(onBlockEndForTasksMock).toHaveBeenCalledWith(['task-async'], 'block-task-async');
       expect(transitionTaskMock).toHaveBeenCalledWith('task-async', 'completed');
     });
   });

--- a/tests/unit/environment/bootstrap.test.ts
+++ b/tests/unit/environment/bootstrap.test.ts
@@ -14,12 +14,12 @@ describe('environment bootstrap', () => {
     expect(result.clipboard.constructor.name).toBe('WebClipboardAdapter');
     expect(result.storage.constructor.name).toBe('WebStorageAdapter');
     expect(result.eventlog.constructor.name).toBe('WebEventLogStorageAdapter');
-    expect(result.task.constructor.name).toBe('TaskPouchAdapter');
+    expect(result.task.constructor.name).toBe('TaskRtAdapter');
     expect(result.me.constructor.name).toBe('MeWebAdapter');
     expect(result.agent.constructor.name).toBe('AgentWebAdapter');
   });
 
-  it('createRuntimeBootstrap should use pouchdb eventlog adapter for tauri runtime', () => {
+  it('createRuntimeBootstrap should use RT adapters for tauri runtime by default', () => {
     const webResult = createRuntimeBootstrap({ runtime: 'web', useMockData: false });
     const tauriResult = createRuntimeBootstrap({ runtime: 'tauri', useMockData: false });
 
@@ -28,9 +28,9 @@ describe('environment bootstrap', () => {
     expect(tauriResult.clipboard.constructor.name).not.toBe(webResult.clipboard.constructor.name);
     expect(tauriResult.storage.constructor.name).toBe('TauriStorageAdapter');
     expect(tauriResult.storage.constructor.name).not.toBe(webResult.storage.constructor.name);
-    expect(tauriResult.eventlog.constructor.name).toBe('WebEventLogStorageAdapter');
-    expect(tauriResult.eventlog.constructor.name).toBe(webResult.eventlog.constructor.name);
-    expect(tauriResult.task.constructor.name).toBe('TaskPouchAdapter');
+    expect(tauriResult.eventlog.constructor.name).toBe('EventLogRtAdapter');
+    expect(tauriResult.eventlog.constructor.name).not.toBe(webResult.eventlog.constructor.name);
+    expect(tauriResult.task.constructor.name).toBe('TaskRtAdapter');
     expect(tauriResult.me.constructor.name).toBe('MeWebAdapter');
     expect(tauriResult.agent.constructor.name).toBe('AgentWebAdapter');
   });

--- a/tests/unit/environment/environment-mock-data-sync.issue204.test.ts
+++ b/tests/unit/environment/environment-mock-data-sync.issue204.test.ts
@@ -14,7 +14,7 @@ describe('environment mock-data sync issue-204（环境应在运行中同步 moc
     ExoMindEnvironment.resetForTests();
     const environmentBeforeToggle = ExoMindEnvironment.getInstance();
     expect(environmentBeforeToggle.agent.constructor.name).toBe('AgentWebAdapter');
-    expect(environmentBeforeToggle.task.constructor.name).toBe('TaskPouchAdapter');
+    expect(environmentBeforeToggle.task.constructor.name).toBe('TaskRtAdapter');
 
     window.localStorage.setItem('exomind:useMockData', 'true');
 

--- a/tests/unit/pr-lock-offline.test.ts
+++ b/tests/unit/pr-lock-offline.test.ts
@@ -53,7 +53,7 @@ describe('PR Lock - 降级路径测试', () => {
         lockComment!.body.match(/<!-- LOCK_METADATA\n([\s\S]*?)\n-->/)?.[1] || '{}'
       );
       expect(metadata.released).toBe(true);
-    });
+    }, 15000);
 
     test('本地状态 lock_id 不匹配时，应按 lock_id 查找并更新原始评论', async () => {
       // 1. Agent A 获取锁
@@ -82,7 +82,7 @@ describe('PR Lock - 降级路径测试', () => {
         lockComment!.body.match(/<!-- LOCK_METADATA\n([\s\S]*?)\n-->/)?.[1] || '{}'
       );
       expect(metadata.released).toBe(true);
-    });
+    }, 15000);
   });
 
   describe('场景 3: Local state missing（本地状态丢失）', () => {
@@ -113,7 +113,7 @@ describe('PR Lock - 降级路径测试', () => {
         lockComment!.body.match(/<!-- LOCK_METADATA\n([\s\S]*?)\n-->/)?.[1] || '{}'
       );
       expect(metadata.released).toBe(true);
-    });
+    }, 15000);
   });
 
   describe('场景 3.5: Renew metadata cleanliness（续期元数据清洁性）', () => {
@@ -161,7 +161,7 @@ describe('PR Lock - 降级路径测试', () => {
       expect(renewResult.lock!.expires_at).toBeDefined();
       expect(renewResult.lock!.remaining_minutes).toBeGreaterThan(0);
       expect(renewResult.lock!.is_expired).toBe(false);
-    });
+    }, 15000);
   });
 
   describe('场景 3.6: Release with no remote lock（远程锁不存在时释放）', () => {
@@ -185,7 +185,7 @@ describe('PR Lock - 降级路径测试', () => {
       // 5. 验证本地状态已被清理
       const localStateAfter = await agentA.loadLockState();
       expect(localStateAfter).toBeNull();
-    });
+    }, 15000);
   });
 
   describe('场景 4: Force release（强制释放）', () => {

--- a/tests/unit/scripts/tauri-dev-manager-lib.test.ts
+++ b/tests/unit/scripts/tauri-dev-manager-lib.test.ts
@@ -1,7 +1,12 @@
 import path from 'node:path';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { describe, expect, it } from 'vitest';
 import {
+  appendManagedTauriLogSessionStart,
   buildManagedTauriCommand,
+  collectManagedTauriCleanupPids,
+  evaluateManagedTauriInstanceHealth,
   resolveManagedTauriInstancePaths,
 } from '../../../Scripts/dev/tauri-dev-manager-lib';
 
@@ -44,5 +49,112 @@ describe('tauri-dev-manager-lib', () => {
     });
 
     expect(command).toContain('set "EXOMIND_TAURI_ENABLE_WATCH=1"');
+  });
+
+  it('appends a new manager session marker instead of truncating old logs（启动新会话应追加旧日志而不是覆盖）', async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'tauri-dev-manager-log-'));
+    const logPath = path.join(tempDir, 'desktop.log');
+
+    try {
+      await writeFile(logPath, 'previous line\n', 'utf8');
+      await appendManagedTauriLogSessionStart(logPath, {
+        name: 'desktop',
+        target: 'desktop',
+        webPort: 1420,
+        hmrPort: 1421,
+        startedAt: '2026-03-18T10:02:03.000Z',
+      });
+
+      const content = await readFile(logPath, 'utf8');
+      expect(content).toContain('previous line');
+      expect(content).toContain('manager session start');
+      expect(content).toContain('name=desktop');
+      expect(content).toContain('web=1420');
+      expect(content.indexOf('previous line')).toBeLessThan(content.indexOf('manager session start'));
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('marks desktop instances stale when the Tauri app process is gone even if web ports still listen（桌面窗口进程消失但端口残留时应判定为 stale）', () => {
+    const health = evaluateManagedTauriInstanceHealth(
+      {
+        name: 'desktop',
+        projectRoot: 'D:\\project\\exomind',
+        rootPid: 1234,
+        webPort: 1420,
+        hmrPort: 1421,
+        logPath: 'D:\\project\\exomind\\.tmp\\tauri-dev-instances\\desktop.log',
+        metaPath: 'D:\\project\\exomind\\.tmp\\tauri-dev-instances\\desktop.json',
+        startedAt: '2026-03-18T10:02:03.000Z',
+        enableWatch: false,
+        target: 'desktop',
+      },
+      {
+        rootPidAlive: true,
+        webPortListening: true,
+        hmrPortListening: true,
+        appProcessAlive: false,
+      },
+    );
+
+    expect(health.status).toBe('stale');
+    expect(health.detail).toContain('desktop app process missing');
+    expect(health.detail).toContain('web=1420');
+    expect(health.detail).toContain('hmr=1421');
+  });
+
+  it('keeps desktop instances running only when root pid app process and ports are all healthy（桌面实例需进程和端口都健康才算 running）', () => {
+    const health = evaluateManagedTauriInstanceHealth(
+      {
+        name: 'desktop',
+        projectRoot: 'D:\\project\\exomind',
+        rootPid: 1234,
+        webPort: 1420,
+        hmrPort: 1421,
+        logPath: 'D:\\project\\exomind\\.tmp\\tauri-dev-instances\\desktop.log',
+        metaPath: 'D:\\project\\exomind\\.tmp\\tauri-dev-instances\\desktop.json',
+        startedAt: '2026-03-18T10:02:03.000Z',
+        enableWatch: false,
+        target: 'desktop',
+      },
+      {
+        rootPidAlive: true,
+        webPortListening: true,
+        hmrPortListening: true,
+        appProcessAlive: true,
+      },
+    );
+
+    expect(health.status).toBe('running');
+    expect(health.detail).toBe('ok');
+  });
+
+  it('collects leftover listener pids when the root process already died（根进程已死时 stop 应回收残留监听进程）', () => {
+    const cleanupPids = collectManagedTauriCleanupPids(
+      {
+        name: 'desktop',
+        projectRoot: 'D:\\project\\exomind',
+        rootPid: 1234,
+        webPort: 1420,
+        hmrPort: 1421,
+        logPath: 'D:\\project\\exomind\\.tmp\\tauri-dev-instances\\desktop.log',
+        metaPath: 'D:\\project\\exomind\\.tmp\\tauri-dev-instances\\desktop.json',
+        startedAt: '2026-03-18T10:02:03.000Z',
+        enableWatch: false,
+        target: 'desktop',
+      },
+      {
+        rootPidAlive: false,
+        webPortListening: true,
+        hmrPortListening: true,
+        appProcessAlive: false,
+        webPortPids: [333436],
+        hmrPortPids: [333436],
+        appPids: [],
+      },
+    );
+
+    expect(cleanupPids).toEqual([333436]);
   });
 });

--- a/tests/unit/scripts/tauri-wrapper.test.ts
+++ b/tests/unit/scripts/tauri-wrapper.test.ts
@@ -76,7 +76,7 @@ describeWindowsOnly('tauri-wrapper', () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
-  });
+  }, 20000);
 
   it('injects isolated CARGO_TARGET_DIR for tauri dev（tauri dev 应注入独立构建目录）', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'tauri-wrapper-target-dir-'));
@@ -118,7 +118,7 @@ describeWindowsOnly('tauri-wrapper', () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
-  });
+  }, 20000);
 
   it('disables tauri watcher by default for dev（默认关闭 tauri watcher 避免无关改动触发黑屏重启）', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'tauri-wrapper-no-watch-'));
@@ -160,7 +160,7 @@ describeWindowsOnly('tauri-wrapper', () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
-  });
+  }, 20000);
 
   it('does not treat tauri stderr status lines as wrapper failure（tauri stderr 状态日志不应让包装脚本失败）', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'tauri-wrapper-stderr-status-'));
@@ -200,7 +200,7 @@ describeWindowsOnly('tauri-wrapper', () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
-  });
+  }, 20000);
 
   it('falls back to adb install for android dev install failures（android dev 安装失败时走 adb 兜底安装）', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'tauri-wrapper-android-fallback-'));
@@ -283,5 +283,5 @@ describeWindowsOnly('tauri-wrapper', () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
-  });
+  }, 20000);
 });

--- a/tests/unit/services/task-timer.issue337.test.ts
+++ b/tests/unit/services/task-timer.issue337.test.ts
@@ -5,6 +5,7 @@
  * - startBlockForTask 创建时间块并关联到任务
  * - startBlockForTask 自动将 pending 转为 in_progress
  * - onBlockEndForTask 追加 blockId 到 timeBlockIds
+ * - #418 多任务关联：批量启动 / 运行中增删 / 结束时按仍关联任务回写
  * - getBlockIdsForTask 返回已关联的时间块列表
  * - calculateSpentMinutes 正确累计
  * - 重复 blockId 不重复添加
@@ -45,6 +46,8 @@ function makeActiveBlock(overrides: Partial<ActiveBlockData> = {}): ActiveBlockD
     paused: false,
     phase: 'running',
     version: 1,
+    taskIds: [],
+    taskAssociationLog: [],
     ...overrides,
   }
 }
@@ -102,7 +105,37 @@ function createMockTBService(
   return {
     loadTimeBlocks: vi.fn(async () => completedBlocks),
     loadActiveBlock: vi.fn(async () => activeBlock),
-    startBlock: vi.fn(async (name: string, _config?: unknown, _desc?: string, taskId?: string) => makeActiveBlock({ name, startId: `block-${Date.now()}`, taskId })),
+    startBlock: vi.fn(async (
+      name: string,
+      _config?: unknown,
+      _desc?: string,
+      taskBinding?: string | { taskIds: string[] },
+    ) => {
+      const taskIds = typeof taskBinding === 'string'
+        ? [taskBinding]
+        : taskBinding?.taskIds ?? []
+      return makeActiveBlock({
+        name,
+        startId: `block-${Date.now()}`,
+        taskIds,
+        taskId: taskIds[0],
+        taskAssociationLog: taskIds.map((taskId) => ({
+          blockId: 'block-1',
+          taskId,
+          action: 'associated',
+          timestamp: Date.now(),
+          source: 'block_start',
+        })),
+      })
+    }),
+    updateActiveBlock: vi.fn(async (patch) => {
+      if (!activeBlock) return null
+      activeBlock = {
+        ...activeBlock,
+        ...patch,
+      }
+      return activeBlock
+    }),
     markEnding: vi.fn(async () => {}),
     endBlock: vi.fn(async () => null),
     pauseBlock: vi.fn(async () => {}),
@@ -117,7 +150,7 @@ function createMockTBService(
 /* ── tests ── */
 
 describe('TaskTimerService: startBlockForTask', () => {
-  it('creates time block and associates blockId to task', async () => {
+  it('creates time block with multi-task binding payload', async () => {
     const tasks = new Map([['t1', makeTask({ id: 't1', status: 'in_progress' })]])
     const taskSvc = createMockTaskService(tasks)
     const tbSvc = createMockTBService()
@@ -126,12 +159,9 @@ describe('TaskTimerService: startBlockForTask', () => {
     const block = await svc.startBlockForTask('t1', { mode: 'countup' })
 
     expect(block).not.toBeNull()
-    expect(tbSvc.startBlock).toHaveBeenCalledWith('Test Task', { mode: 'countup' }, undefined, 't1')
-    expect(block!.taskId).toBe('t1')
-    // Should update task with new blockId in timeBlockIds
-    expect(taskSvc.updateTask).toHaveBeenCalledWith('t1', {
-      timeBlockIds: [block!.startId],
-    })
+    expect(tbSvc.startBlock).toHaveBeenCalledWith('Test Task', { mode: 'countup' }, undefined, { taskIds: ['t1'] })
+    expect(block!.taskIds).toEqual(['t1'])
+    expect(taskSvc.updateTask).not.toHaveBeenCalled()
   })
 
   it('auto-transitions pending to in_progress', async () => {
@@ -326,5 +356,103 @@ describe('TaskTimerService: calculateSpentMinutes', () => {
 
     const result = await svc.calculateSpentMinutes('nope')
     expect(result).toBe(0)
+  })
+})
+
+describe('#418 multi-task association', () => {
+  it('startBlockForTasks associates multiple tasks', async () => {
+    const tasks = new Map([
+      ['task-1', makeTask({ id: 'task-1', title: 'Task 1', status: 'pending' })],
+      ['task-2', makeTask({ id: 'task-2', title: 'Task 2', status: 'pending' })],
+    ])
+    const taskSvc = createMockTaskService(tasks)
+    const tbSvc = createMockTBService()
+    const svc = new TaskTimerServiceImpl(taskSvc, tbSvc)
+
+    const block = await svc.startBlockForTasks(['task-1', 'task-2'])
+
+    expect(block).not.toBeNull()
+    expect(tbSvc.startBlock).toHaveBeenCalledWith('Task 1', { mode: 'countup' }, undefined, { taskIds: ['task-1', 'task-2'] })
+    expect(taskSvc.transitionTask).toHaveBeenCalledTimes(2)
+    expect(block?.taskIds).toEqual(['task-1', 'task-2'])
+  })
+
+  it('addTaskToBlock adds task to running block with audit log', async () => {
+    const tasks = new Map([
+      ['task-1', makeTask({ id: 'task-1', status: 'in_progress' })],
+      ['task-2', makeTask({ id: 'task-2', status: 'in_progress' })],
+    ])
+    const activeBlock = makeActiveBlock({
+      startId: 'block-live',
+      taskIds: ['task-1'],
+      taskAssociationLog: [],
+    })
+    const taskSvc = createMockTaskService(tasks)
+    const tbSvc = createMockTBService(activeBlock)
+    const svc = new TaskTimerServiceImpl(taskSvc, tbSvc)
+
+    await svc.addTaskToBlock('task-2')
+
+    expect(tbSvc.updateActiveBlock).toHaveBeenCalledWith(expect.objectContaining({
+      taskIds: ['task-1', 'task-2'],
+      taskAssociationLog: expect.arrayContaining([
+        expect.objectContaining({ taskId: 'task-2', action: 'associated', source: 'manual' }),
+      ]),
+    }))
+  })
+
+  it('removeTaskFromBlock removes task with disassociation log', async () => {
+    const tasks = new Map([
+      ['task-1', makeTask({ id: 'task-1', status: 'in_progress' })],
+      ['task-2', makeTask({ id: 'task-2', status: 'in_progress' })],
+    ])
+    const activeBlock = makeActiveBlock({
+      startId: 'block-live',
+      taskIds: ['task-1', 'task-2'],
+      taskAssociationLog: [],
+    })
+    const taskSvc = createMockTaskService(tasks)
+    const tbSvc = createMockTBService(activeBlock)
+    const svc = new TaskTimerServiceImpl(taskSvc, tbSvc)
+
+    await svc.removeTaskFromBlock('task-2')
+
+    expect(tbSvc.updateActiveBlock).toHaveBeenCalledWith(expect.objectContaining({
+      taskIds: ['task-1'],
+      taskAssociationLog: expect.arrayContaining([
+        expect.objectContaining({ taskId: 'task-2', action: 'disassociated', source: 'manual' }),
+      ]),
+    }))
+  })
+
+  it('onBlockEndForTasks only writes timeBlockIds for tasks still associated at end', async () => {
+    const tasks = new Map([
+      ['task-1', makeTask({ id: 'task-1', timeBlockIds: [] })],
+      ['task-2', makeTask({ id: 'task-2', timeBlockIds: [] })],
+    ])
+    const taskSvc = createMockTaskService(tasks)
+    const tbSvc = createMockTBService()
+    const svc = new TaskTimerServiceImpl(taskSvc, tbSvc)
+
+    await svc.onBlockEndForTasks(['task-1'], 'block-1')
+
+    expect(taskSvc.updateTask).toHaveBeenCalledWith('task-1', {
+      timeBlockIds: ['block-1'],
+    })
+    expect(taskSvc.updateTask).not.toHaveBeenCalledWith('task-2', expect.anything())
+  })
+
+  it('startBlockForTask delegates to startBlockForTasks', async () => {
+    const tasks = new Map([
+      ['task-1', makeTask({ id: 'task-1', status: 'pending' })],
+    ])
+    const taskSvc = createMockTaskService(tasks)
+    const tbSvc = createMockTBService()
+    const svc = new TaskTimerServiceImpl(taskSvc, tbSvc)
+
+    const block = await svc.startBlockForTask('task-1')
+
+    expect(block?.taskIds).toEqual(['task-1'])
+    expect(tbSvc.startBlock).toHaveBeenCalledWith('Test Task', { mode: 'countup' }, undefined, { taskIds: ['task-1'] })
   })
 })

--- a/tests/unit/services/timeblock.service.test.ts
+++ b/tests/unit/services/timeblock.service.test.ts
@@ -700,4 +700,129 @@ describe('TimeBlockServiceImpl', () => {
       'event-6',
     ]);
   });
+
+  describe('#418 multi-task support', () => {
+    it('startBlock accepts taskIds object', async () => {
+      const env = createMemoryEnv();
+      const service = new TimeBlockServiceImpl(env as never);
+
+      const block = await service.startBlock('Test', { mode: 'countup' }, undefined, { taskIds: ['t1', 't2'] });
+
+      expect(block.taskIds).toEqual(['t1', 't2']);
+      expect(block.taskAssociationLog).toHaveLength(2);
+      expect(block.taskId).toBeUndefined();
+    });
+
+    it('startBlock with legacy string taskId still works', async () => {
+      const env = createMemoryEnv();
+      const service = new TimeBlockServiceImpl(env as never);
+
+      const block = await service.startBlock('Test', { mode: 'countup' }, undefined, 'single-task');
+
+      expect(block.taskIds).toEqual(['single-task']);
+      expect(block.taskAssociationLog).toEqual([
+        expect.objectContaining({
+          taskId: 'single-task',
+          action: 'associated',
+          source: 'block_start',
+        }),
+      ]);
+    });
+
+    it('updateActiveBlock returns null when no active block exists', async () => {
+      const env = createMemoryEnv();
+      const service = new TimeBlockServiceImpl(env as never);
+
+      await expect(service.updateActiveBlock({ taskIds: ['t1'] })).resolves.toBeNull();
+    });
+
+    it('updateActiveBlock patches taskIds on running block', async () => {
+      const env = createMemoryEnv();
+      const service = new TimeBlockServiceImpl(env as never);
+
+      await service.startBlock('Test', { mode: 'countup' });
+      const updated = await service.updateActiveBlock({ taskIds: ['t1'] });
+
+      expect(updated?.taskIds).toEqual(['t1']);
+      expect((await service.loadActiveBlock())?.taskIds).toEqual(['t1']);
+    });
+
+    it('updateActiveBlock returns null for feedback-submitted block and does not resurrect it', async () => {
+      const env = createMemoryEnv();
+      const service = new TimeBlockServiceImpl(env as never);
+
+      await service.startBlock('Test', { mode: 'countup' });
+      await service.markEnding();
+      await service.endBlock('done');
+
+      await expect(service.updateActiveBlock({ taskIds: ['t1'] })).resolves.toBeNull();
+      await expect(service.loadActiveBlock()).resolves.toBeNull();
+    });
+
+    it('endBlock writes taskIds and taskStatusOutcomes to completed block', async () => {
+      const env = createMemoryEnv();
+      const service = new TimeBlockServiceImpl(env as never);
+
+      await service.startBlock('Test', { mode: 'countup' }, undefined, { taskIds: ['t1', 't2'] });
+      await service.markEnding();
+      const completed = await service.endBlock('done', {
+        taskStatusOutcomes: {
+          t1: 'completed',
+          t2: 'continue',
+        },
+        taskTitles: {
+          t1: 'Task 1',
+          t2: 'Task 2',
+        },
+      });
+
+      expect(completed).toEqual(expect.objectContaining({
+        taskIds: ['t1', 't2'],
+        taskStatusOutcomes: {
+          t1: 'completed',
+          t2: 'continue',
+        },
+      }));
+      expect(completed?.taskAssociationLog).toHaveLength(2);
+    });
+
+    it('buildFeedbackReport includes task status section', () => {
+      const env = createMemoryEnv();
+      const service = new TimeBlockServiceImpl(env as never);
+
+      const report = (service as unknown as {
+        buildFeedbackReport: (input: Record<string, unknown>) => string
+      }).buildFeedbackReport({
+        timeBlockName: 'Test Block',
+        feedbackText: 'done',
+        hasFeedback: true,
+        feedbackPreferences: {
+          timingInfoEnabled: false,
+          statisticsEnabled: false,
+          quickFeedbackEnabled: true,
+        },
+        feedbackDurationMs: 1_000,
+        pausedDurationMs: 0,
+        workDurationMs: 5_000,
+        totalDurationMs: 6_000,
+        expectedDurationMs: null,
+        expectedEndAt: null,
+        actionStartAt: 1_700_000_000_000,
+        actionEndedAt: 1_700_000_005_000,
+        submittedAt: 1_700_000_006_000,
+        taskStatusOutcomes: {
+          t1: 'completed',
+          t2: 'continue',
+        },
+        taskTitles: {
+          t1: 'Task 1',
+          t2: 'Task 2',
+        },
+      });
+
+      expect(report).toContain('### 任务状态');
+      expect(report).toContain('- Task 1：已完成');
+      expect(report).toContain('- Task 2：将继续');
+    });
+  });
 });

--- a/tests/unit/services/voice-shortcut.service.test.ts
+++ b/tests/unit/services/voice-shortcut.service.test.ts
@@ -695,6 +695,7 @@ describe('VoiceShortcutService（全局语音快捷键服务）', () => {
     window.localStorage.setItem(VOLCANO_STORAGE_KEYS.accessKey, 'test-access-key');
     window.localStorage.setItem(VOLCANO_STORAGE_KEYS.resourceId, 'volc.seedasr.sauc.duration');
 
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
     const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -704,11 +705,13 @@ describe('VoiceShortcutService（全局语音快捷键服务）', () => {
     await emitVoiceShortcut('start');
     await flushAsync();
 
+    expect(debugSpy).not.toHaveBeenCalled();
     expect(infoSpy).not.toHaveBeenCalled();
     expect(logSpy).not.toHaveBeenCalled();
     expect(warnSpy).not.toHaveBeenCalled();
 
     service.destroy();
+    debugSpy.mockRestore();
     infoSpy.mockRestore();
     logSpy.mockRestore();
     warnSpy.mockRestore();
@@ -722,7 +725,7 @@ describe('VoiceShortcutService（全局语音快捷键服务）', () => {
     window.localStorage.setItem(VOLCANO_STORAGE_KEYS.accessKey, 'test-access-key');
     window.localStorage.setItem(VOLCANO_STORAGE_KEYS.resourceId, 'volc.seedasr.sauc.duration');
 
-    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
 
     const service = new VoiceShortcutService();
     await service.init();
@@ -730,11 +733,11 @@ describe('VoiceShortcutService（全局语音快捷键服务）', () => {
     await flushAsync();
 
     expect(
-      infoSpy.mock.calls.some((call) => call.map(String).join(' ').includes('[trace voice-'))
+      debugSpy.mock.calls.some((call) => call.map(String).join(' ').includes('[trace voice-'))
     ).toBe(true);
 
     service.destroy();
-    infoSpy.mockRestore();
+    debugSpy.mockRestore();
   });
 
   it('rotates standby session before the idle window expires（待命会话在空闲窗口到期前主动轮换）', async () => {
@@ -831,7 +834,7 @@ describe('VoiceShortcutService（全局语音快捷键服务）', () => {
     window.localStorage.setItem(VOLCANO_STORAGE_KEYS.accessKey, 'test-access-key');
     window.localStorage.setItem(VOLCANO_STORAGE_KEYS.resourceId, 'volc.seedasr.sauc.duration');
 
-    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
     let now = 1000;
     const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
 
@@ -865,7 +868,7 @@ describe('VoiceShortcutService（全局语音快捷键服务）', () => {
     });
     await flushAsync();
 
-    const loggedMessages = infoSpy.mock.calls.map((call) => call.map(String).join(' '));
+    const loggedMessages = debugSpy.mock.calls.map((call) => call.map(String).join(' '));
     expect(
       loggedMessages.some((message) =>
         message.includes('standby prepared')
@@ -886,7 +889,7 @@ describe('VoiceShortcutService（全局语音快捷键服务）', () => {
 
     service.destroy();
     nowSpy.mockRestore();
-    infoSpy.mockRestore();
+    debugSpy.mockRestore();
   });
 
   it('recreates missing warmed volcano session before first start（warm session 已失效时首按自动重建）', async () => {

--- a/tests/unit/settings/settings-input-section.issue199.test.tsx
+++ b/tests/unit/settings/settings-input-section.issue199.test.tsx
@@ -74,8 +74,8 @@ describe('SettingsPage input section（输入分组语音配置）', () => {
     render(<SettingsPage />);
 
     expect(screen.getByText('MOSS 语音测试')).toBeInTheDocument();
-    expect(screen.getByText('火山引擎 ASR 测试')).toBeInTheDocument();
-    expect(screen.getAllByText('可用')).toHaveLength(2);
+    expect(screen.queryByText('火山引擎 ASR 测试')).not.toBeInTheDocument();
+    expect(screen.getAllByText('可用')).toHaveLength(1);
   });
 
   it('switches shortcut voice provider from input section', async () => {

--- a/tests/unit/sync/remote-url-wiring.test.ts
+++ b/tests/unit/sync/remote-url-wiring.test.ts
@@ -8,9 +8,10 @@ describe('eventlog sync remote url wiring', () => {
   const chatPage = readFileSync(chatPagePath, 'utf-8');
   const adapter = readFileSync(adapterPath, 'utf-8');
 
-  it('ChatPage should use shared remote DB URL builder', () => {
-    expect(chatPage).toContain("from '@/lib/sync/remote-db-url'");
-    expect(chatPage).toContain('buildRemoteDbUrl(');
+  it('ChatPage should read/write events through EventLogService', () => {
+    expect(chatPage).toContain("from '@/lib/services/eventlog.service'");
+    expect(chatPage).toContain('getEventLogService()');
+    expect(chatPage).toContain('loadEvents()');
   });
 
   it('PouchSyncAdapter should use shared remote DB URL builder', () => {
@@ -18,8 +19,10 @@ describe('eventlog sync remote url wiring', () => {
     expect(adapter).toContain('buildRemoteDbUrl(');
   });
 
-  it('ChatPage should not use legacy /database path prefix', () => {
+  it('ChatPage should not wire UI directly to legacy sync URL builders', () => {
     expect(chatPage).not.toContain('/database/');
+    expect(chatPage).not.toContain('buildRemoteDbUrl(');
+    expect(chatPage).not.toContain('resolveSyncServerUrl(');
   });
 
   it('PouchSyncAdapter should not use legacy /database path prefix', () => {

--- a/tests/unit/types/block-task-association.test.ts
+++ b/tests/unit/types/block-task-association.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeActiveBlockTaskIds,
+  normalizeTimeBlockTaskIds,
+  type BlockTaskAssociationEvent,
+} from '@/lib/types/event'
+
+describe('BlockTaskAssociationEvent type', () => {
+  it('can be constructed with required fields', () => {
+    const event: BlockTaskAssociationEvent = {
+      blockId: 'block-1',
+      taskId: 'task-1',
+      action: 'associated',
+      timestamp: Date.now(),
+      source: 'block_start',
+    }
+
+    expect(event.action).toBe('associated')
+    expect(event.source).toBe('block_start')
+  })
+})
+
+describe('normalizeActiveBlockTaskIds', () => {
+  it('converts legacy taskId to taskIds', () => {
+    const legacy = { taskId: 'task-1' } as const
+
+    const result = normalizeActiveBlockTaskIds(legacy)
+
+    expect(result.taskIds).toEqual(['task-1'])
+    expect(result.taskId).toBeUndefined()
+  })
+
+  it('preserves existing taskIds', () => {
+    const modern = { taskIds: ['task-1', 'task-2'] } as const
+
+    const result = normalizeActiveBlockTaskIds(modern)
+
+    expect(result.taskIds).toEqual(['task-1', 'task-2'])
+  })
+
+  it('defaults to empty array when no task fields', () => {
+    const empty = {} as const
+
+    const result = normalizeActiveBlockTaskIds(empty)
+
+    expect(result.taskIds).toEqual([])
+  })
+})
+
+describe('normalizeTimeBlockTaskIds', () => {
+  it('defaults to empty array when no taskIds', () => {
+    const block = { id: 'b1', name: 'test' } as const
+
+    const result = normalizeTimeBlockTaskIds(block)
+
+    expect(result.taskIds).toEqual([])
+  })
+
+  it('preserves existing taskIds', () => {
+    const block = { taskIds: ['t1', 't2'] } as const
+
+    const result = normalizeTimeBlockTaskIds(block)
+
+    expect(result.taskIds).toEqual(['t1', 't2'])
+  })
+})

--- a/tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx
+++ b/tests/unit/ui/agent-hub/agent-device-runtime-host.issue205.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { AgentsPage } from '@/ui/app/pages/AgentsPage';
 import { AGENT_HUB_MOCK_FIXTURE } from '@/lib/adapters/mock/fixtures/agent-hub';
@@ -47,6 +47,7 @@ vi.mock('@/lib/services/runtime-control.service', () => ({
 describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）', () => {
   let hosts: RuntimeHostRecord[];
   let hostState: Record<string, 'online' | 'offline' | 'error'>;
+  let fetchMock: ReturnType<typeof vi.fn>;
 
   const buildSnapshot = () => ({
     updatedAt: '2026-02-27T10:00:00.000Z',
@@ -85,6 +86,11 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
 
   beforeEach(() => {
     window.localStorage.clear();
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => [],
+    }));
+    vi.stubGlobal('fetch', fetchMock);
 
     hosts = [
       {
@@ -159,6 +165,10 @@ describe('agent device runtime host issue-205（设备页 RuntimeHost 管理）'
       host: '127.0.0.1',
       port: DEFAULT_EMBEDDED_RUNTIME_PORT,
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('opens manager sheet from device view and adds runtime host with host-only input（设备页支持 host-only 手工地址）', async () => {

--- a/tests/unit/ui/agent-hub/agents-page.energy.test.tsx
+++ b/tests/unit/ui/agent-hub/agents-page.energy.test.tsx
@@ -1,12 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
 import type { AgentEnergySnapshot } from '@/lib/types/agent-hub';
 import type { RuntimeAggregatedAgent } from '@/services/runtime-manager';
 import {
   buildListSectionsFromRuntimeAgents,
   ENERGY_PHASE_COLORS,
   mapRuntimeStatusToNodeStatus,
-} from '@/ui/app/pages/AgentsPage';
+} from '@/ui/app/pages/agents/agents-utils';
 
 vi.mock('@xyflow/react', () => ({
   ReactFlow: () => null,

--- a/tests/unit/ui/agent-hub/tiled-grid.quick-actions.issue523.test.tsx
+++ b/tests/unit/ui/agent-hub/tiled-grid.quick-actions.issue523.test.tsx
@@ -3,6 +3,10 @@ import { render, screen } from '@testing-library/react';
 import { TiledGrid } from '@/ui/app/pages/agents/TiledGrid';
 import type { SessionInfo } from '@/lib/types/session';
 
+vi.mock('@/ui/app/components/PtyTerminal', () => ({
+  PtyTerminal: () => <div data-testid="mock-pty-terminal">Mock PTY Terminal</div>,
+}));
+
 function buildSession(overrides: Partial<SessionInfo>): SessionInfo {
   return {
     id: 'session-523',

--- a/tests/unit/ui/focus-layout.issue175.test.ts
+++ b/tests/unit/ui/focus-layout.issue175.test.ts
@@ -6,14 +6,13 @@ describe('new focus layout issue-175 structure', () => {
   const focusPagePath = path.resolve('src/ui/app/pages/FocusPage.tsx');
   const source = readFileSync(focusPagePath, 'utf-8');
 
-  it('removes legacy top hero card and keeps only chat container（移除旧顶部卡片）', () => {
-    expect(source).not.toContain('data-testid="new-now-task-card-glow"');
-    expect(source).not.toContain('data-testid="new-now-task-card"');
-    expect(source).not.toContain('设计系统重构');
+  it('turns FocusPage into a thin shell over NowPage（FocusPage 退化为 NowPage 壳层）', () => {
+    expect(source).toContain("import { NowPage } from './NowPage'");
+    expect(source).toContain('return <NowPage />');
   });
 
-  it('uses new-mobile chat variant consistently（当下页统一使用新移动端聊天样式）', () => {
-    expect(source).toContain('data-testid="new-now-chat-section"');
-    expect(source).toContain('<ChatPage variant="new-mobile" hideHeader />');
+  it('no longer renders ChatPage directly inside FocusPage（FocusPage 不再直接渲染 ChatPage）', () => {
+    expect(source).not.toContain('data-testid="new-now-chat-section"');
+    expect(source).not.toContain('<ChatPage variant="new-mobile" hideHeader />');
   });
 });

--- a/tests/unit/ui/focus-widget-wiring.issue175.test.ts
+++ b/tests/unit/ui/focus-widget-wiring.issue175.test.ts
@@ -6,8 +6,14 @@ describe('new focus timer widget wiring issue-175（新专注计时组件接线�
   const chatPagePath = path.resolve('src/components/Chat/ChatPage.tsx');
   const source = readFileSync(chatPagePath, 'utf-8');
 
-  it('uses FocusTimerWidget for new-mobile variant（新移动端改用新组件）', () => {
+  it('adds showTimerWidget prop for new-mobile record tab reuse（为记录 Tab 复用增加 showTimerWidget 开关）', () => {
+    expect(source).toContain('showTimerWidget?: boolean');
+    expect(source).toContain('showTimerWidget = true');
+  });
+
+  it('uses FocusTimerWidget for new-mobile variant only when enabled（新移动端仅在开启时渲染新组件）', () => {
     expect(source).toContain("import { FocusTimerWidget");
+    expect(source).toContain("variant === 'new-mobile' && showTimerWidget ? (");
     expect(source).toContain('<FocusTimerWidget ref={focusTimerWidgetRef} />');
   });
 

--- a/tests/unit/ui/now-input-row.test.tsx
+++ b/tests/unit/ui/now-input-row.test.tsx
@@ -192,7 +192,7 @@ describe('NowInputRow', () => {
       getLatestVoiceProps()?.onResult?.('  直接发送内容  ');
     });
 
-    expect(onSend).toHaveBeenCalledWith('直接发送内容');
+    expect(onSend).toHaveBeenCalledWith('直接发送内容', ['voice']);
     expect((textarea as HTMLTextAreaElement).value).toBe('');
   });
 

--- a/tests/unit/ui/now-today-blocks-view.issue516.test.ts
+++ b/tests/unit/ui/now-today-blocks-view.issue516.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import type { TaskNode } from '@/lib/types/task'
+import type { TimeBlock } from '@/lib/types/event'
+
+function createTask(input: Partial<TaskNode> & Pick<TaskNode, 'id' | 'title' | 'status'>): TaskNode {
+  const now = Date.UTC(2026, 2, 18, 9, 0, 0)
+  return {
+    id: input.id,
+    title: input.title,
+    status: input.status,
+    priority: input.priority ?? 'medium',
+    dependsOn: input.dependsOn ?? [],
+    tags: input.tags ?? [],
+    createdAt: input.createdAt ?? now,
+    updatedAt: input.updatedAt ?? now,
+    timeBlockIds: input.timeBlockIds,
+    description: input.description,
+    estimatedMinutes: input.estimatedMinutes,
+    completedAt: input.completedAt,
+    dueAt: input.dueAt,
+    source: input.source,
+    parentId: input.parentId,
+    doneCondition: input.doneCondition,
+  }
+}
+
+function createBlock(input: Partial<TimeBlock> & Pick<TimeBlock, 'id' | 'name' | 'startId' | 'endId' | 'startTime' | 'endTime'>): TimeBlock {
+  return {
+    id: input.id,
+    name: input.name,
+    startId: input.startId,
+    endId: input.endId,
+    startTime: input.startTime,
+    endTime: input.endTime,
+    tags: input.tags ?? new Set(['block_feedback']),
+    note: input.note,
+    taskIds: input.taskIds,
+    taskStatusOutcomes: input.taskStatusOutcomes,
+    taskAssociationLog: input.taskAssociationLog,
+  }
+}
+
+describe('buildNowTodayBlocksView（今日 Tab 时间块视图模型）', () => {
+  it('sorts today blocks by startTime desc and uses block title as primary text（按开始时间倒序且以时间块为主标题）', async () => {
+    const module = await import('@/ui/app/pages/now-today-blocks-view')
+    const view = module.buildNowTodayBlocksView({
+      now: new Date('2026-03-18T20:00:00+08:00'),
+      blocks: [
+        createBlock({
+          id: 'block-1',
+          startId: 'block-1',
+          endId: 'end-1',
+          name: '上午深度开发',
+          startTime: new Date('2026-03-18T09:00:00+08:00').getTime(),
+          endTime: new Date('2026-03-18T10:00:00+08:00').getTime(),
+          taskIds: ['task-1'],
+        }),
+        createBlock({
+          id: 'block-2',
+          startId: 'block-2',
+          endId: 'end-2',
+          name: '下午联调',
+          startTime: new Date('2026-03-18T15:00:00+08:00').getTime(),
+          endTime: new Date('2026-03-18T16:00:00+08:00').getTime(),
+          taskIds: ['task-2', 'task-3'],
+        }),
+      ],
+      tasksById: new Map([
+        ['task-1', createTask({ id: 'task-1', title: '任务一', status: 'completed' })],
+        ['task-2', createTask({ id: 'task-2', title: '任务二', status: 'in_progress' })],
+        ['task-3', createTask({ id: 'task-3', title: '任务三', status: 'pending' })],
+      ]),
+    })
+
+    expect(view.items.map((item: { blockId: string }) => item.blockId)).toEqual(['block-2', 'block-1'])
+    expect(view.items[0]?.title).toBe('下午联调')
+    expect(view.items[0]?.href).toBe('/tasks/block/block-2')
+  })
+
+  it('only includes blocks started today and exposes linked task outcomes（仅保留今日时间块并展开关联任务结果）', async () => {
+    const module = await import('@/ui/app/pages/now-today-blocks-view')
+    const view = module.buildNowTodayBlocksView({
+      now: new Date('2026-03-18T20:00:00+08:00'),
+      blocks: [
+        createBlock({
+          id: 'block-old',
+          startId: 'block-old',
+          endId: 'end-old',
+          name: '昨天的块',
+          startTime: new Date('2026-03-17T23:00:00+08:00').getTime(),
+          endTime: new Date('2026-03-18T00:00:00+08:00').getTime(),
+          taskIds: ['task-old'],
+        }),
+        createBlock({
+          id: 'block-today',
+          startId: 'block-today',
+          endId: 'end-today',
+          name: '今天的块',
+          startTime: new Date('2026-03-18T11:00:00+08:00').getTime(),
+          endTime: new Date('2026-03-18T12:00:00+08:00').getTime(),
+          taskIds: ['task-a', 'task-b'],
+          taskStatusOutcomes: {
+            'task-a': 'completed',
+          },
+        }),
+      ],
+      tasksById: new Map([
+        ['task-a', createTask({ id: 'task-a', title: '任务甲', status: 'completed' })],
+        ['task-b', createTask({ id: 'task-b', title: '任务乙', status: 'in_progress' })],
+      ]),
+    })
+
+    expect(view.items).toHaveLength(1)
+    expect(view.items[0]?.linkedTasks).toEqual([
+      { taskId: 'task-a', title: '任务甲', outcome: 'completed' },
+      { taskId: 'task-b', title: '任务乙', outcome: undefined },
+    ])
+  })
+})

--- a/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
+++ b/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
@@ -311,4 +311,25 @@ describe('TaskDetailPage timeblock detail layout（时间块详情布局）', ()
       expect(startBlockForTaskMock).toHaveBeenCalledWith('task-2', { mode: 'countdown', minutes: 30 });
     });
   });
+
+  it('recognizes active block through taskIds includes（通过 taskIds.includes 识别当前任务的活跃时间块）', async () => {
+    loadActiveBlockMock.mockResolvedValue({
+      startId: 'active-1',
+      name: '多任务块',
+      mode: 'countup',
+      startTime: new Date('2026-03-06T09:00:00+08:00').getTime(),
+      elapsed: 15 * 60 * 1000,
+      paused: false,
+      phase: 'running',
+      version: 1,
+      taskIds: ['task-1'],
+      taskAssociationLog: [],
+    });
+    mockMatchMedia(false);
+    render(<TaskDetailPage />);
+
+    await screen.findByText('时间块详情');
+
+    expect(await screen.findByTestId('task-pause-button')).toHaveTextContent('暂停并前往当下');
+  });
 });

--- a/tests/unit/ui/task-timeblock-detail-view.test.ts
+++ b/tests/unit/ui/task-timeblock-detail-view.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { TaskNode } from '@/lib/types/task';
-import type { TimeBlock } from '@/lib/types/event';
+import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
 import { buildTaskTimeblockDetailViewModel } from '@/ui/app/pages/task-timeblock-detail-view';
 
 function makeTask(overrides: Partial<TaskNode> & { id: string; title: string }): TaskNode {
@@ -30,6 +30,33 @@ function makeBlock(overrides: Partial<TimeBlock> & { id: string; name: string; s
     tags: overrides.tags ?? new Set(['block_feedback']),
     startTime: overrides.startTime,
     endTime: overrides.endTime,
+  };
+}
+
+function makeActiveBlock(overrides: Partial<ActiveBlockData> = {}): ActiveBlockData {
+  return {
+    startId: overrides.startId ?? 'active-block',
+    name: overrides.name ?? '进行中时间块',
+    mode: overrides.mode ?? 'countup',
+    startTime: overrides.startTime ?? Date.now(),
+    elapsed: overrides.elapsed ?? 20 * 60 * 1000,
+    paused: overrides.paused ?? false,
+    phase: overrides.phase ?? 'running',
+    version: overrides.version ?? 1,
+    taskIds: overrides.taskIds ?? [],
+    taskAssociationLog: overrides.taskAssociationLog ?? [],
+    taskId: overrides.taskId,
+    updatedAt: overrides.updatedAt,
+    actorId: overrides.actorId,
+    lastTransitionAt: overrides.lastTransitionAt,
+    lastResumedAt: overrides.lastResumedAt,
+    accumulatedRunMs: overrides.accumulatedRunMs,
+    actionEndedAt: overrides.actionEndedAt,
+    feedbackStartedAt: overrides.feedbackStartedAt,
+    feedbackSubmittedAt: overrides.feedbackSubmittedAt,
+    pauseAccumulatedMs: overrides.pauseAccumulatedMs,
+    pausedAt: overrides.pausedAt,
+    targetMinutes: overrides.targetMinutes,
   };
 }
 
@@ -193,5 +220,30 @@ describe('buildTaskTimeblockDetailViewModel（时间块详情视图模型）', (
 
     expect(model.timeline.items.map((item) => item.title)).toEqual(['开始时间块', '事件记录', '结束时间块']);
     expect(model.timeline.items[1].description).toContain('处理中途阻塞');
+  });
+
+  it('treats active block taskIds as linked to the task（activeBlock.taskIds 包含任务时应识别为当前任务时间块）', () => {
+    const task = makeTask({
+      id: 'task-active',
+      title: '处理 activeBlock 多任务兼容',
+      estimatedMinutes: 30,
+    });
+
+    const model = buildTaskTimeblockDetailViewModel({
+      task,
+      blocks: [],
+      activeBlock: makeActiveBlock({
+        startId: 'active-block-1',
+        name: '进行中的多任务块',
+        startTime: start,
+        taskIds: ['task-active'],
+      }),
+      now: new Date(end),
+      reviewMarkdown: '',
+      useMockData: true,
+    });
+
+    expect(model.summary.blockName).toBe('进行中的多任务块');
+    expect(model.summary.metrics.find((item) => item.key === 'duration')?.value).toBe('1h 30m');
   });
 });

--- a/tests/unit/ui/tasks-today-timeblock-view.test.ts
+++ b/tests/unit/ui/tasks-today-timeblock-view.test.ts
@@ -1,6 +1,6 @@
 ﻿import { describe, expect, it } from 'vitest';
 import type { TaskNode } from '@/lib/types/task';
-import type { TimeBlock } from '@/lib/types/event';
+import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
 import { buildTasksTodayViewModel } from '@/ui/app/pages/tasks-today-view';
 
 function makeTask(overrides: Partial<TaskNode> & { id: string; title: string }): TaskNode {
@@ -28,6 +28,33 @@ function makeBlock(overrides: Partial<TimeBlock> & { id: string; name: string; s
     tags: overrides.tags ?? new Set(['block_feedback']),
     startTime: overrides.startTime,
     endTime: overrides.endTime,
+  };
+}
+
+function makeActiveBlock(overrides: Partial<ActiveBlockData> = {}): ActiveBlockData {
+  return {
+    startId: overrides.startId ?? 'active-block-1',
+    name: overrides.name ?? '进行中的时间块',
+    mode: overrides.mode ?? 'countup',
+    startTime: overrides.startTime ?? Date.now(),
+    elapsed: overrides.elapsed ?? 15 * 60 * 1000,
+    paused: overrides.paused ?? false,
+    phase: overrides.phase ?? 'running',
+    version: overrides.version ?? 1,
+    taskIds: overrides.taskIds ?? [],
+    taskAssociationLog: overrides.taskAssociationLog ?? [],
+    taskId: overrides.taskId,
+    updatedAt: overrides.updatedAt,
+    actorId: overrides.actorId,
+    lastTransitionAt: overrides.lastTransitionAt,
+    lastResumedAt: overrides.lastResumedAt,
+    accumulatedRunMs: overrides.accumulatedRunMs,
+    actionEndedAt: overrides.actionEndedAt,
+    feedbackStartedAt: overrides.feedbackStartedAt,
+    feedbackSubmittedAt: overrides.feedbackSubmittedAt,
+    pauseAccumulatedMs: overrides.pauseAccumulatedMs,
+    pausedAt: overrides.pausedAt,
+    targetMinutes: overrides.targetMinutes,
   };
 }
 
@@ -103,6 +130,36 @@ describe('buildTasksTodayViewModel（任务页 today 时间块视图模型）', 
       timeLabel: '09:00 - 10:30',
       note: '顺利完成，比预期快 30 分钟',
       meta: '预计 2h',
+    });
+  });
+
+  it('resolves active block task association through taskIds（进行中时间块通过 taskIds 反查任务）', () => {
+    const model = buildTasksTodayViewModel({
+      tasks: [
+        makeTask({
+          id: 'task-1',
+          title: '联调当下页读路径',
+          status: 'in_progress',
+          estimatedMinutes: 45,
+        }),
+      ],
+      blocks: [],
+      now: today,
+      activeBlock: makeActiveBlock({
+        startId: 'active-taskids',
+        name: '多任务专注块',
+        startTime: morning,
+        taskIds: ['task-1'],
+      }),
+    });
+
+    expect(model.timelineSections).toHaveLength(1);
+    expect(model.timelineSections[0].items[0]).toMatchObject({
+      taskId: 'task-1',
+      title: '联调当下页读路径',
+      tagLabel: '进行中',
+      timeLabel: '09:00 - 进行中',
+      meta: '预计 45min',
     });
   });
 });

--- a/tests/unit/ui/timeblock-detail-view.issue418.test.ts
+++ b/tests/unit/ui/timeblock-detail-view.issue418.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import type { TaskNode } from '@/lib/types/task'
+import type { TimeBlock } from '@/lib/types/event'
+
+function createTask(input: Partial<TaskNode> & Pick<TaskNode, 'id' | 'title' | 'status'>): TaskNode {
+  const now = Date.UTC(2026, 2, 18, 9, 0, 0)
+  return {
+    id: input.id,
+    title: input.title,
+    status: input.status,
+    priority: input.priority ?? 'medium',
+    dependsOn: input.dependsOn ?? [],
+    tags: input.tags ?? [],
+    createdAt: input.createdAt ?? now,
+    updatedAt: input.updatedAt ?? now,
+    timeBlockIds: input.timeBlockIds,
+    description: input.description,
+    estimatedMinutes: input.estimatedMinutes,
+    completedAt: input.completedAt,
+    dueAt: input.dueAt,
+    source: input.source,
+    parentId: input.parentId,
+    doneCondition: input.doneCondition,
+  }
+}
+
+function createBlock(): TimeBlock {
+  return {
+    id: 'block-1',
+    name: '多任务专注块',
+    startId: 'block-1',
+    endId: 'end-1',
+    note: '完成了核心联调',
+    tags: new Set(['block_feedback']),
+    startTime: Date.UTC(2026, 2, 18, 9, 0, 0),
+    endTime: Date.UTC(2026, 2, 18, 10, 30, 0),
+    taskIds: ['task-1', 'task-2'],
+    taskStatusOutcomes: {
+      'task-1': 'completed',
+      'task-2': 'continue',
+    },
+    taskAssociationLog: [
+      {
+        blockId: 'block-1',
+        taskId: 'task-1',
+        action: 'associated',
+        timestamp: Date.UTC(2026, 2, 18, 9, 0, 0),
+        source: 'block_start',
+      },
+      {
+        blockId: 'block-1',
+        taskId: 'task-2',
+        action: 'associated',
+        timestamp: Date.UTC(2026, 2, 18, 9, 10, 0),
+        source: 'manual',
+      },
+      {
+        blockId: 'block-1',
+        taskId: 'task-2',
+        action: 'disassociated',
+        timestamp: Date.UTC(2026, 2, 18, 10, 0, 0),
+        source: 'manual',
+      },
+    ],
+  }
+}
+
+describe('buildTimeBlockDetailView（时间块详情视图模型）', () => {
+  it('expands summary, linked tasks and association timeline（展开概览、关联任务和关联日志）', async () => {
+    const module = await import('@/ui/app/pages/timeblock-detail-view')
+    const view = module.buildTimeBlockDetailView({
+      block: createBlock(),
+      tasksById: new Map([
+        ['task-1', createTask({ id: 'task-1', title: '任务一', status: 'completed' })],
+        ['task-2', createTask({ id: 'task-2', title: '任务二', status: 'in_progress' })],
+      ]),
+    })
+
+    expect(view.summary.title).toBe('多任务专注块')
+    expect(view.summary.feedback).toBe('完成了核心联调')
+    expect(view.linkedTasks).toEqual([
+      { taskId: 'task-1', title: '任务一', outcome: 'completed' },
+      { taskId: 'task-2', title: '任务二', outcome: 'continue' },
+    ])
+    expect(view.associationTimeline.map((item: { action: string }) => item.action)).toEqual([
+      'associated',
+      'associated',
+      'disassociated',
+    ])
+  })
+
+  it('falls back to task id when task title is missing（缺少任务标题时回退到 taskId）', async () => {
+    const module = await import('@/ui/app/pages/timeblock-detail-view')
+    const view = module.buildTimeBlockDetailView({
+      block: createBlock(),
+      tasksById: new Map(),
+    })
+
+    expect(view.linkedTasks[0]).toEqual({
+      taskId: 'task-1',
+      title: 'task-1',
+      outcome: 'completed',
+    })
+  })
+})

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "astro/tsconfigs/strict"
+  "extends": "./node_modules/astro/tsconfigs/strict.json"
 }


### PR DESCRIPTION
## 摘要
- 通过引入 `taskIds[]`、`taskAssociationLog`、结构化结束反馈，以及与 Rust / SQLite Runtime 持久化对齐，解除时间块与单任务的强绑定。
- 将当下页重构为 `专注 / 记录 / 今日` 三个 Tab；保留 `记录` 页签上的记录输入区，不再在该路径展示计时器，并新增以时间块为主的详情页。
- 为多任务关联、今日 Tab 渲染、时间块详情视图以及相关 Windows 易波动测试补齐集成、单测与 Playwright 覆盖。

## 测试计划
- [x] `bunx vitest run --reporter=json --outputFile .tmp/vitest-full-final-3.json`
- [x] `bunx tsc --noEmit`
- [x] `cargo test -p exomind-runtime`
- [x] `bun run build`
- [x] `bun run test:e2e:issue418-516`
- [x] `bun run tauri:manager -- start --name issue418516-desktop --web-port 1590 --hmr-port 1591`
- [x] Tauri MCP 桌面端桥接 `9226` 实机验证：创建本地档案，验证 `专注 / 记录 / 今日` 三个 Tab，确认 `记录` 页不展示计时器，确认 `今日` 页以时间块视图为主，并打开 `/tasks/block/issue418516-desktop-block-1` 验证关联任务与关联日志在真实桌面窗口中的表现。
