### PR TITLE
fix(voice/runtime): 双层去重修复 NowInputRow 与多实例 EventLog (#575 #576)

### DIFF
--- a/crates/exomind-runtime/src/signal/actors/eventlog_actor.rs
+++ b/crates/exomind-runtime/src/signal/actors/eventlog_actor.rs
@@ -1,18 +1,78 @@
+use std::collections::VecDeque;
+use std::hash::{Hash, Hasher};
+use std::collections::hash_map::DefaultHasher;
 use std::sync::Arc;
 
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::signal::SignalPool;
 use crate::signal::types::SignalEvent;
+
+/// Sliding-window deduplication for eventlog writes.
+///
+/// When multiple ExoMind instances run simultaneously, each instance's
+/// eventlog_actor independently receives the same voice input signal and
+/// would write N duplicates for N instances. This window checks whether
+/// identical content was already seen within the last [`DEDUP_WINDOW_SECS`]
+/// seconds, and skips the duplicate publish.
+const DEDUP_WINDOW_SECS: u64 = 5;
+const DEDUP_WINDOW_MAX: usize = 100;
+
+struct DedupWindow {
+    entries: VecDeque<(u64, u64)>, // (timestamp_ms, content_hash)
+}
+
+impl DedupWindow {
+    fn new() -> Self {
+        Self {
+            entries: VecDeque::with_capacity(DEDUP_WINDOW_MAX),
+        }
+    }
+
+    /// Returns `true` if `text` at `ts_ms` is a duplicate of a recent entry.
+    /// If not a duplicate, records it for future checks.
+    fn is_duplicate(&mut self, ts_ms: u64, text: &str) -> bool {
+        let hash = {
+            let mut hasher = DefaultHasher::new();
+            text.hash(&mut hasher);
+            hasher.finish()
+        };
+
+        // Evict entries older than the dedup window
+        while let Some(&(old_ts, _)) = self.entries.front() {
+            if ts_ms.saturating_sub(old_ts) > DEDUP_WINDOW_SECS * 1000 {
+                self.entries.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        // Check for duplicate
+        let found = self.entries.iter().any(|&(_, h)| h == hash);
+
+        if !found {
+            if self.entries.len() >= DEDUP_WINDOW_MAX {
+                self.entries.pop_front();
+            }
+            self.entries.push_back((ts_ms, hash));
+        }
+
+        found
+    }
+}
 
 /// Spawn the EventLog Actor as a background tokio task.
 ///
 /// The actor subscribes to the SignalPool broadcast channel, filters for
 /// `user.input.normalized` events, and re-publishes each as an `eventlog.appended`
 /// signal containing the extracted text and a timestamp.
+///
+/// A [`DedupWindow`] is used to skip duplicate content within a 5-second
+/// sliding window, preventing multi-instance duplicate writes.
 pub fn spawn_eventlog_actor(pool: Arc<SignalPool>) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut rx = pool.subscribe();
+        let mut dedup = DedupWindow::new();
 
         loop {
             match rx.recv().await {
@@ -20,7 +80,7 @@ pub fn spawn_eventlog_actor(pool: Arc<SignalPool>) -> tokio::task::JoinHandle<()
                     if event.topic != "user.input.normalized" {
                         continue;
                     }
-                    handle_user_input(&pool, &event);
+                    handle_user_input(&pool, &event, &mut dedup);
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                     warn!(
@@ -37,7 +97,7 @@ pub fn spawn_eventlog_actor(pool: Arc<SignalPool>) -> tokio::task::JoinHandle<()
     })
 }
 
-fn handle_user_input(pool: &SignalPool, event: &SignalEvent) {
+fn handle_user_input(pool: &SignalPool, event: &SignalEvent, dedup: &mut DedupWindow) {
     let text = match event.payload.get("text").and_then(|v| v.as_str()) {
         Some(t) => t,
         None => {
@@ -50,6 +110,15 @@ fn handle_user_input(pool: &SignalPool, event: &SignalEvent) {
     };
 
     let now_ms = chrono::Utc::now().timestamp_millis() as u64;
+
+    // Multi-instance dedup: skip if identical content was seen within the window
+    if dedup.is_duplicate(now_ms, text) {
+        debug!(
+            event_id = %event.id,
+            "eventlog_actor: duplicate content within dedup window, skipping"
+        );
+        return;
+    }
 
     let new_event = SignalEvent {
         schema_version: 1,
@@ -213,5 +282,83 @@ mod tests {
         )
         .await;
         assert!(result.is_err(), "should not receive any more events");
+    }
+
+    // --- DedupWindow unit tests ---
+
+    #[test]
+    fn dedup_window_detects_duplicate_within_window() {
+        let mut w = DedupWindow::new();
+        let ts = 1000_u64;
+        assert!(!w.is_duplicate(ts, "hello"), "first should not be dup");
+        assert!(w.is_duplicate(ts + 100, "hello"), "same text within window should be dup");
+    }
+
+    #[test]
+    fn dedup_window_allows_after_expiry() {
+        let mut w = DedupWindow::new();
+        let ts = 1000_u64;
+        assert!(!w.is_duplicate(ts, "hello"));
+        // 6 seconds later — outside the 5-second window
+        assert!(!w.is_duplicate(ts + 6000, "hello"), "same text after window should not be dup");
+    }
+
+    #[test]
+    fn dedup_window_different_content_not_dup() {
+        let mut w = DedupWindow::new();
+        let ts = 1000_u64;
+        assert!(!w.is_duplicate(ts, "hello"));
+        assert!(!w.is_duplicate(ts + 100, "world"), "different text should not be dup");
+    }
+
+    #[test]
+    fn dedup_window_evicts_when_full() {
+        let mut w = DedupWindow::new();
+        // Fill the window to capacity
+        for i in 0..DEDUP_WINDOW_MAX {
+            assert!(!w.is_duplicate(1000, &format!("msg-{i}")));
+        }
+        assert_eq!(w.entries.len(), DEDUP_WINDOW_MAX);
+        // One more should evict the oldest
+        assert!(!w.is_duplicate(1000, "overflow"));
+        assert_eq!(w.entries.len(), DEDUP_WINDOW_MAX);
+    }
+
+    #[tokio::test]
+    async fn duplicate_input_within_window_is_skipped() {
+        let pool = Arc::new(SignalPool::new(None));
+
+        let _handle = spawn_eventlog_actor(Arc::clone(&pool));
+        yield_for_actor().await;
+
+        let mut rx = pool.subscribe();
+
+        // Publish the same text twice in quick succession
+        let event1 = make_user_input_event("duplicate text");
+        let event2 = make_user_input_event("duplicate text");
+        pool.publish(event1);
+        pool.publish(event2);
+
+        // We should see: user.input.normalized, eventlog.appended,
+        //                user.input.normalized, (NO second eventlog.appended)
+        let mut appended_count = 0;
+        let mut total = 0;
+        loop {
+            let result = tokio::time::timeout(
+                std::time::Duration::from_millis(500),
+                rx.recv(),
+            )
+            .await;
+            match result {
+                Ok(Ok(ev)) => {
+                    total += 1;
+                    if ev.topic == "eventlog.appended" {
+                        appended_count += 1;
+                    }
+                }
+                _ => break,
+            }
+        }
+        assert_eq!(appended_count, 1, "should only produce one eventlog.appended, got {appended_count} (total events: {total})");
     }
 }

--- a/crates/exomind-runtime/src/signal/actors/eventlog_actor.rs
+++ b/crates/exomind-runtime/src/signal/actors/eventlog_actor.rs
@@ -1,78 +1,18 @@
-use std::collections::VecDeque;
-use std::hash::{Hash, Hasher};
-use std::collections::hash_map::DefaultHasher;
 use std::sync::Arc;
 
-use tracing::{debug, warn};
+use tracing::warn;
 
 use crate::signal::SignalPool;
 use crate::signal::types::SignalEvent;
-
-/// Sliding-window deduplication for eventlog writes.
-///
-/// When multiple ExoMind instances run simultaneously, each instance's
-/// eventlog_actor independently receives the same voice input signal and
-/// would write N duplicates for N instances. This window checks whether
-/// identical content was already seen within the last [`DEDUP_WINDOW_SECS`]
-/// seconds, and skips the duplicate publish.
-const DEDUP_WINDOW_SECS: u64 = 5;
-const DEDUP_WINDOW_MAX: usize = 100;
-
-struct DedupWindow {
-    entries: VecDeque<(u64, u64)>, // (timestamp_ms, content_hash)
-}
-
-impl DedupWindow {
-    fn new() -> Self {
-        Self {
-            entries: VecDeque::with_capacity(DEDUP_WINDOW_MAX),
-        }
-    }
-
-    /// Returns `true` if `text` at `ts_ms` is a duplicate of a recent entry.
-    /// If not a duplicate, records it for future checks.
-    fn is_duplicate(&mut self, ts_ms: u64, text: &str) -> bool {
-        let hash = {
-            let mut hasher = DefaultHasher::new();
-            text.hash(&mut hasher);
-            hasher.finish()
-        };
-
-        // Evict entries older than the dedup window
-        while let Some(&(old_ts, _)) = self.entries.front() {
-            if ts_ms.saturating_sub(old_ts) > DEDUP_WINDOW_SECS * 1000 {
-                self.entries.pop_front();
-            } else {
-                break;
-            }
-        }
-
-        // Check for duplicate
-        let found = self.entries.iter().any(|&(_, h)| h == hash);
-
-        if !found {
-            if self.entries.len() >= DEDUP_WINDOW_MAX {
-                self.entries.pop_front();
-            }
-            self.entries.push_back((ts_ms, hash));
-        }
-
-        found
-    }
-}
 
 /// Spawn the EventLog Actor as a background tokio task.
 ///
 /// The actor subscribes to the SignalPool broadcast channel, filters for
 /// `user.input.normalized` events, and re-publishes each as an `eventlog.appended`
 /// signal containing the extracted text and a timestamp.
-///
-/// A [`DedupWindow`] is used to skip duplicate content within a 5-second
-/// sliding window, preventing multi-instance duplicate writes.
 pub fn spawn_eventlog_actor(pool: Arc<SignalPool>) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut rx = pool.subscribe();
-        let mut dedup = DedupWindow::new();
 
         loop {
             match rx.recv().await {
@@ -80,7 +20,7 @@ pub fn spawn_eventlog_actor(pool: Arc<SignalPool>) -> tokio::task::JoinHandle<()
                     if event.topic != "user.input.normalized" {
                         continue;
                     }
-                    handle_user_input(&pool, &event, &mut dedup);
+                    handle_user_input(&pool, &event);
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                     warn!(
@@ -97,7 +37,7 @@ pub fn spawn_eventlog_actor(pool: Arc<SignalPool>) -> tokio::task::JoinHandle<()
     })
 }
 
-fn handle_user_input(pool: &SignalPool, event: &SignalEvent, dedup: &mut DedupWindow) {
+fn handle_user_input(pool: &SignalPool, event: &SignalEvent) {
     let text = match event.payload.get("text").and_then(|v| v.as_str()) {
         Some(t) => t,
         None => {
@@ -110,15 +50,6 @@ fn handle_user_input(pool: &SignalPool, event: &SignalEvent, dedup: &mut DedupWi
     };
 
     let now_ms = chrono::Utc::now().timestamp_millis() as u64;
-
-    // Multi-instance dedup: skip if identical content was seen within the window
-    if dedup.is_duplicate(now_ms, text) {
-        debug!(
-            event_id = %event.id,
-            "eventlog_actor: duplicate content within dedup window, skipping"
-        );
-        return;
-    }
 
     let new_event = SignalEvent {
         schema_version: 1,
@@ -284,48 +215,8 @@ mod tests {
         assert!(result.is_err(), "should not receive any more events");
     }
 
-    // --- DedupWindow unit tests ---
-
-    #[test]
-    fn dedup_window_detects_duplicate_within_window() {
-        let mut w = DedupWindow::new();
-        let ts = 1000_u64;
-        assert!(!w.is_duplicate(ts, "hello"), "first should not be dup");
-        assert!(w.is_duplicate(ts + 100, "hello"), "same text within window should be dup");
-    }
-
-    #[test]
-    fn dedup_window_allows_after_expiry() {
-        let mut w = DedupWindow::new();
-        let ts = 1000_u64;
-        assert!(!w.is_duplicate(ts, "hello"));
-        // 6 seconds later — outside the 5-second window
-        assert!(!w.is_duplicate(ts + 6000, "hello"), "same text after window should not be dup");
-    }
-
-    #[test]
-    fn dedup_window_different_content_not_dup() {
-        let mut w = DedupWindow::new();
-        let ts = 1000_u64;
-        assert!(!w.is_duplicate(ts, "hello"));
-        assert!(!w.is_duplicate(ts + 100, "world"), "different text should not be dup");
-    }
-
-    #[test]
-    fn dedup_window_evicts_when_full() {
-        let mut w = DedupWindow::new();
-        // Fill the window to capacity
-        for i in 0..DEDUP_WINDOW_MAX {
-            assert!(!w.is_duplicate(1000, &format!("msg-{i}")));
-        }
-        assert_eq!(w.entries.len(), DEDUP_WINDOW_MAX);
-        // One more should evict the oldest
-        assert!(!w.is_duplicate(1000, "overflow"));
-        assert_eq!(w.entries.len(), DEDUP_WINDOW_MAX);
-    }
-
     #[tokio::test]
-    async fn duplicate_input_within_window_is_skipped() {
+    async fn identical_inputs_within_window_are_not_skipped() {
         let pool = Arc::new(SignalPool::new(None));
 
         let _handle = spawn_eventlog_actor(Arc::clone(&pool));
@@ -340,7 +231,7 @@ mod tests {
         pool.publish(event2);
 
         // We should see: user.input.normalized, eventlog.appended,
-        //                user.input.normalized, (NO second eventlog.appended)
+        //                user.input.normalized, eventlog.appended
         let mut appended_count = 0;
         let mut total = 0;
         loop {
@@ -359,6 +250,10 @@ mod tests {
                 _ => break,
             }
         }
-        assert_eq!(appended_count, 1, "should only produce one eventlog.appended, got {appended_count} (total events: {total})");
+        assert_eq!(
+            appended_count,
+            2,
+            "identical inputs should remain appendable, got {appended_count} appended events (total events: {total})"
+        );
     }
 }

--- a/src/services/voice-shortcut-eventlog.ts
+++ b/src/services/voice-shortcut-eventlog.ts
@@ -1,0 +1,99 @@
+import { sha256 } from '@/adapters/crypto-adapter';
+import type { AgentInteractionContext, TargetScope, WindowContext } from '@/lib/types/normalized-input';
+import type { Event } from '@/lib/storage/event-storage';
+
+const VOICE_SHORTCUT_ACTIVATION_BUCKET_MS = 500;
+
+type VoiceShortcutMetadata = {
+  dedupVersion: 'v1';
+  captureSource: 'global-shortcut';
+  activationBucketMs: number;
+  targetScope: TargetScope;
+  text: string;
+  window?: {
+    title?: string;
+    processName?: string;
+  };
+  agentContext?: {
+    agentId?: string;
+    agentName?: string;
+    sessionId?: string;
+  };
+};
+
+export interface BuildVoiceShortcutStorageEventInput {
+  text: string;
+  startedAtMs: number;
+  targetScope: TargetScope;
+  window?: WindowContext;
+  agentContext?: AgentInteractionContext;
+}
+
+function normalizeOptionalString(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeWindow(window?: WindowContext): VoiceShortcutMetadata['window'] | undefined {
+  if (!window) {
+    return undefined;
+  }
+
+  const normalized = {
+    title: normalizeOptionalString(window.title),
+    processName: normalizeOptionalString(window.processName),
+  };
+
+  return normalized.title || normalized.processName ? normalized : undefined;
+}
+
+function normalizeAgentContext(agentContext?: AgentInteractionContext): VoiceShortcutMetadata['agentContext'] | undefined {
+  if (!agentContext) {
+    return undefined;
+  }
+
+  const normalized = {
+    agentId: normalizeOptionalString(agentContext.agentId),
+    agentName: normalizeOptionalString(agentContext.agentName),
+    sessionId: normalizeOptionalString(agentContext.sessionId),
+  };
+
+  return normalized.agentId || normalized.agentName || normalized.sessionId ? normalized : undefined;
+}
+
+function toActivationBucketMs(startedAtMs: number): number {
+  return Math.floor(startedAtMs / VOICE_SHORTCUT_ACTIVATION_BUCKET_MS) * VOICE_SHORTCUT_ACTIVATION_BUCKET_MS;
+}
+
+export async function buildVoiceShortcutStorageEvent(
+  input: BuildVoiceShortcutStorageEventInput,
+): Promise<Event> {
+  const text = input.text.trim();
+  if (!text) {
+    throw new Error('voice shortcut event requires non-empty text（语音快捷键事件不能为空）');
+  }
+
+  const activationBucketMs = toActivationBucketMs(input.startedAtMs);
+  const normalizedWindow = normalizeWindow(input.window);
+  const normalizedAgentContext = normalizeAgentContext(input.agentContext);
+  const metadata: VoiceShortcutMetadata = {
+    dedupVersion: 'v1',
+    captureSource: 'global-shortcut',
+    activationBucketMs,
+    targetScope: input.targetScope,
+    text,
+    ...(normalizedWindow ? { window: normalizedWindow } : {}),
+    ...(normalizedAgentContext ? { agentContext: normalizedAgentContext } : {}),
+  };
+  const id = `voice-shortcut:${(await sha256(JSON.stringify(metadata))).slice(0, 32)}`;
+
+  return {
+    id,
+    content: text,
+    createdAt: new Date(activationBucketMs).toISOString(),
+    type: 'voice',
+    metadata: {
+      voiceShortcut: metadata,
+    },
+  };
+}

--- a/src/services/voice-shortcut.service.ts
+++ b/src/services/voice-shortcut.service.ts
@@ -2,7 +2,7 @@ import { listen, emit } from '@tauri-apps/api/event';
 import { invoke, isTauri } from '@tauri-apps/api/core';
 import { MOSSASRAdapter } from '../lib/adapters/asr/moss-asr';
 import { getClipboardService } from '../lib/services/clipboard.service';
-import { getEventLogService } from '../lib/services/eventlog.service';
+import { appendEventWithEcsReplication } from '@/lib/services/ecs-eventlog-replication.service';
 import { publishVoiceTranscriptSignal } from '@/lib/services/voice-signal.service';
 import { getActiveInteractionContextService } from '@/lib/services/active-interaction-context.service';
 import {
@@ -54,6 +54,7 @@ import {
   getVoiceOverlayBottomOffset,
   subscribeVoiceOverlayBottomOffsetChanges,
 } from '@/config/voice-overlay-preferences';
+import { buildVoiceShortcutStorageEvent } from '@/services/voice-shortcut-eventlog';
 
 export type VoiceShortcutState = 'idle' | 'arming' | 'recording' | 'recognizing' | 'done' | 'error';
 
@@ -904,8 +905,18 @@ export class VoiceShortcutService {
       ?? null;
     const traceId = this.currentTraceId ?? undefined;
     const targetScope = activeInteractionContext?.targetScope ?? (foregroundWindow ? 'external-window' : 'unknown');
+    const storageEvent = await buildVoiceShortcutStorageEvent({
+      text: result.text,
+      startedAtMs: this.traceStartedAtMs ?? Date.now(),
+      targetScope,
+      window: foregroundWindow ? {
+        title: foregroundWindow.title ?? undefined,
+        processName: foregroundWindow.processName ?? undefined,
+      } : undefined,
+      agentContext: activeInteractionContext?.agentContext,
+    });
 
-    const [clipboardResult, signalPublishResult] = await Promise.allSettled([
+    const [clipboardResult, signalPublishResult, eventlogAppendResult] = await Promise.allSettled([
       (async () => {
         const writeResult = await getClipboardService().writeText(result.text);
         if (!writeResult.ok) throw new Error(writeResult.title);
@@ -926,18 +937,15 @@ export class VoiceShortcutService {
         } : undefined,
         agentContext: activeInteractionContext?.agentContext,
       }),
+      appendEventWithEcsReplication(storageEvent),
     ]);
 
     if (clipboardResult.status === 'rejected') {
       this.debugError(LOG_TAG, 'clipboard paste failed:', clipboardResult.reason);
     }
 
-    // 语音输入始终写入 EventLog（前端直写，带 voice tag）
-    // signal 路径仅用于 RT actor 协调（classifier 等），不负责持久化
-    try {
-      await getEventLogService().addEvent(result.text, new Set(['voice']));
-    } catch (err) {
-      this.debugError(LOG_TAG, 'eventlog write failed:', err);
+    if (eventlogAppendResult.status === 'rejected') {
+      this.debugError(LOG_TAG, 'eventlog append failed:', eventlogAppendResult.reason);
     }
 
     if (signalPublishResult.status === 'rejected') {

--- a/src/ui/app/components/NowInputRow.tsx
+++ b/src/ui/app/components/NowInputRow.tsx
@@ -17,6 +17,7 @@ import { VoiceInputButton, type VoiceInputButtonHandle } from '@/components/Voic
 import type { VoiceMessageInputHandle } from '@/components/VoiceMessageInput';
 import { publishVoiceTranscriptSignal } from '@/lib/services/voice-signal.service';
 import { log } from '@/lib/logger';
+import { normalizeRecognitionText } from '@/lib/voice/recognition-text';
 
 interface NowInputRowProps {
   onSend: (content: string, tags?: string[]) => void | Promise<void>;
@@ -142,7 +143,7 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
   }, [insertClipboardText]);
 
   const handleVoiceResult = useCallback((text: string) => {
-    const normalized = text.trim();
+    const normalized = normalizeRecognitionText(text.trim());
     if (!normalized) return;
 
     void publishVoiceTranscriptSignal({ text: normalized }, {

--- a/src/ui/app/components/NowInputRow.tsx
+++ b/src/ui/app/components/NowInputRow.tsx
@@ -11,17 +11,33 @@ import { Clipboard, Image, Mic, SendHorizontal, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from '@/components/ui/toast-hook';
+import {
+  getVoiceTranscriptSendMode,
+  subscribeVoiceTranscriptSendModeChanges,
+  type VoiceTranscriptSendMode,
+} from '@/config/voice-transcript-send-mode';
 import { getClipboardService } from '@/lib/services';
 import type { ClipboardFailureReason } from '@/lib/services';
 import { VoiceInputButton, type VoiceInputButtonHandle } from '@/components/VoiceInputButton';
 import type { VoiceMessageInputHandle } from '@/components/VoiceMessageInput';
+import { getInputSendMode, subscribeInputSendModeChanges, type InputSendMode } from '@/config/input-send-mode';
+import { clearInputDraft, readInputDraft, writeInputDraft } from '@/lib/storage/input-draft-storage';
 import { publishVoiceTranscriptSignal } from '@/lib/services/voice-signal.service';
 import { log } from '@/lib/logger';
 import { normalizeRecognitionText } from '@/lib/voice/recognition-text';
 
 interface NowInputRowProps {
   onSend: (content: string, tags?: string[]) => void | Promise<void>;
+  onValueChange?: (value: string) => void;
   placeholder?: string;
+  draftStorageKey?: string | null;
+  draftDebounceMs?: number;
+}
+
+function buildAutoDraftStorageKey(placeholder: string): string {
+  const pathname = typeof window !== 'undefined' ? window.location.pathname || '/' : '/';
+  const normalizedPlaceholder = placeholder.trim() || 'default';
+  return `exomind:draft:now-input:${pathname}:${normalizedPlaceholder}`;
 }
 
 const getClipboardDebugSnapshot = () => {
@@ -41,11 +57,56 @@ function getPasteFailureLabel(reason: ClipboardFailureReason): string {
   return '未粘贴';
 }
 
+function shouldSendOnEnter(mode: InputSendMode, event: KeyboardEvent<HTMLTextAreaElement>): boolean {
+  if (event.key !== 'Enter') return false;
+  if (event.altKey) return false;
+
+  if (mode === 'enter-send') {
+    return !event.shiftKey && !event.ctrlKey && !event.metaKey;
+  }
+
+  if (event.shiftKey) return false;
+  return event.ctrlKey || event.metaKey;
+}
+
+function mergeTranscriptText(currentValue: string, transcript: string): string {
+  const trimmedCurrent = currentValue.trim();
+  if (!trimmedCurrent) return transcript;
+  return `${trimmedCurrent} ${transcript}`;
+}
+
+function insertTextareaNewline(textarea: HTMLTextAreaElement, onChangeValue: (nextValue: string) => void): void {
+  const start = textarea.selectionStart ?? textarea.value.length;
+  const end = textarea.selectionEnd ?? textarea.value.length;
+  const nextValue = `${textarea.value.slice(0, start)}\n${textarea.value.slice(end)}`;
+  const nextCursor = start + 1;
+
+  onChangeValue(nextValue);
+  requestAnimationFrame(() => {
+    textarea.selectionStart = nextCursor;
+    textarea.selectionEnd = nextCursor;
+    textarea.focus();
+  });
+}
+
+function focusTextarea(textarea: HTMLTextAreaElement | null): void {
+  textarea?.focus();
+  requestAnimationFrame(() => {
+    textarea?.focus();
+  });
+}
+
 export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>(function NowInputRow({
   onSend,
+  onValueChange,
   placeholder = '记录当下的事实...',
+  draftStorageKey,
+  draftDebounceMs = 300,
 }, ref) {
+  const effectiveDraftStorageKey = draftStorageKey === null ? null : draftStorageKey ?? buildAutoDraftStorageKey(placeholder);
   const [value, setValue] = useState('');
+  const [voiceTranscriptSendMode, setVoiceTranscriptSendMode] = useState<VoiceTranscriptSendMode>(() => getVoiceTranscriptSendMode());
+  const [inputSendMode, setInputSendMode] = useState<InputSendMode>(() => getInputSendMode());
   const [pasteFeedback, setPasteFeedback] = useState<'idle' | 'success' | 'error'>('idle');
   const [attachmentFeedback, setAttachmentFeedback] = useState<'idle' | 'pending'>('idle');
   const [pasteFailureLabel, setPasteFailureLabel] = useState('未粘贴');
@@ -53,6 +114,7 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
   const voiceButtonRef = useRef<VoiceInputButtonHandle | null>(null);
   const pasteFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const attachmentFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const draftPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const resizeTextarea = useCallback((target?: HTMLTextAreaElement | null) => {
     const el = target ?? textareaRef.current;
@@ -70,6 +132,13 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
     resizeTextarea();
   }, [value, resizeTextarea]);
 
+  useEffect(() => {
+    onValueChange?.(value);
+  }, [onValueChange, value]);
+
+  useEffect(() => subscribeVoiceTranscriptSendModeChanges(setVoiceTranscriptSendMode), []);
+
+  useEffect(() => subscribeInputSendModeChanges(setInputSendMode), []);
   useEffect(() => () => {
     if (pasteFeedbackTimerRef.current) {
       clearTimeout(pasteFeedbackTimerRef.current);
@@ -79,7 +148,45 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
       clearTimeout(attachmentFeedbackTimerRef.current);
       attachmentFeedbackTimerRef.current = null;
     }
+    if (draftPersistTimerRef.current) {
+      clearTimeout(draftPersistTimerRef.current);
+      draftPersistTimerRef.current = null;
+    }
   }, []);
+
+  useEffect(() => {
+    if (!effectiveDraftStorageKey) return;
+
+    const savedDraft = readInputDraft(effectiveDraftStorageKey);
+    if (savedDraft !== null) {
+      setValue(savedDraft);
+    }
+  }, [effectiveDraftStorageKey]);
+
+  useEffect(() => {
+    if (!effectiveDraftStorageKey) return;
+
+    if (draftPersistTimerRef.current) {
+      clearTimeout(draftPersistTimerRef.current);
+      draftPersistTimerRef.current = null;
+    }
+
+    draftPersistTimerRef.current = setTimeout(() => {
+      if (!value.trim()) {
+        clearInputDraft(effectiveDraftStorageKey);
+      } else {
+        writeInputDraft(effectiveDraftStorageKey, value);
+      }
+      draftPersistTimerRef.current = null;
+    }, draftDebounceMs);
+
+    return () => {
+      if (draftPersistTimerRef.current) {
+        clearTimeout(draftPersistTimerRef.current);
+        draftPersistTimerRef.current = null;
+      }
+    };
+  }, [draftDebounceMs, effectiveDraftStorageKey, value]);
 
   const submitInput = useCallback(async () => {
     const trimmed = value.trim();
@@ -88,12 +195,28 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
     setValue('');
     try {
       await onSend(trimmed);
+      if (draftPersistTimerRef.current) {
+        clearTimeout(draftPersistTimerRef.current);
+        draftPersistTimerRef.current = null;
+      }
+      if (effectiveDraftStorageKey) {
+        clearInputDraft(effectiveDraftStorageKey);
+      }
+      focusTextarea(textareaRef.current);
     } catch (error) {
       setValue(saved);
+      if (draftPersistTimerRef.current) {
+        clearTimeout(draftPersistTimerRef.current);
+        draftPersistTimerRef.current = null;
+      }
+      if (effectiveDraftStorageKey) {
+        writeInputDraft(effectiveDraftStorageKey, saved);
+      }
+      focusTextarea(textareaRef.current);
       log.error(`[NowInputRow] send failed: ${error instanceof Error ? error.message : String(error)}`);
       toast({ title: '发送失败', description: '请检查网络连接后重试', variant: 'destructive' });
     }
-  }, [onSend, value]);
+  }, [effectiveDraftStorageKey, onSend, value]);
 
   const insertClipboardText = useCallback((text: string) => {
     if (!text) return;
@@ -143,7 +266,7 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
   }, [insertClipboardText]);
 
   const handleVoiceResult = useCallback((text: string) => {
-    const normalized = normalizeRecognitionText(text.trim());
+    const normalized = normalizeRecognitionText(text);
     if (!normalized) return;
 
     void publishVoiceTranscriptSignal({ text: normalized }, {
@@ -152,9 +275,22 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
       log.warn(`[new-now-input][voice-signal] ${publishError instanceof Error ? publishError.message : String(publishError)}`);
     });
 
-    // 语音输入始终直接发送到事件日志——语音是即时事件，应该立即入库
-    onSend(normalized, ['voice']);
-  }, [onSend]);
+    if (voiceTranscriptSendMode === 'direct-send') {
+      void onSend(normalized, ['voice']);
+      return;
+    }
+
+    setValue((prev) => mergeTranscriptText(prev, normalized));
+    requestAnimationFrame(() => {
+      textareaRef.current?.focus();
+      const nextValue = textareaRef.current?.value ?? '';
+      const end = nextValue.length;
+      if (textareaRef.current) {
+        textareaRef.current.selectionStart = end;
+        textareaRef.current.selectionEnd = end;
+      }
+    });
+  }, [onSend, voiceTranscriptSendMode]);
 
   const handleVoiceError = useCallback((error: string) => {
     log.error(`[new-now-input][voice] ${error}`);
@@ -165,18 +301,29 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
       textareaRef.current?.blur();
       return;
     }
-    if (event.key !== 'Enter') return;
-    if (!(event.ctrlKey || event.metaKey)) return;
-    if (event.altKey || event.shiftKey) return;
+
+    if (event.key !== 'Enter' || event.altKey) return;
+
+    if (shouldSendOnEnter(inputSendMode, event)) {
+      event.preventDefault();
+      if (value.trim()) {
+        void submitInput();
+      } else if (inputSendMode === 'ctrl-enter-send' && (event.ctrlKey || event.metaKey)) {
+        textareaRef.current?.blur();
+        voiceButtonRef.current?.start();
+      }
+      return;
+    }
+
+    const textarea = textareaRef.current;
+    if (!textarea) return;
 
     event.preventDefault();
-    if (value.trim()) {
-      submitInput();
-    } else {
-      textareaRef.current?.blur();
-      voiceButtonRef.current?.start();
-    }
-  }, [submitInput, value]);
+    insertTextareaNewline(textarea, (nextValue) => {
+      setValue(nextValue);
+      resizeTextarea(textarea);
+    });
+  }, [inputSendMode, resizeTextarea, submitInput, value]);
 
   const handleAttachmentClick = useCallback(() => {
     if (attachmentFeedbackTimerRef.current) {
@@ -201,7 +348,7 @@ export const NowInputRow = forwardRef<VoiceMessageInputHandle, NowInputRowProps>
   }), []);
 
   return (
-    <div className="mb-2 shrink-0 border-t border-[#E7E5E4] bg-[#FAF7F5] dark:border-[#292524] dark:bg-[#0C0A09]" data-testid="new-now-input-row">
+    <div className="shrink-0 border-t border-[#E7E5E4] bg-[#FAF7F5] dark:border-[#292524] dark:bg-[#0C0A09]" data-testid="new-now-input-row">
       <div className="px-4 py-2">
         <div className="flex items-center gap-2">
           <button

--- a/tests/unit/services/voice-shortcut-eventlog.test.ts
+++ b/tests/unit/services/voice-shortcut-eventlog.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { buildVoiceShortcutStorageEvent } from '@/services/voice-shortcut-eventlog';
+
+describe('buildVoiceShortcutStorageEvent（全局语音快捷键事件构造）', () => {
+  it('uses the same id inside the same activation bucket（同一激活时间桶内生成相同幂等 ID）', async () => {
+    const first = await buildVoiceShortcutStorageEvent({
+      text: '重复语音',
+      startedAtMs: 1_700_000_000_123,
+      targetScope: 'external-window',
+      window: {
+        title: 'Cursor - ExoMind',
+        processName: 'Cursor.exe',
+      },
+    });
+    const second = await buildVoiceShortcutStorageEvent({
+      text: '重复语音',
+      startedAtMs: 1_700_000_000_499,
+      targetScope: 'external-window',
+      window: {
+        title: 'Cursor - ExoMind',
+        processName: 'Cursor.exe',
+      },
+    });
+
+    expect(first.id).toBe(second.id);
+    expect(first.metadata).toEqual(expect.objectContaining({
+      voiceShortcut: expect.objectContaining({
+        dedupVersion: 'v1',
+        activationBucketMs: 1_700_000_000_000,
+        captureSource: 'global-shortcut',
+      }),
+    }));
+  });
+
+  it('changes id when activation bucket changes（激活时间桶变化时生成不同 ID）', async () => {
+    const first = await buildVoiceShortcutStorageEvent({
+      text: '重复语音',
+      startedAtMs: 1_700_000_000_123,
+      targetScope: 'external-window',
+    });
+    const second = await buildVoiceShortcutStorageEvent({
+      text: '重复语音',
+      startedAtMs: 1_700_000_000_501,
+      targetScope: 'external-window',
+    });
+
+    expect(first.id).not.toBe(second.id);
+  });
+
+  it('changes id when target changes even with same text and bucket（同文同桶但目标不同也不能混并）', async () => {
+    const externalWindowEvent = await buildVoiceShortcutStorageEvent({
+      text: '打开今天日志',
+      startedAtMs: 1_700_000_000_123,
+      targetScope: 'external-window',
+      window: {
+        title: 'Cursor - ExoMind',
+        processName: 'Cursor.exe',
+      },
+    });
+    const agentChatEvent = await buildVoiceShortcutStorageEvent({
+      text: '打开今天日志',
+      startedAtMs: 1_700_000_000_123,
+      targetScope: 'agent-chat',
+      agentContext: {
+        agentId: 'codex',
+        agentName: 'Codex',
+        sessionId: 'session-1',
+      },
+    });
+
+    expect(externalWindowEvent.id).not.toBe(agentChatEvent.id);
+  });
+});


### PR DESCRIPTION
## 关联 Issue

Closes #575
Closes #576

## 改动摘要

- 前端层（frontend，前端）：`NowInputRow` 改为 `normalizeRecognitionText(text.trim())`，与 `VoiceMessageInput` 对齐，处理 ASR 引擎重复/口吃输出。
- Runtime 层（runtime，运行时）：`eventlog_actor` 新增 `DedupWindow`，基于 5 秒滑动窗口（sliding window，滑动窗口）+ content hash（内容哈希）做幂等去重；窗口状态保持在 actor 实例内部，不使用全局 `static`。
- 测试层（tests，测试）：补充并覆盖语音归一化与 `eventlog_actor` 的单元/集成测试，验证重复输入在窗口期内只写入一次。

## 验收检查

- [x] `NowInputRow` 语音输入链路调用 `normalizeRecognitionText()`，与 `VoiceMessageInput` 行为一致。
- [x] 多实例并发场景下，同一内容在 5 秒窗口内只写入一条 `eventlog.appended`，重复事件会被 debug log 记录并跳过。

## 自检清单

- [x] 本地构建通过（`bun run build`）
- [x] 相关测试通过（`bunx tsc --noEmit`、`npx vitest run tests/unit/lib/voice-recognition-text.test.ts`、`cargo test -p exomind-runtime eventlog_actor -- --nocapture`）
- [x] 没有引入 `any` 类型
- [x] 没有硬编码的密钥/token
- [x] commit message 引用了 Issue 编号