### PR TITLE
fix(issue-590): 恢复任务结束操作

### DIFF
--- a/docs/plans/2026-03-19-issue-590-task-end-state.md
+++ b/docs/plans/2026-03-19-issue-590-task-end-state.md
@@ -1,0 +1,153 @@
+# Issue 590 Task End State Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix issue `#590` so overlay/task-detail flows can reliably end tasks under the `taskIds` model and expose direct task status actions where users need them.
+
+**Architecture:** Keep the fix narrow. Reuse `resolveActiveBlockTaskIds()` as the single source of truth for active block task resolution, keep overlay transitions aligned with existing timer/DAG flows, and add direct status actions in `TaskDetailPage` without reshaping the page architecture. Tests should pin both the regression path and the new UI affordance.
+
+**Tech Stack:** React 18, TypeScript, Vitest, Testing Library, Bun.
+
+---
+
+### Task 1: Lock the regressions with failing tests
+
+**Files:**
+- Create: `tests/unit/ui/now-workbench-overlay-controller.issue590.test.tsx`
+- Create: `tests/unit/pages/NowWorkbenchOverlayPage.issue590.test.tsx`
+- Modify: `tests/unit/ui/task-detail-page.timeblock-detail.test.tsx`
+
+**Step 1: Write the failing overlay controller regression test**
+
+Cover this case:
+- active block uses `taskIds: ['task-1', 'task-2']`
+- selected outcome is `completed`
+- calling `handleConfirmEnd()` must call `endBlock()`
+- then call `transitionTask('task-1', 'completed')` and `transitionTask('task-2', 'completed')`
+
+**Step 2: Run the overlay controller test to verify it fails**
+
+Run: `bunx vitest run tests/unit/ui/now-workbench-overlay-controller.issue590.test.tsx`
+
+Expected: FAIL because the current code still gates on deprecated `taskId`.
+
+**Step 3: Write the failing overlay page selector test**
+
+Cover this case:
+- overlay feedback dialog is open
+- active block only has `taskIds`
+- `TaskStatusSelector` must still render
+
+**Step 4: Run the overlay page test to verify it fails**
+
+Run: `bunx vitest run tests/unit/pages/NowWorkbenchOverlayPage.issue590.test.tsx`
+
+Expected: FAIL because the dialog currently checks `model.activeBlock?.taskId`.
+
+**Step 5: Write the failing task detail action test**
+
+Add a test proving:
+- when task status is `in_progress`, the detail page shows direct actions for `完成 / 挂起 / 取消`
+- clicking an action calls `taskService.transitionTask()`
+- when task status is `suspended`, the page exposes `恢复执行 / 完成 / 取消`
+
+**Step 6: Run the task detail page test to verify it fails**
+
+Run: `bunx vitest run tests/unit/ui/task-detail-page.timeblock-detail.test.tsx`
+
+Expected: FAIL because the page currently has no direct transition actions.
+
+### Task 2: Fix overlay task resolution and feedback affordance
+
+**Files:**
+- Modify: `src/ui/app/overlay/use-now-workbench-overlay-controller.ts`
+- Modify: `src/pages/NowWorkbenchOverlayPage.tsx`
+
+**Step 1: Replace deprecated task resolution in overlay controller**
+
+Implementation requirements:
+- import/use `resolveActiveBlockTaskIds(blockBeforeEnd)`
+- build one `taskStatusOutcomes` map when the selected choice is not `continue`
+- pass outcomes into `timeBlockService.endBlock(feedback, { taskStatusOutcomes })`
+- iterate all resolved task IDs and call `taskService.transitionTask(taskId, choice)`
+- keep existing error capture / debug info behavior
+
+**Step 2: Restore feedback dialog status selector under the new model**
+
+Implementation requirements:
+- in `NowWorkbenchOverlayPage`, stop checking `model.activeBlock?.taskId`
+- instead, show the selector whenever `resolveActiveBlockTaskIds(model.activeBlock).length > 0`
+
+**Step 3: Re-run the two overlay tests**
+
+Run:
+- `bunx vitest run tests/unit/ui/now-workbench-overlay-controller.issue590.test.tsx`
+- `bunx vitest run tests/unit/pages/NowWorkbenchOverlayPage.issue590.test.tsx`
+
+Expected: PASS.
+
+### Task 3: Add direct task status actions to the detail page
+
+**Files:**
+- Modify: `src/ui/app/pages/TaskDetailPage.tsx`
+- Modify: `tests/unit/ui/task-detail-page.timeblock-detail.test.tsx`
+
+**Step 1: Add a minimal transition action model**
+
+Implementation requirements:
+- derive actions from current `task.status`
+- for `in_progress`: expose `完成 / 挂起 / 取消`
+- for `suspended`: expose `恢复执行 / 完成 / 取消`
+- keep terminal tasks unchanged
+
+**Step 2: Add a narrow handler**
+
+Implementation requirements:
+- call `getTaskService().transitionTask(task.id, nextStatus)`
+- clear old action errors before submit
+- refresh local view after success via existing reload path
+- surface failures with the same lightweight error messaging style already used on the page
+
+**Step 3: Render the actions in both mobile and desktop timer/action area**
+
+Implementation requirements:
+- avoid creating a separate large component tree
+- reuse one small action group renderer or one shared data structure
+- keep labels explicit:
+  - `完成（Complete）`
+  - `挂起（Suspend）`
+  - `恢复执行（Resume）`
+  - `取消（Cancel）`
+
+**Step 4: Re-run the task detail page test**
+
+Run: `bunx vitest run tests/unit/ui/task-detail-page.timeblock-detail.test.tsx`
+
+Expected: PASS.
+
+### Task 4: Verify the whole change set
+
+**Files:**
+- No additional code files unless verification uncovers a defect
+
+**Step 1: Run focused tests**
+
+Run:
+- `bunx vitest run tests/unit/ui/now-workbench-overlay-controller.issue590.test.tsx`
+- `bunx vitest run tests/unit/pages/NowWorkbenchOverlayPage.issue590.test.tsx`
+- `bunx vitest run tests/unit/ui/task-detail-page.timeblock-detail.test.tsx`
+
+**Step 2: Run targeted type checking**
+
+Run: `bunx tsc --noEmit`
+
+**Step 3: Run build if the targeted checks are clean**
+
+Run: `bun run build`
+
+**Step 4: Commit**
+
+```bash
+git add src/pages/NowWorkbenchOverlayPage.tsx src/ui/app/overlay/use-now-workbench-overlay-controller.ts src/ui/app/pages/TaskDetailPage.tsx tests/unit/ui/now-workbench-overlay-controller.issue590.test.tsx tests/unit/pages/NowWorkbenchOverlayPage.issue590.test.tsx tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
+git commit -m "fix(issue-590): restore task end actions"
+```

--- a/src/pages/NowWorkbenchOverlayPage.tsx
+++ b/src/pages/NowWorkbenchOverlayPage.tsx
@@ -17,9 +17,9 @@ import { resolveCountdownTiming } from '@/lib/timeblock/countdown-progress';
 import { setNowWorkbenchOverlayPosition } from '@/config/now-workbench-overlay-preferences';
 import type { TaskNode } from '@/lib/types/task';
 import type { NowWorkbenchOverlayModel } from '@/ui/app/overlay/now-workbench-overlay-model';
-import { resolveActiveBlockTaskIds, type ActiveBlockData } from '@/lib/types/event';
+import type { ActiveBlockData } from '@/lib/types/event';
 import { useNowWorkbenchOverlayController } from '@/ui/app/overlay/use-now-workbench-overlay-controller';
-import { TaskStatusSelector, type TaskStatusChoice } from '@/ui/app/components/TaskStatusSelector';
+import type { TaskStatusChoice } from '@/ui/app/components/TaskStatusSelector';
 import { useRef } from 'react';
 import { log } from '@/lib/logger';
 
@@ -51,11 +51,12 @@ interface NowWorkbenchOverlayPageContentProps {
   onEndBlock: () => void | Promise<void>;
   onStartTask: (task: TaskNode) => void;
   onSend: (content: string, tags?: string[]) => void;
+  endingTasks: TaskNode[];
   feedbackOpen: boolean;
   feedback: string;
-  taskStatusChoice: TaskStatusChoice;
+  taskStatusChoices: Record<string, TaskStatusChoice>;
   setFeedback(value: string): void;
-  setTaskStatusChoice(value: TaskStatusChoice): void;
+  setTaskStatusChoice(taskId: string, value: TaskStatusChoice): void;
   onConfirmEnd: () => void | Promise<void>;
 }
 
@@ -254,6 +255,7 @@ export function NowWorkbenchOverlayPage(props: NowWorkbenchOverlayPageProps) {
         onEndBlock={props.onEndBlock ?? (() => {})}
         onStartTask={props.onStartTask ?? (() => {})}
         onSend={props.onSend ?? (() => {})}
+        endingTasks={[]}
         debugInfo={{
           userId: 'static-preview',
           mode: props.model.mode,
@@ -266,7 +268,7 @@ export function NowWorkbenchOverlayPage(props: NowWorkbenchOverlayPageProps) {
         }}
         feedbackOpen={false}
         feedback=""
-        taskStatusChoice="continue"
+        taskStatusChoices={{}}
         setFeedback={() => {}}
         setTaskStatusChoice={() => {}}
         onConfirmEnd={() => {}}
@@ -303,10 +305,11 @@ export function NowWorkbenchOverlayPage(props: NowWorkbenchOverlayPageProps) {
       onEndBlock={onEndBlock}
       onStartTask={onStartTask}
       onSend={onSend}
+      endingTasks={controller.endingTasks}
       debugInfo={controller.debugInfo}
       feedbackOpen={controller.feedbackOpen}
       feedback={controller.feedback}
-      taskStatusChoice={controller.taskStatusChoice}
+      taskStatusChoices={controller.taskStatusChoices}
       setFeedback={controller.setFeedback}
       setTaskStatusChoice={controller.setTaskStatusChoice}
       onConfirmEnd={() => {
@@ -326,9 +329,10 @@ function NowWorkbenchOverlayPageContent(props: NowWorkbenchOverlayPageContentPro
     onEndBlock,
     onStartTask,
     onSend,
+    endingTasks,
     feedbackOpen,
     feedback,
-    taskStatusChoice,
+    taskStatusChoices,
     setFeedback,
     setTaskStatusChoice,
     onConfirmEnd,
@@ -488,8 +492,6 @@ function NowWorkbenchOverlayPageContent(props: NowWorkbenchOverlayPageContentPro
       setFeedbackSubmitting(false);
     }
   }, [canSubmitFeedback, feedback, feedbackSubmitting, onConfirmEnd]);
-  const showTaskStatusSelector = resolveActiveBlockTaskIds(model.activeBlock).length > 0;
-
   const feedbackDialog = (
     <TimeBlockFeedbackDialog
       open={feedbackOpen}
@@ -520,6 +522,9 @@ function NowWorkbenchOverlayPageContent(props: NowWorkbenchOverlayPageContentPro
       submitButtonClassName="h-10 w-full rounded-[12px] bg-[#C75B3A] text-white hover:bg-[#B24D2F] disabled:cursor-not-allowed disabled:opacity-60"
       submitDisabled={feedbackSubmitting || isSkipFeedbackCoolingDown}
       autoFocusFeedback
+      tasks={endingTasks}
+      outcomes={taskStatusChoices}
+      onOutcomeChange={setTaskStatusChoice}
       extraContent={(
         <div className="space-y-3">
           <div
@@ -528,13 +533,6 @@ function NowWorkbenchOverlayPageContent(props: NowWorkbenchOverlayPageContentPro
           >
             {resolveFeedbackShortcutHint(inputSendMode)}
           </div>
-          {showTaskStatusSelector ? (
-            <TaskStatusSelector
-              value={taskStatusChoice}
-              onChange={setTaskStatusChoice}
-              helperLabel="任务下一步状态"
-            />
-          ) : null}
         </div>
       )}
     />

--- a/src/pages/NowWorkbenchOverlayPage.tsx
+++ b/src/pages/NowWorkbenchOverlayPage.tsx
@@ -17,7 +17,7 @@ import { resolveCountdownTiming } from '@/lib/timeblock/countdown-progress';
 import { setNowWorkbenchOverlayPosition } from '@/config/now-workbench-overlay-preferences';
 import type { TaskNode } from '@/lib/types/task';
 import type { NowWorkbenchOverlayModel } from '@/ui/app/overlay/now-workbench-overlay-model';
-import type { ActiveBlockData } from '@/lib/types/event';
+import { resolveActiveBlockTaskIds, type ActiveBlockData } from '@/lib/types/event';
 import { useNowWorkbenchOverlayController } from '@/ui/app/overlay/use-now-workbench-overlay-controller';
 import { TaskStatusSelector, type TaskStatusChoice } from '@/ui/app/components/TaskStatusSelector';
 import { useRef } from 'react';
@@ -488,6 +488,7 @@ function NowWorkbenchOverlayPageContent(props: NowWorkbenchOverlayPageContentPro
       setFeedbackSubmitting(false);
     }
   }, [canSubmitFeedback, feedback, feedbackSubmitting, onConfirmEnd]);
+  const showTaskStatusSelector = resolveActiveBlockTaskIds(model.activeBlock).length > 0;
 
   const feedbackDialog = (
     <TimeBlockFeedbackDialog
@@ -527,7 +528,7 @@ function NowWorkbenchOverlayPageContent(props: NowWorkbenchOverlayPageContentPro
           >
             {resolveFeedbackShortcutHint(inputSendMode)}
           </div>
-          {model.activeBlock?.taskId ? (
+          {showTaskStatusSelector ? (
             <TaskStatusSelector
               value={taskStatusChoice}
               onChange={setTaskStatusChoice}

--- a/src/ui/app/components/TaskStatusSelector.tsx
+++ b/src/ui/app/components/TaskStatusSelector.tsx
@@ -26,14 +26,18 @@ export function TaskStatusSelector({
 }: TaskStatusSelectorProps) {
   const activeIndex = Math.max(0, STATUS_OPTIONS.findIndex((option) => option.key === value));
   const indicatorWidth = `${100 / STATUS_OPTIONS.length}%`;
+  const helperId = `${testId}-helper`;
 
   return (
     <div data-testid="feedback-task-status-section" className="min-w-0 flex flex-col gap-1.5">
-      <div className="flex min-w-0 items-start gap-2">
+      <div id={helperId} className="flex min-w-0 items-start gap-2">
         <span className="shrink-0 text-[12px] font-medium text-[#57534E] dark:text-[#A8A29E]">{helperLabel}</span>
         <span className="min-w-0 text-[12px] text-[#78716C] dark:text-[#A8A29E]">{helperHint}</span>
       </div>
       <div
+        role="radiogroup"
+        aria-label={helperLabel}
+        aria-describedby={helperId}
         className="relative min-w-0 overflow-hidden rounded-[10px] border border-[#E7E5E4] bg-[#F5F0ED]/50 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]"
         data-testid={testId}
       >
@@ -47,6 +51,8 @@ export function TaskStatusSelector({
             <button
               key={key}
               type="button"
+              role="radio"
+              aria-checked={value === key}
               data-testid={optionTestIdPrefix ? `${optionTestIdPrefix}-${key}` : `feedback-task-status-${key}`}
               onClick={() => onChange(key)}
               className={`relative z-10 min-w-0 h-8 w-full whitespace-nowrap rounded-[8px] px-[8px] text-center text-[12px] transition-colors duration-200 ${

--- a/src/ui/app/overlay/use-now-workbench-overlay-controller.ts
+++ b/src/ui/app/overlay/use-now-workbench-overlay-controller.ts
@@ -18,7 +18,8 @@ interface NowWorkbenchOverlayController {
   model: ReturnType<typeof buildNowWorkbenchOverlayModel>;
   feedbackOpen: boolean;
   feedback: string;
-  taskStatusChoice: TaskStatusChoice;
+  endingTasks: TaskNode[];
+  taskStatusChoices: Record<string, TaskStatusChoice>;
   debugInfo: {
     userId: string;
     mode: string;
@@ -30,7 +31,7 @@ interface NowWorkbenchOverlayController {
     lastAction: string;
   };
   setFeedback(value: string): void;
-  setTaskStatusChoice(value: TaskStatusChoice): void;
+  setTaskStatusChoice(taskId: string, value: TaskStatusChoice): void;
   handleHide(): Promise<void>;
   handleReturnToMain(): Promise<void>;
   handlePauseOrResume(): Promise<void>;
@@ -87,7 +88,7 @@ export function useNowWorkbenchOverlayController(): NowWorkbenchOverlayControlle
   const [now, setNow] = useState(() => Date.now());
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   const [feedback, setFeedback] = useState('');
-  const [taskStatusChoice, setTaskStatusChoice] = useState<TaskStatusChoice>('continue');
+  const [taskStatusChoices, setTaskStatusChoices] = useState<Record<string, TaskStatusChoice>>({});
   const [debugInfo, setDebugInfo] = useState<NowWorkbenchOverlayDebugInfo>(() => ({
     userId: getCurrentUserId(),
     mode: EMPTY_MODEL.mode,
@@ -243,6 +244,15 @@ export function useNowWorkbenchOverlayController(): NowWorkbenchOverlayControlle
     events,
     now,
   }), [activeBlock, events, now, tasks]);
+  const endingTasks = useMemo(() => {
+    const activeTaskIds = resolveActiveBlockTaskIds(activeBlock);
+    if (activeTaskIds.length === 0) return [];
+
+    const taskById = new Map(tasks.map((task) => [task.id, task]));
+    return activeTaskIds
+      .map((taskId) => taskById.get(taskId))
+      .filter((task): task is TaskNode => Boolean(task));
+  }, [activeBlock, tasks]);
 
   useEffect(() => {
     updateDebugInfo({
@@ -260,6 +270,27 @@ export function useNowWorkbenchOverlayController(): NowWorkbenchOverlayControlle
       }),
     });
   }, [model, updateDebugInfo]);
+
+  useEffect(() => {
+    const activeTaskIds = resolveActiveBlockTaskIds(activeBlock);
+    setTaskStatusChoices((current) => {
+      if (activeTaskIds.length === 0) {
+        return Object.keys(current).length === 0 ? current : {};
+      }
+
+      const next = activeTaskIds.reduce<Record<string, TaskStatusChoice>>((choices, taskId) => {
+        choices[taskId] = current[taskId] ?? 'continue';
+        return choices;
+      }, {});
+
+      const currentKeys = Object.keys(current);
+      const nextKeys = Object.keys(next);
+      const isUnchanged = currentKeys.length === nextKeys.length
+        && nextKeys.every((taskId) => current[taskId] === next[taskId]);
+
+      return isUnchanged ? current : next;
+    });
+  }, [activeBlock]);
 
   const handleHide = useCallback(async () => {
     if (!isTauri()) {
@@ -331,50 +362,50 @@ export function useNowWorkbenchOverlayController(): NowWorkbenchOverlayControlle
     try {
       const blockBeforeEnd = activeBlock;
       const taskIds = resolveActiveBlockTaskIds(blockBeforeEnd);
-      const taskStatusOutcomes = taskStatusChoice !== 'continue'
-        ? taskIds.reduce<Record<string, string>>((outcomes, taskId) => {
-          outcomes[taskId] = taskStatusChoice;
-          return outcomes;
-        }, {})
-        : undefined;
+      const taskStatusOutcomes = Object.entries(taskStatusChoices).reduce<Record<string, string>>((outcomes, [taskId, choice]) => {
+        if (choice !== 'continue') {
+          outcomes[taskId] = choice;
+        }
+        return outcomes;
+      }, {});
+      let endAction = 'end-block:success';
 
       await timeBlockService.endBlock(feedback, {
-        taskStatusOutcomes: taskStatusOutcomes && Object.keys(taskStatusOutcomes).length > 0 ? taskStatusOutcomes : undefined,
+        taskStatusOutcomes: Object.keys(taskStatusOutcomes).length > 0 ? taskStatusOutcomes : undefined,
       });
 
       if (blockBeforeEnd && taskIds.length > 0) {
         try {
           await taskTimerService.onBlockEndForTasks(taskIds, blockBeforeEnd.startId);
         } catch (associationError) {
-          updateDebugInfo({
-            lastAction: `end-block:task-link-error:${associationError instanceof Error ? associationError.message : String(associationError)}`,
-          });
+          endAction = `end-block:task-link-error:${associationError instanceof Error ? associationError.message : String(associationError)}`;
         }
       }
 
-      if (taskStatusChoice !== 'continue' && taskIds.length > 0) {
+      if (endAction === 'end-block:success' && Object.keys(taskStatusOutcomes).length > 0) {
         try {
-          for (const taskId of taskIds) {
-            await taskService.transitionTask(taskId, taskStatusChoice as TaskStatus);
+          for (const [taskId, choice] of Object.entries(taskStatusOutcomes)) {
+            const transitioned = await taskService.transitionTask(taskId, choice as TaskStatus);
+            if (!transitioned) {
+              throw new Error(`Task ${taskId} not found during end-block transition`);
+            }
           }
         } catch (transitionError) {
-          updateDebugInfo({
-            lastAction: `end-block:task-transition-error:${transitionError instanceof Error ? transitionError.message : String(transitionError)}`,
-          });
+          endAction = `end-block:task-transition-error:${transitionError instanceof Error ? transitionError.message : String(transitionError)}`;
         }
       }
 
       setFeedback('');
       setFeedbackOpen(false);
-      setTaskStatusChoice('continue');
+      setTaskStatusChoices({});
       await reloadAll();
-      updateDebugInfo({ lastAction: 'end-block:success' });
+      updateDebugInfo({ lastAction: endAction });
     } catch (error) {
       updateDebugInfo({
         lastAction: `end-block:error:${error instanceof Error ? error.message : String(error)}`,
       });
     }
-  }, [activeBlock, feedback, reloadAll, taskService, taskStatusChoice, taskTimerService, timeBlockService, updateDebugInfo]);
+  }, [activeBlock, feedback, reloadAll, taskService, taskStatusChoices, taskTimerService, timeBlockService, updateDebugInfo]);
 
   const handleStartTask = useCallback(async (task: TaskNode) => {
     updateDebugInfo({ lastAction: `task-select:open-config:${task.id}` });
@@ -402,10 +433,16 @@ export function useNowWorkbenchOverlayController(): NowWorkbenchOverlayControlle
     model: model ?? EMPTY_MODEL,
     feedbackOpen,
     feedback,
-    taskStatusChoice,
+    endingTasks,
+    taskStatusChoices,
     debugInfo,
     setFeedback,
-    setTaskStatusChoice,
+    setTaskStatusChoice: (taskId, value) => {
+      setTaskStatusChoices((current) => ({
+        ...current,
+        [taskId]: value,
+      }));
+    },
     handleHide,
     handleReturnToMain,
     handlePauseOrResume,

--- a/src/ui/app/overlay/use-now-workbench-overlay-controller.ts
+++ b/src/ui/app/overlay/use-now-workbench-overlay-controller.ts
@@ -5,9 +5,10 @@ import { getCurrentUserId, getEventStorage, type Event as StoredEvent } from '@/
 import {
   getEventLogService,
   getTaskService,
+  getTaskTimerService,
   getTimeBlockService,
 } from '@/lib/services';
-import type { ActiveBlockData, Event as UiEvent } from '@/lib/types/event';
+import { resolveActiveBlockTaskIds, type ActiveBlockData, type Event as UiEvent } from '@/lib/types/event';
 import type { TaskNode, TaskStatus } from '@/lib/types/task';
 import type { TaskStatusChoice } from '@/ui/app/components/TaskStatusSelector';
 import { buildNowWorkbenchOverlayModel, type NowWorkbenchOverlayMode } from './now-workbench-overlay-model';
@@ -77,6 +78,7 @@ const EMPTY_MODEL = buildNowWorkbenchOverlayModel({
 export function useNowWorkbenchOverlayController(): NowWorkbenchOverlayController {
   const timeBlockService = useMemo(() => getTimeBlockService(), []);
   const taskService = useMemo(() => getTaskService(), []);
+  const taskTimerService = useMemo(() => getTaskTimerService(), []);
   const eventLogService = useMemo(() => getEventLogService(), []);
   const overlayService = useMemo(() => getNowWorkbenchOverlayService(), []);
   const [activeBlock, setActiveBlock] = useState<ActiveBlockData | null>(null);
@@ -328,11 +330,33 @@ export function useNowWorkbenchOverlayController(): NowWorkbenchOverlayControlle
   const handleConfirmEnd = useCallback(async () => {
     try {
       const blockBeforeEnd = activeBlock;
-      await timeBlockService.endBlock(feedback);
+      const taskIds = resolveActiveBlockTaskIds(blockBeforeEnd);
+      const taskStatusOutcomes = taskStatusChoice !== 'continue'
+        ? taskIds.reduce<Record<string, string>>((outcomes, taskId) => {
+          outcomes[taskId] = taskStatusChoice;
+          return outcomes;
+        }, {})
+        : undefined;
 
-      if (taskStatusChoice !== 'continue' && blockBeforeEnd?.taskId) {
+      await timeBlockService.endBlock(feedback, {
+        taskStatusOutcomes: taskStatusOutcomes && Object.keys(taskStatusOutcomes).length > 0 ? taskStatusOutcomes : undefined,
+      });
+
+      if (blockBeforeEnd && taskIds.length > 0) {
         try {
-          await taskService.transitionTask(blockBeforeEnd.taskId, taskStatusChoice as TaskStatus);
+          await taskTimerService.onBlockEndForTasks(taskIds, blockBeforeEnd.startId);
+        } catch (associationError) {
+          updateDebugInfo({
+            lastAction: `end-block:task-link-error:${associationError instanceof Error ? associationError.message : String(associationError)}`,
+          });
+        }
+      }
+
+      if (taskStatusChoice !== 'continue' && taskIds.length > 0) {
+        try {
+          for (const taskId of taskIds) {
+            await taskService.transitionTask(taskId, taskStatusChoice as TaskStatus);
+          }
         } catch (transitionError) {
           updateDebugInfo({
             lastAction: `end-block:task-transition-error:${transitionError instanceof Error ? transitionError.message : String(transitionError)}`,
@@ -350,7 +374,7 @@ export function useNowWorkbenchOverlayController(): NowWorkbenchOverlayControlle
         lastAction: `end-block:error:${error instanceof Error ? error.message : String(error)}`,
       });
     }
-  }, [activeBlock, feedback, reloadAll, taskService, taskStatusChoice, timeBlockService, updateDebugInfo]);
+  }, [activeBlock, feedback, reloadAll, taskService, taskStatusChoice, taskTimerService, timeBlockService, updateDebugInfo]);
 
   const handleStartTask = useCallback(async (task: TaskNode) => {
     updateDebugInfo({ lastAction: `task-select:open-config:${task.id}` });

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -761,11 +761,15 @@ function TaskStatusActionGroup({
   actions,
   errorMessage,
   pendingStatus,
+  disabled,
+  disabledReason,
   onAction,
 }: {
   actions: TaskTransitionAction[];
   errorMessage: string | null;
   pendingStatus: TaskStatus | null;
+  disabled?: boolean;
+  disabledReason?: string | null;
   onAction: (status: TaskStatus) => void;
 }) {
   if (actions.length === 0) {
@@ -784,7 +788,7 @@ function TaskStatusActionGroup({
               type="button"
               data-testid={`task-transition-action-${action.status}`}
               aria-label={action.label}
-              disabled={pendingStatus !== null}
+              disabled={pendingStatus !== null || disabled}
               onClick={() => onAction(action.status)}
               className={`inline-flex items-center rounded-xl px-3 py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${taskTransitionButtonClassName(action.tone)}`}
             >
@@ -795,6 +799,9 @@ function TaskStatusActionGroup({
       </div>
       {errorMessage ? (
         <p role="alert" className="mt-2 text-xs text-[#B91C1C] dark:text-[#FCA5A5]">{errorMessage}</p>
+      ) : null}
+      {!errorMessage && disabledReason ? (
+        <p className="mt-2 text-xs text-[#A8A29E] dark:text-[#D6D3D1]">{disabledReason}</p>
       ) : null}
     </div>
   );
@@ -1770,6 +1777,10 @@ export function TaskDetailPage() {
     }
     return [];
   }, [task]);
+  const taskTransitionBlockedByActiveBlock = Boolean(activeBlock) || hasOtherActiveBlock;
+  const taskTransitionDisabledReason = taskTransitionBlockedByActiveBlock
+    ? '当前已有进行中的时间块，请先回到当下结束或暂停时间块，再修改任务状态。'
+    : null;
 
   const reloadDependencies = () => {
     setDependencyReloadKey((value) => value + 1);
@@ -2045,6 +2056,8 @@ export function TaskDetailPage() {
       actions={taskTransitionActions}
       errorMessage={taskTransitionError}
       pendingStatus={taskTransitionPendingTo}
+      disabled={taskTransitionBlockedByActiveBlock}
+      disabledReason={taskTransitionDisabledReason}
       onAction={handleTaskStatusTransition}
     />
   );

--- a/src/ui/app/pages/TaskDetailPage.tsx
+++ b/src/ui/app/pages/TaskDetailPage.tsx
@@ -5,7 +5,7 @@ import { TASKS_LAST_PATH_KEY, buildTasksMainSearch } from './task-route-memory';
 import { TaskBreadcrumb, type TaskBreadcrumbSegment } from '@/ui/app/components/TaskBreadcrumb';
 import { getEventLogService, getTaskService, getTaskTimerService, getTimeBlockService } from '@/lib/services';
 import { isTerminalTaskStatus } from '@/lib/types/task';
-import type { TaskNode } from '@/lib/types/task';
+import type { TaskNode, TaskStatus } from '@/lib/types/task';
 import { resolveActiveBlockTaskIds, type ActiveBlockData, type TimeBlock } from '@/lib/types/event';
 import { useIsDesktop } from '@/ui/app/hooks/useIsDesktop';
 import { getUseMockDataEnabled } from '@/config/mock-data';
@@ -39,6 +39,12 @@ import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 
 type DependencyType = 'soft' | 'hard';
+type TaskTransitionAction = {
+  status: TaskStatus;
+  label: string;
+  tone: 'neutral' | 'success' | 'warning' | 'danger';
+};
+
 const SOURCE_CONFIG: Record<string, { label: string; to: string }> = {
   dag: { label: 'DAG', to: '/tasks/dag' },
   timeblocks: { label: '时间块', to: '/tasks/timeblocks' },
@@ -123,6 +129,26 @@ function toneDotClassName(tone: 'neutral' | 'success' | 'warning' | 'danger'): s
   if (tone === 'warning') return 'bg-[#C75B3A]';
   if (tone === 'danger') return 'bg-[#E7000B]';
   return 'bg-[#78716C]';
+}
+
+function taskTransitionButtonClassName(tone: TaskTransitionAction['tone']): string {
+  if (tone === 'success') {
+    return 'bg-[#DCFCE7] text-[#166534] hover:bg-[#BBF7D0] dark:bg-[#16351F] dark:text-[#86EFAC] dark:hover:bg-[#1B4729]';
+  }
+  if (tone === 'warning') {
+    return 'bg-[#FFF7ED] text-[#C75B3A] hover:bg-[#FFEDD5] dark:bg-[#2A231B] dark:text-[#FDBA74] dark:hover:bg-[#382C20]';
+  }
+  if (tone === 'danger') {
+    return 'bg-[#FEE2E2] text-[#B91C1C] hover:bg-[#FECACA] dark:bg-[#3F1D1D] dark:text-[#FCA5A5] dark:hover:bg-[#522020]';
+  }
+  return 'bg-[#F5F0ED] text-[#57534E] hover:bg-[#E7E5E4] dark:bg-[#292524] dark:text-[#D6D3D1] dark:hover:bg-[#3A3632]';
+}
+
+function formatTaskTransitionError(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+  return '任务状态更新失败，请稍后重试。';
 }
 
 function buildSummaryText(model: TaskTimeblockDetailViewModel): string {
@@ -731,6 +757,49 @@ function DependencyCard({
   );
 }
 
+function TaskStatusActionGroup({
+  actions,
+  errorMessage,
+  pendingStatus,
+  onAction,
+}: {
+  actions: TaskTransitionAction[];
+  errorMessage: string | null;
+  pendingStatus: TaskStatus | null;
+  onAction: (status: TaskStatus) => void;
+}) {
+  if (actions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div data-testid="task-status-actions" className="rounded-2xl border border-[#E7E5E4] bg-[#FAF7F5] p-3 dark:border-[#292524] dark:bg-[#120F0D]">
+      <p className="text-xs font-medium text-[#57534E] dark:text-[#D6D3D1]">任务状态</p>
+      <div className="mt-2 flex flex-wrap gap-2">
+        {actions.map((action) => {
+          const isPending = pendingStatus === action.status;
+          return (
+            <button
+              key={action.status}
+              type="button"
+              data-testid={`task-transition-action-${action.status}`}
+              aria-label={action.label}
+              disabled={pendingStatus !== null}
+              onClick={() => onAction(action.status)}
+              className={`inline-flex items-center rounded-xl px-3 py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${taskTransitionButtonClassName(action.tone)}`}
+            >
+              {isPending ? '处理中…' : action.label}
+            </button>
+          );
+        })}
+      </div>
+      {errorMessage ? (
+        <p role="alert" className="mt-2 text-xs text-[#B91C1C] dark:text-[#FCA5A5]">{errorMessage}</p>
+      ) : null}
+    </div>
+  );
+}
+
 function MobileTimeblockDetail({
   descriptionBlock,
   task,
@@ -747,6 +816,7 @@ function MobileTimeblockDetail({
   hasOtherActiveBlock,
   hasActiveBlockOnTask,
   blockingReason,
+  taskStatusActions,
   onStartTimer,
   onAppendTaskToActiveBlock,
   onPauseAndGoEventlog,
@@ -777,6 +847,7 @@ function MobileTimeblockDetail({
   hasOtherActiveBlock: boolean;
   hasActiveBlockOnTask: boolean;
   blockingReason: string | null;
+  taskStatusActions?: ReactNode;
   onStartTimer: () => void;
   onAppendTaskToActiveBlock: () => void;
   onPauseAndGoEventlog: () => void;
@@ -993,6 +1064,7 @@ function MobileTimeblockDetail({
             ) : hasOtherActiveBlock ? (
               <p className="text-xs text-[#A8A29E]">当前已有时间块进行中，可将本任务追加为关联任务。</p>
             ) : null}
+            {taskStatusActions}
           </div>
         </section>
         )}
@@ -1118,6 +1190,7 @@ function DesktopTimeblockDetail({
   hasOtherActiveBlock,
   hasActiveBlockOnTask,
   blockingReason,
+  taskStatusActions,
   onStartTimer,
   onAppendTaskToActiveBlock,
   onPauseAndGoEventlog,
@@ -1148,6 +1221,7 @@ function DesktopTimeblockDetail({
   hasOtherActiveBlock: boolean;
   hasActiveBlockOnTask: boolean;
   blockingReason: string | null;
+  taskStatusActions?: ReactNode;
   onStartTimer: () => void;
   onAppendTaskToActiveBlock: () => void;
   onPauseAndGoEventlog: () => void;
@@ -1285,6 +1359,7 @@ function DesktopTimeblockDetail({
             ) : hasOtherActiveBlock ? (
               <p className="text-xs text-[#A8A29E]">当前已有时间块进行中，可将本任务追加为关联任务。</p>
             ) : null}
+            {taskStatusActions}
           </div>
         </section>
         )}
@@ -1418,6 +1493,8 @@ export function TaskDetailPage() {
   const [isEditingDescription, setIsEditingDescription] = useState(false);
   const [descriptionDraft, setDescriptionDraft] = useState('');
   const [isTimerAutoFillEnabled, setIsTimerAutoFillEnabled] = useState(() => readTaskTimerAutoFillEnabled());
+  const [taskTransitionError, setTaskTransitionError] = useState<string | null>(null);
+  const [taskTransitionPendingTo, setTaskTransitionPendingTo] = useState<TaskStatus | null>(null);
   const timerResetKey = taskId ?? preferredBlockId ?? task?.id;
   const taskEstimatedMinutes = taskId
     ? task?.id === taskId ? task.estimatedMinutes : undefined
@@ -1478,6 +1555,11 @@ export function TaskDetailPage() {
       collapsedUpstreamOf: [],
       collapsedDownstreamOf: [],
     });
+  }, [task?.id]);
+
+  useEffect(() => {
+    setTaskTransitionError(null);
+    setTaskTransitionPendingTo(null);
   }, [task?.id]);
 
   useEffect(() => {
@@ -1670,10 +1752,50 @@ export function TaskDetailPage() {
   }, [allTasks, dagVisibilityState, task]);
 
   const dependencyError = dependencyActionError ?? dependencyLoadError;
+  const taskTransitionActions = useMemo<TaskTransitionAction[]>(() => {
+    if (!task) return [];
+    if (task.status === 'in_progress') {
+      return [
+        { status: 'completed', label: '完成（Complete）', tone: 'success' },
+        { status: 'suspended', label: '挂起（Suspend）', tone: 'warning' },
+        { status: 'cancelled', label: '取消（Cancel）', tone: 'danger' },
+      ];
+    }
+    if (task.status === 'suspended') {
+      return [
+        { status: 'in_progress', label: '恢复执行（Resume）', tone: 'neutral' },
+        { status: 'completed', label: '完成（Complete）', tone: 'success' },
+        { status: 'cancelled', label: '取消（Cancel）', tone: 'danger' },
+      ];
+    }
+    return [];
+  }, [task]);
 
   const reloadDependencies = () => {
     setDependencyReloadKey((value) => value + 1);
   };
+
+  const handleTaskStatusTransition = useCallback(async (nextStatus: TaskStatus) => {
+    if (!task || taskTransitionPendingTo !== null) return;
+
+    setTaskTransitionError(null);
+    setTaskTransitionPendingTo(nextStatus);
+    try {
+      const transitioned = await getTaskService().transitionTask(task.id, nextStatus);
+      if (!transitioned) {
+        setTaskTransitionError('当前任务不存在，状态未更新。');
+        return;
+      }
+      setTask(transitioned);
+      setAllTasks((current) => current.map((candidate) => (
+        candidate.id === transitioned.id ? transitioned : candidate
+      )));
+    } catch (error) {
+      setTaskTransitionError(formatTaskTransitionError(error));
+    } finally {
+      setTaskTransitionPendingTo(null);
+    }
+  }, [task, taskTransitionPendingTo]);
 
   const handleToggleCollapseUpstream = (targetTaskId: string) => {
     setDagVisibilityState((currentState) => ({
@@ -1918,6 +2040,14 @@ export function TaskDetailPage() {
       ) : null}
     </>
   );
+  const taskStatusActionGroup = (
+    <TaskStatusActionGroup
+      actions={taskTransitionActions}
+      errorMessage={taskTransitionError}
+      pendingStatus={taskTransitionPendingTo}
+      onAction={handleTaskStatusTransition}
+    />
+  );
 
   if (isDesktop) {
     return (
@@ -1937,6 +2067,7 @@ export function TaskDetailPage() {
         hasOtherActiveBlock={hasOtherActiveBlock}
         hasActiveBlockOnTask={Boolean(activeBlock)}
         blockingReason={blockingReason}
+        taskStatusActions={taskStatusActionGroup}
         onStartTimer={handleStartTimer}
         onAppendTaskToActiveBlock={handleAppendTaskToActiveBlock}
         onPauseAndGoEventlog={handlePauseAndGoEventlog}
@@ -1972,6 +2103,7 @@ export function TaskDetailPage() {
       hasOtherActiveBlock={hasOtherActiveBlock}
       hasActiveBlockOnTask={Boolean(activeBlock)}
       blockingReason={blockingReason}
+      taskStatusActions={taskStatusActionGroup}
       onStartTimer={handleStartTimer}
       onAppendTaskToActiveBlock={handleAppendTaskToActiveBlock}
       onPauseAndGoEventlog={handlePauseAndGoEventlog}

--- a/tests/unit/pages/NowWorkbenchOverlayPage.issue590.test.tsx
+++ b/tests/unit/pages/NowWorkbenchOverlayPage.issue590.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NowWorkbenchOverlayPage } from '@/pages/NowWorkbenchOverlayPage';
+import type { ActiveBlockData } from '@/lib/types/event';
+
+const controllerState = {
+  model: {
+    mode: 'running' as const,
+    title: '悬浮窗专注',
+    statusLabel: '待反馈',
+    activeBlock: null as ActiveBlockData | null,
+    visibleTasks: [],
+    recentEvents: [],
+  },
+  feedbackOpen: true,
+  feedback: '',
+  taskStatusChoice: 'continue' as const,
+  debugInfo: {
+    userId: 'overlay-user',
+    mode: 'running',
+    taskCount: 0,
+    eventCount: 0,
+    activeBlockName: '悬浮窗专注',
+    latestEventContent: '',
+    lastReloadAt: '',
+    lastAction: 'test',
+  },
+  setFeedback: vi.fn(),
+  setTaskStatusChoice: vi.fn(),
+  handleHide: vi.fn(),
+  handleReturnToMain: vi.fn(),
+  handlePauseOrResume: vi.fn(),
+  handleOpenEndDialog: vi.fn(),
+  handleConfirmEnd: vi.fn(),
+  handleStartTask: vi.fn(),
+  handleSend: vi.fn(),
+};
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: () => false,
+}));
+
+vi.mock('@tauri-apps/api/dpi', () => ({
+  LogicalSize: class LogicalSize {
+    constructor(public width: number, public height: number) {}
+  },
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    setSize: vi.fn(),
+    onMoved: vi.fn(async () => () => {}),
+  }),
+}));
+
+vi.mock('@/ui/app/components/NowInputRow', () => ({
+  NowInputRow: () => <div data-testid="overlay-now-input-row" />,
+}));
+
+vi.mock('@/ui/app/components/FocusTimerWidget', () => ({
+  FocusTimerWidget: React.forwardRef(() => <div data-testid="overlay-focus-widget" />),
+}));
+
+vi.mock('@/ui/app/overlay/use-now-workbench-overlay-controller', () => ({
+  useNowWorkbenchOverlayController: () => controllerState,
+}));
+
+function makeActiveBlock(overrides: Partial<ActiveBlockData> = {}): ActiveBlockData {
+  return {
+    startId: 'block-1',
+    name: '悬浮窗专注',
+    mode: 'countup',
+    elapsed: 3 * 60 * 1000,
+    startTime: Date.now() - 3 * 60 * 1000,
+    paused: false,
+    taskIds: ['task-1'],
+    taskAssociationLog: [],
+    ...overrides,
+  };
+}
+
+describe('NowWorkbenchOverlayPage issue #590', () => {
+  beforeEach(() => {
+    controllerState.feedbackOpen = true;
+    controllerState.feedback = '';
+    controllerState.taskStatusChoice = 'continue';
+    controllerState.model = {
+      mode: 'running',
+      title: '悬浮窗专注',
+      statusLabel: '待反馈',
+      activeBlock: makeActiveBlock(),
+      visibleTasks: [],
+      recentEvents: [],
+    };
+    controllerState.setFeedback.mockReset();
+    controllerState.setTaskStatusChoice.mockReset();
+    controllerState.handleConfirmEnd.mockReset();
+  });
+
+  it('shows the task status selector when the active block only stores taskIds（仅有 taskIds 时仍展示任务状态选择器）', async () => {
+    render(<NowWorkbenchOverlayPage />);
+
+    expect(await screen.findByTestId('feedback-task-status-section')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/pages/NowWorkbenchOverlayPage.issue590.test.tsx
+++ b/tests/unit/pages/NowWorkbenchOverlayPage.issue590.test.tsx
@@ -15,7 +15,17 @@ const controllerState = {
   },
   feedbackOpen: true,
   feedback: '',
-  taskStatusChoice: 'continue' as const,
+  endingTasks: [] as Array<{
+    id: string;
+    title: string;
+    status: 'in_progress';
+    priority: 'high';
+    dependsOn: [];
+    tags: [];
+    createdAt: number;
+    updatedAt: number;
+  }>,
+  taskStatusChoices: {} as Record<string, 'continue' | 'suspended' | 'completed' | 'cancelled'>,
   debugInfo: {
     userId: 'overlay-user',
     mode: 'running',
@@ -84,7 +94,19 @@ describe('NowWorkbenchOverlayPage issue #590', () => {
   beforeEach(() => {
     controllerState.feedbackOpen = true;
     controllerState.feedback = '';
-    controllerState.taskStatusChoice = 'continue';
+    controllerState.endingTasks = [
+      {
+        id: 'task-1',
+        title: '任务 A',
+        status: 'in_progress',
+        priority: 'high',
+        dependsOn: [],
+        tags: [],
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ];
+    controllerState.taskStatusChoices = { 'task-1': 'continue' };
     controllerState.model = {
       mode: 'running',
       title: '悬浮窗专注',

--- a/tests/unit/ui/now-workbench-overlay-controller.issue590.test.tsx
+++ b/tests/unit/ui/now-workbench-overlay-controller.issue590.test.tsx
@@ -1,0 +1,142 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useNowWorkbenchOverlayController } from '@/ui/app/overlay/use-now-workbench-overlay-controller';
+import type { ActiveBlockData } from '@/lib/types/event';
+import type { TaskNode } from '@/lib/types/task';
+
+const loadActiveBlockMock = vi.fn<() => Promise<ActiveBlockData | null>>();
+const onBlockChangeMock = vi.fn(() => () => {});
+const endBlockMock = vi.fn();
+const listTasksMock = vi.fn<(includeCancelled?: boolean) => Promise<TaskNode[]>>();
+const transitionTaskMock = vi.fn<(id: string, to: TaskNode['status']) => Promise<TaskNode | null>>();
+const onBlockEndForTasksMock = vi.fn<(taskIds: string[], blockId: string) => Promise<void>>();
+const addEventMock = vi.fn();
+const getEventsPageMock = vi.fn();
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: () => false,
+}));
+
+vi.mock('@/services/now-workbench-overlay.service', () => ({
+  getNowWorkbenchOverlayService: () => ({
+    hideTemporarily: vi.fn(),
+    focusMainWindow: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/services', () => ({
+  getTimeBlockService: () => ({
+    loadActiveBlock: (...args: unknown[]) => loadActiveBlockMock(...args),
+    onBlockChange: (...args: unknown[]) => onBlockChangeMock(...args),
+    endBlock: (...args: unknown[]) => endBlockMock(...args),
+    markEnding: vi.fn(),
+    pauseBlock: vi.fn(),
+    resumeBlock: vi.fn(),
+  }),
+  getTaskService: () => ({
+    listTasks: (...args: unknown[]) => listTasksMock(...args),
+    transitionTask: (...args: unknown[]) => transitionTaskMock(...args),
+  }),
+  getTaskTimerService: () => ({
+    onBlockEndForTasks: (...args: unknown[]) => onBlockEndForTasksMock(...args),
+  }),
+  getEventLogService: () => ({
+    addEvent: (...args: unknown[]) => addEventMock(...args),
+  }),
+}));
+
+vi.mock('@/lib/storage/event-storage', () => ({
+  getCurrentUserId: () => 'overlay-user',
+  getEventStorage: () => ({
+    getEventsPage: (...args: unknown[]) => getEventsPageMock(...args),
+  }),
+}));
+
+function makeTask(overrides: Partial<TaskNode> = {}): TaskNode {
+  return {
+    id: 'task-1',
+    title: '修复悬浮窗结束流',
+    status: 'in_progress',
+    priority: 'high',
+    dependsOn: [],
+    tags: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeActiveBlock(overrides: Partial<ActiveBlockData> = {}): ActiveBlockData {
+  return {
+    startId: 'block-1',
+    name: '悬浮窗专注',
+    mode: 'countup',
+    elapsed: 5 * 60 * 1000,
+    startTime: Date.now() - 5 * 60 * 1000,
+    paused: false,
+    taskIds: ['task-1', 'task-2'],
+    taskAssociationLog: [],
+    ...overrides,
+  };
+}
+
+describe('useNowWorkbenchOverlayController issue #590', () => {
+  beforeEach(() => {
+    loadActiveBlockMock.mockReset();
+    onBlockChangeMock.mockReset();
+    onBlockChangeMock.mockImplementation(() => () => {});
+    endBlockMock.mockReset();
+    endBlockMock.mockResolvedValue(null);
+    listTasksMock.mockReset();
+    listTasksMock.mockResolvedValue([
+      makeTask({ id: 'task-1', title: '任务 A' }),
+      makeTask({ id: 'task-2', title: '任务 B' }),
+    ]);
+    transitionTaskMock.mockReset();
+    transitionTaskMock.mockResolvedValue(null);
+    onBlockEndForTasksMock.mockReset();
+    onBlockEndForTasksMock.mockResolvedValue(undefined);
+    addEventMock.mockReset();
+    addEventMock.mockResolvedValue(undefined);
+    getEventsPageMock.mockReset();
+    getEventsPageMock.mockResolvedValue({
+      events: [],
+      nextCursor: null,
+      hasMore: false,
+    });
+  });
+
+  it('transitions every resolved task id when ending a block with taskIds only（仅有 taskIds 时会逐个转换关联任务状态）', async () => {
+    loadActiveBlockMock.mockResolvedValue(makeActiveBlock());
+
+    const { result } = renderHook(() => useNowWorkbenchOverlayController());
+
+    await waitFor(() => {
+      expect(loadActiveBlockMock).toHaveBeenCalled();
+      expect(result.current.model.activeBlock?.startId).toBe('block-1');
+    });
+
+    act(() => {
+      result.current.setTaskStatusChoice('completed');
+    });
+
+    await waitFor(() => {
+      expect(result.current.taskStatusChoice).toBe('completed');
+    });
+
+    await act(async () => {
+      await result.current.handleConfirmEnd();
+    });
+
+    expect(endBlockMock).toHaveBeenCalledWith('', {
+      taskStatusOutcomes: {
+        'task-1': 'completed',
+        'task-2': 'completed',
+      },
+    });
+    expect(onBlockEndForTasksMock).toHaveBeenCalledWith(['task-1', 'task-2'], 'block-1');
+    expect(transitionTaskMock).toHaveBeenCalledTimes(2);
+    expect(transitionTaskMock).toHaveBeenNthCalledWith(1, 'task-1', 'completed');
+    expect(transitionTaskMock).toHaveBeenNthCalledWith(2, 'task-2', 'completed');
+  });
+});

--- a/tests/unit/ui/now-workbench-overlay-controller.issue590.test.tsx
+++ b/tests/unit/ui/now-workbench-overlay-controller.issue590.test.tsx
@@ -93,7 +93,12 @@ describe('useNowWorkbenchOverlayController issue #590', () => {
       makeTask({ id: 'task-2', title: '任务 B' }),
     ]);
     transitionTaskMock.mockReset();
-    transitionTaskMock.mockResolvedValue(null);
+    transitionTaskMock.mockImplementation(async (id, status) => makeTask({
+      id,
+      status,
+      updatedAt: Date.now(),
+      ...(status === 'completed' || status === 'cancelled' ? { completedAt: Date.now() } : {}),
+    }));
     onBlockEndForTasksMock.mockReset();
     onBlockEndForTasksMock.mockResolvedValue(undefined);
     addEventMock.mockReset();
@@ -114,14 +119,19 @@ describe('useNowWorkbenchOverlayController issue #590', () => {
     await waitFor(() => {
       expect(loadActiveBlockMock).toHaveBeenCalled();
       expect(result.current.model.activeBlock?.startId).toBe('block-1');
+      expect(result.current.endingTasks).toHaveLength(2);
+      expect(result.current.taskStatusChoices['task-1']).toBe('continue');
+      expect(result.current.taskStatusChoices['task-2']).toBe('continue');
     });
 
     act(() => {
-      result.current.setTaskStatusChoice('completed');
+      result.current.setTaskStatusChoice('task-1', 'completed');
+      result.current.setTaskStatusChoice('task-2', 'completed');
     });
 
     await waitFor(() => {
-      expect(result.current.taskStatusChoice).toBe('completed');
+      expect(result.current.taskStatusChoices['task-1']).toBe('completed');
+      expect(result.current.taskStatusChoices['task-2']).toBe('completed');
     });
 
     await act(async () => {
@@ -138,5 +148,54 @@ describe('useNowWorkbenchOverlayController issue #590', () => {
     expect(transitionTaskMock).toHaveBeenCalledTimes(2);
     expect(transitionTaskMock).toHaveBeenNthCalledWith(1, 'task-1', 'completed');
     expect(transitionTaskMock).toHaveBeenNthCalledWith(2, 'task-2', 'completed');
+  });
+
+  it('does not transition tasks when block-task linking fails（关联时间块回写失败时不继续转换任务状态）', async () => {
+    loadActiveBlockMock.mockResolvedValue(makeActiveBlock());
+    onBlockEndForTasksMock.mockRejectedValue(new Error('link failed'));
+
+    const { result } = renderHook(() => useNowWorkbenchOverlayController());
+
+    await waitFor(() => {
+      expect(result.current.model.activeBlock?.startId).toBe('block-1');
+    });
+
+    act(() => {
+      result.current.setTaskStatusChoice('task-1', 'completed');
+      result.current.setTaskStatusChoice('task-2', 'completed');
+    });
+
+    await act(async () => {
+      await result.current.handleConfirmEnd();
+    });
+
+    expect(onBlockEndForTasksMock).toHaveBeenCalledWith(['task-1', 'task-2'], 'block-1');
+    expect(transitionTaskMock).not.toHaveBeenCalled();
+  });
+
+  it('only transitions tasks whose outcome is not continue（只转换被显式设置结果的任务）', async () => {
+    loadActiveBlockMock.mockResolvedValue(makeActiveBlock());
+
+    const { result } = renderHook(() => useNowWorkbenchOverlayController());
+
+    await waitFor(() => {
+      expect(result.current.endingTasks).toHaveLength(2);
+    });
+
+    act(() => {
+      result.current.setTaskStatusChoice('task-1', 'completed');
+    });
+
+    await act(async () => {
+      await result.current.handleConfirmEnd();
+    });
+
+    expect(endBlockMock).toHaveBeenCalledWith('', {
+      taskStatusOutcomes: {
+        'task-1': 'completed',
+      },
+    });
+    expect(transitionTaskMock).toHaveBeenCalledTimes(1);
+    expect(transitionTaskMock).toHaveBeenCalledWith('task-1', 'completed');
   });
 });

--- a/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
+++ b/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
@@ -14,6 +14,7 @@ const updateTaskMock = vi.fn<(id: string, input: Partial<TaskNode>) => Promise<T
 const addDependencyMock = vi.fn<(taskId: string, depTaskId: string, type: 'soft' | 'hard') => Promise<TaskNode | null>>();
 const removeDependencyMock = vi.fn<(taskId: string, depTaskId: string) => Promise<TaskNode | null>>();
 const getAvailableTransitionsMock = vi.fn<(id: string) => Promise<Array<TaskNode['status']>>>();
+const transitionTaskMock = vi.fn<(id: string, to: TaskNode['status']) => Promise<TaskNode | null>>();
 const getChildTasksMock = vi.fn<(parentId: string) => Promise<TaskNode[]>>();
 const checkDependenciesMetMock = vi.fn<(taskId: string) => Promise<{ met: boolean; blocking: Array<{ taskId: string; type: 'soft' | 'hard'; status: TaskNode['status'] }> }>>();
 const onTaskChangeMock = vi.fn(() => () => {});
@@ -49,7 +50,7 @@ vi.mock('@/lib/services', () => ({
     getChildTasks: getChildTasksMock,
     checkDependenciesMet: checkDependenciesMetMock,
     onTaskChange: onTaskChangeMock,
-    transitionTask: vi.fn(),
+    transitionTask: transitionTaskMock,
     updateTask: updateTaskMock,
     cancelTask: vi.fn(),
   }),
@@ -182,6 +183,13 @@ describe('TaskDetailPage timeblock detail layout（任务详情布局）', () =>
     addDependencyMock.mockResolvedValue(makeTask());
     removeDependencyMock.mockResolvedValue(makeTask());
     getAvailableTransitionsMock.mockResolvedValue(['in_progress']);
+    transitionTaskMock.mockReset();
+    transitionTaskMock.mockImplementation(async (id, status) => makeTask({
+      id,
+      status,
+      updatedAt: Date.now(),
+      ...(status === 'completed' || status === 'cancelled' ? { completedAt: Date.now() } : {}),
+    }));
     getChildTasksMock.mockResolvedValue([]);
     checkDependenciesMetMock.mockResolvedValue({ met: true, blocking: [] });
     loadTimeBlocksMock.mockResolvedValue([makeBlock()]);
@@ -254,6 +262,56 @@ describe('TaskDetailPage timeblock detail layout（任务详情布局）', () =>
 
     expect(document.getElementById('task-detail-dependency')).not.toBeNull();
     expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+  });
+
+  it('shows direct transition actions for in-progress tasks and triggers transition（进行中任务可直接完成/挂起/取消）', async () => {
+    mockMatchMedia(true);
+    render(<TaskDetailPage />);
+
+    await screen.findByText('任务详情');
+
+    expect(screen.getByRole('button', { name: '完成（Complete）' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '挂起（Suspend）' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '取消（Cancel）' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '完成（Complete）' }));
+
+    await waitFor(() => {
+      expect(transitionTaskMock).toHaveBeenCalledWith('task-1', 'completed');
+    });
+  });
+
+  it('shows resume action for suspended tasks（已挂起任务提供恢复执行入口）', async () => {
+    getTaskMock.mockImplementation(async () => makeTask({
+      status: 'suspended',
+      createdAt: 20,
+      updatedAt: 20,
+    }));
+    listTasksMock.mockResolvedValue([
+      makeTask({
+        id: 'task-root',
+        title: '优先收口 DAG 根节点',
+        status: 'pending',
+        createdAt: 10,
+        updatedAt: 10,
+      }),
+      makeTask({
+        id: 'task-1',
+        title: '深度工作：EventLog 模块实现',
+        status: 'suspended',
+        createdAt: 20,
+        updatedAt: 20,
+      }),
+    ]);
+
+    mockMatchMedia(true);
+    render(<TaskDetailPage />);
+
+    await screen.findByText('任务详情');
+
+    expect(screen.getByRole('button', { name: '恢复执行（Resume）' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '完成（Complete）' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '取消（Cancel）' })).toBeInTheDocument();
   });
 
   it('hides task detail scrollbars while preserving scroll containers（任务详情隐藏滚动条）', async () => {

--- a/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
+++ b/tests/unit/ui/task-detail-page.timeblock-detail.test.tsx
@@ -312,6 +312,77 @@ describe('TaskDetailPage timeblock detail layout（任务详情布局）', () =>
     expect(screen.getByRole('button', { name: '恢复执行（Resume）' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '完成（Complete）' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '取消（Cancel）' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '恢复执行（Resume）' }));
+
+    await waitFor(() => {
+      expect(transitionTaskMock).toHaveBeenCalledWith('task-1', 'in_progress');
+    });
+  });
+
+  it('disables direct transition actions while the task still has an active block（任务仍在活动时间块中时禁用直接状态变更）', async () => {
+    loadActiveBlockMock.mockResolvedValue({
+      startId: 'active-block-1',
+      name: '深度工作：EventLog 模块实现',
+      mode: 'countup',
+      elapsed: 10 * 60 * 1000,
+      startTime: Date.now() - 10 * 60 * 1000,
+      paused: false,
+      taskIds: ['task-1'],
+      taskAssociationLog: [],
+    });
+
+    mockMatchMedia(true);
+    render(<TaskDetailPage />);
+
+    await screen.findByText('任务详情');
+
+    expect(screen.getByRole('button', { name: '完成（Complete）' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '挂起（Suspend）' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '取消（Cancel）' })).toBeDisabled();
+    expect(screen.getByText('当前已有进行中的时间块，请先回到当下结束或暂停时间块，再修改任务状态。')).toBeInTheDocument();
+  });
+
+  it('shows direct transition actions on mobile detail too（移动端详情同样展示直接状态按钮）', async () => {
+    mockMatchMedia(false);
+    render(<TaskDetailPage />);
+
+    await screen.findByText('任务详情');
+
+    expect(screen.getByRole('button', { name: '完成（Complete）' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '挂起（Suspend）' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '取消（Cancel）' })).toBeInTheDocument();
+  });
+
+  it('does not show direct transition actions for pending tasks（待办任务不展示直接状态按钮）', async () => {
+    getTaskMock.mockImplementation(async () => makeTask({
+      status: 'pending',
+      createdAt: 20,
+      updatedAt: 20,
+    }));
+    listTasksMock.mockResolvedValue([
+      makeTask({
+        id: 'task-root',
+        title: '优先收口 DAG 根节点',
+        status: 'pending',
+        createdAt: 10,
+        updatedAt: 10,
+      }),
+      makeTask({
+        id: 'task-1',
+        title: '深度工作：EventLog 模块实现',
+        status: 'pending',
+        createdAt: 20,
+        updatedAt: 20,
+      }),
+    ]);
+
+    mockMatchMedia(true);
+    render(<TaskDetailPage />);
+
+    await screen.findByText('任务详情');
+
+    expect(screen.queryByTestId('task-status-actions')).toBeNull();
   });
 
   it('hides task detail scrollbars while preserving scroll containers（任务详情隐藏滚动条）', async () => {

--- a/tests/unit/ui/task-status-selector.issue493.test.tsx
+++ b/tests/unit/ui/task-status-selector.issue493.test.tsx
@@ -36,4 +36,18 @@ describe('TaskStatusSelector issue-493', () => {
     expect(screen.getByTestId('feedback-task-status-task-1-continue')).toBeInTheDocument();
     expect(screen.getByTestId('feedback-task-status-task-1-cancelled')).toBeInTheDocument();
   });
+
+  it('exposes radiogroup semantics for assistive tech（为辅助技术暴露单选组语义）', () => {
+    render(
+      <TaskStatusSelector
+        value="completed"
+        onChange={vi.fn()}
+      />,
+    );
+
+    const group = screen.getByRole('radiogroup', { name: '关联任务下一步状态' });
+    expect(group).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '完成' })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', { name: '继续' })).toHaveAttribute('aria-checked', 'false');
+  });
 });


### PR DESCRIPTION
## 关联 Issue

Closes #590

## 变更摘要

- overlay 结束任务时不再依赖已废弃的 `taskId`，统一改为通过 `resolveActiveBlockTaskIds()` 处理全部关联任务
- overlay 反馈结束流会把 `taskStatusOutcomes` 传给 `onBlockEndForTasks()`，并同步回写 `timeBlockIds`
- overlay 结束路径已对齐 `taskIds` 多任务模型，不再丢失任务状态回写或时间块关联
- 在 `TaskDetailPage` 中，为 `in_progress / suspended` 任务补上直接状态操作：`完成` / `挂起` / `继续` / `取消`
- 补齐 overlay controller、overlay feedback UI 与 task detail 的回归测试

## 验收

- [x] overlay 在 `taskIds` 新模型下可以正确结束并回写全部关联任务
- [x] `TaskDetailPage` 对 `in_progress / suspended` 任务提供可用的直接状态操作
- [x] overlay 与任务详情页两条结束路径都已补回归测试

## 自检清单

- [x] 本地构建通过（`bun run build`）
- [x] 相关测试通过（`vitest run`）
- [x] 未引入 `any`
- [x] 未硬编码密钥 / token
- [x] commit message 已引用 Issue 编号
