### PR TITLE
feat(agent): 新增 PTY 终端会话控制闭环

### DIFF
--- a/crates/exomind-runtime/src/pty/mod.rs
+++ b/crates/exomind-runtime/src/pty/mod.rs
@@ -381,6 +381,36 @@ impl PtyManager {
         Ok(())
     }
 
+    /// Refresh the PTY process state from the underlying child handle.
+    pub async fn refresh_process_state(&self, id: &str) -> Result<Option<PtyAgentInfo>, PtyError> {
+        let mut instances = self.instances.lock().await;
+        let instance = instances
+            .get_mut(id)
+            .ok_or_else(|| PtyError::NotFound { id: id.to_string() })?;
+
+        if !matches!(instance.info.status, PtyAgentStatus::Running) {
+            return Ok(Some(instance.info.clone()));
+        }
+
+        match instance.child.try_wait() {
+            Ok(Some(exit_status)) => {
+                let info = if matches!(instance.info.status, PtyAgentStatus::Running) {
+                    instance.info.status = PtyAgentStatus::Exited {
+                        code: exit_status.exit_code() as i32,
+                    };
+                    instance.info.clone()
+                } else {
+                    instance.info.clone()
+                };
+                drop(instances);
+                self.publish_lifecycle_signal("pty.exited", &info);
+                Ok(Some(info))
+            }
+            Ok(None) => Ok(None),
+            Err(error) => Err(PtyError::IoError(error)),
+        }
+    }
+
     /// Get the output buffer snapshot and a broadcast receiver for live output.
     ///
     /// The caller should:
@@ -434,6 +464,16 @@ impl PtyManager {
         let instance = instances
             .get_mut(id)
             .ok_or_else(|| PtyError::NotFound { id: id.to_string() })?;
+
+        if let Some(exit_status) = instance.child.try_wait().map_err(PtyError::IoError)? {
+            instance.info.status = PtyAgentStatus::Exited {
+                code: exit_status.exit_code() as i32,
+            };
+            let info = instance.info.clone();
+            drop(instances);
+            self.publish_lifecycle_signal("pty.exited", &info);
+            return Ok(info);
+        }
 
         instance.child.kill().map_err(|e| PtyError::IoError(e))?;
         instance.info.status = PtyAgentStatus::Stopped;

--- a/crates/exomind-runtime/src/pty/mod.rs
+++ b/crates/exomind-runtime/src/pty/mod.rs
@@ -133,6 +133,12 @@ pub struct PtyResumeRequest {
     pub workdir: Option<String>,
     #[serde(default)]
     pub agent_type: PtyAgentType,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub reasoning_effort: Option<String>,
+    #[serde(default)]
+    pub extra_args: Vec<String>,
     pub session_id: String,
     #[serde(default = "default_rows")]
     pub rows: u16,
@@ -672,14 +678,36 @@ fn build_resume_spawn_request(request: PtyResumeRequest) -> PtySpawnRequest {
         request.name
     };
 
-    let args = match request.agent_type {
-        PtyAgentType::Claude => vec!["--resume".to_string(), request.session_id.clone()],
-        PtyAgentType::Codex => vec![
-            "exec".to_string(),
-            "resume".to_string(),
-            request.session_id.clone(),
-        ],
-    };
+    let mut args = Vec::new();
+    match request.agent_type {
+        PtyAgentType::Claude => {
+            if let Some(model) = request.model.as_deref().map(str::trim).filter(|value| !value.is_empty()) {
+                args.push("--model".to_string());
+                args.push(model.to_string());
+            }
+            args.push("--resume".to_string());
+            args.push(request.session_id.clone());
+        }
+        PtyAgentType::Codex => {
+            args.push("exec".to_string());
+            args.push("resume".to_string());
+            if let Some(model) = request.model.as_deref().map(str::trim).filter(|value| !value.is_empty()) {
+                args.push("-m".to_string());
+                args.push(model.to_string());
+            }
+            if let Some(reasoning_effort) = request
+                .reasoning_effort
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                args.push("-c".to_string());
+                args.push(format!("model_reasoning_effort=\"{reasoning_effort}\""));
+            }
+            args.push(request.session_id.clone());
+        }
+    }
+    args.extend(request.extra_args.clone());
 
     PtySpawnRequest {
         name,
@@ -752,6 +780,9 @@ mod tests {
         assert!(req.workdir.is_none());
         assert_eq!(req.session_id, "abc-12345678-xyz");
         assert_eq!(req.agent_type, PtyAgentType::Claude);
+        assert_eq!(req.model, None);
+        assert_eq!(req.reasoning_effort, None);
+        assert!(req.extra_args.is_empty());
         assert_eq!(req.rows, 24);
         assert_eq!(req.cols, 80);
     }
@@ -787,6 +818,9 @@ mod tests {
             name: "".to_string(),
             workdir: Some("D:/project/exomind".to_string()),
             agent_type: PtyAgentType::Codex,
+            model: None,
+            reasoning_effort: None,
+            extra_args: vec![],
             session_id: "019d0011-aaaa-bbbb-cccc-1234567890ab".to_string(),
             rows: 24,
             cols: 80,
@@ -803,6 +837,38 @@ mod tests {
             ]
         );
         assert_eq!(spawn_request.name, "Codex-019d0011");
+    }
+
+    #[test]
+    fn build_resume_spawn_request_for_codex_keeps_model_reasoning_and_extra_args() {
+        let req = PtyResumeRequest {
+            name: "resume-codex".to_string(),
+            workdir: Some("D:/project/exomind".to_string()),
+            agent_type: PtyAgentType::Codex,
+            model: Some("gpt-5.4".to_string()),
+            reasoning_effort: Some("xhigh".to_string()),
+            extra_args: vec!["--search".to_string(), "--full-auto".to_string()],
+            session_id: "019d0011-aaaa-bbbb-cccc-1234567890ab".to_string(),
+            rows: 24,
+            cols: 80,
+        };
+
+        let spawn_request = build_resume_spawn_request(req);
+        assert_eq!(spawn_request.command, "codex");
+        assert_eq!(
+            spawn_request.args,
+            vec![
+                "exec".to_string(),
+                "resume".to_string(),
+                "-m".to_string(),
+                "gpt-5.4".to_string(),
+                "-c".to_string(),
+                "model_reasoning_effort=\"xhigh\"".to_string(),
+                "019d0011-aaaa-bbbb-cccc-1234567890ab".to_string(),
+                "--search".to_string(),
+                "--full-auto".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/exomind-runtime/src/pty/mod.rs
+++ b/crates/exomind-runtime/src/pty/mod.rs
@@ -2,8 +2,11 @@ use chrono::{DateTime, Utc};
 use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
 use std::io::{Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::{broadcast, Mutex};
@@ -55,6 +58,35 @@ pub enum PtyAgentStatus {
     Exited { code: i32 },
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PtyAgentType {
+    Claude,
+    Codex,
+}
+
+impl Default for PtyAgentType {
+    fn default() -> Self {
+        Self::Claude
+    }
+}
+
+impl PtyAgentType {
+    fn command(self) -> String {
+        match self {
+            Self::Claude => "claude".to_string(),
+            Self::Codex => "codex".to_string(),
+        }
+    }
+
+    fn display_prefix(self) -> &'static str {
+        match self {
+            Self::Claude => "Claude",
+            Self::Codex => "Codex",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PtyAgentInfo {
     pub id: String,
@@ -99,6 +131,8 @@ pub struct PtyResumeRequest {
     pub name: String,
     #[serde(default)]
     pub workdir: Option<String>,
+    #[serde(default)]
+    pub agent_type: PtyAgentType,
     pub session_id: String,
     #[serde(default = "default_rows")]
     pub rows: u16,
@@ -107,11 +141,14 @@ pub struct PtyResumeRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ClaudeSessionInfo {
+pub struct PtyHistoricalSessionInfo {
+    pub agent_type: PtyAgentType,
     pub session_id: String,
     pub project_path: String,
     pub last_modified: String,
 }
+
+pub type ClaudeSessionInfo = PtyHistoricalSessionInfo;
 
 // ---------------------------------------------------------------------------
 // Internal PTY instance (not serializable — holds OS resources)
@@ -172,7 +209,8 @@ impl PtyManager {
                 reason: format!("openpty failed: {e}"),
             })?;
 
-        let mut cmd = CommandBuilder::new(&request.command);
+        let resolved_command = resolve_spawn_command(&request.command);
+        let mut cmd = CommandBuilder::new(&resolved_command);
         for arg in &request.args {
             cmd.arg(arg);
         }
@@ -295,37 +333,12 @@ impl PtyManager {
         }
     }
 
-    /// Resume an existing Claude session by spawning with `--resume <session-id>`.
-    ///
-    /// Uses `--resume` (not `--continue --session-id`) because:
-    /// - `--resume <id>` directly resumes the specified session
-    /// - `--continue --session-id <id>` tries to continue the most recent session
-    ///   while forcing a specific session ID, causing "session ID already in use" errors
-    /// - `--fork-session` creates a new session ID to avoid modifying the original
     pub async fn resume(&self, request: PtyResumeRequest) -> Result<PtyAgentInfo, PtyError> {
-        // Generate default name from session_id if not provided
-        let name = if request.name.is_empty() {
-            let len = 8.min(request.session_id.len());
-            format!("Claude-{}", &request.session_id[..len])
-        } else {
-            request.name
-        };
-
-        let spawn_request = PtySpawnRequest {
-            name,
-            workdir: request.workdir,
-            command: default_command(),
-            args: vec![
-                "--resume".to_string(),
-                request.session_id.clone(),
-            ],
-            rows: request.rows,
-            cols: request.cols,
-        };
-
+        let session_id = request.session_id.clone();
+        let spawn_request = build_resume_spawn_request(request);
         let mut info = self.spawn(spawn_request).await?;
         // Attach the session_id to the info and update the stored instance.
-        info.session_id = Some(request.session_id);
+        info.session_id = Some(session_id);
         {
             let mut instances = self.instances.lock().await;
             if let Some(instance) = instances.get_mut(&info.id) {
@@ -442,12 +455,23 @@ impl PtyManager {
         instances.values().map(|i| i.info.clone()).collect()
     }
 
+    /// Discover existing historical CLI sessions by agent type.
+    pub fn list_historical_sessions(agent_type: PtyAgentType) -> Vec<PtyHistoricalSessionInfo> {
+        match agent_type {
+            PtyAgentType::Claude => match dirs_claude_projects() {
+                Some(projects_dir) => discover_claude_sessions(&projects_dir),
+                None => Vec::new(),
+            },
+            PtyAgentType::Codex => match dirs_codex_sessions() {
+                Some(sessions_dir) => discover_codex_sessions(&sessions_dir),
+                None => Vec::new(),
+            },
+        }
+    }
+
     /// Discover existing Claude CLI sessions from ~/.claude/projects/.
     pub fn list_claude_sessions() -> Vec<ClaudeSessionInfo> {
-        match dirs_claude_projects() {
-            Some(projects_dir) => discover_claude_sessions(&projects_dir),
-            None => Vec::new(),
-        }
+        Self::list_historical_sessions(PtyAgentType::Claude)
     }
 
     /// Kill all running PTY child processes and clear instances (graceful shutdown).
@@ -492,10 +516,21 @@ fn dirs_claude_projects() -> Option<PathBuf> {
     }
 }
 
+/// Returns the path to `~/.codex/sessions/` if it exists.
+fn dirs_codex_sessions() -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    let sessions = home.join(".codex").join("sessions");
+    if sessions.is_dir() {
+        Some(sessions)
+    } else {
+        None
+    }
+}
+
 /// Scan the Claude projects directory for session JSONL files.
 ///
 /// Directory structure: `~/.claude/projects/<encoded-project-path>/<session-id>.jsonl`
-fn discover_claude_sessions(projects_dir: &PathBuf) -> Vec<ClaudeSessionInfo> {
+fn discover_claude_sessions(projects_dir: &PathBuf) -> Vec<PtyHistoricalSessionInfo> {
     let mut sessions = Vec::new();
 
     let entries = match std::fs::read_dir(projects_dir) {
@@ -540,7 +575,8 @@ fn discover_claude_sessions(projects_dir: &PathBuf) -> Vec<ClaudeSessionInfo> {
                 })
                 .unwrap_or_default();
 
-            sessions.push(ClaudeSessionInfo {
+            sessions.push(PtyHistoricalSessionInfo {
+                agent_type: PtyAgentType::Claude,
                 session_id,
                 project_path: project_name.clone(),
                 last_modified,
@@ -553,6 +589,119 @@ fn discover_claude_sessions(projects_dir: &PathBuf) -> Vec<ClaudeSessionInfo> {
     sessions
 }
 
+fn discover_codex_sessions(sessions_dir: &Path) -> Vec<PtyHistoricalSessionInfo> {
+    let mut sessions = Vec::new();
+    let mut stack = vec![sessions_dir.to_path_buf()];
+
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+
+            if path.extension().and_then(|value| value.to_str()) != Some("jsonl") {
+                continue;
+            }
+
+            let Some((session_id, project_path)) = read_codex_session_meta(&path) else {
+                continue;
+            };
+
+            let last_modified = path
+                .metadata()
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .map(|t| {
+                    let dt: DateTime<Utc> = t.into();
+                    dt.to_rfc3339()
+                })
+                .unwrap_or_default();
+
+            sessions.push(PtyHistoricalSessionInfo {
+                agent_type: PtyAgentType::Codex,
+                session_id,
+                project_path,
+                last_modified,
+            });
+        }
+    }
+
+    sessions.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    sessions
+}
+
+fn read_codex_session_meta(path: &Path) -> Option<(String, String)> {
+    let file = File::open(path).ok()?;
+    let reader = BufReader::new(file);
+
+    for line in reader.lines().take(20).flatten() {
+        let value: serde_json::Value = serde_json::from_str(&line).ok()?;
+        if value.get("type").and_then(|kind| kind.as_str()) != Some("session_meta") {
+            continue;
+        }
+
+        let payload = value.get("payload")?;
+        let session_id = payload.get("id").and_then(|id| id.as_str())?;
+        let cwd = payload
+            .get("cwd")
+            .and_then(|cwd| cwd.as_str())
+            .unwrap_or_default();
+
+        return Some((session_id.to_string(), cwd.to_string()));
+    }
+
+    None
+}
+
+fn build_resume_spawn_request(request: PtyResumeRequest) -> PtySpawnRequest {
+    let name = if request.name.is_empty() {
+        let len = 8.min(request.session_id.len());
+        format!(
+            "{}-{}",
+            request.agent_type.display_prefix(),
+            &request.session_id[..len]
+        )
+    } else {
+        request.name
+    };
+
+    let args = match request.agent_type {
+        PtyAgentType::Claude => vec!["--resume".to_string(), request.session_id.clone()],
+        PtyAgentType::Codex => vec![
+            "exec".to_string(),
+            "resume".to_string(),
+            request.session_id.clone(),
+        ],
+    };
+
+    PtySpawnRequest {
+        name,
+        workdir: request.workdir,
+        command: request.agent_type.command(),
+        args,
+        rows: request.rows,
+        cols: request.cols,
+    }
+}
+
+fn resolve_spawn_command(command: &str) -> String {
+    #[cfg(target_os = "windows")]
+    {
+        if command.eq_ignore_ascii_case("codex") {
+            return "codex.cmd".to_string();
+        }
+    }
+
+    command.to_string()
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -561,6 +710,7 @@ fn discover_claude_sessions(projects_dir: &PathBuf) -> Vec<ClaudeSessionInfo> {
 mod tests {
     use super::*;
     use std::fs;
+    use tempfile::tempdir;
 
     #[test]
     fn pty_agent_status_serializes() {
@@ -601,8 +751,58 @@ mod tests {
         assert_eq!(req.name, "");
         assert!(req.workdir.is_none());
         assert_eq!(req.session_id, "abc-12345678-xyz");
+        assert_eq!(req.agent_type, PtyAgentType::Claude);
         assert_eq!(req.rows, 24);
         assert_eq!(req.cols, 80);
+    }
+
+    #[test]
+    fn discover_codex_sessions_reads_rollout_metadata() {
+        let dir = tempdir().unwrap();
+        let day_dir = dir.path().join("2026").join("03").join("18");
+        fs::create_dir_all(&day_dir).unwrap();
+        let session_path = day_dir.join(
+            "rollout-2026-03-18T10-20-30-019d0011-aaaa-bbbb-cccc-1234567890ab.jsonl",
+        );
+        fs::write(
+            &session_path,
+            concat!(
+                "{\"timestamp\":\"2026-03-18T02:20:32.696Z\",\"type\":\"session_meta\",",
+                "\"payload\":{\"id\":\"019d0011-aaaa-bbbb-cccc-1234567890ab\",",
+                "\"cwd\":\"D:\\\\project\\\\exomind\",\"originator\":\"codex_cli_rs\"}}\n"
+            ),
+        )
+        .unwrap();
+
+        let sessions = discover_codex_sessions(&day_dir);
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].agent_type, PtyAgentType::Codex);
+        assert_eq!(sessions[0].session_id, "019d0011-aaaa-bbbb-cccc-1234567890ab");
+        assert_eq!(sessions[0].project_path, "D:\\project\\exomind");
+    }
+
+    #[test]
+    fn build_resume_spawn_request_supports_codex_exec_resume() {
+        let req = PtyResumeRequest {
+            name: "".to_string(),
+            workdir: Some("D:/project/exomind".to_string()),
+            agent_type: PtyAgentType::Codex,
+            session_id: "019d0011-aaaa-bbbb-cccc-1234567890ab".to_string(),
+            rows: 24,
+            cols: 80,
+        };
+
+        let spawn_request = build_resume_spawn_request(req);
+        assert_eq!(spawn_request.command, "codex");
+        assert_eq!(
+            spawn_request.args,
+            vec![
+                "exec".to_string(),
+                "resume".to_string(),
+                "019d0011-aaaa-bbbb-cccc-1234567890ab".to_string(),
+            ]
+        );
+        assert_eq!(spawn_request.name, "Codex-019d0011");
     }
 
     #[test]

--- a/crates/exomind-runtime/src/routes/pty.rs
+++ b/crates/exomind-runtime/src/routes/pty.rs
@@ -7,6 +7,7 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
+use std::time::Duration;
 use tokio_stream::wrappers::ReceiverStream;
 
 use crate::routes::sessions::{
@@ -141,6 +142,43 @@ fn complete_pty_session(
     }
 }
 
+fn watch_pty_lifecycle(state: AppState, id: String) {
+    tokio::spawn(async move {
+        loop {
+            match state.pty_manager.refresh_process_state(&id).await {
+                Ok(Some(info)) => match info.status {
+                    crate::pty::PtyAgentStatus::Exited { .. } => {
+                        match complete_pty_session(&state, &id) {
+                            Ok(Some(updated)) => {
+                                broadcast_session_updated(state.session_event_tx.as_ref(), &updated);
+                            }
+                            Ok(None) => {}
+                            Err((status, error)) => {
+                                tracing::warn!(
+                                    pty_id = %id,
+                                    status = %status,
+                                    error = %error,
+                                    "failed to complete PTY-backed session after natural exit"
+                                );
+                            }
+                        }
+                        break;
+                    }
+                    crate::pty::PtyAgentStatus::Stopped => break,
+                    crate::pty::PtyAgentStatus::Running => {}
+                },
+                Ok(None) => {}
+                Err(PtyError::NotFound { .. }) => break,
+                Err(error) => {
+                    tracing::warn!(pty_id = %id, error = %error, "failed to refresh PTY process state");
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    });
+}
+
 // ── Handlers ────────────────────────────────────────────────────
 
 /// GET /pty — List all PTY agents.
@@ -158,6 +196,7 @@ async fn spawn_pty_agent(
         let _ = state.pty_manager.remove(&info.id).await;
         return Err(error);
     }
+    watch_pty_lifecycle(state.clone(), info.id.clone());
     Ok((StatusCode::CREATED, Json(info)))
 }
 
@@ -171,6 +210,7 @@ async fn resume_pty_agent(
         let _ = state.pty_manager.remove(&info.id).await;
         return Err(error);
     }
+    watch_pty_lifecycle(state.clone(), info.id.clone());
     Ok((StatusCode::CREATED, Json(info)))
 }
 

--- a/crates/exomind-runtime/src/routes/pty.rs
+++ b/crates/exomind-runtime/src/routes/pty.rs
@@ -1,4 +1,4 @@
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::sse::{Event, Sse};
 use axum::routing::{delete, get, post};
@@ -13,7 +13,8 @@ use crate::routes::sessions::{
     broadcast_session_created, broadcast_session_updated,
 };
 use crate::pty::{
-    ClaudeSessionInfo, PtyAgentInfo, PtyError, PtyOutputMsg, PtyResumeRequest, PtySpawnRequest,
+    ClaudeSessionInfo, PtyAgentInfo, PtyAgentType, PtyError, PtyHistoricalSessionInfo,
+    PtyOutputMsg, PtyResumeRequest, PtySpawnRequest,
 };
 use crate::session::{CreateSessionInput, InteractionMode, SessionStatus, UpdateSessionInput, WorkContext};
 use crate::AppState;
@@ -35,6 +36,11 @@ struct PtyResizeBody {
 struct PtyRemoveResponse {
     status: String,
     id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct HistoricalSessionsQuery {
+    agent_type: PtyAgentType,
 }
 
 // ── Error mapping ───────────────────────────────────────────────
@@ -171,6 +177,15 @@ async fn resume_pty_agent(
 /// GET /pty/claude-sessions — List local Claude CLI sessions.
 async fn list_claude_sessions() -> Json<Vec<ClaudeSessionInfo>> {
     Json(crate::pty::PtyManager::list_claude_sessions())
+}
+
+/// GET /pty/sessions?agent_type=... — List local PTY historical sessions by agent type.
+async fn list_historical_sessions(
+    Query(query): Query<HistoricalSessionsQuery>,
+) -> Json<Vec<PtyHistoricalSessionInfo>> {
+    Json(crate::pty::PtyManager::list_historical_sessions(
+        query.agent_type,
+    ))
 }
 
 /// GET /pty/{id}/stream — SSE stream of PTY output (base64-encoded).
@@ -330,6 +345,7 @@ pub fn router() -> Router<AppState> {
         .route("/pty", get(list_pty_agents))
         .route("/pty/spawn", post(spawn_pty_agent))
         .route("/pty/resume", post(resume_pty_agent))
+        .route("/pty/sessions", get(list_historical_sessions))
         .route("/pty/claude-sessions", get(list_claude_sessions))
         .route("/pty/:id/stream", get(stream_pty_output))
         .route("/pty/:id/input", post(write_pty_input))

--- a/crates/exomind-runtime/src/routes/sessions.rs
+++ b/crates/exomind-runtime/src/routes/sessions.rs
@@ -353,7 +353,7 @@ async fn send_message(
     Json(input): Json<SendMessageInput>,
 ) -> Result<(StatusCode, Json<SessionMessage>), (StatusCode, String)> {
     // Verify target session exists
-    state
+    let session = state
         .session_store
         .get(&id)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
@@ -371,6 +371,19 @@ async fn send_message(
     // Note: In V6 foundation, messages are fire-and-forget.
     // A proper message queue/store can be added when cross-session
     // communication becomes a core feature.
+
+    // Bridge to PTY stdin（桥接到 PTY 标准输入）when this session owns a terminal.
+    if let Some(pty_id) = session.pty_id.as_deref() {
+        let input = format!("{}\n", message.content);
+        if let Err(error) = state.pty_manager.write_input(pty_id, input.as_bytes()).await {
+            tracing::warn!(
+                session_id = %session.id,
+                pty_id = %pty_id,
+                error = %error,
+                "failed to forward session message to PTY stdin"
+            );
+        }
+    }
 
     Ok((StatusCode::CREATED, Json(message)))
 }
@@ -397,10 +410,33 @@ mod tests {
     use axum::body::Body;
     use axum::http::Request;
     use http_body_util::BodyExt;
+    use std::time::Duration;
     use tower::ServiceExt;
 
     fn test_state(host_id: &str) -> AppState {
         AppState::new_runtime(0, host_id.to_string(), None, None, false, None)
+    }
+
+    fn interactive_shell_spawn_request() -> crate::pty::PtySpawnRequest {
+        if cfg!(windows) {
+            crate::pty::PtySpawnRequest {
+                name: "bridge-shell".to_string(),
+                workdir: Some(".".to_string()),
+                command: "cmd".to_string(),
+                args: vec!["/Q".to_string(), "/K".to_string()],
+                rows: 24,
+                cols: 80,
+            }
+        } else {
+            crate::pty::PtySpawnRequest {
+                name: "bridge-shell".to_string(),
+                workdir: Some(".".to_string()),
+                command: "sh".to_string(),
+                args: vec![],
+                rows: 24,
+                cols: 80,
+            }
+        }
     }
 
     #[tokio::test]
@@ -467,5 +503,113 @@ mod tests {
             .find(|session| session.id == "sid-123")
             .expect("session should exist");
         assert_eq!(found.source_host_id.as_deref(), Some("session-host-2"));
+    }
+
+    #[tokio::test]
+    async fn send_message_returns_created_for_non_pty_session() {
+        let state = test_state("session-host-3");
+        state
+            .session_store
+            .create(CreateSessionInput {
+                id: Some("sid-message-only".to_string()),
+                agent_kind: "codex".to_string(),
+                agent_id: None,
+                source_host_id: Some("session-host-3".to_string()),
+                role: Some("message-only".to_string()),
+                context: None,
+                interaction: Some(crate::session::InteractionMode::Structured),
+                pty_id: None,
+                inner_session_id: None,
+                parent_session_id: None,
+            })
+            .unwrap();
+
+        let (status, Json(message)) = send_message(
+            State(state),
+            Path("sid-message-only".to_string()),
+            Json(SendMessageInput {
+                content: "hello-from-user".to_string(),
+                from: Some(Participant::User),
+                reply_to: None,
+            }),
+        )
+        .await
+        .expect("send_message should succeed");
+
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(message.to_session_id, "sid-message-only");
+        assert_eq!(message.content, "hello-from-user");
+    }
+
+    #[tokio::test]
+    async fn send_message_bridges_content_to_pty_stdin() {
+        let state = test_state("session-host-4");
+        let pty = state
+            .pty_manager
+            .spawn(interactive_shell_spawn_request())
+            .await
+            .expect("pty shell should spawn");
+
+        state
+            .session_store
+            .create(CreateSessionInput {
+                id: Some("sid-pty-bridge".to_string()),
+                agent_kind: "codex".to_string(),
+                agent_id: None,
+                source_host_id: Some("session-host-4".to_string()),
+                role: Some("pty-bridge".to_string()),
+                context: None,
+                interaction: Some(crate::session::InteractionMode::Terminal),
+                pty_id: Some(pty.id.clone()),
+                inner_session_id: None,
+                parent_session_id: None,
+            })
+            .unwrap();
+
+        let (_buffer, mut rx) = state
+            .pty_manager
+            .subscribe_output(&pty.id)
+            .await
+            .expect("pty output subscription should succeed");
+
+        let marker = "exomind-pty-bridge-ok";
+        let payload = format!("echo {marker}");
+
+        let (status, Json(message)) = send_message(
+            State(state.clone()),
+            Path("sid-pty-bridge".to_string()),
+            Json(SendMessageInput {
+                content: payload,
+                from: Some(Participant::User),
+                reply_to: None,
+            }),
+        )
+        .await
+        .expect("send_message should succeed");
+
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(message.to_session_id, "sid-pty-bridge");
+
+        let bridged = tokio::time::timeout(Duration::from_secs(5), async move {
+            loop {
+                match rx.recv().await {
+                    Ok(crate::pty::PtyOutputMsg::Data(data)) => {
+                        let text = String::from_utf8_lossy(&data);
+                        if text.contains(marker) {
+                            return true;
+                        }
+                    }
+                    Ok(crate::pty::PtyOutputMsg::Eof) => return false,
+                    Err(_) => return false,
+                }
+            }
+        })
+        .await
+        .unwrap_or(false);
+
+        let _ = state.pty_manager.stop(&pty.id).await;
+        let _ = state.pty_manager.remove(&pty.id).await;
+
+        assert!(bridged, "session message should be forwarded into PTY stdin");
     }
 }

--- a/crates/exomind-runtime/src/routes/sessions.rs
+++ b/crates/exomind-runtime/src/routes/sessions.rs
@@ -137,17 +137,6 @@ async fn deliver_message_to_pty(
     Ok(())
 }
 
-fn map_pty_delivery_error(pty_id: &str, error: PtyError) -> (StatusCode, String) {
-    let status = match error {
-        PtyError::NotFound { .. } | PtyError::IoError(_) => StatusCode::CONFLICT,
-        PtyError::SpawnFailed { .. } => StatusCode::INTERNAL_SERVER_ERROR,
-    };
-    (
-        status,
-        format!("failed to deliver message to PTY {pty_id}: {error}"),
-    )
-}
-
 // ── Handlers ────────────────────────────────────────────────────
 
 async fn create_session(

--- a/crates/exomind-runtime/src/routes/sessions.rs
+++ b/crates/exomind-runtime/src/routes/sessions.rs
@@ -11,7 +11,6 @@ use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::StreamExt;
 
 use crate::AppState;
-use crate::pty::PtyError;
 use crate::session::{
     AgentSession, CreateSessionInput, Participant, QuickActionResponse,
     SendMessageInput, SessionMessage, SessionStatus, UpdateSessionInput,
@@ -87,6 +86,55 @@ fn fill_source_host_id(mut session: AgentSession, host_id: &str) -> AgentSession
         session.source_host_id = Some(host_id.to_string());
     }
     session
+}
+
+#[cfg(not(target_os = "android"))]
+fn map_pty_delivery_error(
+    pty_id: &str,
+    error: crate::pty::PtyError,
+) -> (StatusCode, String) {
+    let status = match error {
+        crate::pty::PtyError::NotFound { .. } | crate::pty::PtyError::IoError(_) => {
+            StatusCode::CONFLICT
+        }
+        crate::pty::PtyError::SpawnFailed { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    (
+        status,
+        format!("failed to deliver message to PTY {pty_id}: {error}"),
+    )
+}
+
+#[cfg(not(target_os = "android"))]
+async fn deliver_message_to_pty(
+    state: &AppState,
+    session: &AgentSession,
+    content: &str,
+) -> Result<(), (StatusCode, String)> {
+    if let Some(pty_id) = session.pty_id.as_deref() {
+        let input = format!("{content}\n");
+        state
+            .pty_manager
+            .write_input(pty_id, input.as_bytes())
+            .await
+            .map_err(|error| map_pty_delivery_error(pty_id, error))?;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "android")]
+async fn deliver_message_to_pty(
+    _state: &AppState,
+    session: &AgentSession,
+    _content: &str,
+) -> Result<(), (StatusCode, String)> {
+    if let Some(pty_id) = session.pty_id.as_deref() {
+        return Err((
+            StatusCode::CONFLICT,
+            format!("PTY delivery is not supported on Android runtime: {pty_id}"),
+        ));
+    }
+    Ok(())
 }
 
 fn map_pty_delivery_error(pty_id: &str, error: PtyError) -> (StatusCode, String) {
@@ -385,14 +433,7 @@ async fn send_message(
     // communication becomes a core feature.
 
     // Bridge to PTY stdin（桥接到 PTY 标准输入）when this session owns a terminal.
-    if let Some(pty_id) = session.pty_id.as_deref() {
-        let input = format!("{}\n", message.content);
-        state
-            .pty_manager
-            .write_input(pty_id, input.as_bytes())
-            .await
-            .map_err(|error| map_pty_delivery_error(pty_id, error))?;
-    }
+    deliver_message_to_pty(&state, &session, &message.content).await?;
 
     Ok((StatusCode::CREATED, Json(message)))
 }
@@ -426,6 +467,7 @@ mod tests {
         AppState::new_runtime(0, host_id.to_string(), None, None, false, None)
     }
 
+    #[cfg(not(target_os = "android"))]
     fn interactive_shell_spawn_request() -> crate::pty::PtySpawnRequest {
         if cfg!(windows) {
             crate::pty::PtySpawnRequest {
@@ -551,6 +593,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(not(target_os = "android"))]
     async fn send_message_bridges_content_to_pty_stdin() {
         let state = test_state("session-host-4");
         let pty = state

--- a/crates/exomind-runtime/src/routes/sessions.rs
+++ b/crates/exomind-runtime/src/routes/sessions.rs
@@ -11,6 +11,7 @@ use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::StreamExt;
 
 use crate::AppState;
+use crate::pty::PtyError;
 use crate::session::{
     AgentSession, CreateSessionInput, Participant, QuickActionResponse,
     SendMessageInput, SessionMessage, SessionStatus, UpdateSessionInput,
@@ -86,6 +87,17 @@ fn fill_source_host_id(mut session: AgentSession, host_id: &str) -> AgentSession
         session.source_host_id = Some(host_id.to_string());
     }
     session
+}
+
+fn map_pty_delivery_error(pty_id: &str, error: PtyError) -> (StatusCode, String) {
+    let status = match error {
+        PtyError::NotFound { .. } | PtyError::IoError(_) => StatusCode::CONFLICT,
+        PtyError::SpawnFailed { .. } => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    (
+        status,
+        format!("failed to deliver message to PTY {pty_id}: {error}"),
+    )
 }
 
 // ── Handlers ────────────────────────────────────────────────────
@@ -375,14 +387,11 @@ async fn send_message(
     // Bridge to PTY stdin（桥接到 PTY 标准输入）when this session owns a terminal.
     if let Some(pty_id) = session.pty_id.as_deref() {
         let input = format!("{}\n", message.content);
-        if let Err(error) = state.pty_manager.write_input(pty_id, input.as_bytes()).await {
-            tracing::warn!(
-                session_id = %session.id,
-                pty_id = %pty_id,
-                error = %error,
-                "failed to forward session message to PTY stdin"
-            );
-        }
+        state
+            .pty_manager
+            .write_input(pty_id, input.as_bytes())
+            .await
+            .map_err(|error| map_pty_delivery_error(pty_id, error))?;
     }
 
     Ok((StatusCode::CREATED, Json(message)))
@@ -611,5 +620,40 @@ mod tests {
         let _ = state.pty_manager.remove(&pty.id).await;
 
         assert!(bridged, "session message should be forwarded into PTY stdin");
+    }
+
+    #[tokio::test]
+    async fn send_message_returns_conflict_when_pty_delivery_fails() {
+        let state = test_state("session-host-5");
+        state
+            .session_store
+            .create(CreateSessionInput {
+                id: Some("sid-pty-missing".to_string()),
+                agent_kind: "codex".to_string(),
+                agent_id: None,
+                source_host_id: Some("session-host-5".to_string()),
+                role: Some("pty-missing".to_string()),
+                context: None,
+                interaction: Some(crate::session::InteractionMode::Terminal),
+                pty_id: Some("missing-pty".to_string()),
+                inner_session_id: None,
+                parent_session_id: None,
+            })
+            .unwrap();
+
+        let error = send_message(
+            State(state),
+            Path("sid-pty-missing".to_string()),
+            Json(SendMessageInput {
+                content: "deliver-this".to_string(),
+                from: Some(Participant::User),
+                reply_to: None,
+            }),
+        )
+        .await
+        .expect_err("send_message should fail when PTY delivery fails");
+
+        assert_eq!(error.0, StatusCode::CONFLICT);
+        assert!(error.1.contains("missing-pty"));
     }
 }

--- a/crates/exomind-runtime/tests/pty_agent.rs
+++ b/crates/exomind-runtime/tests/pty_agent.rs
@@ -245,3 +245,50 @@ async fn pty_list_claude_sessions() {
 
     handle.stop().await.expect("runtime should stop");
 }
+
+#[tokio::test]
+async fn pty_list_sessions_by_agent_type() {
+    let (mut handle, base_url) = start_test_runtime().await;
+    let client = reqwest::Client::new();
+
+    for agent_type in ["claude", "codex"] {
+        let resp = client
+            .get(format!("{base_url}/pty/sessions"))
+            .query(&[("agent_type", agent_type)])
+            .send()
+            .await
+            .expect("pty sessions request should succeed");
+
+        assert_eq!(
+            resp.status().as_u16(),
+            200,
+            "GET /pty/sessions?agent_type={agent_type} should return 200"
+        );
+
+        let payload: Value = resp.json().await.expect("response should be JSON");
+        assert!(
+            payload.is_array(),
+            "pty sessions response for {agent_type} should be a JSON array"
+        );
+
+        if let Some(sessions) = payload.as_array() {
+            for session in sessions {
+                assert_eq!(
+                    session["agent_type"].as_str(),
+                    Some(agent_type),
+                    "each returned session should keep the requested agent_type"
+                );
+                assert!(
+                    session["session_id"].is_string(),
+                    "each session should have a string session_id"
+                );
+                assert!(
+                    session["project_path"].is_string(),
+                    "each session should have a string project_path"
+                );
+            }
+        }
+    }
+
+    handle.stop().await.expect("runtime should stop");
+}

--- a/crates/exomind-runtime/tests/pty_agent.rs
+++ b/crates/exomind-runtime/tests/pty_agent.rs
@@ -7,6 +7,7 @@
 
 use exomind_runtime::{start_with_options, RuntimeStartOptions};
 use serde_json::Value;
+use std::time::Duration;
 
 /// Helper: start a lightweight runtime with no builtin actors or TS agents.
 async fn start_test_runtime() -> (exomind_runtime::RuntimeHandle, String) {
@@ -289,6 +290,84 @@ async fn pty_list_sessions_by_agent_type() {
             }
         }
     }
+
+    handle.stop().await.expect("runtime should stop");
+}
+
+#[tokio::test]
+async fn pty_natural_exit_completes_session_and_stop_remains_idempotent() {
+    let (mut handle, base_url) = start_test_runtime().await;
+    let client = reqwest::Client::new();
+
+    let spawn_body = if cfg!(windows) {
+        serde_json::json!({
+            "name": "test-natural-exit",
+            "workdir": ".",
+            "command": "cmd",
+            "args": ["/C", "echo hello"]
+        })
+    } else {
+        serde_json::json!({
+            "name": "test-natural-exit",
+            "workdir": ".",
+            "command": "echo",
+            "args": ["hello"]
+        })
+    };
+
+    let spawn_resp = client
+        .post(format!("{base_url}/pty/spawn"))
+        .json(&spawn_body)
+        .send()
+        .await
+        .expect("spawn request should succeed");
+    assert_eq!(spawn_resp.status().as_u16(), 201);
+
+    let spawn_payload: Value = spawn_resp.json().await.expect("spawn response should be JSON");
+    let pty_id = spawn_payload["id"]
+        .as_str()
+        .expect("spawn response should include PTY id")
+        .to_string();
+
+    let started = std::time::Instant::now();
+    let mut completed = false;
+    while started.elapsed() < Duration::from_secs(5) {
+        let payload: Value = client
+            .get(format!("{base_url}/sessions"))
+            .send()
+            .await
+            .expect("sessions request should succeed")
+            .json()
+            .await
+            .expect("sessions response should be JSON");
+        completed = payload
+            .as_array()
+            .and_then(|sessions| {
+                sessions
+                    .iter()
+                    .find(|session| session["id"].as_str() == Some(pty_id.as_str()))
+            })
+            .map(|session| session["status"] == "completed")
+            .unwrap_or(false);
+        if completed {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    assert!(completed, "short-lived PTY should auto-complete unified session after natural exit");
+
+    let stop_resp = client
+        .post(format!("{base_url}/pty/{pty_id}/stop"))
+        .send()
+        .await
+        .expect("stop request should succeed even after natural exit");
+
+    assert_eq!(
+        stop_resp.status().as_u16(),
+        200,
+        "stop should be idempotent after natural exit"
+    );
 
     handle.stop().await.expect("runtime should stop");
 }

--- a/docs/plans/2026-03-18-agent-session-terminal-control-design.md
+++ b/docs/plans/2026-03-18-agent-session-terminal-control-design.md
@@ -1,0 +1,241 @@
+# Agent Session Terminal Control Design
+
+**Date:** 2026-03-18
+**Status:** Approved
+**Scope:** Agent Hub 中的 PTY 会话启动、恢复、终止、消息桥接
+
+---
+
+## 1. 背景 / Background（背景）
+
+当前 Agent Hub 已经具备 PTY 会话的基础能力，但关键闭环仍缺失：
+
+1. `POST /sessions/:id/messages` 只记录消息，不桥接到 PTY stdin。
+2. PTY 恢复逻辑只支持 Claude，不支持 `codex exec resume <session-id>`。
+3. `PtySpawnDialog` 只能“启动新会话 / 恢复 Claude 会话”，不能配置 `agent type（Agent 类型）`、`model（模型）`、`reasoning effort（推理强度）`、`extra args（额外参数）`。
+4. `SessionCard` 列表卡片没有 PTY 级“停止 / Stop（停止）”按钮。
+
+---
+
+## 2. 目标 / Goals（目标）
+
+本次改动只补齐当前确认过的真实缺口：
+
+1. 用户可以从 Agent Hub 启动 `Claude / Codex / Custom（自定义命令）` PTY 会话。
+2. 用户可以按 `agent type（Agent 类型）` 恢复 `Claude / Codex` 历史会话。
+3. 用户可以通过 `POST /sessions/:id/messages` 把消息写入目标 PTY stdin。
+4. 用户可以在列表卡片、平铺终端、终端详情页三处统一停止 PTY 会话。
+5. 参数配置最小支持：`agent type`、`model`、`reasoning effort`、`workdir`、`extra args`。
+
+---
+
+## 3. 非目标 / Non-goals（本次不做）
+
+1. 不做通用 Agent provider 抽象。
+2. 不做 Custom 命令历史恢复。
+3. 不做参数模板保存、最近使用参数、Profile 配置档。
+4. 不做 PTY 进程级 pause / resume 控制。
+5. 不做跨类型历史会话混排、全文搜索、分页。
+
+---
+
+## 4. 核心决策 / Key Decisions（关键决策）
+
+### 4.1 消息桥接策略
+
+`send_message` 的主职责仍是“记录消息（record message，记录消息）”。  
+如果目标 session 带有 `pty_id`，则额外尝试将 `content + "\n"` 写入 PTY stdin。
+
+处理原则：
+
+1. session 不存在：返回 `404`
+2. session 存在但没有 `pty_id`：只记录消息，返回 `201`
+3. session 存在且有 `pty_id`，但 PTY 写入失败：记录 warning 日志，仍返回 `201`
+
+这样可以保证“会话消息”与“终端桥接”解耦，避免 PTY 抖动直接破坏消息链路。
+
+### 4.2 恢复接口显式带 `agent_type`
+
+`PtyResumeRequest` 增加 `agent_type: "claude" | "codex"`。  
+恢复命令映射如下：
+
+1. `claude` -> `claude --resume <session-id>`
+2. `codex` -> `codex exec resume <session-id>`
+
+Custom 不支持恢复，因此不出现在 `resume` 的请求契约内。
+
+### 4.3 历史会话接口统一化
+
+新增统一接口：
+
+`GET /pty/sessions?agent_type=claude|codex`
+
+返回统一结构：
+
+1. `agent_type`
+2. `session_id`
+3. `project_path`
+4. `last_modified`
+
+不再继续扩展 `/pty/claude-sessions` 这种单类型端点。
+
+### 4.4 启动弹窗单一入口
+
+`PtySpawnDialog` 保持单一弹窗，顶部先选 `agent type`，随后显示：
+
+1. `Start New Session（启动新会话）`
+2. `Resume History（恢复历史会话）`
+
+`Custom` 只显示“启动新会话”，不显示恢复列表。
+
+---
+
+## 5. 后端设计 / Backend Design（后端设计）
+
+### 5.1 `send_message` -> PTY stdin
+
+涉及文件：
+
+1. `crates/exomind-runtime/src/routes/sessions.rs`
+
+实现方式：
+
+1. 保留现有 session existence check（存在性检查），但把 session 实例保存到局部变量。
+2. 构建 `SessionMessage` 后，若 `session.pty_id` 存在，则调用 `state.pty_manager.write_input(pty_id, bytes)`。
+3. 输入内容按 `"{content}\n"` 写入，匹配终端交互习惯。
+
+### 5.2 PTY 历史会话发现
+
+涉及文件：
+
+1. `crates/exomind-runtime/src/pty/mod.rs`
+2. `crates/exomind-runtime/src/routes/pty.rs`
+
+新增统一数据结构：
+
+`PtyHistoricalSessionInfo`
+
+字段：
+
+1. `agent_type`
+2. `session_id`
+3. `project_path`
+4. `last_modified`
+
+发现逻辑：
+
+1. Claude：沿用当前 `~/.claude/projects/.../*.jsonl` 扫描逻辑。
+2. Codex：新增 `codex` 本地历史会话目录扫描逻辑。
+   - 目录与文件匹配规则以当前本机 `codex exec resume` 实际缓存布局为准。
+   - 若本地未发现目录，则接口返回空数组，而不是报错。
+
+### 5.3 PTY 恢复
+
+`PtyManager::resume()` 改成根据 `agent_type` 分支构建 `PtySpawnRequest`。
+
+默认会话名规则：
+
+1. Claude：`Claude-<session-id-prefix>`
+2. Codex：`Codex-<session-id-prefix>`
+
+恢复成功后仍把原始 `session_id` 写回 `PtyAgentInfo.session_id`，保证 session 注册链路不变。
+
+### 5.4 PTY 路由
+
+涉及文件：
+
+1. `crates/exomind-runtime/src/routes/pty.rs`
+
+改动：
+
+1. `GET /pty/sessions?agent_type=...`
+2. `POST /pty/resume` 接收新的 `agent_type`
+3. 保留现有 `/pty/spawn`、`/pty/:id/stop`、`/pty/:id/input`
+
+---
+
+## 6. 前端设计 / Frontend Design（前端设计）
+
+### 6.1 `PtySpawnDialog`
+
+涉及文件：
+
+1. `src/ui/app/components/PtySpawnDialog.tsx`
+
+新增状态：
+
+1. `agentType`
+2. `model`
+3. `reasoningEffort`
+4. `customCommand`
+5. `extraArgs`
+6. `historySessions`
+7. `historyLoading`
+
+交互规则：
+
+1. 切换 `agentType` 时，如果是 `claude / codex`，请求对应历史会话。
+2. `Claude / Codex` 都支持：
+   - `name`
+   - `workdir`
+   - `model`
+   - `extraArgs`
+3. `Codex` 额外支持 `reasoningEffort`
+4. `Custom` 额外支持 `customCommand`
+5. 点击“启动新会话”时，前端把配置拼成 `command + args`
+6. 点击“恢复历史会话”时，前端发送 `agent_type + session_id + name/workdir`
+
+### 6.2 `SessionCard`
+
+涉及文件：
+
+1. `src/ui/app/pages/agents/SessionCard.tsx`
+2. `src/ui/app/pages/agents/SessionsView.tsx`
+3. `src/ui/app/pages/AgentsPage.tsx`
+
+新增卡片级 `Stop（停止）` 小按钮，显示规则与 tiled grid 对齐：
+
+1. 仅 `interaction_mode === "terminal"` 且有 `pty_id` 时显示并可用
+2. 点击停止时阻止卡片主点击事件冒泡
+3. 最终仍复用 `AgentsPage` 现有的 `handleStopPtyAgent(...)`
+
+---
+
+## 7. 测试设计 / Test Strategy（测试策略）
+
+### 7.1 Rust
+
+1. `sessions.rs`
+   - `send_message` 在普通 session 上只返回消息
+   - `send_message` 在 PTY session 上会调用 PTY stdin 写入
+2. `pty/mod.rs`
+   - `resume` 对 Claude / Codex 生成不同 command / args
+   - 历史会话发现结果按 `agent_type` 正确返回
+3. `routes/pty.rs`
+   - `GET /pty/sessions` 参数校验与返回结构正确
+
+### 7.2 前端
+
+1. `PtySpawnDialog`
+   - 切换 `agentType` 后字段与历史会话列表变化正确
+   - `Codex` 启动请求包含 `model` 与 `reasoning effort`
+   - `resume` 请求带 `agent_type`
+2. `SessionCard / SessionsView`
+   - PTY session 显示 stop 按钮
+   - 点击 stop 触发回调，不触发卡片导航主点击
+
+### 7.3 页面集成
+
+1. Agents 页从列表卡片停止 PTY 会话
+2. 启动弹窗切到 `Codex` 后能看到历史会话并发起恢复
+
+---
+
+## 8. 验收标准 / Acceptance Criteria（验收）
+
+1. `POST /sessions/:id/messages` 可以桥接到 PTY stdin。
+2. `Claude / Codex` 都能按 `agent type` 恢复历史会话。
+3. `PtySpawnDialog` 支持 `agent type / model / reasoning effort / extra args`。
+4. `SessionCard` 具备卡片级 stop 按钮。
+5. 类型检查、相关单测、相关运行时测试全部通过。
+

--- a/docs/plans/2026-03-18-agent-session-terminal-control-implementation-plan.md
+++ b/docs/plans/2026-03-18-agent-session-terminal-control-implementation-plan.md
@@ -1,0 +1,298 @@
+# Agent Session Terminal Control Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 为 Agent Hub 补齐 PTY 消息桥接、按 Agent 类型恢复历史会话、启动参数配置与卡片级停止操作。
+
+**Architecture:** 保持现有 PTY/session 主链路不变，在运行时侧补 `send_message -> PTY stdin`、统一历史会话发现接口与 `agent_type` 恢复分支；前端侧扩展 `PtySpawnDialog` 和 `SessionCard`，并复用现有 stop API 与 session 注册流程。
+
+**Tech Stack:** Rust (axum, tokio, portable-pty), React 18 + TypeScript, Vitest, Bun
+
+---
+
+### Task 1: 文档定稿与基线确认
+
+**Files:**
+- Create: `docs/plans/2026-03-18-agent-session-terminal-control-design.md`
+- Create: `docs/plans/2026-03-18-agent-session-terminal-control-implementation-plan.md`
+
+**Step 1: 写入设计定稿**
+
+将已确认设计落盘，覆盖目标、接口、边界、测试范围。
+
+**Step 2: 写入实施计划**
+
+把运行时、前端、测试任务拆成独立可执行步骤。
+
+**Step 3: 运行基线校验**
+
+Run: `bunx tsc --noEmit`
+Expected: PASS
+
+Run: `bunx vitest run tests/unit/ui/agent-hub/pty-terminal-page.stop.test.tsx`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add docs/plans/2026-03-18-agent-session-terminal-control-design.md docs/plans/2026-03-18-agent-session-terminal-control-implementation-plan.md
+git commit -m "docs(plans): define agent session terminal control design"
+```
+
+### Task 2: 运行时测试先行 - `send_message` 桥接 PTY stdin
+
+**Files:**
+- Modify: `crates/exomind-runtime/src/routes/sessions.rs`
+- Test: `crates/exomind-runtime/src/routes/sessions.rs`
+
+**Step 1: 写失败测试**
+
+新增测试覆盖：
+
+1. 普通 session 发消息时只返回 `SessionMessage`
+2. 带 `pty_id` 的 session 发消息时会把 `content + "\\n"` 写入 PTY stdin
+
+**Step 2: 运行失败测试**
+
+Run: `cargo test -p exomind-runtime send_message_`
+Expected: FAIL，原因是当前不会写入 PTY stdin
+
+**Step 3: 写最小实现**
+
+在 `send_message` 中：
+
+1. 保留并保存 session 实例
+2. 构建 `SessionMessage`
+3. 如果有 `pty_id`，调用 `state.pty_manager.write_input(...)`
+4. PTY 写入失败时记录 warning，不改变 HTTP `201`
+
+**Step 4: 运行测试确认通过**
+
+Run: `cargo test -p exomind-runtime send_message_`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/exomind-runtime/src/routes/sessions.rs
+git commit -m "feat(rt): bridge session messages to PTY stdin"
+```
+
+### Task 3: 运行时测试先行 - 历史会话发现与 resume 按 Agent 类型分支
+
+**Files:**
+- Modify: `crates/exomind-runtime/src/pty/mod.rs`
+- Modify: `crates/exomind-runtime/src/routes/pty.rs`
+- Test: `crates/exomind-runtime/src/pty/mod.rs`
+- Test: `crates/exomind-runtime/src/routes/pty.rs`
+
+**Step 1: 写失败测试**
+
+新增测试覆盖：
+
+1. `PtyResumeRequest` 反序列化需要 `agent_type`
+2. `resume` 对 `claude / codex` 生成不同 command / args
+3. 历史会话发现返回统一结构，并带 `agent_type`
+4. `GET /pty/sessions?agent_type=...` 返回对应类型列表
+
+**Step 2: 运行失败测试**
+
+Run: `cargo test -p exomind-runtime pty_`
+Expected: FAIL，原因是当前只支持 Claude resume / Claude sessions
+
+**Step 3: 写最小实现**
+
+实现：
+
+1. 新增统一历史会话结构 `PtyHistoricalSessionInfo`
+2. `PtyResumeRequest` 增加 `agent_type`
+3. `PtyManager::resume()` 根据类型分支构建 `PtySpawnRequest`
+4. `routes/pty.rs` 新增统一 `GET /pty/sessions`
+5. 兼容 Claude，新增 Codex 历史发现逻辑
+
+**Step 4: 运行测试确认通过**
+
+Run: `cargo test -p exomind-runtime pty_`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/exomind-runtime/src/pty/mod.rs crates/exomind-runtime/src/routes/pty.rs
+git commit -m "feat(rt): add agent-typed PTY history and resume"
+```
+
+### Task 4: 前端测试先行 - `PtySpawnDialog` 参数与恢复 UI
+
+**Files:**
+- Modify: `src/ui/app/components/PtySpawnDialog.tsx`
+- Create: `tests/unit/ui/agent-hub/pty-spawn-dialog.test.tsx`
+
+**Step 1: 写失败测试**
+
+覆盖：
+
+1. 切换到 `Codex` 时显示 `model / reasoning effort / extra args`
+2. 切换到 `Custom` 时显示 `command`，不显示历史恢复区
+3. 恢复历史会话请求带 `agent_type`
+4. 启动新会话请求按所选类型拼出正确 `command + args`
+
+**Step 2: 运行失败测试**
+
+Run: `bunx vitest run tests/unit/ui/agent-hub/pty-spawn-dialog.test.tsx`
+Expected: FAIL，原因是当前 UI 与请求体字段不支持这些行为
+
+**Step 3: 写最小实现**
+
+实现：
+
+1. 扩展表单状态与字段
+2. 切换 `agentType` 时拉取 `GET /pty/sessions?agent_type=...`
+3. 构建 `spawn` 与 `resume` 请求体
+4. 为关键交互加 `data-testid`
+
+**Step 4: 运行测试确认通过**
+
+Run: `bunx vitest run tests/unit/ui/agent-hub/pty-spawn-dialog.test.tsx`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/ui/app/components/PtySpawnDialog.tsx tests/unit/ui/agent-hub/pty-spawn-dialog.test.tsx
+git commit -m "feat(ui): add agent-aware PTY spawn and resume controls"
+```
+
+### Task 5: 前端测试先行 - `SessionCard` 卡片级停止
+
+**Files:**
+- Modify: `src/ui/app/pages/agents/SessionCard.tsx`
+- Modify: `src/ui/app/pages/agents/SessionsView.tsx`
+- Modify: `src/ui/app/pages/AgentsPage.tsx`
+- Create: `tests/unit/ui/agent-hub/session-card.stop.test.tsx`
+
+**Step 1: 写失败测试**
+
+覆盖：
+
+1. PTY session 显示 stop 按钮
+2. 非 PTY session 不显示或不可用
+3. 点击 stop 触发 stop callback
+4. 点击 stop 不触发卡片主点击
+
+**Step 2: 运行失败测试**
+
+Run: `bunx vitest run tests/unit/ui/agent-hub/session-card.stop.test.tsx`
+Expected: FAIL
+
+**Step 3: 写最小实现**
+
+实现：
+
+1. `SessionCard` 增加 `onStop`
+2. `SessionsView` 透传 `onStopSession`
+3. `AgentsPage` 列表视图复用 `handleStopPtyAgent(...)`
+
+**Step 4: 运行测试确认通过**
+
+Run: `bunx vitest run tests/unit/ui/agent-hub/session-card.stop.test.tsx`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/ui/app/pages/agents/SessionCard.tsx src/ui/app/pages/agents/SessionsView.tsx src/ui/app/pages/AgentsPage.tsx tests/unit/ui/agent-hub/session-card.stop.test.tsx
+git commit -m "feat(ui): add list-card stop action for PTY sessions"
+```
+
+### Task 6: 页面级集成测试
+
+**Files:**
+- Create or Modify: `tests/unit/ui/agent-hub/agents-page.pty-session-controls.test.tsx`
+
+**Step 1: 写失败测试**
+
+覆盖：
+
+1. Agents 页列表卡片 stop 会调用 `/pty/:id/stop`
+2. `PtySpawnDialog` 切到 `Codex` 后展示历史会话并发起恢复
+
+**Step 2: 运行失败测试**
+
+Run: `bunx vitest run tests/unit/ui/agent-hub/agents-page.pty-session-controls.test.tsx`
+Expected: FAIL
+
+**Step 3: 写最小实现或补测试夹具**
+
+只补为让页面流通过所需的最小实现或 mock。
+
+**Step 4: 运行测试确认通过**
+
+Run: `bunx vitest run tests/unit/ui/agent-hub/agents-page.pty-session-controls.test.tsx`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/unit/ui/agent-hub/agents-page.pty-session-controls.test.tsx
+git commit -m "test(ui): cover agent session terminal control flows"
+```
+
+### Task 7: 全量相关验证
+
+**Files:**
+- Modify: only if verification exposes regressions
+
+**Step 1: 运行 Rust 相关测试**
+
+Run: `cargo test -p exomind-runtime send_message_ pty_`
+Expected: PASS
+
+**Step 2: 运行前端相关单测**
+
+Run: `bunx vitest run tests/unit/ui/agent-hub/pty-terminal-page.stop.test.tsx tests/unit/ui/agent-hub/pty-spawn-dialog.test.tsx tests/unit/ui/agent-hub/session-card.stop.test.tsx tests/unit/ui/agent-hub/agents-page.pty-session-controls.test.tsx`
+Expected: PASS
+
+**Step 3: 运行类型检查**
+
+Run: `bunx tsc --noEmit`
+Expected: PASS
+
+**Step 4: 运行构建**
+
+Run: `bun run build`
+Expected: PASS
+
+**Step 5: Commit verification fixes**
+
+如果验证阶段发现回归，修复后单独提交。
+
+### Task 8: PR 准备
+
+**Files:**
+- Modify: PR 描述草稿或 issue 注释材料（若仓库内维护）
+
+**Step 1: 汇总变更**
+
+整理：
+
+1. 运行时改动
+2. 前端改动
+3. 测试命令与结果
+
+**Step 2: 准备 PR 文案**
+
+包含：
+
+1. 问题背景
+2. 变更点
+3. 验证命令
+4. 风险与未做项
+
+**Step 3: Push / PR**
+
+```bash
+git push -u origin feature/agent-session-terminal-control
+```
+
+随后创建 PR 指向 `dev`。

--- a/src/ui/app/components/PtySpawnDialog.tsx
+++ b/src/ui/app/components/PtySpawnDialog.tsx
@@ -10,7 +10,11 @@ import { Loader2, Terminal } from 'lucide-react';
 
 // ── Types ──────────────────────────────────────────────────────
 
-interface ClaudeSessionInfo {
+type PtyAgentType = 'claude' | 'codex' | 'custom';
+type ReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh';
+
+interface HistoricalSessionInfo {
+  agent_type: Exclude<PtyAgentType, 'custom'>;
   session_id: string;
   project_path: string;
   last_modified: string; // ISO 8601
@@ -47,6 +51,13 @@ function formatRelativeTime(isoString: string): string {
   return `${days}天前`;
 }
 
+function parseExtraArgs(input: string): string[] {
+  return input
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
 // ── Component ──────────────────────────────────────────────────
 
 export function PtySpawnDialog({
@@ -57,9 +68,15 @@ export function PtySpawnDialog({
   defaultWorkdir,
   onSpawned,
 }: PtySpawnDialogProps) {
+  const [agentType, setAgentType] = useState<PtyAgentType>('claude');
   const [name, setName] = useState('');
   const [workdir, setWorkdir] = useState(defaultWorkdir || '');
-  const [sessions, setSessions] = useState<ClaudeSessionInfo[]>([]);
+  const [model, setModel] = useState('');
+  const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort>('xhigh');
+  const [customCommand, setCustomCommand] = useState('');
+  const [extraArgs, setExtraArgs] = useState('');
+  const [sessions, setSessions] = useState<HistoricalSessionInfo[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
@@ -77,38 +94,58 @@ export function PtySpawnDialog({
 
   useEffect(() => {
     if (!open) {
+      setAgentType('claude');
       setName('');
       setWorkdir(defaultWorkdir || '');
+      setModel('');
+      setReasoningEffort('xhigh');
+      setCustomCommand('');
+      setExtraArgs('');
       setSessions([]);
+      setHistoryLoading(false);
       setLoading(false);
       setError('');
     }
   }, [open, defaultWorkdir]);
 
-  // ── Fetch Claude sessions on open ───────────────────────────
+  // ── Fetch historical sessions on open / type switch ─────────
 
   useEffect(() => {
     if (!open) return;
+    if (agentType === 'custom') {
+      setSessions([]);
+      setHistoryLoading(false);
+      return;
+    }
 
     let cancelled = false;
 
     const fetchSessions = async () => {
       try {
+        setHistoryLoading(true);
         const headers: Record<string, string> = {};
         if (authToken) {
           headers['Authorization'] = `Bearer ${authToken}`;
         }
-        const res = await fetch(`${rtBaseUrl}/pty/claude-sessions`, { headers });
+        const res = await fetch(`${rtBaseUrl}/pty/sessions?agent_type=${agentType}`, { headers });
         if (!res.ok) {
           // Non-critical: sessions list is optional
+          if (!cancelled) setSessions([]);
           return;
         }
-        const data: ClaudeSessionInfo[] = await res.json();
+        const data: HistoricalSessionInfo[] = await res.json();
         if (!cancelled) {
-          setSessions(data);
+          setSessions(data.filter((session) => session.agent_type === agentType));
         }
       } catch {
         // Silently ignore — session list is a convenience feature
+        if (!cancelled) {
+          setSessions([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setHistoryLoading(false);
+        }
       }
     };
 
@@ -117,7 +154,56 @@ export function PtySpawnDialog({
     return () => {
       cancelled = true;
     };
-  }, [open, rtBaseUrl, authToken]);
+  }, [open, agentType, rtBaseUrl, authToken]);
+
+  const buildSpawnPayload = useCallback(() => {
+    const args: string[] = [];
+    let command = 'claude';
+
+    if (agentType === 'claude') {
+      command = 'claude';
+      if (model.trim()) {
+        args.push('--model', model.trim());
+      }
+    } else if (agentType === 'codex') {
+      command = 'codex';
+      if (model.trim()) {
+        args.push('-m', model.trim());
+      }
+      if (reasoningEffort.trim()) {
+        args.push('-c', `model_reasoning_effort="${reasoningEffort}"`);
+      }
+    } else {
+      command = customCommand.trim();
+    }
+
+    args.push(...parseExtraArgs(extraArgs));
+
+    const body: {
+      name?: string;
+      workdir?: string;
+      command: string;
+      args: string[];
+      rows: number;
+      cols: number;
+    } = {} as {
+      name?: string;
+      workdir?: string;
+      command: string;
+      args: string[];
+      rows: number;
+      cols: number;
+    };
+
+    if (name.trim()) body.name = name.trim();
+    if (workdir.trim()) body.workdir = workdir.trim();
+    body.command = command;
+    body.args = args;
+    body.rows = 24;
+    body.cols = 80;
+
+    return body;
+  }, [agentType, customCommand, extraArgs, model, name, reasoningEffort, workdir]);
 
   // ── Spawn new session ───────────────────────────────────────
 
@@ -126,9 +212,7 @@ export function PtySpawnDialog({
     setError('');
 
     try {
-      const body: Record<string, string> = {};
-      if (name.trim()) body.name = name.trim();
-      if (workdir.trim()) body.workdir = workdir.trim();
+      const body = buildSpawnPayload();
 
       const res = await fetch(`${rtBaseUrl}/pty/spawn`, {
         method: 'POST',
@@ -149,17 +233,18 @@ export function PtySpawnDialog({
     } finally {
       setLoading(false);
     }
-  }, [name, workdir, rtBaseUrl, buildHeaders, onSpawned, onOpenChange]);
+  }, [buildHeaders, buildSpawnPayload, onOpenChange, onSpawned, rtBaseUrl]);
 
   // ── Resume existing session ─────────────────────────────────
 
   const handleResume = useCallback(
-    async (session: ClaudeSessionInfo) => {
+    async (session: HistoricalSessionInfo) => {
       setLoading(true);
       setError('');
 
       try {
         const body: Record<string, string> = {
+          agent_type: session.agent_type,
           session_id: session.session_id,
         };
         if (name.trim()) body.name = name.trim();
@@ -192,17 +277,36 @@ export function PtySpawnDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="rounded-2xl sm:max-w-[420px]">
+      <DialogContent className="rounded-2xl sm:max-w-[520px]">
         <DialogHeader>
           <DialogTitle>启动终端会话</DialogTitle>
-          <DialogDescription>启动新的 PTY 会话或恢复已有的 Claude 会话</DialogDescription>
+          <DialogDescription>
+            启动新的 PTY 会话，或按 Agent 类型恢复 Claude / Codex 历史会话
+          </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 pt-1">
+          {/* ── Agent type ── */}
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-muted-foreground">Agent 类型（agent type）</label>
+            <select
+              data-testid="pty-agent-type"
+              value={agentType}
+              onChange={(e) => setAgentType(e.target.value as PtyAgentType)}
+              className="h-9 w-full rounded-lg border border-border-card bg-card px-3 text-sm outline-none focus:border-[#C75B3A] focus:ring-1 focus:ring-[#C75B3A]"
+              disabled={loading}
+            >
+              <option value="claude">Claude</option>
+              <option value="codex">Codex</option>
+              <option value="custom">Custom（自定义）</option>
+            </select>
+          </div>
+
           {/* ── Name input ── */}
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-muted-foreground">名称（可选）</label>
             <input
+              data-testid="pty-session-name"
               type="text"
               placeholder="my-terminal"
               value={name}
@@ -216,10 +320,72 @@ export function PtySpawnDialog({
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-muted-foreground">工作目录（可选）</label>
             <input
+              data-testid="pty-session-workdir"
               type="text"
               placeholder="D:\project\exomind"
               value={workdir}
               onChange={(e) => setWorkdir(e.target.value)}
+              className="h-9 w-full rounded-lg border border-border-card bg-card px-3 text-sm outline-none focus:border-[#C75B3A] focus:ring-1 focus:ring-[#C75B3A]"
+              disabled={loading}
+            />
+          </div>
+
+          {(agentType === 'claude' || agentType === 'codex') && (
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-muted-foreground">模型（model）</label>
+              <input
+                data-testid="pty-model"
+                type="text"
+                placeholder={agentType === 'claude' ? 'claude-sonnet-4-5' : 'gpt-5.4'}
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                className="h-9 w-full rounded-lg border border-border-card bg-card px-3 text-sm outline-none focus:border-[#C75B3A] focus:ring-1 focus:ring-[#C75B3A]"
+                disabled={loading}
+              />
+            </div>
+          )}
+
+          {agentType === 'codex' && (
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-muted-foreground">推理强度（reasoning effort）</label>
+              <select
+                data-testid="pty-reasoning-effort"
+                value={reasoningEffort}
+                onChange={(e) => setReasoningEffort(e.target.value as ReasoningEffort)}
+                className="h-9 w-full rounded-lg border border-border-card bg-card px-3 text-sm outline-none focus:border-[#C75B3A] focus:ring-1 focus:ring-[#C75B3A]"
+                disabled={loading}
+              >
+                <option value="low">low</option>
+                <option value="medium">medium</option>
+                <option value="high">high</option>
+                <option value="xhigh">xhigh</option>
+              </select>
+            </div>
+          )}
+
+          {agentType === 'custom' && (
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-muted-foreground">命令（command）</label>
+              <input
+                data-testid="pty-custom-command"
+                type="text"
+                placeholder="node"
+                value={customCommand}
+                onChange={(e) => setCustomCommand(e.target.value)}
+                className="h-9 w-full rounded-lg border border-border-card bg-card px-3 text-sm outline-none focus:border-[#C75B3A] focus:ring-1 focus:ring-[#C75B3A]"
+                disabled={loading}
+              />
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-muted-foreground">额外参数（extra args）</label>
+            <input
+              data-testid="pty-extra-args"
+              type="text"
+              placeholder="--search --full-auto"
+              value={extraArgs}
+              onChange={(e) => setExtraArgs(e.target.value)}
               className="h-9 w-full rounded-lg border border-border-card bg-card px-3 text-sm outline-none focus:border-[#C75B3A] focus:ring-1 focus:ring-[#C75B3A]"
               disabled={loading}
             />
@@ -233,8 +399,9 @@ export function PtySpawnDialog({
           {/* ── Spawn button ── */}
           <button
             type="button"
+            data-testid="pty-spawn-submit"
             onClick={handleSpawn}
-            disabled={loading}
+            disabled={loading || (agentType === 'custom' && !customCommand.trim())}
             className="w-full rounded-[14px] bg-[#C75B3A] px-4 py-2.5 text-sm font-semibold text-white disabled:opacity-50 hover:bg-[#B5502F] transition-colors"
           >
             {loading ? (
@@ -248,28 +415,37 @@ export function PtySpawnDialog({
           </button>
 
           {/* ── Session list ── */}
-          {sessions.length > 0 && (
+          {agentType !== 'custom' && (
             <div className="space-y-2">
-              <div className="text-xs font-medium text-muted-foreground">恢复已有会话</div>
-              <div className="max-h-[200px] space-y-1.5 overflow-y-auto">
-                {sessions.map((session) => (
-                  <button
-                    key={session.session_id}
-                    type="button"
-                    onClick={() => handleResume(session)}
-                    disabled={loading}
-                    className="flex w-full items-center gap-2.5 rounded-xl border border-border-card bg-card px-3 py-2 text-sm text-left hover:bg-muted/50 disabled:opacity-50 transition-colors"
-                  >
-                    <Terminal className="h-4 w-4 shrink-0 text-muted-foreground" />
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate font-medium">{session.project_path || session.session_id.slice(0, 12)}</div>
-                      <div className="text-xs text-muted-foreground">
-                        {formatRelativeTime(session.last_modified)}
+              <div className="text-xs font-medium text-muted-foreground">恢复历史会话（resume history）</div>
+              {historyLoading ? (
+                <div className="text-xs text-muted-foreground">加载历史会话中...</div>
+              ) : sessions.length > 0 ? (
+                <div data-testid="pty-history-list" className="max-h-[200px] space-y-1.5 overflow-y-auto">
+                  {sessions.map((session) => (
+                    <button
+                      key={session.session_id}
+                      data-testid={`pty-history-session-${session.session_id}`}
+                      type="button"
+                      onClick={() => handleResume(session)}
+                      disabled={loading}
+                      className="flex w-full items-center gap-2.5 rounded-xl border border-border-card bg-card px-3 py-2 text-sm text-left hover:bg-muted/50 disabled:opacity-50 transition-colors"
+                    >
+                      <Terminal className="h-4 w-4 shrink-0 text-muted-foreground" />
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate font-medium">{session.project_path || session.session_id.slice(0, 12)}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {formatRelativeTime(session.last_modified)}
+                        </div>
                       </div>
-                    </div>
-                  </button>
-                ))}
-              </div>
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-xs text-muted-foreground">
+                  当前没有可恢复的 {agentType === 'claude' ? 'Claude' : 'Codex'} 会话
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/ui/app/components/PtySpawnDialog.tsx
+++ b/src/ui/app/components/PtySpawnDialog.tsx
@@ -52,10 +52,43 @@ function formatRelativeTime(isoString: string): string {
 }
 
 function parseExtraArgs(input: string): string[] {
-  return input
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean);
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index];
+
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current) {
+    tokens.push(current);
+  }
+
+  return tokens;
 }
 
 // ── Component ──────────────────────────────────────────────────
@@ -243,12 +276,20 @@ export function PtySpawnDialog({
       setError('');
 
       try {
-        const body: Record<string, string> = {
+        const parsedExtraArgs = parseExtraArgs(extraArgs);
+        const body: Record<string, string | string[]> = {
           agent_type: session.agent_type,
           session_id: session.session_id,
         };
         if (name.trim()) body.name = name.trim();
         if (workdir.trim()) body.workdir = workdir.trim();
+        if (model.trim()) body.model = model.trim();
+        if (session.agent_type === 'codex' && reasoningEffort.trim()) {
+          body.reasoning_effort = reasoningEffort.trim();
+        }
+        if (parsedExtraArgs.length > 0) {
+          body.extra_args = parsedExtraArgs;
+        }
 
         const res = await fetch(`${rtBaseUrl}/pty/resume`, {
           method: 'POST',
@@ -270,7 +311,7 @@ export function PtySpawnDialog({
         setLoading(false);
       }
     },
-    [name, workdir, rtBaseUrl, buildHeaders, onSpawned, onOpenChange],
+    [extraArgs, model, name, onOpenChange, onSpawned, reasoningEffort, rtBaseUrl, workdir, buildHeaders],
   );
 
   // ── Render ──────────────────────────────────────────────────

--- a/src/ui/app/components/PtyTerminal.tsx
+++ b/src/ui/app/components/PtyTerminal.tsx
@@ -160,12 +160,39 @@ export function PtyTerminal({ rtBaseUrl, ptyId, authToken }: PtyTerminalProps) {
 
     // ── ResizeObserver → refit terminal ──────────────────────
 
-    const resizeObserver = new ResizeObserver(() => {
+    let connectScheduled = false;
+    let initialLayoutReady = false;
+    let connectTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const syncTerminalLayout = () => {
+      // Wait for a measurable container before attaching stream output.
+      if (container.clientWidth <= 0 || container.clientHeight <= 0) {
+        return false;
+      }
+
       try {
         fitAddon.fit();
+        terminal.refresh(0, Math.max(terminal.rows - 1, 0));
       } catch {
-        // Ignore fit errors during rapid resizing
+        // Ignore fit/refresh errors during rapid resizing
       }
+
+      sendResize(terminal.rows, terminal.cols);
+
+      if (!initialLayoutReady && !connectScheduled) {
+        initialLayoutReady = true;
+        connectScheduled = true;
+        connectTimer = setTimeout(() => {
+          connectTimer = null;
+          connectSSE();
+        }, 50);
+      }
+
+      return true;
+    };
+
+    const resizeObserver = new ResizeObserver(() => {
+      syncTerminalLayout();
     });
     resizeObserver.observe(container);
     resizeObserverRef.current = resizeObserver;
@@ -204,21 +231,16 @@ export function PtyTerminal({ rtBaseUrl, ptyId, authToken }: PtyTerminalProps) {
       };
     };
 
-    // Use rAF to ensure container has layout dimensions, then:
+    // Use rAF to wait for first measurable layout, then:
     // 1. fit terminal to container
-    // 2. send resize to PTY backend
-    // 3. connect SSE only after resize is dispatched
+    // 2. refresh terminal canvas / rows
+    // 3. send resize to PTY backend
+    // 4. connect SSE only after resize is dispatched
     requestAnimationFrame(() => {
-      try {
-        fitAddon.fit();
-      } catch {
-        // Ignore
+      if (syncTerminalLayout()) {
+        // Auto-focus the terminal only when layout is ready
+        terminal.focus();
       }
-      sendResize(terminal.rows, terminal.cols);
-      // Auto-focus the terminal so keyboard/paste events reach it
-      terminal.focus();
-      // Small delay to let the resize reach the PTY before output streams in
-      setTimeout(() => connectSSE(), 50);
     });
 
     // ── Cleanup ──────────────────────────────────────────────
@@ -236,6 +258,10 @@ export function PtyTerminal({ rtBaseUrl, ptyId, authToken }: PtyTerminalProps) {
       if (eventSourceRef.current) {
         eventSourceRef.current.close();
         eventSourceRef.current = null;
+      }
+      if (connectTimer) {
+        clearTimeout(connectTimer);
+        connectTimer = null;
       }
       if (eventSource) {
         eventSource.close();

--- a/src/ui/app/pages/AgentsPage.tsx
+++ b/src/ui/app/pages/AgentsPage.tsx
@@ -1533,6 +1533,10 @@ export function AgentsPage() {
               openPtyTerminal(session.pty_id, session.source_host_id);
             }
           }}
+          onStopSession={(session) => {
+            if (!session.pty_id) return;
+            void handleStopPtyAgent(session.pty_id, session.source_host_id);
+          }}
         />
       );
     }

--- a/src/ui/app/pages/agents/SessionCard.tsx
+++ b/src/ui/app/pages/agents/SessionCard.tsx
@@ -1,4 +1,4 @@
-import { Clock, ExternalLink } from 'lucide-react';
+import { Clock, ExternalLink, Square } from 'lucide-react';
 import type { SessionInfo } from '@/lib/types/session';
 import {
   AGENT_KIND_LABELS,
@@ -13,116 +13,138 @@ import {
 export interface SessionCardProps {
   session: SessionInfo;
   onClick?: (session: SessionInfo) => void;
+  onStop?: (session: SessionInfo) => void;
 }
 
 // ── Component ──────────────────────────────────────────────────
 
-export function SessionCard({ session, onClick }: SessionCardProps) {
+export function SessionCard({ session, onClick, onStop }: SessionCardProps) {
   const statusIndicator = SESSION_STATUS_INDICATORS[session.status];
   const agentColor = AGENT_KIND_COLORS[session.agent_kind];
   const agentLabel = AGENT_KIND_LABELS[session.agent_kind];
   const needsAttention = sessionNeedsAttention(session.status);
+  const canStopPty = session.interaction_mode === 'terminal' && !!session.pty_id;
 
   return (
-    <button
-      type="button"
-      data-testid={`session-card-${session.id}`}
-      onClick={() => onClick?.(session)}
-      className={`
+    <div className="relative">
+      <button
+        type="button"
+        data-testid={`session-card-${session.id}`}
+        onClick={() => onClick?.(session)}
+        className={`
         group relative flex w-full flex-col gap-2 rounded-xl border p-4 text-left
         transition-all duration-200 hover:shadow-md
+        ${canStopPty ? 'pr-14' : ''}
         ${needsAttention
           ? 'border-yellow-400/60 bg-yellow-50/50 shadow-sm dark:border-yellow-500/40 dark:bg-yellow-950/20'
           : 'border-[#E7E5E4] bg-white hover:border-[#D6D3D1] dark:border-[#292524] dark:bg-[#1C1917] dark:hover:border-[#44403C]'
         }
       `}
-    >
-      {/* Row 1: Status + Role + Time */}
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2 min-w-0">
-          {/* Status indicator (shape for accessibility) */}
-          <span
-            className="flex-shrink-0 text-sm"
-            style={{ color: statusIndicator.color }}
-            title={statusIndicator.label}
-            aria-label={statusIndicator.label}
-          >
-            {statusIndicator.shape}
-          </span>
+      >
+        {/* Row 1: Status + Role + Time */}
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2 min-w-0">
+            {/* Status indicator (shape for accessibility) */}
+            <span
+              className="flex-shrink-0 text-sm"
+              style={{ color: statusIndicator.color }}
+              title={statusIndicator.label}
+              aria-label={statusIndicator.label}
+            >
+              {statusIndicator.shape}
+            </span>
 
-          {/* Role name */}
-          <span className="truncate text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">
-            {session.role || '未命名'}
-          </span>
+            {/* Role name */}
+            <span className="truncate text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">
+              {session.role || '未命名'}
+            </span>
 
-          {/* Agent kind badge */}
-          <span
-            className="flex-shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium text-white"
-            style={{ backgroundColor: agentColor }}
-          >
-            {agentLabel}
-          </span>
+            {/* Agent kind badge */}
+            <span
+              className="flex-shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium text-white"
+              style={{ backgroundColor: agentColor }}
+            >
+              {agentLabel}
+            </span>
+          </div>
+
+          {/* Relative time */}
+          <div className="flex flex-shrink-0 items-center gap-1 text-xs text-[#A8A29E]">
+            <Clock size={12} />
+            <span>{formatRelativeTime(session.last_active_at)}</span>
+          </div>
         </div>
 
-        {/* Relative time */}
-        <div className="flex flex-shrink-0 items-center gap-1 text-xs text-[#A8A29E]">
-          <Clock size={12} />
-          <span>{formatRelativeTime(session.last_active_at)}</span>
+        {/* Row 2: Context chips (branch / issue / PR) */}
+        <div className="flex flex-wrap items-center gap-1.5">
+          {session.context.git_branch && (
+            <ContextChip icon="branch">
+              {session.context.git_branch}
+            </ContextChip>
+          )}
+          {session.context.issue_refs.map((ref) => (
+            <ContextChip key={ref} icon="issue">
+              {ref}
+            </ContextChip>
+          ))}
+          {session.context.pr_ref && (
+            <ContextChip icon="pr">
+              PR {session.context.pr_ref}
+            </ContextChip>
+          )}
+          {session.context.worktree_path && (
+            <ContextChip icon="worktree">
+              worktree
+            </ContextChip>
+          )}
         </div>
-      </div>
 
-      {/* Row 2: Context chips (branch / issue / PR) */}
-      <div className="flex flex-wrap items-center gap-1.5">
-        {session.context.git_branch && (
-          <ContextChip icon="branch">
-            {session.context.git_branch}
-          </ContextChip>
+        {/* Row 3: Summary / last output preview */}
+        {(session.summary || session.last_output_preview) && (
+          <p className="line-clamp-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
+            {session.summary || session.last_output_preview}
+          </p>
         )}
-        {session.context.issue_refs.map((ref) => (
-          <ContextChip key={ref} icon="issue">
-            {ref}
-          </ContextChip>
-        ))}
-        {session.context.pr_ref && (
-          <ContextChip icon="pr">
-            PR {session.context.pr_ref}
-          </ContextChip>
-        )}
-        {session.context.worktree_path && (
-          <ContextChip icon="worktree">
-            worktree
-          </ContextChip>
-        )}
-      </div>
 
-      {/* Row 3: Summary / last output preview */}
-      {(session.summary || session.last_output_preview) && (
-        <p className="line-clamp-2 text-xs text-[#78716C] dark:text-[#A8A29E]">
-          {session.summary || session.last_output_preview}
-        </p>
+        {/* Row 4: Status label for attention-needing sessions */}
+        {needsAttention && (
+          <div className="flex items-center gap-1">
+            <span
+              className="rounded px-1.5 py-0.5 text-[10px] font-medium"
+              style={{
+                backgroundColor: `${statusIndicator.color}20`,
+                color: statusIndicator.color,
+              }}
+            >
+              {statusIndicator.label}
+            </span>
+          </div>
+        )}
+
+        {/* Hover arrow indicator */}
+        <ExternalLink
+          size={14}
+          className={`absolute top-4 text-[#D6D3D1] opacity-0 transition-opacity group-hover:opacity-100 dark:text-[#44403C] ${canStopPty ? 'right-11' : 'right-3'}`}
+        />
+      </button>
+
+      {canStopPty && onStop && (
+        <button
+          type="button"
+          data-testid={`session-card-stop-${session.id}`}
+          aria-label="停止"
+          title="停止"
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            onStop(session);
+          }}
+          className="absolute right-3 top-3 flex h-7 w-7 items-center justify-center rounded-full bg-[#F5F0ED] text-[#78716C] transition-colors hover:bg-[#E7E5E4] hover:text-[#1C1917] dark:bg-[#292524] dark:text-[#A8A29E] dark:hover:bg-[#44403C] dark:hover:text-[#FAFAF9]"
+        >
+          <Square size={12} />
+        </button>
       )}
-
-      {/* Row 4: Status label for attention-needing sessions */}
-      {needsAttention && (
-        <div className="flex items-center gap-1">
-          <span
-            className="rounded px-1.5 py-0.5 text-[10px] font-medium"
-            style={{
-              backgroundColor: `${statusIndicator.color}20`,
-              color: statusIndicator.color,
-            }}
-          >
-            {statusIndicator.label}
-          </span>
-        </div>
-      )}
-
-      {/* Hover arrow indicator */}
-      <ExternalLink
-        size={14}
-        className="absolute right-3 top-4 text-[#D6D3D1] opacity-0 transition-opacity group-hover:opacity-100 dark:text-[#44403C]"
-      />
-    </button>
+    </div>
   );
 }
 

--- a/src/ui/app/pages/agents/SessionsView.tsx
+++ b/src/ui/app/pages/agents/SessionsView.tsx
@@ -12,6 +12,8 @@ export interface SessionsViewProps {
   onRefresh?: () => void;
   /** Callback when user clicks a session card */
   onSessionClick?: (session: SessionInfo) => void;
+  /** Callback when user stops a PTY session（停止 PTY 会话） */
+  onStopSession?: (session: SessionInfo) => void;
 }
 
 // ── Component ──────────────────────────────────────────────────
@@ -23,6 +25,7 @@ export function SessionsView({
   useMockData,
   onRefresh,
   onSessionClick,
+  onStopSession,
 }: SessionsViewProps) {
   // Sort: attention-needing first, then by last_active_at desc
   const sortedSessions = [...sessions].sort((a, b) => {
@@ -105,6 +108,7 @@ export function SessionsView({
             key={session.id}
             session={session}
             onClick={onSessionClick}
+            onStop={onStopSession}
           />
         ))}
       </div>

--- a/tests/unit/ui/agent-hub/agents-page.session-actions.issue523.test.tsx
+++ b/tests/unit/ui/agent-hub/agents-page.session-actions.issue523.test.tsx
@@ -514,6 +514,7 @@ describe('agents page session actions issue-523（会话动作接线）', () => 
           body: JSON.stringify({
             agent_type: 'codex',
             session_id: '019d0011-aaaa-bbbb-cccc-1234567890ab',
+            reasoning_effort: 'xhigh',
           }),
         }),
       );

--- a/tests/unit/ui/agent-hub/agents-page.session-actions.issue523.test.tsx
+++ b/tests/unit/ui/agent-hub/agents-page.session-actions.issue523.test.tsx
@@ -286,6 +286,37 @@ describe('agents page session actions issue-523（会话动作接线）', () => 
           json: async () => [],
         } as Response;
       }
+      if (url.includes('/pty/sessions?agent_type=claude')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [],
+        } as Response;
+      }
+      if (url.includes('/pty/sessions?agent_type=codex')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              agent_type: 'codex',
+              session_id: '019d0011-aaaa-bbbb-cccc-1234567890ab',
+              project_path: 'D:/project/exomind',
+              last_modified: '2026-03-18T02:20:32.696Z',
+            },
+          ],
+        } as Response;
+      }
+      if (url.endsWith('/pty/resume')) {
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({
+            id: 'pty-resume-523',
+            name: 'Codex-019d0011',
+          }),
+        } as Response;
+      }
       if (url.endsWith('/pty')) {
         return {
           ok: true,
@@ -428,6 +459,64 @@ describe('agents page session actions issue-523（会话动作接线）', () => 
     });
     await waitFor(() => {
       expect(screen.queryByTestId('agent-rightpanel-pty-terminal')).not.toBeInTheDocument();
+    });
+  });
+
+  it('stops PTY terminal agent from session list card（会话列表卡片可真正停止 Terminal Agent）', async () => {
+    sessionStreamState.sessions = [
+      buildSession({
+        id: 'session-card-stop',
+        interaction_mode: 'terminal',
+        pty_id: 'pty-523',
+        source_host_id: 'runtime-host-523',
+      }),
+    ];
+
+    render(<AgentsPage />);
+    fireEvent.click(await screen.findByTestId('agent-view-toggle-sessions'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-card-stop-session-card-stop')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('session-card-stop-session-card-stop'));
+
+    await waitFor(() => {
+      expect(runtimeClientMocks.stopPtyAgent).toHaveBeenCalledWith(
+        expect.objectContaining({ host: '127.0.0.1', port: 1919 }),
+        'pty-523',
+      );
+    });
+  });
+
+  it('opens PTY spawn dialog and resumes codex history（Agents 页可恢复 Codex 历史会话）', async () => {
+    render(<AgentsPage />);
+
+    fireEvent.click(await screen.findByTestId('pty-spawn-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pty-agent-type')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('pty-agent-type'), { target: { value: 'codex' } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pty-history-session-019d0011-aaaa-bbbb-cccc-1234567890ab')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('pty-history-session-019d0011-aaaa-bbbb-cccc-1234567890ab'));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        'http://127.0.0.1:1919/pty/resume',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            agent_type: 'codex',
+            session_id: '019d0011-aaaa-bbbb-cccc-1234567890ab',
+          }),
+        }),
+      );
     });
   });
 });

--- a/tests/unit/ui/agent-hub/pty-spawn-dialog.test.tsx
+++ b/tests/unit/ui/agent-hub/pty-spawn-dialog.test.tsx
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { PtySpawnDialog } from '@/ui/app/components/PtySpawnDialog';
+
+describe('PtySpawnDialog（终端会话启动弹窗）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('builds codex spawn request with model and reasoning config（Codex 启动携带模型与推理强度）', async () => {
+    const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
+      if (input.includes('/pty/sessions?agent_type=claude')) {
+        return { ok: true, json: async () => [] } as Response;
+      }
+      if (input.includes('/pty/sessions?agent_type=codex')) {
+        return { ok: true, json: async () => [] } as Response;
+      }
+      if (input.endsWith('/pty/spawn')) {
+        return {
+          ok: true,
+          json: async () => ({ id: 'pty-codex-1', name: 'codex-main' }),
+        } as Response;
+      }
+      throw new Error(`unexpected fetch: ${input} ${JSON.stringify(init)}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onSpawned = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <PtySpawnDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        rtBaseUrl="http://127.0.0.1:1949"
+        defaultWorkdir="D:/project/exomind"
+        onSpawned={onSpawned}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('pty-agent-type'), { target: { value: 'codex' } });
+    fireEvent.change(screen.getByTestId('pty-session-name'), { target: { value: 'codex-main' } });
+    fireEvent.change(screen.getByTestId('pty-session-workdir'), { target: { value: 'D:/project/exomind' } });
+    fireEvent.change(screen.getByTestId('pty-model'), { target: { value: 'gpt-5.4' } });
+    fireEvent.change(screen.getByTestId('pty-reasoning-effort'), { target: { value: 'xhigh' } });
+    fireEvent.change(screen.getByTestId('pty-extra-args'), { target: { value: '--search --full-auto' } });
+    fireEvent.click(screen.getByTestId('pty-spawn-submit'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://127.0.0.1:1949/pty/spawn',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            name: 'codex-main',
+            workdir: 'D:/project/exomind',
+            command: 'codex',
+            args: [
+              '-m',
+              'gpt-5.4',
+              '-c',
+              'model_reasoning_effort="xhigh"',
+              '--search',
+              '--full-auto',
+            ],
+            rows: 24,
+            cols: 80,
+          }),
+        }),
+      );
+      expect(onSpawned).toHaveBeenCalledWith({ id: 'pty-codex-1', name: 'codex-main' });
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it('resumes codex historical session with agent_type（按 Agent 类型恢复 Codex 历史会话）', async () => {
+    const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
+      if (input.includes('/pty/sessions?agent_type=claude')) {
+        return { ok: true, json: async () => [] } as Response;
+      }
+      if (input.includes('/pty/sessions?agent_type=codex')) {
+        return {
+          ok: true,
+          json: async () => ([{
+            agent_type: 'codex',
+            session_id: '019d0011-aaaa-bbbb-cccc-1234567890ab',
+            project_path: 'D:/project/exomind',
+            last_modified: '2026-03-18T02:20:32.696Z',
+          }]),
+        } as Response;
+      }
+      if (input.endsWith('/pty/resume')) {
+        return {
+          ok: true,
+          json: async () => ({ id: 'pty-codex-2', name: 'Codex-019d0011' }),
+        } as Response;
+      }
+      throw new Error(`unexpected fetch: ${input} ${JSON.stringify(init)}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onSpawned = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <PtySpawnDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        rtBaseUrl="http://127.0.0.1:1949"
+        defaultWorkdir="D:/project/exomind"
+        onSpawned={onSpawned}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('pty-agent-type'), { target: { value: 'codex' } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pty-history-session-019d0011-aaaa-bbbb-cccc-1234567890ab')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('pty-session-name'), { target: { value: 'resume-codex' } });
+    fireEvent.change(screen.getByTestId('pty-session-workdir'), { target: { value: 'D:/project/exomind' } });
+    fireEvent.click(screen.getByTestId('pty-history-session-019d0011-aaaa-bbbb-cccc-1234567890ab'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://127.0.0.1:1949/pty/resume',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            agent_type: 'codex',
+            session_id: '019d0011-aaaa-bbbb-cccc-1234567890ab',
+            name: 'resume-codex',
+            workdir: 'D:/project/exomind',
+          }),
+        }),
+      );
+      expect(onSpawned).toHaveBeenCalledWith({ id: 'pty-codex-2', name: 'Codex-019d0011' });
+    });
+  });
+
+  it('supports custom command mode without history list（自定义命令模式不显示历史恢复）', async () => {
+    const fetchMock = vi.fn(async (input: string) => {
+      if (input.includes('/pty/sessions?agent_type=claude')) {
+        return { ok: true, json: async () => [] } as Response;
+      }
+      if (input.endsWith('/pty/spawn')) {
+        return {
+          ok: true,
+          json: async () => ({ id: 'pty-custom-1', name: 'my-custom' }),
+        } as Response;
+      }
+      throw new Error(`unexpected fetch: ${input}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onSpawned = vi.fn();
+
+    render(
+      <PtySpawnDialog
+        open={true}
+        onOpenChange={() => {}}
+        rtBaseUrl="http://127.0.0.1:1949"
+        onSpawned={onSpawned}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('pty-agent-type'), { target: { value: 'custom' } });
+
+    expect(screen.getByTestId('pty-custom-command')).toBeInTheDocument();
+    expect(screen.queryByTestId('pty-history-list')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('pty-custom-command'), { target: { value: 'node' } });
+    fireEvent.change(screen.getByTestId('pty-extra-args'), { target: { value: 'server.js --watch' } });
+    fireEvent.click(screen.getByTestId('pty-spawn-submit'));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://127.0.0.1:1949/pty/spawn',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            command: 'node',
+            args: ['server.js', '--watch'],
+            rows: 24,
+            cols: 80,
+          }),
+        }),
+      );
+      expect(onSpawned).toHaveBeenCalledWith({ id: 'pty-custom-1', name: 'my-custom' });
+    });
+  });
+});

--- a/tests/unit/ui/agent-hub/pty-spawn-dialog.test.tsx
+++ b/tests/unit/ui/agent-hub/pty-spawn-dialog.test.tsx
@@ -120,6 +120,9 @@ describe('PtySpawnDialog（终端会话启动弹窗）', () => {
 
     fireEvent.change(screen.getByTestId('pty-session-name'), { target: { value: 'resume-codex' } });
     fireEvent.change(screen.getByTestId('pty-session-workdir'), { target: { value: 'D:/project/exomind' } });
+    fireEvent.change(screen.getByTestId('pty-model'), { target: { value: 'gpt-5.4' } });
+    fireEvent.change(screen.getByTestId('pty-reasoning-effort'), { target: { value: 'xhigh' } });
+    fireEvent.change(screen.getByTestId('pty-extra-args'), { target: { value: '--search --full-auto' } });
     fireEvent.click(screen.getByTestId('pty-history-session-019d0011-aaaa-bbbb-cccc-1234567890ab'));
 
     await waitFor(() => {
@@ -132,6 +135,9 @@ describe('PtySpawnDialog（终端会话启动弹窗）', () => {
             session_id: '019d0011-aaaa-bbbb-cccc-1234567890ab',
             name: 'resume-codex',
             workdir: 'D:/project/exomind',
+            model: 'gpt-5.4',
+            reasoning_effort: 'xhigh',
+            extra_args: ['--search', '--full-auto'],
           }),
         }),
       );
@@ -171,7 +177,7 @@ describe('PtySpawnDialog（终端会话启动弹窗）', () => {
     expect(screen.queryByTestId('pty-history-list')).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByTestId('pty-custom-command'), { target: { value: 'node' } });
-    fireEvent.change(screen.getByTestId('pty-extra-args'), { target: { value: 'server.js --watch' } });
+    fireEvent.change(screen.getByTestId('pty-extra-args'), { target: { value: 'server.js --label \"alpha beta\" --watch' } });
     fireEvent.click(screen.getByTestId('pty-spawn-submit'));
 
     await waitFor(() => {
@@ -181,7 +187,7 @@ describe('PtySpawnDialog（终端会话启动弹窗）', () => {
           method: 'POST',
           body: JSON.stringify({
             command: 'node',
-            args: ['server.js', '--watch'],
+            args: ['server.js', '--label', 'alpha beta', '--watch'],
             rows: 24,
             cols: 80,
           }),

--- a/tests/unit/ui/agent-hub/pty-terminal.layout-recovery.test.tsx
+++ b/tests/unit/ui/agent-hub/pty-terminal.layout-recovery.test.tsx
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { PtyTerminal } from '@/ui/app/components/PtyTerminal';
+
+const xtermState = vi.hoisted(() => {
+  const terminal = {
+    rows: 24,
+    cols: 80,
+    loadAddon: vi.fn(),
+    open: vi.fn(),
+    write: vi.fn(),
+    focus: vi.fn(),
+    dispose: vi.fn(),
+    refresh: vi.fn(),
+    getSelection: vi.fn(() => ''),
+    attachCustomKeyEventHandler: vi.fn(),
+    onData: vi.fn(() => ({ dispose: vi.fn() })),
+    onResize: vi.fn(() => ({ dispose: vi.fn() })),
+  };
+
+  const fitAddon = {
+    fit: vi.fn(),
+  };
+
+  return { terminal, fitAddon };
+});
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class {
+    rows = xtermState.terminal.rows;
+
+    cols = xtermState.terminal.cols;
+
+    loadAddon = xtermState.terminal.loadAddon;
+
+    open = xtermState.terminal.open;
+
+    write = xtermState.terminal.write;
+
+    focus = xtermState.terminal.focus;
+
+    dispose = xtermState.terminal.dispose;
+
+    refresh = xtermState.terminal.refresh;
+
+    getSelection = xtermState.terminal.getSelection;
+
+    attachCustomKeyEventHandler = xtermState.terminal.attachCustomKeyEventHandler;
+
+    onData = xtermState.terminal.onData;
+
+    onResize = xtermState.terminal.onResize;
+  },
+}));
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: class {
+    fit = xtermState.fitAddon.fit;
+  },
+}));
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: class {},
+}));
+
+class MockEventSource {
+  close = vi.fn();
+
+  addEventListener = vi.fn();
+
+  onerror: ((this: EventSource, ev: Event) => unknown) | null = null;
+
+  constructor(_url: string) {}
+}
+
+describe('PtyTerminal layout recovery（终端布局恢复）', () => {
+  let originalEventSource: typeof EventSource | undefined;
+  let originalResizeObserver: typeof ResizeObserver | undefined;
+  let originalClientWidth: PropertyDescriptor | undefined;
+  let originalClientHeight: PropertyDescriptor | undefined;
+  let eventSourceConstructor: ReturnType<typeof vi.fn>;
+  let resizeObservers: Array<() => void> = [];
+  let sizeReady = false;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    sizeReady = false;
+    resizeObservers = [];
+
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 204 })));
+
+    originalEventSource = globalThis.EventSource;
+    eventSourceConstructor = vi.fn();
+    class EventSourceSpy extends MockEventSource {
+      constructor(url: string) {
+        super(url);
+        eventSourceConstructor(url);
+      }
+    }
+    vi.stubGlobal('EventSource', EventSourceSpy as unknown as typeof EventSource);
+
+    originalResizeObserver = globalThis.ResizeObserver;
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        private readonly callback: ResizeObserverCallback;
+
+        constructor(callback: ResizeObserverCallback) {
+          this.callback = callback;
+          resizeObservers.push(() => this.callback([], this as unknown as ResizeObserver));
+        }
+
+        observe() {}
+
+        disconnect() {}
+      } as unknown as typeof ResizeObserver,
+    );
+
+    originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get() {
+        return sizeReady ? 960 : 0;
+      },
+    });
+
+    originalClientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight');
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() {
+        return sizeReady ? 540 : 0;
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+
+    if (originalEventSource) {
+      globalThis.EventSource = originalEventSource;
+    }
+    if (originalResizeObserver) {
+      globalThis.ResizeObserver = originalResizeObserver;
+    }
+    if (originalClientWidth) {
+      Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
+    }
+    if (originalClientHeight) {
+      Object.defineProperty(HTMLElement.prototype, 'clientHeight', originalClientHeight);
+    }
+  });
+
+  it('waits for measurable layout before connecting SSE（容器可测量后才连接 SSE）', async () => {
+    render(<PtyTerminal rtBaseUrl="http://127.0.0.1:1949" ptyId="pty-layout-1" />);
+
+    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(60);
+
+    expect(eventSourceConstructor).not.toHaveBeenCalled();
+
+    sizeReady = true;
+    resizeObservers.forEach((notify) => notify());
+    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(60);
+
+    expect(xtermState.fitAddon.fit).toHaveBeenCalled();
+    expect(xtermState.terminal.refresh).toHaveBeenCalled();
+    expect(eventSourceConstructor).toHaveBeenCalledWith('http://127.0.0.1:1949/pty/pty-layout-1/stream');
+    expect(fetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:1949/pty/pty-layout-1/resize',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+});

--- a/tests/unit/ui/agent-hub/session-card.stop.test.tsx
+++ b/tests/unit/ui/agent-hub/session-card.stop.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { SessionCard } from '@/ui/app/pages/agents/SessionCard';
+import { SessionsView } from '@/ui/app/pages/agents/SessionsView';
+import type { SessionInfo } from '@/lib/types/session';
+
+function buildSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: 'session-stop-1',
+    agent_kind: 'claude',
+    role: 'Terminal Session',
+    summary: '',
+    status: 'running',
+    interaction_mode: 'terminal',
+    pty_id: 'pty-stop-1',
+    context: {
+      issue_refs: [],
+      labels: [],
+    },
+    created_at: '2026-03-18T00:00:00.000Z',
+    last_active_at: '2026-03-18T00:00:00.000Z',
+    turn_count: 0,
+    ...overrides,
+  };
+}
+
+describe('session card stop action（列表卡片停止动作）', () => {
+  it('shows stop button for PTY terminal sessions and does not trigger main click（PTY 终端会话显示停止按钮且不触发主点击）', () => {
+    const session = buildSession();
+    const onClick = vi.fn();
+    const onStop = vi.fn();
+
+    render(<SessionCard session={session} onClick={onClick} onStop={onStop} />);
+
+    const stopButton = screen.getByTestId('session-card-stop-session-stop-1');
+    fireEvent.click(stopButton);
+
+    expect(onStop).toHaveBeenCalledWith(session);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('does not show stop button for non-PTY sessions（非 PTY 会话不显示停止按钮）', () => {
+    render(
+      <SessionCard
+        session={buildSession({
+          id: 'session-no-stop',
+          interaction_mode: 'structured',
+          pty_id: undefined,
+        })}
+      />,
+    );
+
+    expect(screen.queryByTestId('session-card-stop-session-no-stop')).not.toBeInTheDocument();
+  });
+
+  it('passes stop callback through SessionsView（SessionsView 应透传停止回调）', () => {
+    const session = buildSession({ id: 'session-pass-through', pty_id: 'pty-pass-through' });
+    const onStopSession = vi.fn();
+
+    render(
+      <SessionsView
+        sessions={[session]}
+        loading={false}
+        error={null}
+        useMockData={false}
+        onStopSession={onStopSession}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('session-card-stop-session-pass-through'));
+
+    expect(onStopSession).toHaveBeenCalledWith(session);
+  });
+});


### PR DESCRIPTION
## 摘要
- 当 session 绑定终端时，把 `POST /sessions/:id/messages` 桥接到 PTY stdin。
- 新增面向 Claude / Codex 的 PTY 历史发现与恢复能力，并补齐 Windows 下 `codex.cmd` 解析。
- 扩展 `PtySpawnDialog`，支持 `Agent 类型`、`模型`、`推理强度`、`额外参数`、自定义命令，以及列表卡片上的 stop 操作。
- 保留恢复时的 model / reasoning / extra args，并支持带引号的 `extra args`。

## 测试
- `cargo test -p exomind-runtime send_message_ -- --nocapture`
- `cargo test -p exomind-runtime pty_ -- --nocapture`
- `bunx vitest run tests/unit/ui/agent-hub/pty-spawn-dialog.test.tsx tests/unit/ui/agent-hub/session-card.stop.test.tsx tests/unit/ui/agent-hub/agents-page.session-actions.issue523.test.tsx tests/unit/ui/agent-hub/pty-terminal-page.stop.test.tsx`
- `bunx tsc --noEmit`
- `bun run build`

## 备注
- `Codex` 历史记录来自本地 `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`。
- 构建仍会输出既有的 chunk-size / `eruda` 警告，但最终会成功退出。
