### PR TITLE
feat(runtime): 外部输入管线接入信号池

### DIFF
--- a/Scripts/dev/tauri-dev-manager-lib.ts
+++ b/Scripts/dev/tauri-dev-manager-lib.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { appendFile, mkdir } from 'node:fs/promises';
 import { resolveTauriDevInstanceName } from './tauri-dev-target-dir-lib';
 
 export type ManagedTauriInstancePaths = {
@@ -21,6 +22,29 @@ export type ManagedTauriInstanceRecord = {
   startedAt: string;
   enableWatch: boolean;
   target: TauriDevTarget;
+};
+
+export type ManagedTauriLogSessionStart = {
+  name: string;
+  target: TauriDevTarget;
+  webPort: number;
+  hmrPort: number;
+  startedAt: string;
+};
+
+export type ManagedTauriInstanceHealthSnapshot = {
+  rootPidAlive: boolean;
+  webPortListening: boolean;
+  hmrPortListening: boolean;
+  appProcessAlive?: boolean;
+  webPortPids?: number[];
+  hmrPortPids?: number[];
+  appPids?: number[];
+};
+
+export type ManagedTauriInstanceHealth = {
+  status: 'running' | 'degraded' | 'stale';
+  detail: string;
 };
 
 export type BuildManagedTauriCommandInput = {
@@ -70,4 +94,109 @@ export function buildManagedTauriCommand(input: BuildManagedTauriCommandInput): 
   );
 
   return commands.join(' && ');
+}
+
+function collectListeningPortLabels(
+  record: ManagedTauriInstanceRecord,
+  snapshot: ManagedTauriInstanceHealthSnapshot,
+): string[] {
+  const labels: string[] = [];
+  if (snapshot.webPortListening) {
+    labels.push(`web=${record.webPort}`);
+  }
+  if (snapshot.hmrPortListening) {
+    labels.push(`hmr=${record.hmrPort}`);
+  }
+  return labels;
+}
+
+function uniquePositivePids(values: Array<number | undefined>): number[] {
+  return [...new Set(values.filter((value): value is number => Number.isInteger(value) && value > 0))];
+}
+
+export function formatManagedTauriLogSessionStart(input: ManagedTauriLogSessionStart): string {
+  const timestamp = input.startedAt.trim();
+  return [
+    '',
+    `===== manager session start [${timestamp}] name=${input.name} target=${input.target} web=${input.webPort} hmr=${input.hmrPort} =====`,
+    '',
+  ].join('\n');
+}
+
+export async function appendManagedTauriLogSessionStart(
+  logPath: string,
+  input: ManagedTauriLogSessionStart,
+): Promise<void> {
+  await mkdir(path.dirname(logPath), { recursive: true });
+  await appendFile(logPath, formatManagedTauriLogSessionStart(input), 'utf8');
+}
+
+export function evaluateManagedTauriInstanceHealth(
+  record: ManagedTauriInstanceRecord,
+  snapshot: ManagedTauriInstanceHealthSnapshot,
+): ManagedTauriInstanceHealth {
+  const listeningLabels = collectListeningPortLabels(record, snapshot);
+
+  if (!snapshot.rootPidAlive) {
+    if (listeningLabels.length > 0) {
+      return {
+        status: 'stale',
+        detail: `root pid exited; lingering listeners: ${listeningLabels.join(', ')}`,
+      };
+    }
+
+    return {
+      status: 'stale',
+      detail: 'root pid exited',
+    };
+  }
+
+  if (record.target === 'desktop' && snapshot.appProcessAlive === false) {
+    if (listeningLabels.length > 0) {
+      return {
+        status: 'stale',
+        detail: `desktop app process missing; lingering listeners: ${listeningLabels.join(', ')}`,
+      };
+    }
+
+    return {
+      status: 'stale',
+      detail: 'desktop app process missing',
+    };
+  }
+
+  const missingLabels: string[] = [];
+  if (!snapshot.webPortListening) {
+    missingLabels.push(`web=${record.webPort}`);
+  }
+  if (!snapshot.hmrPortListening) {
+    missingLabels.push(`hmr=${record.hmrPort}`);
+  }
+
+  if (missingLabels.length > 0) {
+    return {
+      status: 'degraded',
+      detail: `missing listeners: ${missingLabels.join(', ')}`,
+    };
+  }
+
+  return {
+    status: 'running',
+    detail: 'ok',
+  };
+}
+
+export function collectManagedTauriCleanupPids(
+  record: ManagedTauriInstanceRecord,
+  snapshot: ManagedTauriInstanceHealthSnapshot,
+): number[] {
+  if (snapshot.rootPidAlive) {
+    return uniquePositivePids([record.rootPid]);
+  }
+
+  return uniquePositivePids([
+    ...(snapshot.webPortPids ?? []),
+    ...(snapshot.hmrPortPids ?? []),
+    ...(snapshot.appPids ?? []),
+  ]);
 }

--- a/Scripts/dev/tauri-dev-manager.ts
+++ b/Scripts/dev/tauri-dev-manager.ts
@@ -5,7 +5,11 @@ import { createServer } from 'node:net';
 import { access, mkdir, open, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import {
+  appendManagedTauriLogSessionStart,
+  collectManagedTauriCleanupPids,
+  evaluateManagedTauriInstanceHealth,
   resolveManagedTauriInstancePaths,
+  type ManagedTauriInstanceHealthSnapshot,
   type ManagedTauriInstanceRecord,
   type TauriDevTarget,
 } from './tauri-dev-manager-lib';
@@ -19,6 +23,19 @@ type ParsedArgs = {
 
 const PROJECT_ROOT = process.cwd();
 const DEFAULT_WEB_PORT = 1420;
+const WINDOWS_TOOL_PROCESS_NAMES = new Set(['bun.exe', 'cargo.exe', 'node.exe', 'vite.exe']);
+const desktopProcessNameCache = new Map<string, Promise<string | null>>();
+
+type WindowsProcessInfo = {
+  ProcessId: number;
+  ParentProcessId: number;
+  Name: string;
+};
+
+type PortListenerInfo = {
+  LocalPort: number;
+  OwningProcess: number;
+};
 
 function printUsage(): never {
   console.log(`Usage:
@@ -171,6 +188,171 @@ function escapePowerShellLiteral(value: string): string {
   return value.replaceAll("'", "''");
 }
 
+function normalizeJsonArray<T>(value: T | T[] | null | undefined): T[] {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function runPowerShellJson<T>(script: string): T[] {
+  const result = spawnSync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-Command',
+      script,
+    ],
+    {
+      cwd: PROJECT_ROOT,
+      encoding: 'utf8',
+      windowsHide: true,
+    },
+  );
+
+  if (result.status !== 0) {
+    const stderr = result.stderr?.trim();
+    const stdout = result.stdout?.trim();
+    throw new Error(stderr || stdout || 'powershell health probe failed');
+  }
+
+  const raw = result.stdout.trim();
+  if (!raw) {
+    return [];
+  }
+
+  return normalizeJsonArray(JSON.parse(raw) as T | T[] | null);
+}
+
+function getDescendantProcesses(processes: WindowsProcessInfo[], rootPid: number): WindowsProcessInfo[] {
+  const childrenByParent = new Map<number, WindowsProcessInfo[]>();
+  for (const processInfo of processes) {
+    const siblings = childrenByParent.get(processInfo.ParentProcessId) ?? [];
+    siblings.push(processInfo);
+    childrenByParent.set(processInfo.ParentProcessId, siblings);
+  }
+
+  const descendants: WindowsProcessInfo[] = [];
+  const queue = [...(childrenByParent.get(rootPid) ?? [])];
+  const seen = new Set<number>();
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || seen.has(current.ProcessId)) {
+      continue;
+    }
+
+    seen.add(current.ProcessId);
+    descendants.push(current);
+    queue.push(...(childrenByParent.get(current.ProcessId) ?? []));
+  }
+
+  return descendants;
+}
+
+async function resolveDesktopProcessBaseName(projectRoot: string): Promise<string | null> {
+  const cached = desktopProcessNameCache.get(projectRoot);
+  if (cached) {
+    return await cached;
+  }
+
+  const pending = (async () => {
+    try {
+      const cargoTomlPath = path.join(projectRoot, 'src-tauri', 'Cargo.toml');
+      const cargoToml = await readFile(cargoTomlPath, 'utf8');
+      const packageSectionMatch = cargoToml.match(/\[package\][\s\S]*?^name\s*=\s*"([^"]+)"/m);
+      return packageSectionMatch?.[1]?.trim() || null;
+    } catch {
+      return null;
+    }
+  })();
+
+  desktopProcessNameCache.set(projectRoot, pending);
+  return await pending;
+}
+
+function matchesDesktopProcessName(name: string, expectedBaseName: string | null): boolean {
+  const normalized = name.trim().toLowerCase();
+  if (expectedBaseName) {
+    const expected = expectedBaseName.trim().toLowerCase();
+    return normalized === expected || normalized === `${expected}.exe`;
+  }
+
+  return !WINDOWS_TOOL_PROCESS_NAMES.has(normalized);
+}
+
+function groupListenerPidsByPort(portListeners: PortListenerInfo[], port: number): number[] {
+  return [...new Set(
+    portListeners
+      .filter((listener) => listener.LocalPort === port)
+      .map((listener) => listener.OwningProcess)
+      .filter((pid) => Number.isInteger(pid) && pid > 0),
+  )];
+}
+
+async function collectManagedTauriHealthSnapshot(
+  record: ManagedTauriInstanceRecord,
+): Promise<ManagedTauriInstanceHealthSnapshot> {
+  const rootPidAlive = isPidAlive(record.rootPid);
+  const portProbeScript = [
+    `$ports = @(${record.webPort}, ${record.hmrPort})`,
+    "Get-NetTCPConnection -State Listen -ErrorAction SilentlyContinue | Where-Object { $ports -contains $_.LocalPort } | Select-Object LocalPort, OwningProcess | ConvertTo-Json -Compress",
+  ].join('; ');
+  const portListeners = runPowerShellJson<PortListenerInfo>(portProbeScript);
+  const webPortPids = groupListenerPidsByPort(portListeners, record.webPort);
+  const hmrPortPids = groupListenerPidsByPort(portListeners, record.hmrPort);
+
+  if (record.target !== 'desktop') {
+    return {
+      rootPidAlive,
+      webPortListening: webPortPids.length > 0,
+      hmrPortListening: hmrPortPids.length > 0,
+      webPortPids,
+      hmrPortPids,
+    };
+  }
+
+  if (!rootPidAlive) {
+    return {
+      rootPidAlive,
+      webPortListening: webPortPids.length > 0,
+      hmrPortListening: hmrPortPids.length > 0,
+      appProcessAlive: false,
+      webPortPids,
+      hmrPortPids,
+      appPids: [],
+    };
+  }
+
+  const expectedDesktopProcess = await resolveDesktopProcessBaseName(record.projectRoot);
+  const processes = runPowerShellJson<WindowsProcessInfo>(
+    'Get-CimInstance Win32_Process | Select-Object ProcessId, ParentProcessId, Name | ConvertTo-Json -Compress',
+  );
+  const descendants = getDescendantProcesses(processes, record.rootPid);
+  const appPids = descendants
+    .filter((processInfo) => matchesDesktopProcessName(processInfo.Name, expectedDesktopProcess))
+    .map((processInfo) => processInfo.ProcessId);
+
+  return {
+    rootPidAlive,
+    webPortListening: webPortPids.length > 0,
+    hmrPortListening: hmrPortPids.length > 0,
+    appProcessAlive: appPids.length > 0,
+    webPortPids,
+    hmrPortPids,
+    appPids,
+  };
+}
+
+function stopWindowsProcess(pid: number): void {
+  const result = spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], {
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+
+  if (result.status !== 0 && isPidAlive(pid)) {
+    throw new Error(result.stderr || result.stdout || `failed to stop PID ${pid}`);
+  }
+}
+
 function parseTarget(flags: Map<string, string | true>): TauriDevTarget {
   const raw = getFlagValue(flags, '--target');
   if (!raw) return 'desktop';
@@ -194,10 +376,6 @@ async function startCommand(flags: Map<string, string | true>): Promise<void> {
     throw new Error(`instance already running: ${paths.name} (PID ${existing.rootPid})`);
   }
 
-  if (await fileExists(paths.logPath)) {
-    await rm(paths.logPath, { force: true });
-  }
-
   const env = {
     ...process.env,
     EXOMIND_WEB_PORT: String(webPort),
@@ -205,6 +383,15 @@ async function startCommand(flags: Map<string, string | true>): Promise<void> {
     EXOMIND_TAURI_INSTANCE_NAME: paths.name,
     ...(enableWatch ? { EXOMIND_TAURI_ENABLE_WATCH: '1' } : {}),
   };
+  const startedAt = new Date().toISOString();
+
+  await appendManagedTauriLogSessionStart(paths.logPath, {
+    name: paths.name,
+    target,
+    webPort,
+    hmrPort,
+    startedAt,
+  });
 
   const logHandle = await open(paths.logPath, 'a');
   const tauriArgs = target === 'android'
@@ -228,7 +415,7 @@ async function startCommand(flags: Map<string, string | true>): Promise<void> {
     hmrPort,
     logPath: paths.logPath,
     metaPath: paths.metaPath,
-    startedAt: new Date().toISOString(),
+    startedAt,
     enableWatch,
     target,
   };
@@ -257,14 +444,19 @@ async function listCommand(): Promise<void> {
     return;
   }
 
-  const rows = records.map((record) => ({
-    name: record.name,
-    target: record.target ?? 'desktop',
-    pid: record.rootPid,
-    status: isPidAlive(record.rootPid) ? 'running' : 'stale',
-    web: `http://localhost:${record.webPort}`,
-    hmr: record.hmrPort,
-    log: path.relative(PROJECT_ROOT, record.logPath),
+  const rows = await Promise.all(records.map(async (record) => {
+    const snapshot = await collectManagedTauriHealthSnapshot(record);
+    const health = evaluateManagedTauriInstanceHealth(record, snapshot);
+    return {
+      name: record.name,
+      target: record.target ?? 'desktop',
+      pid: record.rootPid,
+      status: health.status,
+      detail: health.detail,
+      web: `http://localhost:${record.webPort}`,
+      hmr: record.hmrPort,
+      log: path.relative(PROJECT_ROOT, record.logPath),
+    };
   }));
 
   console.table(rows);
@@ -282,15 +474,11 @@ async function stopCommand(flags: Map<string, string | true>): Promise<void> {
     throw new Error(`instance not found: ${paths.name}`);
   }
 
-  if (isPidAlive(record.rootPid)) {
-    const result = spawnSync('taskkill', ['/PID', String(record.rootPid), '/T', '/F'], {
-      encoding: 'utf8',
-      windowsHide: true,
-    });
+  const snapshot = await collectManagedTauriHealthSnapshot(record);
+  const cleanupPids = collectManagedTauriCleanupPids(record, snapshot);
 
-    if (result.status !== 0) {
-      throw new Error(result.stderr || result.stdout || `failed to stop PID ${record.rootPid}`);
-    }
+  for (const pid of cleanupPids) {
+    stopWindowsProcess(pid);
   }
 
   await rm(paths.metaPath, { force: true });
@@ -339,7 +527,10 @@ async function pruneCommand(): Promise<void> {
   let removed = 0;
 
   for (const record of records) {
-    if (isPidAlive(record.rootPid)) {
+    const snapshot = await collectManagedTauriHealthSnapshot(record);
+    const cleanupPids = collectManagedTauriCleanupPids(record, snapshot);
+
+    if (snapshot.rootPidAlive || cleanupPids.length > 0) {
       continue;
     }
 

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -470,6 +470,17 @@ pub async fn start_with_options(
         actor_tasks.push(signal::actors::input_ingest_actor::spawn_input_ingest_actor(
             Arc::clone(&state.signal_pool),
         ));
+        actor_tasks.push(
+            signal::actors::external_input_actor::spawn_external_input_actor(Arc::clone(
+                &state.signal_pool,
+            )),
+        );
+        actor_tasks.push(
+            signal::actors::external_source_actor::spawn_external_source_actor(
+                Arc::clone(&state.signal_pool),
+                signal::actors::external_source_actor::ExternalSourceConfig::default(),
+            ),
+        );
         actor_tasks.push(signal::actors::task_classifier_actor::spawn_task_actor(
             Arc::clone(&state.signal_pool),
         ));

--- a/crates/exomind-runtime/src/signal/actors/external_input_actor.rs
+++ b/crates/exomind-runtime/src/signal/actors/external_input_actor.rs
@@ -1,0 +1,303 @@
+use std::sync::Arc;
+
+use tracing::warn;
+
+use crate::signal::types::SignalEvent;
+use crate::signal::SignalPool;
+
+const EXTERNAL_INPUT_RECEIVED_TOPIC: &str = "external.input.received";
+const USER_INPUT_NORMALIZED_TOPIC: &str = "user.input.normalized";
+const EXTERNAL_INPUT_INGESTED_TOPIC: &str = "external.input.ingested";
+
+pub fn spawn_external_input_actor(pool: Arc<SignalPool>) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut rx = pool.subscribe();
+
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    if event.topic != EXTERNAL_INPUT_RECEIVED_TOPIC {
+                        continue;
+                    }
+                    handle_external_input(&pool, &event);
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    warn!(
+                        skipped = n,
+                        "external_input_actor: broadcast receiver lagged, skipped {n} events"
+                    );
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    warn!("external_input_actor: broadcast channel closed, shutting down");
+                    break;
+                }
+            }
+        }
+    })
+}
+
+fn handle_external_input(pool: &SignalPool, event: &SignalEvent) {
+    let payload = match event.payload.as_object() {
+        Some(payload) => payload,
+        None => {
+            warn!(
+                event_id = %event.id,
+                "external_input_actor: payload is not an object, skipping"
+            );
+            return;
+        }
+    };
+
+    let text = payload
+        .get("text")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let url = payload
+        .get("url")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    let effective_text = match text.or(url) {
+        Some(value) => value,
+        None => {
+            warn!(
+                event_id = %event.id,
+                "external_input_actor: no usable text or url, skipping"
+            );
+            return;
+        }
+    };
+
+    let source_type = payload
+        .get("source_type")
+        .and_then(|value| value.as_str())
+        .unwrap_or("unknown");
+    let sender = payload
+        .get("sender")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let chatroom_id = payload
+        .get("chatroom_id")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let dedup_key = payload
+        .get("dedup_key")
+        .and_then(|value| value.as_str())
+        .unwrap_or("");
+
+    let capture_source = if let Some(chatroom_id) = chatroom_id {
+        format!("{source_type}:{chatroom_id}")
+    } else if let Some(sender) = sender {
+        format!("{source_type}:{sender}")
+    } else {
+        source_type.to_string()
+    };
+
+    let now_ms = chrono::Utc::now().timestamp_millis() as u64;
+
+    let normalized_event = SignalEvent {
+        schema_version: 1,
+        id: uuid::Uuid::new_v4().to_string(),
+        topic: USER_INPUT_NORMALIZED_TOPIC.to_string(),
+        ts: now_ms,
+        source: "actor:external_input".to_string(),
+        origin_host_id: event.origin_host_id.clone(),
+        hop: event.hop + 1,
+        trace_id: event.trace_id.clone(),
+        payload: serde_json::json!({
+            "text": effective_text,
+            "rawText": text.unwrap_or(effective_text),
+            "inputMode": "external",
+            "captureSource": capture_source,
+            "externalMeta": {
+                "sourceType": source_type,
+                "sender": sender,
+                "originalTimestamp": payload.get("original_timestamp").cloned().unwrap_or(serde_json::Value::Null),
+                "chatroomId": chatroom_id,
+                "mediaType": payload.get("media_type").cloned().unwrap_or(serde_json::Value::Null),
+                "url": url,
+                "dedupKey": dedup_key,
+            }
+        }),
+    };
+    pool.publish(normalized_event);
+
+    let ingested_event = SignalEvent {
+        schema_version: 1,
+        id: uuid::Uuid::new_v4().to_string(),
+        topic: EXTERNAL_INPUT_INGESTED_TOPIC.to_string(),
+        ts: now_ms,
+        source: "actor:external_input".to_string(),
+        origin_host_id: event.origin_host_id.clone(),
+        hop: event.hop + 1,
+        trace_id: event.trace_id.clone(),
+        payload: serde_json::json!({
+            "dedupKey": dedup_key,
+            "sourceType": source_type,
+            "ts": now_ms,
+        }),
+    };
+    pool.publish(ingested_event);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_event(topic: &str, payload: serde_json::Value) -> SignalEvent {
+        SignalEvent {
+            schema_version: 1,
+            id: uuid::Uuid::new_v4().to_string(),
+            topic: topic.to_string(),
+            ts: chrono::Utc::now().timestamp_millis() as u64,
+            source: "test:external".to_string(),
+            origin_host_id: "host-test".to_string(),
+            hop: 2,
+            trace_id: Some("trace-external-1".to_string()),
+            payload,
+        }
+    }
+
+    async fn yield_for_actor() {
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+    }
+
+    async fn recv_next(
+        rx: &mut tokio::sync::broadcast::Receiver<SignalEvent>,
+    ) -> SignalEvent {
+        tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("timeout waiting for signal")
+            .expect("should receive signal")
+    }
+
+    #[tokio::test]
+    async fn text_external_input_produces_normalized_and_ingested_signals() {
+        let pool = Arc::new(SignalPool::new(None));
+        let _handle = spawn_external_input_actor(Arc::clone(&pool));
+        yield_for_actor().await;
+
+        let mut rx = pool.subscribe();
+        pool.publish(make_event(
+            EXTERNAL_INPUT_RECEIVED_TOPIC,
+            serde_json::json!({
+                "source_type": "wechat",
+                "sender": "Alice",
+                "text": "来自微信群的新消息",
+                "media_type": "text",
+                "original_timestamp": 1234567890000_u64,
+                "chatroom_id": "room-1",
+                "dedup_key": "wechat-room-1-1",
+            }),
+        ));
+
+        let first = recv_next(&mut rx).await;
+        assert_eq!(first.topic, EXTERNAL_INPUT_RECEIVED_TOPIC);
+
+        let second = recv_next(&mut rx).await;
+        assert_eq!(second.topic, USER_INPUT_NORMALIZED_TOPIC);
+        assert_eq!(second.source, "actor:external_input");
+        assert_eq!(second.trace_id, Some("trace-external-1".to_string()));
+        assert_eq!(second.hop, 3);
+        assert_eq!(second.payload["text"], "来自微信群的新消息");
+        assert_eq!(second.payload["rawText"], "来自微信群的新消息");
+        assert_eq!(second.payload["inputMode"], "external");
+        assert_eq!(second.payload["captureSource"], "wechat:room-1");
+        assert_eq!(second.payload["externalMeta"]["sourceType"], "wechat");
+        assert_eq!(second.payload["externalMeta"]["sender"], "Alice");
+        assert_eq!(
+            second.payload["externalMeta"]["originalTimestamp"],
+            serde_json::json!(1234567890000_u64)
+        );
+        assert_eq!(second.payload["externalMeta"]["chatroomId"], "room-1");
+        assert_eq!(second.payload["externalMeta"]["mediaType"], "text");
+        assert_eq!(second.payload["externalMeta"]["dedupKey"], "wechat-room-1-1");
+
+        let third = recv_next(&mut rx).await;
+        assert_eq!(third.topic, EXTERNAL_INPUT_INGESTED_TOPIC);
+        assert_eq!(third.source, "actor:external_input");
+        assert_eq!(third.trace_id, Some("trace-external-1".to_string()));
+        assert_eq!(third.hop, 3);
+        assert_eq!(third.payload["dedupKey"], "wechat-room-1-1");
+        assert_eq!(third.payload["sourceType"], "wechat");
+        assert!(third.payload["ts"].is_number());
+    }
+
+    #[tokio::test]
+    async fn link_external_input_uses_url_as_text_when_text_missing() {
+        let pool = Arc::new(SignalPool::new(None));
+        let _handle = spawn_external_input_actor(Arc::clone(&pool));
+        yield_for_actor().await;
+
+        let mut rx = pool.subscribe();
+        pool.publish(make_event(
+            EXTERNAL_INPUT_RECEIVED_TOPIC,
+            serde_json::json!({
+                "source_type": "telegram",
+                "sender": "Bob",
+                "url": "https://example.com/hello",
+                "media_type": "link",
+                "original_timestamp": 1234567890001_u64,
+                "dedup_key": "telegram-bob-1",
+            }),
+        ));
+
+        let _first = recv_next(&mut rx).await;
+        let second = recv_next(&mut rx).await;
+        assert_eq!(second.topic, USER_INPUT_NORMALIZED_TOPIC);
+        assert_eq!(second.payload["text"], "https://example.com/hello");
+        assert_eq!(second.payload["rawText"], "https://example.com/hello");
+        assert_eq!(second.payload["captureSource"], "telegram:Bob");
+        assert_eq!(second.payload["externalMeta"]["url"], "https://example.com/hello");
+    }
+
+    #[tokio::test]
+    async fn missing_text_and_url_skips_output_signals() {
+        let pool = Arc::new(SignalPool::new(None));
+        let _handle = spawn_external_input_actor(Arc::clone(&pool));
+        yield_for_actor().await;
+
+        let mut rx = pool.subscribe();
+        pool.publish(make_event(
+            EXTERNAL_INPUT_RECEIVED_TOPIC,
+            serde_json::json!({
+                "source_type": "clipboard",
+                "sender": "self",
+                "media_type": "text",
+                "dedup_key": "clipboard-1",
+            }),
+        ));
+
+        let first = recv_next(&mut rx).await;
+        assert_eq!(first.topic, EXTERNAL_INPUT_RECEIVED_TOPIC);
+
+        let result = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
+        assert!(result.is_err(), "missing text/url should not publish any derived signal");
+    }
+
+    #[tokio::test]
+    async fn other_topics_are_ignored() {
+        let pool = Arc::new(SignalPool::new(None));
+        let _handle = spawn_external_input_actor(Arc::clone(&pool));
+        yield_for_actor().await;
+
+        let mut rx = pool.subscribe();
+        pool.publish(make_event(
+            "user.input.text",
+            serde_json::json!({
+                "text": "plain input"
+            }),
+        ));
+
+        let first = recv_next(&mut rx).await;
+        assert_eq!(first.topic, "user.input.text");
+
+        let result = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
+        assert!(result.is_err(), "non external topic should not publish any derived signal");
+    }
+}

--- a/crates/exomind-runtime/src/signal/actors/external_source_actor.rs
+++ b/crates/exomind-runtime/src/signal/actors/external_source_actor.rs
@@ -12,6 +12,7 @@ use crate::signal::SignalPool;
 const EXTERNAL_INPUT_RECEIVED_TOPIC: &str = "external.input.received";
 const EXTERNAL_SOURCE_NAME: &str = "actor:external_source";
 const DEFAULT_DEDUP_CAPACITY: usize = 1000;
+const WEFLOW_FETCH_PAGE_SIZE: usize = 20;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExternalSourceConfig {
@@ -68,6 +69,8 @@ impl Default for DedupState {
 struct WeFlowMessagesResponse {
     success: bool,
     talker: String,
+    #[serde(rename = "hasMore", default)]
+    has_more: bool,
     messages: Vec<WeFlowMessage>,
 }
 
@@ -129,12 +132,14 @@ async fn fetch_weflow_messages(
     base_url: &str,
     chatroom_id: &str,
     limit: usize,
-) -> Result<Vec<WeFlowMessage>, reqwest::Error> {
+    offset: usize,
+) -> Result<WeFlowMessagesResponse, reqwest::Error> {
     let response = client
         .get(format!("{}/api/v1/messages", base_url.trim_end_matches('/')))
         .query(&[
             ("talker", chatroom_id),
             ("limit", &limit.min(500).to_string()),
+            ("offset", &offset.to_string()),
         ])
         .send()
         .await?
@@ -143,10 +148,15 @@ async fn fetch_weflow_messages(
         .await?;
 
     if !response.success || response.talker != chatroom_id {
-        return Ok(Vec::new());
+        return Ok(WeFlowMessagesResponse {
+            success: false,
+            talker: chatroom_id.to_string(),
+            has_more: false,
+            messages: Vec::new(),
+        });
     }
 
-    Ok(response.messages)
+    Ok(response)
 }
 
 async fn poll_chatroom_once(
@@ -156,38 +166,58 @@ async fn poll_chatroom_once(
     chatroom: &WatchedChatroom,
     dedup: &mut DedupState,
 ) -> Result<usize, reqwest::Error> {
-    let messages = fetch_weflow_messages(client, base_url, &chatroom.id, 20).await?;
-    if messages.is_empty() {
-        return Ok(0);
-    }
-
     let previous_last_seen = dedup.last_seen_ts.get(&chatroom.id).copied().unwrap_or(0);
     let mut latest_seen = previous_last_seen;
     let mut publishable = Vec::new();
+    let mut offset = 0usize;
 
-    for message in messages {
-        let timestamp_ms = message_timestamp_ms(&message);
-        latest_seen = latest_seen.max(timestamp_ms);
-
-        if timestamp_ms <= previous_last_seen {
-            continue;
+    loop {
+        let page = fetch_weflow_messages(
+            client,
+            base_url,
+            &chatroom.id,
+            WEFLOW_FETCH_PAGE_SIZE,
+            offset,
+        )
+        .await?;
+        if page.messages.is_empty() {
+            break;
         }
 
-        let Some(text) = extract_message_text(&message) else {
-            continue;
-        };
+        let mut reached_old_messages = false;
+        let page_len = page.messages.len();
 
-        if should_skip_text(&text, message.local_type) {
-            continue;
+        for message in page.messages {
+            let timestamp_ms = message_timestamp_ms(&message);
+            latest_seen = latest_seen.max(timestamp_ms);
+
+            if timestamp_ms <= previous_last_seen {
+                reached_old_messages = true;
+                continue;
+            }
+
+            let Some(text) = extract_message_text(&message) else {
+                continue;
+            };
+
+            if should_skip_text(&text, message.local_type) {
+                continue;
+            }
+
+            let url = extract_first_url(&text);
+            let dedup_key = build_dedup_key(chatroom, &message, timestamp_ms, &text);
+            if dedup.seen_keys.iter().any(|key| key == &dedup_key) {
+                continue;
+            }
+
+            publishable.push((timestamp_ms, message, text, url, dedup_key));
         }
 
-        let url = extract_first_url(&text);
-        let dedup_key = build_dedup_key(chatroom, &message, timestamp_ms, &text);
-        if dedup.seen_keys.iter().any(|key| key == &dedup_key) {
-            continue;
+        if reached_old_messages || !page.has_more {
+            break;
         }
 
-        publishable.push((timestamp_ms, message, text, url, dedup_key));
+        offset += page_len;
     }
 
     if latest_seen > previous_last_seen {
@@ -313,6 +343,7 @@ mod tests {
     struct MessageQuery {
         talker: String,
         limit: Option<usize>,
+        offset: Option<usize>,
     }
 
     async fn spawn_weflow_server(
@@ -325,7 +356,26 @@ mod tests {
                 async move {
                     assert!(!query.talker.is_empty(), "talker query param should be present");
                     assert!(query.limit.unwrap_or_default() > 0, "limit should be positive");
-                    Json(response)
+                    let limit = query.limit.unwrap_or(20);
+                    let offset = query.offset.unwrap_or(0);
+                    let source_messages = response
+                        .get("messages")
+                        .and_then(|value| value.as_array())
+                        .cloned()
+                        .unwrap_or_default();
+                    let page = source_messages
+                        .iter()
+                        .skip(offset)
+                        .take(limit)
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    Json(json!({
+                        "success": response.get("success").cloned().unwrap_or(json!(true)),
+                        "talker": response.get("talker").cloned().unwrap_or(json!(query.talker)),
+                        "count": page.len(),
+                        "hasMore": offset + page.len() < source_messages.len(),
+                        "messages": page,
+                    }))
                 }
             }),
         );
@@ -479,6 +529,65 @@ mod tests {
 
         let result = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
         assert!(result.is_err(), "second poll should not publish more events");
+    }
+
+    #[tokio::test]
+    async fn poll_chatroom_consumes_bursts_larger_than_single_page() {
+        let messages = (0..25)
+            .rev()
+            .map(|index| {
+                let sequence = index + 1;
+                json!({
+                    "localId": sequence,
+                    "serverId": 5000 + sequence,
+                    "localType": 1,
+                    "createTime": 1773809000 + sequence,
+                    "sortSeq": 1773809000000_u64 + (sequence as u64 * 1000),
+                    "senderUsername": format!("wxid-{sequence}"),
+                    "content": format!("burst-message-{sequence}"),
+                    "rawContent": format!("wxid-{sequence}:\\nburst-message-{sequence}"),
+                    "parsedContent": format!("burst-message-{sequence}")
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let (base_url, _server) = spawn_weflow_server(json!({
+            "success": true,
+            "talker": "room-burst",
+            "messages": messages,
+        }))
+        .await;
+
+        let pool = Arc::new(SignalPool::new(None));
+        let client = Client::new();
+        let mut dedup = DedupState::default();
+        let chatroom = WatchedChatroom {
+            id: "room-burst".to_string(),
+            label: "room-burst".to_string(),
+        };
+        let mut rx = pool.subscribe();
+
+        let published =
+            poll_chatroom_once(&client, &pool, &base_url, &chatroom, &mut dedup)
+                .await
+                .expect("burst poll should succeed");
+
+        assert_eq!(published, 25, "poll should page through all unseen messages");
+
+        let mut received_texts = Vec::new();
+        for _ in 0..25 {
+            let event = recv_next(&mut rx).await;
+            received_texts.push(event.payload["text"].as_str().unwrap_or_default().to_string());
+        }
+
+        assert!(received_texts.contains(&"burst-message-1".to_string()));
+        assert!(received_texts.contains(&"burst-message-25".to_string()));
+
+        let second_count =
+            poll_chatroom_once(&client, &pool, &base_url, &chatroom, &mut dedup)
+                .await
+                .expect("second burst poll should succeed");
+        assert_eq!(second_count, 0, "cursor should advance only after full backlog is consumed");
     }
 
     #[tokio::test]

--- a/crates/exomind-runtime/src/signal/actors/external_source_actor.rs
+++ b/crates/exomind-runtime/src/signal/actors/external_source_actor.rs
@@ -1,0 +1,504 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tracing::{info, warn};
+
+use crate::signal::types::SignalEvent;
+use crate::signal::SignalPool;
+
+const EXTERNAL_INPUT_RECEIVED_TOPIC: &str = "external.input.received";
+const EXTERNAL_SOURCE_NAME: &str = "actor:external_source";
+const DEFAULT_DEDUP_CAPACITY: usize = 1000;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalSourceConfig {
+    pub enabled: bool,
+    pub poll_interval_secs: u64,
+    pub weflow_base_url: String,
+    pub watched_chatrooms: Vec<WatchedChatroom>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WatchedChatroom {
+    pub id: String,
+    pub label: String,
+}
+
+impl Default for ExternalSourceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            poll_interval_secs: 10,
+            weflow_base_url: "http://127.0.0.1:5031".to_string(),
+            watched_chatrooms: vec![
+                WatchedChatroom {
+                    id: "44880347605@chatroom".to_string(),
+                    label: "collective-buffer".to_string(),
+                },
+                WatchedChatroom {
+                    id: "43757039905@chatroom".to_string(),
+                    label: "personal-external-buffer".to_string(),
+                },
+            ],
+        }
+    }
+}
+
+#[derive(Debug)]
+struct DedupState {
+    seen_keys: VecDeque<String>,
+    last_seen_ts: HashMap<String, u64>,
+    capacity: usize,
+}
+
+impl Default for DedupState {
+    fn default() -> Self {
+        Self {
+            seen_keys: VecDeque::with_capacity(DEFAULT_DEDUP_CAPACITY),
+            last_seen_ts: HashMap::new(),
+            capacity: DEFAULT_DEDUP_CAPACITY,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct WeFlowMessagesResponse {
+    success: bool,
+    talker: String,
+    messages: Vec<WeFlowMessage>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct WeFlowMessage {
+    #[serde(rename = "localId")]
+    local_id: Option<u64>,
+    #[serde(rename = "serverId")]
+    server_id: Option<i64>,
+    #[serde(rename = "localType")]
+    local_type: Option<i64>,
+    #[serde(rename = "createTime")]
+    create_time: Option<u64>,
+    #[serde(rename = "sortSeq")]
+    sort_seq: Option<u64>,
+    #[serde(rename = "senderUsername")]
+    sender_username: Option<String>,
+    content: Option<String>,
+    #[serde(rename = "rawContent")]
+    raw_content: Option<String>,
+    #[serde(rename = "parsedContent")]
+    parsed_content: Option<String>,
+}
+
+pub fn spawn_external_source_actor(
+    pool: Arc<SignalPool>,
+    config: ExternalSourceConfig,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        if !config.enabled {
+            info!("external_source_actor: disabled by config, exiting");
+            return;
+        }
+
+        let client = Client::new();
+        let mut dedup = DedupState::default();
+
+        loop {
+            for chatroom in &config.watched_chatrooms {
+                if let Err(error) =
+                    poll_chatroom_once(&client, &pool, &config.weflow_base_url, chatroom, &mut dedup)
+                        .await
+                {
+                    warn!(
+                        chatroom = %chatroom.id,
+                        error = %error,
+                        "external_source_actor: poll failed"
+                    );
+                }
+            }
+
+            tokio::time::sleep(std::time::Duration::from_secs(config.poll_interval_secs)).await;
+        }
+    })
+}
+
+async fn fetch_weflow_messages(
+    client: &Client,
+    base_url: &str,
+    chatroom_id: &str,
+    limit: usize,
+) -> Result<Vec<WeFlowMessage>, reqwest::Error> {
+    let response = client
+        .get(format!("{}/api/v1/messages", base_url.trim_end_matches('/')))
+        .query(&[
+            ("talker", chatroom_id),
+            ("limit", &limit.min(500).to_string()),
+        ])
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<WeFlowMessagesResponse>()
+        .await?;
+
+    if !response.success || response.talker != chatroom_id {
+        return Ok(Vec::new());
+    }
+
+    Ok(response.messages)
+}
+
+async fn poll_chatroom_once(
+    client: &Client,
+    pool: &SignalPool,
+    base_url: &str,
+    chatroom: &WatchedChatroom,
+    dedup: &mut DedupState,
+) -> Result<usize, reqwest::Error> {
+    let messages = fetch_weflow_messages(client, base_url, &chatroom.id, 20).await?;
+    if messages.is_empty() {
+        return Ok(0);
+    }
+
+    let previous_last_seen = dedup.last_seen_ts.get(&chatroom.id).copied().unwrap_or(0);
+    let mut latest_seen = previous_last_seen;
+    let mut publishable = Vec::new();
+
+    for message in messages {
+        let timestamp_ms = message_timestamp_ms(&message);
+        latest_seen = latest_seen.max(timestamp_ms);
+
+        if timestamp_ms <= previous_last_seen {
+            continue;
+        }
+
+        let Some(text) = extract_message_text(&message) else {
+            continue;
+        };
+
+        if should_skip_text(&text, message.local_type) {
+            continue;
+        }
+
+        let url = extract_first_url(&text);
+        let dedup_key = build_dedup_key(chatroom, &message, timestamp_ms, &text);
+        if dedup.seen_keys.iter().any(|key| key == &dedup_key) {
+            continue;
+        }
+
+        publishable.push((timestamp_ms, message, text, url, dedup_key));
+    }
+
+    if latest_seen > previous_last_seen {
+        dedup.last_seen_ts.insert(chatroom.id.clone(), latest_seen);
+    }
+
+    publishable.sort_by_key(|(timestamp_ms, _, _, _, _)| *timestamp_ms);
+
+    let mut published = 0;
+    for (timestamp_ms, message, text, url, dedup_key) in publishable {
+        remember_dedup_key(dedup, dedup_key.clone());
+        let media_type = if url.is_some() { "link" } else { "text" };
+        let sender = message
+            .sender_username
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string());
+
+        pool.publish(SignalEvent {
+            schema_version: 1,
+            id: uuid::Uuid::new_v4().to_string(),
+            topic: EXTERNAL_INPUT_RECEIVED_TOPIC.to_string(),
+            ts: chrono::Utc::now().timestamp_millis() as u64,
+            source: EXTERNAL_SOURCE_NAME.to_string(),
+            origin_host_id: std::env::var("EXOMIND_RT_HOST_ID")
+                .unwrap_or_else(|_| "rt-external-source".to_string()),
+            hop: 0,
+            trace_id: None,
+            payload: serde_json::json!({
+                "source_type": "wechat",
+                "sender": sender,
+                "text": text,
+                "url": url,
+                "media_type": media_type,
+                "original_timestamp": timestamp_ms,
+                "chatroom_id": chatroom.id,
+                "dedup_key": dedup_key,
+            }),
+        });
+        published += 1;
+    }
+
+    Ok(published)
+}
+
+fn message_timestamp_ms(message: &WeFlowMessage) -> u64 {
+    message
+        .sort_seq
+        .or_else(|| message.create_time.map(|seconds| seconds.saturating_mul(1000)))
+        .unwrap_or(0)
+}
+
+fn extract_message_text(message: &WeFlowMessage) -> Option<String> {
+    message
+        .parsed_content
+        .as_deref()
+        .or(message.content.as_deref())
+        .or(message.raw_content.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn should_skip_text(text: &str, local_type: Option<i64>) -> bool {
+    if matches!(local_type, Some(kind) if kind != 1) {
+        return true;
+    }
+
+    matches!(
+        text,
+        "[图片]" | "[视频]" | "[语音]" | "[动画表情]" | "[表情]" | "[文件]"
+    ) || text.contains("撤回了一条消息")
+}
+
+fn extract_first_url(text: &str) -> Option<String> {
+    text.split_whitespace()
+        .find(|part| part.starts_with("http://") || part.starts_with("https://"))
+        .map(|part| {
+            part.trim_end_matches(|ch: char| {
+                matches!(ch, ',' | '.' | ';' | ')' | ']' | '}' | '"' | '\'')
+            })
+            .to_string()
+        })
+}
+
+fn build_dedup_key(
+    chatroom: &WatchedChatroom,
+    message: &WeFlowMessage,
+    timestamp_ms: u64,
+    text: &str,
+) -> String {
+    if let (Some(server_id), Some(local_id)) = (message.server_id, message.local_id) {
+        return format!("{}:{}:{}", chatroom.id, server_id, local_id);
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(text.as_bytes());
+    let hash = format!("{:x}", hasher.finalize());
+    format!(
+        "{}:{}:{}:{}",
+        chatroom.id,
+        timestamp_ms,
+        message.sender_username.as_deref().unwrap_or("unknown"),
+        &hash[..16]
+    )
+}
+
+fn remember_dedup_key(dedup: &mut DedupState, key: String) {
+    if dedup.seen_keys.len() >= dedup.capacity {
+        dedup.seen_keys.pop_front();
+    }
+    dedup.seen_keys.push_back(key);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{extract::Query, routing::get, Json, Router};
+    use serde::Deserialize;
+    use serde_json::json;
+    use tokio::net::TcpListener;
+
+    #[derive(Debug, Deserialize)]
+    struct MessageQuery {
+        talker: String,
+        limit: Option<usize>,
+    }
+
+    async fn spawn_weflow_server(
+        response: serde_json::Value,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let app = Router::new().route(
+            "/api/v1/messages",
+            get(move |query: Query<MessageQuery>| {
+                let response = response.clone();
+                async move {
+                    assert!(!query.talker.is_empty(), "talker query param should be present");
+                    assert!(query.limit.unwrap_or_default() > 0, "limit should be positive");
+                    Json(response)
+                }
+            }),
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("should bind test server");
+        let addr = listener.local_addr().expect("should read local addr");
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("test server should run");
+        });
+        (format!("http://{}", addr), handle)
+    }
+
+    async fn yield_for_actor() {
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+    }
+
+    async fn recv_next(
+        rx: &mut tokio::sync::broadcast::Receiver<SignalEvent>,
+    ) -> SignalEvent {
+        tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("timeout waiting for signal")
+            .expect("should receive signal")
+    }
+
+    #[tokio::test]
+    async fn poll_chatroom_publishes_text_and_link_messages() {
+        let (base_url, _server) = spawn_weflow_server(json!({
+            "success": true,
+            "talker": "room-1",
+            "count": 3,
+            "hasMore": false,
+            "messages": [
+                {
+                    "localId": 3,
+                    "serverId": 103,
+                    "localType": 1,
+                    "createTime": 1773809300,
+                    "sortSeq": 1773809300000_u64,
+                    "senderUsername": "wxid-c",
+                    "content": "[图片]",
+                    "rawContent": "wxid-c:\n[图片]",
+                    "parsedContent": "[图片]"
+                },
+                {
+                    "localId": 2,
+                    "serverId": 102,
+                    "localType": 1,
+                    "createTime": 1773809200,
+                    "sortSeq": 1773809200000_u64,
+                    "senderUsername": "wxid-b",
+                    "content": "See https://example.com/alpha",
+                    "rawContent": "wxid-b:\nSee https://example.com/alpha",
+                    "parsedContent": "See https://example.com/alpha"
+                },
+                {
+                    "localId": 1,
+                    "serverId": 101,
+                    "localType": 1,
+                    "createTime": 1773809100,
+                    "sortSeq": 1773809100000_u64,
+                    "senderUsername": "wxid-a",
+                    "content": "hello from wechat",
+                    "rawContent": "wxid-a:\nhello from wechat",
+                    "parsedContent": "hello from wechat"
+                }
+            ]
+        }))
+        .await;
+
+        let pool = Arc::new(SignalPool::new(None));
+        let client = Client::new();
+        let mut dedup = DedupState::default();
+        let chatroom = WatchedChatroom {
+            id: "room-1".to_string(),
+            label: "room-1".to_string(),
+        };
+        let mut rx = pool.subscribe();
+
+        let published =
+            poll_chatroom_once(&client, &pool, &base_url, &chatroom, &mut dedup)
+                .await
+                .expect("poll should succeed");
+
+        assert_eq!(published, 2, "image placeholder should be skipped");
+
+        let first = recv_next(&mut rx).await;
+        assert_eq!(first.topic, EXTERNAL_INPUT_RECEIVED_TOPIC);
+        assert_eq!(first.source, EXTERNAL_SOURCE_NAME);
+        assert_eq!(first.payload["chatroom_id"], "room-1");
+        assert_eq!(first.payload["sender"], "wxid-a");
+        assert_eq!(first.payload["text"], "hello from wechat");
+        assert_eq!(first.payload["media_type"], "text");
+
+        let second = recv_next(&mut rx).await;
+        assert_eq!(second.topic, EXTERNAL_INPUT_RECEIVED_TOPIC);
+        assert_eq!(second.payload["sender"], "wxid-b");
+        assert_eq!(second.payload["text"], "See https://example.com/alpha");
+        assert_eq!(second.payload["url"], "https://example.com/alpha");
+        assert_eq!(second.payload["media_type"], "link");
+    }
+
+    #[tokio::test]
+    async fn second_poll_skips_messages_that_were_already_seen() {
+        let (base_url, _server) = spawn_weflow_server(json!({
+            "success": true,
+            "talker": "room-2",
+            "count": 1,
+            "hasMore": false,
+            "messages": [
+                {
+                    "localId": 11,
+                    "serverId": 201,
+                    "localType": 1,
+                    "createTime": 1773809400,
+                    "sortSeq": 1773809400000_u64,
+                    "senderUsername": "wxid-repeat",
+                    "content": "same message",
+                    "rawContent": "wxid-repeat:\nsame message",
+                    "parsedContent": "same message"
+                }
+            ]
+        }))
+        .await;
+
+        let pool = Arc::new(SignalPool::new(None));
+        let client = Client::new();
+        let mut dedup = DedupState::default();
+        let chatroom = WatchedChatroom {
+            id: "room-2".to_string(),
+            label: "room-2".to_string(),
+        };
+        let mut rx = pool.subscribe();
+
+        let first_count =
+            poll_chatroom_once(&client, &pool, &base_url, &chatroom, &mut dedup)
+                .await
+                .expect("first poll should succeed");
+        assert_eq!(first_count, 1);
+        let first = recv_next(&mut rx).await;
+        assert_eq!(first.payload["dedup_key"], "room-2:201:11");
+
+        let second_count =
+            poll_chatroom_once(&client, &pool, &base_url, &chatroom, &mut dedup)
+                .await
+                .expect("second poll should succeed");
+        assert_eq!(second_count, 0, "same payload should not be published twice");
+
+        let result = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv()).await;
+        assert!(result.is_err(), "second poll should not publish more events");
+    }
+
+    #[tokio::test]
+    async fn disabled_actor_exits_without_polling() {
+        let pool = Arc::new(SignalPool::new(None));
+        let handle = spawn_external_source_actor(
+            Arc::clone(&pool),
+            ExternalSourceConfig {
+                enabled: false,
+                poll_interval_secs: 1,
+                weflow_base_url: "http://127.0.0.1:5031".to_string(),
+                watched_chatrooms: vec![WatchedChatroom {
+                    id: "room-disabled".to_string(),
+                    label: "room-disabled".to_string(),
+                }],
+            },
+        );
+
+        yield_for_actor().await;
+        let result = tokio::time::timeout(std::time::Duration::from_secs(1), handle).await;
+        assert!(result.is_ok(), "disabled actor should exit quickly");
+    }
+}

--- a/crates/exomind-runtime/src/signal/actors/mod.rs
+++ b/crates/exomind-runtime/src/signal/actors/mod.rs
@@ -1,4 +1,6 @@
 pub mod eventlog_actor;
+pub mod external_input_actor;
+pub mod external_source_actor;
 pub mod input_ingest_actor;
 pub mod signal_dispatcher_actor;
 pub mod task_classifier_actor;

--- a/crates/exomind-runtime/tests/signal_actors_integration.rs
+++ b/crates/exomind-runtime/tests/signal_actors_integration.rs
@@ -358,6 +358,57 @@ async fn voice_transcript_is_normalized_before_eventlog_append() {
     assert!(topics.iter().any(|topic| topic == "eventlog.appended"));
 }
 
+#[tokio::test]
+async fn external_input_is_normalized_before_eventlog_append() {
+    let pool = Arc::new(SignalPool::new(None));
+    let _external_input =
+        exomind_runtime::signal::actors::external_input_actor::spawn_external_input_actor(
+            Arc::clone(&pool),
+        );
+    let _eventlog = exomind_runtime::signal::actors::eventlog_actor::spawn_eventlog_actor(
+        Arc::clone(&pool),
+    );
+    yield_for_actor().await;
+
+    let mut rx = pool.subscribe();
+    pool.publish(make_event(
+        "external.input.received",
+        json!({
+            "source_type": "wechat",
+            "sender": "wxid-test",
+            "text": "外部输入进入 EventLog",
+            "media_type": "text",
+            "original_timestamp": 1773809500000_u64,
+            "chatroom_id": "room-external",
+            "dedup_key": "room-external:1:1"
+        }),
+    ));
+
+    let mut topics = Vec::new();
+    for _ in 0..4 {
+        let event = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("timeout waiting for external ingest chain")
+            .expect("should receive signal");
+        topics.push(event.topic.clone());
+        if event.topic == "user.input.normalized" {
+            assert_eq!(event.payload["text"], "外部输入进入 EventLog");
+            assert_eq!(event.payload["inputMode"], "external");
+            assert_eq!(event.payload["captureSource"], "wechat:room-external");
+        }
+        if event.topic == "eventlog.appended" {
+            assert_eq!(event.payload["text"], "外部输入进入 EventLog");
+            assert_eq!(event.payload["inputMode"], "external");
+            assert_eq!(event.payload["captureSource"], "wechat:room-external");
+        }
+    }
+
+    assert!(topics.iter().any(|topic| topic == "external.input.received"));
+    assert!(topics.iter().any(|topic| topic == "user.input.normalized"));
+    assert!(topics.iter().any(|topic| topic == "external.input.ingested"));
+    assert!(topics.iter().any(|topic| topic == "eventlog.appended"));
+}
+
 /// Verify the session.end -> review.completed chain.
 /// This is driven by the Reviewer Agent (TypeScript side), but we test
 /// the signal routing infrastructure here.

--- a/src/lib/constants/signal-topics.ts
+++ b/src/lib/constants/signal-topics.ts
@@ -1,6 +1,8 @@
 export const VOICE_INPUT_TRANSCRIPT_TOPIC = 'voice.input.transcript';
 export const USER_INPUT_TEXT_TOPIC = 'user.input.text';
 export const USER_INPUT_NORMALIZED_TOPIC = 'user.input.normalized';
+export const EXTERNAL_INPUT_RECEIVED_TOPIC = 'external.input.received';
+export const EXTERNAL_INPUT_INGESTED_TOPIC = 'external.input.ingested';
 
 export const VOICE_INPUT_NODE_ID = 'input:voice';
 export const VOICE_INPUT_NODE_LABEL = 'Voice Input（语音输入）';
@@ -10,6 +12,8 @@ export const KNOWN_AGENT_HUB_TOPICS = [
   VOICE_INPUT_TRANSCRIPT_TOPIC,
   USER_INPUT_TEXT_TOPIC,
   USER_INPUT_NORMALIZED_TOPIC,
+  EXTERNAL_INPUT_RECEIVED_TOPIC,
+  EXTERNAL_INPUT_INGESTED_TOPIC,
   'session.end',
   'timeblock.completed',
   'input.classified',

--- a/src/lib/services/signal-handlers.ts
+++ b/src/lib/services/signal-handlers.ts
@@ -24,6 +24,8 @@ export interface TaskAutoCreatedPayload {
 export interface EventLogAppendedPayload {
   text: string;
   ts: number;
+  inputMode?: string;
+  captureSource?: string;
 }
 
 /** Payload shape for eventlog.replication.appended signals. */

--- a/src/ui/hooks/useSignalStream.ts
+++ b/src/ui/hooks/useSignalStream.ts
@@ -12,6 +12,7 @@ import { isTauri } from '@tauri-apps/api/core';
 import { SignalStreamService } from '@/lib/services/signal-stream.service';
 import {
   startSignalHandlers,
+  type EventLogAppendedPayload,
   type EventLogReplicationAppendedPayload,
   type ReviewCompletedPayload,
 } from '@/lib/services/signal-handlers';
@@ -30,6 +31,7 @@ import {
   type RuntimeTarget,
 } from '@/config/runtime-target';
 import { getRuntimeControlService } from '@/lib/services/runtime-control.service';
+import { getEventLogService } from '@/lib/services/eventlog.service';
 import { log } from '@/lib/logger';
 
 const EMBEDDED_RUNTIME_STATUS_RETRY_MS = 1_000;
@@ -59,6 +61,22 @@ function formatReviewAsMarkdown(payload: ReviewCompletedPayload): string {
   }
 
   return lines.join('\n').trimEnd();
+}
+
+function buildSignalEventLogId(payload: EventLogAppendedPayload): string {
+  const fingerprint = [
+    payload.ts,
+    payload.captureSource ?? '',
+    payload.inputMode ?? '',
+    payload.text,
+  ].join('|');
+
+  let hash = 0;
+  for (let index = 0; index < fingerprint.length; index += 1) {
+    hash = ((hash * 31) + fingerprint.charCodeAt(index)) >>> 0;
+  }
+
+  return `signal-eventlog-${payload.ts}-${hash.toString(16)}`;
 }
 
 export function useSignalStream(): void {
@@ -162,6 +180,36 @@ export function useSignalStream(): void {
     });
 
     const handler = startSignalHandlers({
+      onEventLogAppended: async (payload: EventLogAppendedPayload) => {
+        const content = payload.text.trim();
+        if (!content) {
+          return;
+        }
+
+        const timestamp = Number.isFinite(payload.ts) && payload.ts > 0
+          ? payload.ts
+          : Date.now();
+
+        await getEventLogService().appendEventData({
+          id: buildSignalEventLogId({
+            ...payload,
+            text: content,
+            ts: timestamp,
+          }),
+          timestamp,
+          content,
+          tags: ['note'],
+          metadata: {
+            source: getEventSourceMetadata(),
+            signal: {
+              topic: 'eventlog.appended',
+              inputMode: payload.inputMode ?? null,
+              captureSource: payload.captureSource ?? null,
+            },
+          },
+        });
+        log.info('[SignalStream] eventlog.appended → EventLogService');
+      },
       onEventLogReplicationAppended: async (payload: EventLogReplicationAppendedPayload) => {
         const result = await projectEventLogReplicationAppend(payload);
         if (result === 'inserted') {

--- a/src/ui/hooks/useSignalStream.ts
+++ b/src/ui/hooks/useSignalStream.ts
@@ -181,6 +181,10 @@ export function useSignalStream(): void {
 
     const handler = startSignalHandlers({
       onEventLogAppended: async (payload: EventLogAppendedPayload) => {
+        if (payload.inputMode !== 'external') {
+          return;
+        }
+
         const content = payload.text.trim();
         if (!content) {
           return;

--- a/tests/unit/scripts/tauri-dev-manager-lib.test.ts
+++ b/tests/unit/scripts/tauri-dev-manager-lib.test.ts
@@ -1,7 +1,12 @@
 import path from 'node:path';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { describe, expect, it } from 'vitest';
 import {
+  appendManagedTauriLogSessionStart,
   buildManagedTauriCommand,
+  collectManagedTauriCleanupPids,
+  evaluateManagedTauriInstanceHealth,
   resolveManagedTauriInstancePaths,
 } from '../../../Scripts/dev/tauri-dev-manager-lib';
 
@@ -44,5 +49,112 @@ describe('tauri-dev-manager-lib', () => {
     });
 
     expect(command).toContain('set "EXOMIND_TAURI_ENABLE_WATCH=1"');
+  });
+
+  it('appends a new manager session marker instead of truncating old logs（启动新会话应追加旧日志而不是覆盖）', async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'tauri-dev-manager-log-'));
+    const logPath = path.join(tempDir, 'desktop.log');
+
+    try {
+      await writeFile(logPath, 'previous line\n', 'utf8');
+      await appendManagedTauriLogSessionStart(logPath, {
+        name: 'desktop',
+        target: 'desktop',
+        webPort: 1420,
+        hmrPort: 1421,
+        startedAt: '2026-03-18T10:02:03.000Z',
+      });
+
+      const content = await readFile(logPath, 'utf8');
+      expect(content).toContain('previous line');
+      expect(content).toContain('manager session start');
+      expect(content).toContain('name=desktop');
+      expect(content).toContain('web=1420');
+      expect(content.indexOf('previous line')).toBeLessThan(content.indexOf('manager session start'));
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('marks desktop instances stale when the Tauri app process is gone even if web ports still listen（桌面窗口进程消失但端口残留时应判定为 stale）', () => {
+    const health = evaluateManagedTauriInstanceHealth(
+      {
+        name: 'desktop',
+        projectRoot: 'D:\\project\\exomind',
+        rootPid: 1234,
+        webPort: 1420,
+        hmrPort: 1421,
+        logPath: 'D:\\project\\exomind\\.tmp\\tauri-dev-instances\\desktop.log',
+        metaPath: 'D:\\project\\exomind\\.tmp\\tauri-dev-instances\\desktop.json',
+        startedAt: '2026-03-18T10:02:03.000Z',
+        enableWatch: false,
+        target: 'desktop',
+      },
+      {
+        rootPidAlive: true,
+        webPortListening: true,
+        hmrPortListening: true,
+        appProcessAlive: false,
+      },
+    );
+
+    expect(health.status).toBe('stale');
+    expect(health.detail).toContain('desktop app process missing');
+    expect(health.detail).toContain('web=1420');
+    expect(health.detail).toContain('hmr=1421');
+  });
+
+  it('keeps desktop instances running only when root pid app process and ports are all healthy（桌面实例需进程和端口都健康才算 running）', () => {
+    const health = evaluateManagedTauriInstanceHealth(
+      {
+        name: 'desktop',
+        projectRoot: 'D:\\project\\exomind',
+        rootPid: 1234,
+        webPort: 1420,
+        hmrPort: 1421,
+        logPath: 'D:\\project\\exomind\\.tmp\\tauri-dev-instances\\desktop.log',
+        metaPath: 'D:\\project\\exomind\\.tmp\\tauri-dev-instances\\desktop.json',
+        startedAt: '2026-03-18T10:02:03.000Z',
+        enableWatch: false,
+        target: 'desktop',
+      },
+      {
+        rootPidAlive: true,
+        webPortListening: true,
+        hmrPortListening: true,
+        appProcessAlive: true,
+      },
+    );
+
+    expect(health.status).toBe('running');
+    expect(health.detail).toBe('ok');
+  });
+
+  it('collects leftover listener pids when the root process already died（根进程已死时 stop 应回收残留监听进程）', () => {
+    const cleanupPids = collectManagedTauriCleanupPids(
+      {
+        name: 'desktop',
+        projectRoot: 'D:\\project\\exomind',
+        rootPid: 1234,
+        webPort: 1420,
+        hmrPort: 1421,
+        logPath: 'D:\\project\\exomind\\.tmp\\tauri-dev-instances\\desktop.log',
+        metaPath: 'D:\\project\\exomind\\.tmp\\tauri-dev-instances\\desktop.json',
+        startedAt: '2026-03-18T10:02:03.000Z',
+        enableWatch: false,
+        target: 'desktop',
+      },
+      {
+        rootPidAlive: false,
+        webPortListening: true,
+        hmrPortListening: true,
+        appProcessAlive: false,
+        webPortPids: [333436],
+        hmrPortPids: [333436],
+        appPids: [],
+      },
+    );
+
+    expect(cleanupPids).toEqual([333436]);
   });
 });

--- a/tests/unit/ui/use-signal-stream.m4.test.tsx
+++ b/tests/unit/ui/use-signal-stream.m4.test.tsx
@@ -235,4 +235,30 @@ describe('useSignalStream m4（SSE Runtime 目标切换）', () => {
       }),
     }));
   });
+
+  it('ignores voice eventlog.appended payloads to avoid duplicate writes（忽略 voice eventlog.appended，避免重复写入）', async () => {
+    runtimeStatuses.push({
+      running: true,
+      host: '127.0.0.1',
+      port: 19574,
+      hostId: 'desktop-host',
+      authSecret: 'embedded-secret',
+    });
+
+    render(<HookHarness />);
+    await flushMicrotasks();
+
+    const onEventLogAppended = signalHandlerOptions[0].onEventLogAppended as
+      | ((payload: { text: string; ts: number; inputMode?: string; captureSource?: string }) => Promise<void>)
+      | undefined;
+
+    await onEventLogAppended?.({
+      text: 'voice duplicate candidate',
+      ts: 1773810310000,
+      inputMode: 'voice',
+      captureSource: 'global-shortcut',
+    });
+
+    expect(appendEventDataMock).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/ui/use-signal-stream.m4.test.tsx
+++ b/tests/unit/ui/use-signal-stream.m4.test.tsx
@@ -9,10 +9,13 @@ const {
   stopMock,
   onSignalMock,
   signalServiceOptions,
+  signalHandlerOptions,
+  appendEventDataMock,
   MockSignalStreamService,
 } = vi.hoisted(() => {
   const queuedStatuses: RuntimeStatus[] = [];
   const queuedSignalServiceOptions: Array<Record<string, unknown>> = [];
+  const queuedSignalHandlerOptions: Array<Record<string, unknown>> = [];
   const queuedGetStatusMock = vi.fn<() => Promise<RuntimeStatus>>(async () => {
     if (queuedStatuses.length === 0) {
       throw new Error('runtime status queue exhausted（运行时状态队列已耗尽）');
@@ -27,6 +30,7 @@ const {
   const queuedStartMock = vi.fn();
   const queuedStopMock = vi.fn();
   const queuedOnSignalMock = vi.fn(() => () => {});
+  const queuedAppendEventDataMock = vi.fn(async () => undefined);
 
   class HoistedMockSignalStreamService {
     constructor(options: Record<string, unknown>) {
@@ -45,6 +49,8 @@ const {
     stopMock: queuedStopMock,
     onSignalMock: queuedOnSignalMock,
     signalServiceOptions: queuedSignalServiceOptions,
+    signalHandlerOptions: queuedSignalHandlerOptions,
+    appendEventDataMock: queuedAppendEventDataMock,
     MockSignalStreamService: HoistedMockSignalStreamService,
   };
 });
@@ -70,7 +76,16 @@ vi.mock('@/lib/services/signal-stream.service', () => ({
 }));
 
 vi.mock('@/lib/services/signal-handlers', () => ({
-  startSignalHandlers: vi.fn(() => async () => {}),
+  startSignalHandlers: vi.fn((options: Record<string, unknown>) => {
+    signalHandlerOptions.push(options);
+    return async () => {};
+  }),
+}));
+
+vi.mock('@/lib/services/eventlog.service', () => ({
+  getEventLogService: () => ({
+    appendEventData: appendEventDataMock,
+  }),
 }));
 
 vi.mock('@/lib/services/ecs-eventlog-replication.service', () => ({
@@ -115,10 +130,12 @@ describe('useSignalStream m4（SSE Runtime 目标切换）', () => {
     window.localStorage.clear();
     runtimeStatuses.length = 0;
     signalServiceOptions.length = 0;
+    signalHandlerOptions.length = 0;
     getStatusMock.mockClear();
     startMock.mockClear();
     stopMock.mockClear();
     onSignalMock.mockClear();
+    appendEventDataMock.mockClear();
     setRuntimeTargetMode('embedded');
     Object.defineProperty(window, '__TAURI_INTERNALS__', {
       configurable: true,
@@ -181,5 +198,41 @@ describe('useSignalStream m4（SSE Runtime 目标切换）', () => {
     });
     expect(window.localStorage.getItem(EMBEDDED_RUNTIME_STATUS_STORAGE_KEY)).toContain('"port":48202');
     expect(window.localStorage.getItem(EMBEDDED_RUNTIME_STATUS_STORAGE_KEY)).toContain('"authSecret":"embedded-secret"');
+  });
+
+  it('bridges eventlog.appended into EventLogService（把 eventlog.appended 桥接进 EventLogService）', async () => {
+    runtimeStatuses.push({
+      running: true,
+      host: '127.0.0.1',
+      port: 19574,
+      hostId: 'desktop-host',
+      authSecret: 'embedded-secret',
+    });
+
+    render(<HookHarness />);
+    await flushMicrotasks();
+
+    expect(signalHandlerOptions).toHaveLength(1);
+    const onEventLogAppended = signalHandlerOptions[0].onEventLogAppended as
+      | ((payload: { text: string; ts: number; inputMode?: string; captureSource?: string }) => Promise<void>)
+      | undefined;
+
+    expect(onEventLogAppended).toEqual(expect.any(Function));
+
+    await onEventLogAppended?.({
+      text: 'external-pipeline-manual-verify-1305',
+      ts: 1773810305000,
+      inputMode: 'external',
+      captureSource: 'manual',
+    });
+
+    expect(appendEventDataMock).toHaveBeenCalledWith(expect.objectContaining({
+      content: 'external-pipeline-manual-verify-1305',
+      timestamp: 1773810305000,
+      tags: ['note'],
+      metadata: expect.objectContaining({
+        source: expect.any(Object),
+      }),
+    }));
   });
 });


### PR DESCRIPTION
## 摘要
- 新增 `external_input_actor`，把 `external.input.received` 归一化为 `user.input.normalized`，并补发 `external.input.ingested`。
- 新增 `external_source_actor`，轮询 WeFlow REST API（`/api/v1/messages`），以有界去重方式发布外部输入信号。
- 将 `eventlog.appended` 桥接到前端 `EventLogService`，确保外部信号能真正出现在 EventLog UI 中。

## 验证
- `bunx vitest run tests/unit/ui/use-signal-stream.m4.test.tsx --reporter verbose`
- `bunx tsc --noEmit`
- `cargo test -p exomind-runtime external_ --manifest-path src-tauri/Cargo.toml -- --nocapture`
- `cargo test -p exomind-runtime external_input_is_normalized_before_eventlog_append --manifest-path src-tauri/Cargo.toml -- --nocapture`
- `cargo build -p exomind-runtime --manifest-path src-tauri/Cargo.toml`
- `bun run build`
- 手动 Runtime 验证：以 `EXOMIND_RT_PORT=19574` 启动 `bun run tauri:manager -- start --name issue574ext --web-port 17540 --hmr-port 17541`，确认真实 WeFlow 消息会出现在 Tauri EventLog UI 中。

## 备注
- 实现已经改为使用真实的 WeFlow HTTP API（`GET /api/v1/messages`），不再沿用计划文档里过时的 `/mcp` 假设。
- 本地 worktree 里仍有一个未暂存的 `src-tauri/Cargo.toml` LF/CRLF 变化，该内容不属于本 PR。

Closes #574
