### PR TITLE
feat(today-planner): add timeline scheduling windows

### DIFF
--- a/crates/exomind-runtime/src/routes/mod.rs
+++ b/crates/exomind-runtime/src/routes/mod.rs
@@ -12,6 +12,7 @@ pub mod pty;
 pub mod sessions;
 pub mod signals;
 pub mod tasks;
+pub mod today_planner;
 pub mod timeblocks;
 pub mod topology;
 pub mod workspace;
@@ -28,6 +29,7 @@ pub fn router() -> Router<AppState> {
         .merge(sessions::router())
         .merge(signals::router())
         .merge(tasks::router())
+        .merge(today_planner::router())
         .merge(timeblocks::router())
         .merge(workspace::router());
     #[cfg(not(target_os = "android"))]

--- a/crates/exomind-runtime/src/routes/timeblocks.rs
+++ b/crates/exomind-runtime/src/routes/timeblocks.rs
@@ -627,6 +627,7 @@ mod tests {
                             task_ids: vec![],
                             task_status_outcomes: None,
                             task_association_log: vec![],
+                            source_planned_block_id: None,
                         }])
                         .unwrap(),
                     ))
@@ -667,6 +668,7 @@ mod tests {
                                     source: "block_start".to_string(),
                                 },
                             ],
+                            source_planned_block_id: None,
                         }])
                         .unwrap(),
                     ))
@@ -714,6 +716,7 @@ mod tests {
                                     source: "block_start".to_string(),
                                 },
                             ],
+                            source_planned_block_id: None,
                             task_id: Some("task-profile-a".to_string()),
                         })
                         .unwrap(),
@@ -827,6 +830,7 @@ mod tests {
                                     source: "block_start".to_string(),
                                 },
                             ],
+                            source_planned_block_id: None,
                         }])
                         .unwrap(),
                     ))
@@ -874,6 +878,7 @@ mod tests {
                                     source: "block_start".to_string(),
                                 },
                             ],
+                            source_planned_block_id: None,
                             task_id: Some("task-user-a".to_string()),
                         })
                         .unwrap(),
@@ -975,6 +980,7 @@ mod tests {
                             paused_at: None,
                             task_ids: vec!["task-a".to_string()],
                             task_association_log: vec![],
+                            source_planned_block_id: None,
                             task_id: Some("task-a".to_string()),
                         })
                         .unwrap(),
@@ -1035,6 +1041,7 @@ mod tests {
                             paused_at: None,
                             task_ids: vec!["task-a".to_string()],
                             task_association_log: vec![],
+                            source_planned_block_id: None,
                             task_id: Some("task-a".to_string()),
                         })
                         .unwrap(),
@@ -1099,6 +1106,7 @@ mod tests {
             paused_at: None,
             task_ids: vec!["task-a".to_string()],
             task_association_log: vec![],
+            source_planned_block_id: None,
             task_id: Some("task-a".to_string()),
         };
 
@@ -1220,6 +1228,7 @@ mod tests {
             paused_at: None,
             task_ids: vec!["task-a".to_string()],
             task_association_log: vec![],
+            source_planned_block_id: None,
             task_id: Some("task-a".to_string()),
         };
 

--- a/crates/exomind-runtime/src/routes/today_planner.rs
+++ b/crates/exomind-runtime/src/routes/today_planner.rs
@@ -179,6 +179,7 @@ fn duration_minutes_from_segment(segment: &PlannedSegmentData) -> u64 {
 
 fn generate_segments_for_window(
     window_id: &str,
+    window_title: Option<&str>,
     window_start_at: u64,
     window_end_at: u64,
     preset: &RhythmPresetData,
@@ -188,6 +189,10 @@ fn generate_segments_for_window(
     let mut order = 0i64;
     let mut work_count = 0u32;
     let mut segments = Vec::new();
+    let normalized_window_title = window_title
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(ToOwned::to_owned);
 
     while cursor < window_end_at {
         let remaining_minutes = window_end_at.saturating_sub(cursor).div_ceil(60_000);
@@ -203,7 +208,9 @@ fn generate_segments_for_window(
             window_id: window_id.to_string(),
             kind: PlannedSegmentKind::Work,
             break_kind: None,
-            title: format!("Work {work_count}"),
+            title: normalized_window_title
+                .clone()
+                .unwrap_or_else(|| format!("Work {work_count}")),
             planned_start_at: cursor,
             planned_end_at: work_end,
             linked_task_ids: Vec::new(),
@@ -369,18 +376,20 @@ async fn create_window(
     let scope_key = scope_key_from_query(&query);
     let now = chrono::Utc::now().timestamp_millis() as u64;
     let window_id = uuid::Uuid::new_v4().to_string();
+    let window_title = payload
+        .title
+        .map(|title| title.trim().to_string())
+        .filter(|title| !title.is_empty());
     let window = SchedulingWindowData {
         id: window_id.clone(),
         date: payload.date.trim().to_string(),
-        title: payload
-            .title
-            .map(|title| title.trim().to_string())
-            .filter(|title| !title.is_empty()),
+        title: window_title.clone(),
         planned_start_at: payload.planned_start_at,
         planned_end_at: payload.planned_end_at,
         rhythm_preset: preset.clone(),
         segments: generate_segments_for_window(
             &window_id,
+            window_title.as_deref(),
             payload.planned_start_at,
             payload.planned_end_at,
             &preset,

--- a/crates/exomind-runtime/src/routes/today_planner.rs
+++ b/crates/exomind-runtime/src/routes/today_planner.rs
@@ -1,0 +1,560 @@
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::routing::{get, patch, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+use crate::timeblock::{
+    ActiveBlockData, BlockTaskAssociationEvent, PlannedTimeBlockData, PlannedTimeBlockType,
+};
+
+#[derive(Debug, Deserialize)]
+struct ScopeQuery {
+    #[serde(default)]
+    profile_id: Option<String>,
+    #[serde(default)]
+    user_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TodayPlannerQuery {
+    date: String,
+    #[serde(default)]
+    profile_id: Option<String>,
+    #[serde(default)]
+    user_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreatePlannedTimeBlockPayload {
+    date: String,
+    #[serde(rename = "type")]
+    block_type: PlannedTimeBlockType,
+    title: String,
+    planned_start_at: u64,
+    planned_duration_minutes: u64,
+    #[serde(default)]
+    note: Option<String>,
+    #[serde(default)]
+    linked_task_ids: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdatePlannedTimeBlockPayload {
+    #[serde(default)]
+    date: Option<String>,
+    #[serde(rename = "type", default)]
+    block_type: Option<PlannedTimeBlockType>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    planned_start_at: Option<u64>,
+    #[serde(default)]
+    planned_duration_minutes: Option<u64>,
+    #[serde(default)]
+    note: Option<Option<String>>,
+    #[serde(default)]
+    linked_task_ids: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReorderPlannedTimeBlocksPayload {
+    date: String,
+    ordered_ids: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TodayPlannerSnapshotResponse {
+    date: String,
+    blocks: Vec<TodayPlannerBlockResponse>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TodayPlannerBlockResponse {
+    #[serde(flatten)]
+    block: PlannedTimeBlockData,
+    status: String,
+    #[serde(rename = "sourceTimeBlockId")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_timeblock_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+fn scope_key_from_query(query: &ScopeQuery) -> Option<&str> {
+    query.profile_id.as_deref().or(query.user_id.as_deref())
+}
+
+fn scope_key_from_today_query(query: &TodayPlannerQuery) -> Option<&str> {
+    query.profile_id.as_deref().or(query.user_id.as_deref())
+}
+
+fn internal_error(message: String) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse { error: message }),
+    )
+}
+
+fn bad_request(message: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse {
+            error: message.into(),
+        }),
+    )
+}
+
+fn conflict(message: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::CONFLICT,
+        Json(ErrorResponse {
+            error: message.into(),
+        }),
+    )
+}
+
+fn not_found(message: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse {
+            error: message.into(),
+        }),
+    )
+}
+
+fn normalize_linked_task_ids(task_ids: Vec<String>) -> Vec<String> {
+    let mut normalized: Vec<String> = Vec::new();
+    for task_id in task_ids {
+        let trimmed = task_id.trim();
+        if trimmed.is_empty() || normalized.iter().any(|value| value == trimmed) {
+            continue;
+        }
+        normalized.push(trimmed.to_string());
+    }
+    normalized
+}
+
+fn build_snapshot_response(
+    state: &AppState,
+    scope_key: Option<&str>,
+    date: &str,
+) -> Result<TodayPlannerSnapshotResponse, (StatusCode, Json<ErrorResponse>)> {
+    let blocks = state
+        .timeblock_store
+        .list_planned_for_date_scoped(scope_key, date)
+        .map_err(|error| internal_error(error.to_string()))?;
+    let active_block = state
+        .timeblock_store
+        .get_active_scoped(scope_key)
+        .map_err(|error| internal_error(error.to_string()))?;
+    let completed_blocks = state
+        .timeblock_store
+        .list_completed_scoped(scope_key)
+        .map_err(|error| internal_error(error.to_string()))?;
+
+    let block_responses = blocks
+        .into_iter()
+        .map(|block| {
+            if let Some(active) = active_block.as_ref() {
+                if active.source_planned_block_id.as_deref() == Some(block.id.as_str()) {
+                    return TodayPlannerBlockResponse {
+                        block,
+                        status: "active".to_string(),
+                        source_timeblock_id: Some(active.start_id.clone()),
+                    };
+                }
+            }
+
+            if let Some(completed) = completed_blocks
+                .iter()
+                .find(|completed| completed.source_planned_block_id.as_deref() == Some(block.id.as_str()))
+            {
+                return TodayPlannerBlockResponse {
+                    block,
+                    status: "completed".to_string(),
+                    source_timeblock_id: Some(completed.id.clone()),
+                };
+            }
+
+            TodayPlannerBlockResponse {
+                block,
+                status: "pending".to_string(),
+                source_timeblock_id: None,
+            }
+        })
+        .collect();
+
+    Ok(TodayPlannerSnapshotResponse {
+        date: date.to_string(),
+        blocks: block_responses,
+    })
+}
+
+async fn get_today_planner(
+    State(state): State<AppState>,
+    Query(query): Query<TodayPlannerQuery>,
+) -> Result<Json<TodayPlannerSnapshotResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let snapshot = build_snapshot_response(&state, scope_key_from_today_query(&query), &query.date)?;
+    Ok(Json(snapshot))
+}
+
+async fn create_planned_block(
+    State(state): State<AppState>,
+    Query(query): Query<ScopeQuery>,
+    Json(payload): Json<CreatePlannedTimeBlockPayload>,
+) -> Result<(StatusCode, Json<TodayPlannerBlockResponse>), (StatusCode, Json<ErrorResponse>)> {
+    if payload.date.trim().is_empty() {
+        return Err(bad_request("date is required"));
+    }
+    if payload.title.trim().is_empty() {
+        return Err(bad_request("title is required"));
+    }
+    if payload.planned_duration_minutes == 0 {
+        return Err(bad_request("plannedDurationMinutes must be greater than 0"));
+    }
+
+    let scope_key = scope_key_from_query(&query);
+    let existing = state
+        .timeblock_store
+        .list_planned_for_date_scoped(scope_key, &payload.date)
+        .map_err(|error| internal_error(error.to_string()))?;
+    let next_order = existing.iter().map(|block| block.order).max().unwrap_or(-1) + 1;
+    let now = chrono::Utc::now().timestamp_millis() as u64;
+    let block = PlannedTimeBlockData {
+        id: uuid::Uuid::new_v4().to_string(),
+        date: payload.date.trim().to_string(),
+        block_type: payload.block_type,
+        title: payload.title.trim().to_string(),
+        planned_start_at: payload.planned_start_at,
+        planned_duration_minutes: payload.planned_duration_minutes,
+        note: payload.note.and_then(|value| {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }),
+        linked_task_ids: normalize_linked_task_ids(payload.linked_task_ids),
+        order: next_order,
+        created_at: now,
+        updated_at: now,
+    };
+
+    state
+        .timeblock_store
+        .put_planned_scoped(scope_key, block.clone())
+        .map_err(|error| internal_error(error.to_string()))?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(TodayPlannerBlockResponse {
+            block,
+            status: "pending".to_string(),
+            source_timeblock_id: None,
+        }),
+    ))
+}
+
+async fn update_planned_block(
+    State(state): State<AppState>,
+    Path(block_id): Path<String>,
+    Query(query): Query<ScopeQuery>,
+    Json(payload): Json<UpdatePlannedTimeBlockPayload>,
+) -> Result<Json<TodayPlannerBlockResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let scope_key = scope_key_from_query(&query);
+    let existing = state
+        .timeblock_store
+        .get_planned_scoped(scope_key, &block_id)
+        .map_err(|error| internal_error(error.to_string()))?
+        .ok_or_else(|| not_found("planned block not found"))?;
+
+    let next_title = payload
+        .title
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or(existing.title.clone());
+    let next_date = payload
+        .date
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or(existing.date.clone());
+    let next_duration = payload
+        .planned_duration_minutes
+        .unwrap_or(existing.planned_duration_minutes);
+    if next_duration == 0 {
+        return Err(bad_request("plannedDurationMinutes must be greater than 0"));
+    }
+
+    let updated = PlannedTimeBlockData {
+        id: existing.id.clone(),
+        date: next_date,
+        block_type: payload.block_type.unwrap_or(existing.block_type),
+        title: next_title,
+        planned_start_at: payload.planned_start_at.unwrap_or(existing.planned_start_at),
+        planned_duration_minutes: next_duration,
+        note: payload
+            .note
+            .map(|value| {
+                value.and_then(|inner| {
+                    let trimmed = inner.trim().to_string();
+                    if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed)
+                    }
+                })
+            })
+            .unwrap_or(existing.note.clone()),
+        linked_task_ids: payload
+            .linked_task_ids
+            .map(normalize_linked_task_ids)
+            .unwrap_or(existing.linked_task_ids.clone()),
+        order: existing.order,
+        created_at: existing.created_at,
+        updated_at: chrono::Utc::now().timestamp_millis() as u64,
+    };
+
+    state
+        .timeblock_store
+        .put_planned_scoped(scope_key, updated.clone())
+        .map_err(|error| internal_error(error.to_string()))?;
+
+    let snapshot = build_snapshot_response(&state, scope_key, &updated.date)?;
+    let response = snapshot
+        .blocks
+        .into_iter()
+        .find(|block| block.block.id == updated.id)
+        .ok_or_else(|| internal_error("updated planned block missing from snapshot".to_string()))?;
+    Ok(Json(response))
+}
+
+async fn reorder_planned_blocks(
+    State(state): State<AppState>,
+    Query(query): Query<ScopeQuery>,
+    Json(payload): Json<ReorderPlannedTimeBlocksPayload>,
+) -> Result<Json<TodayPlannerSnapshotResponse>, (StatusCode, Json<ErrorResponse>)> {
+    if payload.date.trim().is_empty() {
+        return Err(bad_request("date is required"));
+    }
+
+    let scope_key = scope_key_from_query(&query);
+    let mut all_blocks = state
+        .timeblock_store
+        .list_planned_scoped(scope_key)
+        .map_err(|error| internal_error(error.to_string()))?;
+
+    let ordered_ids = payload
+        .ordered_ids
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>();
+    if ordered_ids.is_empty() {
+        return Err(bad_request("orderedIds is required"));
+    }
+
+    let mut next_order = 0i64;
+    for ordered_id in ordered_ids {
+        if let Some(block) = all_blocks
+            .iter_mut()
+            .find(|block| block.date == payload.date && block.id == ordered_id)
+        {
+            block.order = next_order;
+            block.updated_at = chrono::Utc::now().timestamp_millis() as u64;
+            next_order += 1;
+        }
+    }
+
+    for block in all_blocks
+        .iter_mut()
+        .filter(|block| block.date == payload.date && !payload.ordered_ids.iter().any(|id| id == &block.id))
+    {
+        block.order = next_order;
+        block.updated_at = chrono::Utc::now().timestamp_millis() as u64;
+        next_order += 1;
+    }
+
+    state
+        .timeblock_store
+        .replace_planned_scoped(scope_key, &all_blocks)
+        .map_err(|error| internal_error(error.to_string()))?;
+
+    Ok(Json(build_snapshot_response(
+        &state,
+        scope_key,
+        payload.date.trim(),
+    )?))
+}
+
+async fn start_planned_block(
+    State(state): State<AppState>,
+    Path(block_id): Path<String>,
+    Query(query): Query<ScopeQuery>,
+) -> Result<Json<ActiveBlockData>, (StatusCode, Json<ErrorResponse>)> {
+    let scope_key = scope_key_from_query(&query);
+    let planned_block = state
+        .timeblock_store
+        .get_planned_scoped(scope_key, &block_id)
+        .map_err(|error| internal_error(error.to_string()))?
+        .ok_or_else(|| not_found("planned block not found"))?;
+
+    if let Some(active) = state
+        .timeblock_store
+        .get_active_scoped(scope_key)
+        .map_err(|error| internal_error(error.to_string()))?
+    {
+        if !matches!(
+            active.phase.as_deref(),
+            Some("feedback_in_progress" | "feedback_submitted")
+        ) && active.action_ended_at.is_none()
+            && active.feedback_started_at.is_none()
+            && active.feedback_submitted_at.is_none()
+        {
+            return Err(conflict("active timeblock already exists"));
+        }
+    }
+
+    let now = chrono::Utc::now().timestamp_millis() as u64;
+    let start_id = uuid::Uuid::new_v4().to_string();
+    let task_association_log = planned_block
+        .linked_task_ids
+        .iter()
+        .map(|task_id| BlockTaskAssociationEvent {
+            block_id: start_id.clone(),
+            task_id: task_id.clone(),
+            action: "associated".to_string(),
+            timestamp: now,
+            source: "block_start".to_string(),
+        })
+        .collect::<Vec<_>>();
+    let active_block = ActiveBlockData {
+        start_id: start_id.clone(),
+        name: planned_block.title.clone(),
+        mode: "countdown".to_string(),
+        target_minutes: Some(planned_block.planned_duration_minutes),
+        elapsed: planned_block.planned_duration_minutes * 60 * 1000,
+        updated_at: Some(now),
+        phase: Some("running".to_string()),
+        version: Some(1),
+        actor_id: Some("rt:today-planner".to_string()),
+        last_transition_at: Some(now),
+        last_resumed_at: Some(now),
+        accumulated_run_ms: Some(0),
+        start_time: now,
+        action_ended_at: None,
+        feedback_started_at: None,
+        feedback_submitted_at: None,
+        pause_accumulated_ms: Some(0),
+        paused: false,
+        paused_at: None,
+        task_ids: planned_block.linked_task_ids.clone(),
+        task_association_log,
+        source_planned_block_id: Some(planned_block.id.clone()),
+        task_id: None,
+    };
+
+    state
+        .timeblock_store
+        .put_active_scoped(scope_key, active_block.clone())
+        .map_err(|error| internal_error(error.to_string()))?;
+    write_timeblock_eventlog(
+        &state,
+        scope_key,
+        "block_start",
+        &active_block.name,
+        &active_block.start_id,
+        &active_block.task_ids,
+    );
+
+    Ok(Json(active_block))
+}
+
+async fn delete_planned_block(
+    State(state): State<AppState>,
+    Path(block_id): Path<String>,
+    Query(query): Query<ScopeQuery>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let scope_key = scope_key_from_query(&query);
+    let existing = state
+        .timeblock_store
+        .get_planned_scoped(scope_key, &block_id)
+        .map_err(|error| internal_error(error.to_string()))?;
+    if existing.is_none() {
+        return Err(not_found("planned block not found"));
+    }
+
+    state
+        .timeblock_store
+        .delete_planned_scoped(scope_key, &block_id)
+        .map_err(|error| internal_error(error.to_string()))?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+fn write_timeblock_eventlog(
+    state: &AppState,
+    scope_key: Option<&str>,
+    event_type: &str,
+    block_name: &str,
+    start_id: &str,
+    task_ids: &[String],
+) {
+    let content = match event_type {
+        "block_start" => format!("时间块开始: {block_name}"),
+        "block_end" => format!("时间块结束: {block_name}"),
+        "block_pause" => format!("时间块暂停: {block_name}"),
+        "block_resume" => format!("时间块恢复: {block_name}"),
+        _ => format!("时间块事件: {block_name}"),
+    };
+    let event = crate::eventlog::EventRecord {
+        id: uuid::Uuid::new_v4().to_string(),
+        timestamp: chrono::Utc::now().timestamp_millis(),
+        content,
+        tags: vec![event_type.to_string()],
+        metadata: Some(serde_json::json!({
+            "block_name": block_name,
+            "start_id": start_id,
+            "task_ids": task_ids,
+            "source": {
+                "app": "exomind-runtime",
+                "trigger": "http:today-planner/start",
+            }
+        })),
+    };
+
+    if let Err(error) = state.eventlog_store.append_event(scope_key, event) {
+        tracing::warn!(error = %error, "failed to write today planner eventlog");
+    }
+}
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/act/today-planner", get(get_today_planner))
+        .route("/act/today-planner/blocks", post(create_planned_block))
+        .route(
+            "/act/today-planner/blocks/reorder",
+            post(reorder_planned_blocks),
+        )
+        .route(
+            "/act/today-planner/blocks/:block_id",
+            patch(update_planned_block).delete(delete_planned_block),
+        )
+        .route(
+            "/act/today-planner/blocks/:block_id/start",
+            post(start_planned_block),
+        )
+}

--- a/crates/exomind-runtime/src/routes/today_planner.rs
+++ b/crates/exomind-runtime/src/routes/today_planner.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::AppState;
 use crate::timeblock::{
-    ActiveBlockData, BlockTaskAssociationEvent, PlannedTimeBlockData, PlannedTimeBlockType,
+    ActiveBlockData, BlockTaskAssociationEvent, BreakWindowKind, PlannedSegmentData,
+    PlannedSegmentKind, RhythmPresetData, SchedulingWindowData,
 };
 
 #[derive(Debug, Deserialize)]
@@ -28,57 +29,51 @@ struct TodayPlannerQuery {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct CreatePlannedTimeBlockPayload {
+struct CreateSchedulingWindowPayload {
     date: String,
-    #[serde(rename = "type")]
-    block_type: PlannedTimeBlockType,
-    title: String,
+    #[serde(default)]
+    title: Option<String>,
     planned_start_at: u64,
-    planned_duration_minutes: u64,
-    #[serde(default)]
-    note: Option<String>,
-    #[serde(default)]
-    linked_task_ids: Vec<String>,
+    planned_end_at: u64,
+    rhythm_preset_key: String,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct UpdatePlannedTimeBlockPayload {
-    #[serde(default)]
-    date: Option<String>,
-    #[serde(rename = "type", default)]
-    block_type: Option<PlannedTimeBlockType>,
+struct UpdatePlannedSegmentPayload {
     #[serde(default)]
     title: Option<String>,
-    #[serde(default)]
-    planned_start_at: Option<u64>,
-    #[serde(default)]
-    planned_duration_minutes: Option<u64>,
-    #[serde(default)]
-    note: Option<Option<String>>,
     #[serde(default)]
     linked_task_ids: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct ReorderPlannedTimeBlocksPayload {
-    date: String,
-    ordered_ids: Vec<String>,
+struct ReflowWindowPayload {
+    anchor_segment_id: String,
+    actual_end_at: u64,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct TodayPlannerSnapshotResponse {
     date: String,
-    blocks: Vec<TodayPlannerBlockResponse>,
+    windows: Vec<SchedulingWindowResponse>,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct TodayPlannerBlockResponse {
+struct SchedulingWindowResponse {
     #[serde(flatten)]
-    block: PlannedTimeBlockData,
+    window: SchedulingWindowData,
+    segments: Vec<PlannedSegmentResponse>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PlannedSegmentResponse {
+    #[serde(flatten)]
+    segment: PlannedSegmentData,
     status: String,
     #[serde(rename = "sourceTimeBlockId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -144,14 +139,192 @@ fn normalize_linked_task_ids(task_ids: Vec<String>) -> Vec<String> {
     normalized
 }
 
+fn resolve_rhythm_preset(key: &str) -> Option<RhythmPresetData> {
+    match key.trim() {
+        "pomodoro_25_5" => Some(RhythmPresetData {
+            key: "pomodoro_25_5".to_string(),
+            label: "25 / 5".to_string(),
+            work_minutes: 25,
+            short_break_minutes: 5,
+            long_break_minutes: 20,
+            long_break_after_work_segments: 4,
+        }),
+        "focus_45_10" => Some(RhythmPresetData {
+            key: "focus_45_10".to_string(),
+            label: "45 / 10".to_string(),
+            work_minutes: 45,
+            short_break_minutes: 10,
+            long_break_minutes: 20,
+            long_break_after_work_segments: 3,
+        }),
+        "focus_45_15" => Some(RhythmPresetData {
+            key: "focus_45_15".to_string(),
+            label: "45 / 15".to_string(),
+            work_minutes: 45,
+            short_break_minutes: 15,
+            long_break_minutes: 25,
+            long_break_after_work_segments: 3,
+        }),
+        _ => None,
+    }
+}
+
+fn duration_minutes_from_segment(segment: &PlannedSegmentData) -> u64 {
+    let duration_ms = segment
+        .planned_end_at
+        .saturating_sub(segment.planned_start_at);
+    let rounded = duration_ms.div_ceil(60_000);
+    rounded.max(1)
+}
+
+fn generate_segments_for_window(
+    window_id: &str,
+    window_start_at: u64,
+    window_end_at: u64,
+    preset: &RhythmPresetData,
+    now: u64,
+) -> Vec<PlannedSegmentData> {
+    let mut cursor = window_start_at;
+    let mut order = 0i64;
+    let mut work_count = 0u32;
+    let mut segments = Vec::new();
+
+    while cursor < window_end_at {
+        let remaining_minutes = window_end_at.saturating_sub(cursor).div_ceil(60_000);
+        if remaining_minutes == 0 {
+            break;
+        }
+
+        let work_minutes = preset.work_minutes.min(remaining_minutes);
+        let work_end = (cursor + work_minutes * 60_000).min(window_end_at);
+        work_count += 1;
+        segments.push(PlannedSegmentData {
+            id: uuid::Uuid::new_v4().to_string(),
+            window_id: window_id.to_string(),
+            kind: PlannedSegmentKind::Work,
+            break_kind: None,
+            title: format!("Work {work_count}"),
+            planned_start_at: cursor,
+            planned_end_at: work_end,
+            linked_task_ids: Vec::new(),
+            order,
+            created_at: now,
+            updated_at: now,
+        });
+        order += 1;
+        cursor = work_end;
+
+        if cursor >= window_end_at {
+            break;
+        }
+
+        let remaining_after_work = window_end_at.saturating_sub(cursor).div_ceil(60_000);
+        if remaining_after_work == 0 {
+            break;
+        }
+        if remaining_after_work <= preset.short_break_minutes {
+            if let Some(last_work_segment) = segments.last_mut() {
+                last_work_segment.planned_end_at = window_end_at;
+                last_work_segment.updated_at = now;
+            }
+            break;
+        }
+
+        let use_long_break = preset.long_break_after_work_segments > 0
+            && work_count % preset.long_break_after_work_segments == 0
+            && remaining_after_work > preset.short_break_minutes;
+        let break_minutes = if use_long_break {
+            preset.long_break_minutes
+        } else {
+            preset.short_break_minutes
+        }
+        .min(remaining_after_work);
+        let break_end = (cursor + break_minutes * 60_000).min(window_end_at);
+
+        segments.push(PlannedSegmentData {
+            id: uuid::Uuid::new_v4().to_string(),
+            window_id: window_id.to_string(),
+            kind: PlannedSegmentKind::Break,
+            break_kind: Some(if use_long_break {
+                BreakWindowKind::Long
+            } else {
+                BreakWindowKind::Short
+            }),
+            title: if use_long_break {
+                "Long Break".to_string()
+            } else {
+                "Short Break".to_string()
+            },
+            planned_start_at: cursor,
+            planned_end_at: break_end,
+            linked_task_ids: Vec::new(),
+            order,
+            created_at: now,
+            updated_at: now,
+        });
+        order += 1;
+        cursor = break_end;
+    }
+
+    segments
+}
+
+fn build_segment_response(
+    segment: PlannedSegmentData,
+    active_block: Option<&ActiveBlockData>,
+    completed_blocks: &[crate::timeblock::TimeBlockData],
+) -> PlannedSegmentResponse {
+    if let Some(active) = active_block {
+        if active.source_planned_block_id.as_deref() == Some(segment.id.as_str()) {
+            return PlannedSegmentResponse {
+                segment,
+                status: "active".to_string(),
+                source_timeblock_id: Some(active.start_id.clone()),
+            };
+        }
+    }
+
+    if let Some(completed) = completed_blocks
+        .iter()
+        .find(|completed| completed.source_planned_block_id.as_deref() == Some(segment.id.as_str()))
+    {
+        return PlannedSegmentResponse {
+            segment,
+            status: "completed".to_string(),
+            source_timeblock_id: Some(completed.id.clone()),
+        };
+    }
+
+    PlannedSegmentResponse {
+        segment,
+        status: "pending".to_string(),
+        source_timeblock_id: None,
+    }
+}
+
+fn build_window_response(
+    window: SchedulingWindowData,
+    active_block: Option<&ActiveBlockData>,
+    completed_blocks: &[crate::timeblock::TimeBlockData],
+) -> SchedulingWindowResponse {
+    let segments = window
+        .segments
+        .clone()
+        .into_iter()
+        .map(|segment| build_segment_response(segment, active_block, completed_blocks))
+        .collect();
+
+    SchedulingWindowResponse { window, segments }
+}
+
 fn build_snapshot_response(
     state: &AppState,
     scope_key: Option<&str>,
     date: &str,
 ) -> Result<TodayPlannerSnapshotResponse, (StatusCode, Json<ErrorResponse>)> {
-    let blocks = state
+    let windows = state
         .timeblock_store
-        .list_planned_for_date_scoped(scope_key, date)
+        .list_windows_for_date_scoped(scope_key, date)
         .map_err(|error| internal_error(error.to_string()))?;
     let active_block = state
         .timeblock_store
@@ -162,41 +335,12 @@ fn build_snapshot_response(
         .list_completed_scoped(scope_key)
         .map_err(|error| internal_error(error.to_string()))?;
 
-    let block_responses = blocks
-        .into_iter()
-        .map(|block| {
-            if let Some(active) = active_block.as_ref() {
-                if active.source_planned_block_id.as_deref() == Some(block.id.as_str()) {
-                    return TodayPlannerBlockResponse {
-                        block,
-                        status: "active".to_string(),
-                        source_timeblock_id: Some(active.start_id.clone()),
-                    };
-                }
-            }
-
-            if let Some(completed) = completed_blocks
-                .iter()
-                .find(|completed| completed.source_planned_block_id.as_deref() == Some(block.id.as_str()))
-            {
-                return TodayPlannerBlockResponse {
-                    block,
-                    status: "completed".to_string(),
-                    source_timeblock_id: Some(completed.id.clone()),
-                };
-            }
-
-            TodayPlannerBlockResponse {
-                block,
-                status: "pending".to_string(),
-                source_timeblock_id: None,
-            }
-        })
-        .collect();
-
     Ok(TodayPlannerSnapshotResponse {
         date: date.to_string(),
-        blocks: block_responses,
+        windows: windows
+            .into_iter()
+            .map(|window| build_window_response(window, active_block.as_ref(), &completed_blocks))
+            .collect(),
     })
 }
 
@@ -208,210 +352,129 @@ async fn get_today_planner(
     Ok(Json(snapshot))
 }
 
-async fn create_planned_block(
+async fn create_window(
     State(state): State<AppState>,
     Query(query): Query<ScopeQuery>,
-    Json(payload): Json<CreatePlannedTimeBlockPayload>,
-) -> Result<(StatusCode, Json<TodayPlannerBlockResponse>), (StatusCode, Json<ErrorResponse>)> {
+    Json(payload): Json<CreateSchedulingWindowPayload>,
+) -> Result<(StatusCode, Json<SchedulingWindowResponse>), (StatusCode, Json<ErrorResponse>)> {
     if payload.date.trim().is_empty() {
         return Err(bad_request("date is required"));
     }
-    if payload.title.trim().is_empty() {
-        return Err(bad_request("title is required"));
+    if payload.planned_end_at <= payload.planned_start_at {
+        return Err(bad_request("plannedEndAt must be greater than plannedStartAt"));
     }
-    if payload.planned_duration_minutes == 0 {
-        return Err(bad_request("plannedDurationMinutes must be greater than 0"));
-    }
+    let preset = resolve_rhythm_preset(&payload.rhythm_preset_key)
+        .ok_or_else(|| bad_request("unknown rhythmPresetKey"))?;
 
     let scope_key = scope_key_from_query(&query);
-    let existing = state
-        .timeblock_store
-        .list_planned_for_date_scoped(scope_key, &payload.date)
-        .map_err(|error| internal_error(error.to_string()))?;
-    let next_order = existing.iter().map(|block| block.order).max().unwrap_or(-1) + 1;
     let now = chrono::Utc::now().timestamp_millis() as u64;
-    let block = PlannedTimeBlockData {
-        id: uuid::Uuid::new_v4().to_string(),
+    let window_id = uuid::Uuid::new_v4().to_string();
+    let window = SchedulingWindowData {
+        id: window_id.clone(),
         date: payload.date.trim().to_string(),
-        block_type: payload.block_type,
-        title: payload.title.trim().to_string(),
+        title: payload
+            .title
+            .map(|title| title.trim().to_string())
+            .filter(|title| !title.is_empty()),
         planned_start_at: payload.planned_start_at,
-        planned_duration_minutes: payload.planned_duration_minutes,
-        note: payload.note.and_then(|value| {
-            let trimmed = value.trim();
-            if trimmed.is_empty() {
-                None
-            } else {
-                Some(trimmed.to_string())
-            }
-        }),
-        linked_task_ids: normalize_linked_task_ids(payload.linked_task_ids),
-        order: next_order,
+        planned_end_at: payload.planned_end_at,
+        rhythm_preset: preset.clone(),
+        segments: generate_segments_for_window(
+            &window_id,
+            payload.planned_start_at,
+            payload.planned_end_at,
+            &preset,
+            now,
+        ),
         created_at: now,
         updated_at: now,
     };
 
     state
         .timeblock_store
-        .put_planned_scoped(scope_key, block.clone())
+        .put_window_scoped(scope_key, window.clone())
         .map_err(|error| internal_error(error.to_string()))?;
 
     Ok((
         StatusCode::CREATED,
-        Json(TodayPlannerBlockResponse {
-            block,
-            status: "pending".to_string(),
-            source_timeblock_id: None,
-        }),
+        Json(build_window_response(window, None, &[])),
     ))
 }
 
-async fn update_planned_block(
+async fn update_segment(
     State(state): State<AppState>,
-    Path(block_id): Path<String>,
+    Path(segment_id): Path<String>,
     Query(query): Query<ScopeQuery>,
-    Json(payload): Json<UpdatePlannedTimeBlockPayload>,
-) -> Result<Json<TodayPlannerBlockResponse>, (StatusCode, Json<ErrorResponse>)> {
+    Json(payload): Json<UpdatePlannedSegmentPayload>,
+) -> Result<Json<PlannedSegmentResponse>, (StatusCode, Json<ErrorResponse>)> {
     let scope_key = scope_key_from_query(&query);
-    let existing = state
+    let mut window = state
         .timeblock_store
-        .get_planned_scoped(scope_key, &block_id)
+        .get_window_by_segment_scoped(scope_key, &segment_id)
         .map_err(|error| internal_error(error.to_string()))?
-        .ok_or_else(|| not_found("planned block not found"))?;
+        .ok_or_else(|| not_found("planned segment not found"))?;
 
-    let next_title = payload
-        .title
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-        .unwrap_or(existing.title.clone());
-    let next_date = payload
-        .date
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-        .unwrap_or(existing.date.clone());
-    let next_duration = payload
-        .planned_duration_minutes
-        .unwrap_or(existing.planned_duration_minutes);
-    if next_duration == 0 {
-        return Err(bad_request("plannedDurationMinutes must be greater than 0"));
+    let segment = window
+        .segments
+        .iter_mut()
+        .find(|segment| segment.id == segment_id)
+        .ok_or_else(|| not_found("planned segment not found"))?;
+    if segment.kind != PlannedSegmentKind::Work {
+        return Err(bad_request("only work segments can be updated"));
     }
 
-    let updated = PlannedTimeBlockData {
-        id: existing.id.clone(),
-        date: next_date,
-        block_type: payload.block_type.unwrap_or(existing.block_type),
-        title: next_title,
-        planned_start_at: payload.planned_start_at.unwrap_or(existing.planned_start_at),
-        planned_duration_minutes: next_duration,
-        note: payload
-            .note
-            .map(|value| {
-                value.and_then(|inner| {
-                    let trimmed = inner.trim().to_string();
-                    if trimmed.is_empty() {
-                        None
-                    } else {
-                        Some(trimmed)
-                    }
-                })
-            })
-            .unwrap_or(existing.note.clone()),
-        linked_task_ids: payload
-            .linked_task_ids
-            .map(normalize_linked_task_ids)
-            .unwrap_or(existing.linked_task_ids.clone()),
-        order: existing.order,
-        created_at: existing.created_at,
-        updated_at: chrono::Utc::now().timestamp_millis() as u64,
-    };
-
-    state
-        .timeblock_store
-        .put_planned_scoped(scope_key, updated.clone())
-        .map_err(|error| internal_error(error.to_string()))?;
-
-    let snapshot = build_snapshot_response(&state, scope_key, &updated.date)?;
-    let response = snapshot
-        .blocks
-        .into_iter()
-        .find(|block| block.block.id == updated.id)
-        .ok_or_else(|| internal_error("updated planned block missing from snapshot".to_string()))?;
-    Ok(Json(response))
-}
-
-async fn reorder_planned_blocks(
-    State(state): State<AppState>,
-    Query(query): Query<ScopeQuery>,
-    Json(payload): Json<ReorderPlannedTimeBlocksPayload>,
-) -> Result<Json<TodayPlannerSnapshotResponse>, (StatusCode, Json<ErrorResponse>)> {
-    if payload.date.trim().is_empty() {
-        return Err(bad_request("date is required"));
-    }
-
-    let scope_key = scope_key_from_query(&query);
-    let mut all_blocks = state
-        .timeblock_store
-        .list_planned_scoped(scope_key)
-        .map_err(|error| internal_error(error.to_string()))?;
-
-    let ordered_ids = payload
-        .ordered_ids
-        .iter()
-        .map(|value| value.trim())
-        .filter(|value| !value.is_empty())
-        .collect::<Vec<_>>();
-    if ordered_ids.is_empty() {
-        return Err(bad_request("orderedIds is required"));
-    }
-
-    let mut next_order = 0i64;
-    for ordered_id in ordered_ids {
-        if let Some(block) = all_blocks
-            .iter_mut()
-            .find(|block| block.date == payload.date && block.id == ordered_id)
-        {
-            block.order = next_order;
-            block.updated_at = chrono::Utc::now().timestamp_millis() as u64;
-            next_order += 1;
+    if let Some(title) = payload.title {
+        let trimmed = title.trim();
+        if !trimmed.is_empty() {
+            segment.title = trimmed.to_string();
         }
     }
-
-    for block in all_blocks
-        .iter_mut()
-        .filter(|block| block.date == payload.date && !payload.ordered_ids.iter().any(|id| id == &block.id))
-    {
-        block.order = next_order;
-        block.updated_at = chrono::Utc::now().timestamp_millis() as u64;
-        next_order += 1;
+    if let Some(linked_task_ids) = payload.linked_task_ids {
+        segment.linked_task_ids = normalize_linked_task_ids(linked_task_ids);
     }
+    segment.updated_at = chrono::Utc::now().timestamp_millis() as u64;
+    window.updated_at = segment.updated_at;
 
     state
         .timeblock_store
-        .replace_planned_scoped(scope_key, &all_blocks)
+        .put_window_scoped(scope_key, window.clone())
         .map_err(|error| internal_error(error.to_string()))?;
 
-    Ok(Json(build_snapshot_response(
-        &state,
-        scope_key,
-        payload.date.trim(),
-    )?))
+    let active_block = state
+        .timeblock_store
+        .get_active_scoped(scope_key)
+        .map_err(|error| internal_error(error.to_string()))?;
+    let completed_blocks = state
+        .timeblock_store
+        .list_completed_scoped(scope_key)
+        .map_err(|error| internal_error(error.to_string()))?;
+    let updated_segment = window
+        .segments
+        .into_iter()
+        .find(|segment| segment.id == segment_id)
+        .ok_or_else(|| internal_error("updated segment missing from window".to_string()))?;
+
+    Ok(Json(build_segment_response(
+        updated_segment,
+        active_block.as_ref(),
+        &completed_blocks,
+    )))
 }
 
-async fn start_planned_block(
+async fn start_segment(
     State(state): State<AppState>,
-    Path(block_id): Path<String>,
+    Path(segment_id): Path<String>,
     Query(query): Query<ScopeQuery>,
 ) -> Result<Json<ActiveBlockData>, (StatusCode, Json<ErrorResponse>)> {
     let scope_key = scope_key_from_query(&query);
-    let planned_block = state
+    let segment = state
         .timeblock_store
-        .get_planned_scoped(scope_key, &block_id)
+        .get_segment_scoped(scope_key, &segment_id)
         .map_err(|error| internal_error(error.to_string()))?
-        .ok_or_else(|| not_found("planned block not found"))?;
+        .ok_or_else(|| not_found("planned segment not found"))?;
+    if segment.kind != PlannedSegmentKind::Work {
+        return Err(bad_request("only work segments can be started"));
+    }
 
     if let Some(active) = state
         .timeblock_store
@@ -431,7 +494,7 @@ async fn start_planned_block(
 
     let now = chrono::Utc::now().timestamp_millis() as u64;
     let start_id = uuid::Uuid::new_v4().to_string();
-    let task_association_log = planned_block
+    let task_association_log = segment
         .linked_task_ids
         .iter()
         .map(|task_id| BlockTaskAssociationEvent {
@@ -444,10 +507,10 @@ async fn start_planned_block(
         .collect::<Vec<_>>();
     let active_block = ActiveBlockData {
         start_id: start_id.clone(),
-        name: planned_block.title.clone(),
+        name: segment.title.clone(),
         mode: "countdown".to_string(),
-        target_minutes: Some(planned_block.planned_duration_minutes),
-        elapsed: planned_block.planned_duration_minutes * 60 * 1000,
+        target_minutes: Some(duration_minutes_from_segment(&segment)),
+        elapsed: duration_minutes_from_segment(&segment) * 60 * 1000,
         updated_at: Some(now),
         phase: Some("running".to_string()),
         version: Some(1),
@@ -462,9 +525,9 @@ async fn start_planned_block(
         pause_accumulated_ms: Some(0),
         paused: false,
         paused_at: None,
-        task_ids: planned_block.linked_task_ids.clone(),
+        task_ids: segment.linked_task_ids.clone(),
         task_association_log,
-        source_planned_block_id: Some(planned_block.id.clone()),
+        source_planned_block_id: Some(segment.id.clone()),
         task_id: None,
     };
 
@@ -484,25 +547,59 @@ async fn start_planned_block(
     Ok(Json(active_block))
 }
 
-async fn delete_planned_block(
+async fn reflow_window(
     State(state): State<AppState>,
-    Path(block_id): Path<String>,
+    Path(window_id): Path<String>,
     Query(query): Query<ScopeQuery>,
-) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    Json(payload): Json<ReflowWindowPayload>,
+) -> Result<Json<SchedulingWindowResponse>, (StatusCode, Json<ErrorResponse>)> {
     let scope_key = scope_key_from_query(&query);
-    let existing = state
+    let mut window = state
         .timeblock_store
-        .get_planned_scoped(scope_key, &block_id)
-        .map_err(|error| internal_error(error.to_string()))?;
-    if existing.is_none() {
-        return Err(not_found("planned block not found"));
+        .get_window_scoped(scope_key, &window_id)
+        .map_err(|error| internal_error(error.to_string()))?
+        .ok_or_else(|| not_found("planner window not found"))?;
+
+    let anchor_index = window
+        .segments
+        .iter()
+        .position(|segment| segment.id == payload.anchor_segment_id)
+        .ok_or_else(|| not_found("anchor segment not found"))?;
+    let anchor = window.segments[anchor_index].clone();
+    if payload.actual_end_at <= anchor.planned_start_at {
+        return Err(bad_request("actualEndAt must be after anchor segment start"));
     }
+
+    let delta = payload.actual_end_at as i128 - anchor.planned_end_at as i128;
+    if delta != 0 {
+        for segment in window.segments.iter_mut().skip(anchor_index + 1) {
+            segment.planned_start_at = segment.planned_start_at.saturating_add_signed(delta as i64);
+            segment.planned_end_at = segment.planned_end_at.saturating_add_signed(delta as i64);
+            segment.updated_at = chrono::Utc::now().timestamp_millis() as u64;
+        }
+        window.planned_end_at = window.planned_end_at.saturating_add_signed(delta as i64);
+    }
+    window.updated_at = chrono::Utc::now().timestamp_millis() as u64;
 
     state
         .timeblock_store
-        .delete_planned_scoped(scope_key, &block_id)
+        .put_window_scoped(scope_key, window.clone())
         .map_err(|error| internal_error(error.to_string()))?;
-    Ok(StatusCode::NO_CONTENT)
+
+    let active_block = state
+        .timeblock_store
+        .get_active_scoped(scope_key)
+        .map_err(|error| internal_error(error.to_string()))?;
+    let completed_blocks = state
+        .timeblock_store
+        .list_completed_scoped(scope_key)
+        .map_err(|error| internal_error(error.to_string()))?;
+
+    Ok(Json(build_window_response(
+        window,
+        active_block.as_ref(),
+        &completed_blocks,
+    )))
 }
 
 fn write_timeblock_eventlog(
@@ -544,17 +641,17 @@ fn write_timeblock_eventlog(
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/act/today-planner", get(get_today_planner))
-        .route("/act/today-planner/blocks", post(create_planned_block))
+        .route("/act/today-planner/windows", post(create_window))
         .route(
-            "/act/today-planner/blocks/reorder",
-            post(reorder_planned_blocks),
+            "/act/today-planner/windows/:window_id/reflow",
+            post(reflow_window),
         )
         .route(
-            "/act/today-planner/blocks/:block_id",
-            patch(update_planned_block).delete(delete_planned_block),
+            "/act/today-planner/segments/:segment_id",
+            patch(update_segment),
         )
         .route(
-            "/act/today-planner/blocks/:block_id/start",
-            post(start_planned_block),
+            "/act/today-planner/segments/:segment_id/start",
+            post(start_segment),
         )
 }

--- a/crates/exomind-runtime/src/routes/today_planner.rs
+++ b/crates/exomind-runtime/src/routes/today_planner.rs
@@ -64,9 +64,16 @@ struct TodayPlannerSnapshotResponse {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct SchedulingWindowResponse {
-    #[serde(flatten)]
-    window: SchedulingWindowData,
+    id: String,
+    date: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    planned_start_at: u64,
+    planned_end_at: u64,
+    rhythm_preset: RhythmPresetData,
     segments: Vec<PlannedSegmentResponse>,
+    created_at: u64,
+    updated_at: u64,
 }
 
 #[derive(Debug, Serialize)]
@@ -321,7 +328,17 @@ fn build_window_response(
         .map(|segment| build_segment_response(segment, active_block, completed_blocks))
         .collect();
 
-    SchedulingWindowResponse { window, segments }
+    SchedulingWindowResponse {
+        id: window.id,
+        date: window.date,
+        title: window.title,
+        planned_start_at: window.planned_start_at,
+        planned_end_at: window.planned_end_at,
+        rhythm_preset: window.rhythm_preset,
+        segments,
+        created_at: window.created_at,
+        updated_at: window.updated_at,
+    }
 }
 
 fn build_snapshot_response(
@@ -470,6 +487,11 @@ async fn update_segment(
     )))
 }
 
+fn can_replace_active_block_for_planner_start(active: &ActiveBlockData) -> bool {
+    matches!(active.phase.as_deref(), Some("feedback_submitted"))
+        || active.feedback_submitted_at.is_some()
+}
+
 async fn start_segment(
     State(state): State<AppState>,
     Path(segment_id): Path<String>,
@@ -490,13 +512,7 @@ async fn start_segment(
         .get_active_scoped(scope_key)
         .map_err(|error| internal_error(error.to_string()))?
     {
-        if !matches!(
-            active.phase.as_deref(),
-            Some("feedback_in_progress" | "feedback_submitted")
-        ) && active.action_ended_at.is_none()
-            && active.feedback_started_at.is_none()
-            && active.feedback_submitted_at.is_none()
-        {
+        if !can_replace_active_block_for_planner_start(&active) {
             return Err(conflict("active timeblock already exists"));
         }
     }
@@ -580,15 +596,20 @@ async fn reflow_window(
     }
 
     let delta = payload.actual_end_at as i128 - anchor.planned_end_at as i128;
+    let updated_at = chrono::Utc::now().timestamp_millis() as u64;
+    if let Some(anchor_segment) = window.segments.get_mut(anchor_index) {
+        anchor_segment.planned_end_at = payload.actual_end_at;
+        anchor_segment.updated_at = updated_at;
+    }
     if delta != 0 {
         for segment in window.segments.iter_mut().skip(anchor_index + 1) {
             segment.planned_start_at = segment.planned_start_at.saturating_add_signed(delta as i64);
             segment.planned_end_at = segment.planned_end_at.saturating_add_signed(delta as i64);
-            segment.updated_at = chrono::Utc::now().timestamp_millis() as u64;
+            segment.updated_at = updated_at;
         }
         window.planned_end_at = window.planned_end_at.saturating_add_signed(delta as i64);
     }
-    window.updated_at = chrono::Utc::now().timestamp_millis() as u64;
+    window.updated_at = updated_at;
 
     state
         .timeblock_store

--- a/crates/exomind-runtime/src/timeblock.rs
+++ b/crates/exomind-runtime/src/timeblock.rs
@@ -26,6 +26,34 @@ pub struct TimeBlockData {
     pub task_status_outcomes: Option<HashMap<String, String>>,
     #[serde(default)]
     pub task_association_log: Vec<BlockTaskAssociationEvent>,
+    #[serde(default)]
+    pub source_planned_block_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PlannedTimeBlockType {
+    Work,
+    Rest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PlannedTimeBlockData {
+    pub id: String,
+    pub date: String,
+    #[serde(rename = "type")]
+    pub block_type: PlannedTimeBlockType,
+    pub title: String,
+    pub planned_start_at: u64,
+    pub planned_duration_minutes: u64,
+    #[serde(default)]
+    pub note: Option<String>,
+    #[serde(default)]
+    pub linked_task_ids: Vec<String>,
+    pub order: i64,
+    pub created_at: u64,
+    pub updated_at: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -64,6 +92,8 @@ pub struct ActiveBlockData {
     pub task_ids: Vec<String>,
     #[serde(default)]
     pub task_association_log: Vec<BlockTaskAssociationEvent>,
+    #[serde(default)]
+    pub source_planned_block_id: Option<String>,
     /// Deprecated: legacy single-task field. Read for compat, never written.
     #[serde(default, skip_serializing)]
     pub task_id: Option<String>,
@@ -136,6 +166,7 @@ pub enum TimeBlockStoreBackendKind {
 struct TimeBlockScopeState {
     completed: Vec<TimeBlockData>,
     active: Option<ActiveBlockData>,
+    planned: Vec<PlannedTimeBlockData>,
 }
 
 enum TimeBlockStoreBackend {
@@ -171,6 +202,127 @@ impl TimeBlockStore {
 
     pub fn list_completed(&self) -> Result<Vec<TimeBlockData>, TimeBlockStoreError> {
         self.list_completed_scoped(None)
+    }
+
+    pub fn list_planned(&self) -> Result<Vec<PlannedTimeBlockData>, TimeBlockStoreError> {
+        self.list_planned_scoped(None)
+    }
+
+    pub fn list_planned_scoped(
+        &self,
+        scope_key: Option<&str>,
+    ) -> Result<Vec<PlannedTimeBlockData>, TimeBlockStoreError> {
+        match &self.backend {
+            TimeBlockStoreBackend::Memory(state) => Ok(sorted_planned_blocks(
+                state
+                    .read()
+                    .unwrap()
+                    .get(normalize_scope_key(scope_key))
+                    .map(|scope| scope.planned.clone())
+                    .unwrap_or_default(),
+            )),
+            TimeBlockStoreBackend::Sqlite(store) => {
+                store.list_planned_scoped(normalize_scope_key(scope_key))
+            }
+        }
+    }
+
+    pub fn list_planned_for_date_scoped(
+        &self,
+        scope_key: Option<&str>,
+        date: &str,
+    ) -> Result<Vec<PlannedTimeBlockData>, TimeBlockStoreError> {
+        let normalized_date = date.trim();
+        Ok(self
+            .list_planned_scoped(scope_key)?
+            .into_iter()
+            .filter(|block| block.date == normalized_date)
+            .collect())
+    }
+
+    pub fn get_planned_scoped(
+        &self,
+        scope_key: Option<&str>,
+        block_id: &str,
+    ) -> Result<Option<PlannedTimeBlockData>, TimeBlockStoreError> {
+        let normalized_block_id = block_id.trim();
+        if normalized_block_id.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(self
+            .list_planned_scoped(scope_key)?
+            .into_iter()
+            .find(|block| block.id == normalized_block_id))
+    }
+
+    pub fn replace_planned_scoped(
+        &self,
+        scope_key: Option<&str>,
+        blocks: &[PlannedTimeBlockData],
+    ) -> Result<(), TimeBlockStoreError> {
+        let sorted = sorted_planned_blocks(blocks.to_vec());
+        match &self.backend {
+            TimeBlockStoreBackend::Memory(state) => {
+                state
+                    .write()
+                    .unwrap()
+                    .entry(normalize_scope_key(scope_key).to_string())
+                    .or_default()
+                    .planned = sorted;
+                Ok(())
+            }
+            TimeBlockStoreBackend::Sqlite(store) => {
+                store.replace_planned_scoped(normalize_scope_key(scope_key), &sorted)
+            }
+        }
+    }
+
+    pub fn put_planned_scoped(
+        &self,
+        scope_key: Option<&str>,
+        block: PlannedTimeBlockData,
+    ) -> Result<(), TimeBlockStoreError> {
+        match &self.backend {
+            TimeBlockStoreBackend::Memory(state) => {
+                let mut guard = state.write().unwrap();
+                let scope = guard
+                    .entry(normalize_scope_key(scope_key).to_string())
+                    .or_default();
+                if let Some(index) = scope.planned.iter().position(|item| item.id == block.id) {
+                    scope.planned[index] = block;
+                } else {
+                    scope.planned.push(block);
+                }
+                scope.planned = sorted_planned_blocks(scope.planned.clone());
+                Ok(())
+            }
+            TimeBlockStoreBackend::Sqlite(store) => {
+                store.put_planned_scoped(normalize_scope_key(scope_key), &block)
+            }
+        }
+    }
+
+    pub fn delete_planned_scoped(
+        &self,
+        scope_key: Option<&str>,
+        block_id: &str,
+    ) -> Result<(), TimeBlockStoreError> {
+        match &self.backend {
+            TimeBlockStoreBackend::Memory(state) => {
+                if let Some(scope) = state
+                    .write()
+                    .unwrap()
+                    .get_mut(normalize_scope_key(scope_key))
+                {
+                    scope.planned.retain(|block| block.id != block_id);
+                }
+                Ok(())
+            }
+            TimeBlockStoreBackend::Sqlite(store) => {
+                store.delete_planned_scoped(normalize_scope_key(scope_key), block_id)
+            }
+        }
     }
 
     pub fn list_completed_scoped(
@@ -368,6 +520,17 @@ impl TimeBlockStore {
     }
 }
 
+fn sorted_planned_blocks(mut blocks: Vec<PlannedTimeBlockData>) -> Vec<PlannedTimeBlockData> {
+    blocks.sort_by(|left, right| {
+        left.date
+            .cmp(&right.date)
+            .then_with(|| left.order.cmp(&right.order))
+            .then_with(|| left.planned_start_at.cmp(&right.planned_start_at))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    blocks
+}
+
 impl Default for TimeBlockStore {
     fn default() -> Self {
         Self::new()
@@ -379,6 +542,27 @@ mod tests {
     use super::*;
     use serde_json::json;
     use tempfile::tempdir;
+
+    fn sample_planned_block(
+        id: &str,
+        date: &str,
+        block_type: PlannedTimeBlockType,
+        order: i64,
+    ) -> PlannedTimeBlockData {
+        PlannedTimeBlockData {
+            id: id.to_string(),
+            date: date.to_string(),
+            block_type,
+            title: format!("planned-{id}"),
+            planned_start_at: 1_700_000_000_000 + (order as u64 * 60_000),
+            planned_duration_minutes: 25,
+            note: Some("sample note".to_string()),
+            linked_task_ids: vec![format!("task-{id}")],
+            order,
+            created_at: 1_700_000_000_000,
+            updated_at: 1_700_000_000_000,
+        }
+    }
 
     #[test]
     fn sqlite_store_isolates_timeblocks_by_scope() {
@@ -410,6 +594,7 @@ mod tests {
                         timestamp: 1,
                         source: "block_start".to_string(),
                     }],
+                    source_planned_block_id: None,
                 }],
             )
             .unwrap();
@@ -428,6 +613,7 @@ mod tests {
                     task_ids: vec![],
                     task_status_outcomes: None,
                     task_association_log: vec![],
+                    source_planned_block_id: None,
                 }],
             )
             .unwrap();
@@ -463,6 +649,7 @@ mod tests {
                         timestamp: 10,
                         source: "block_start".to_string(),
                     }],
+                    source_planned_block_id: None,
                     task_id: None,
                 },
             )
@@ -551,5 +738,91 @@ mod tests {
         assert_eq!(normalized.task_ids, vec!["task-2".to_string()]);
         assert_eq!(serialized["taskIds"], json!(["task-2"]));
         assert!(serialized.get("taskId").is_none());
+    }
+
+    #[test]
+    fn sqlite_store_isolates_planned_timeblocks_by_scope() {
+        let dir = tempdir().unwrap();
+        let sqlite_path = dir.path().join("planned-timeblocks.sqlite");
+        let store = TimeBlockStore::with_sqlite_path(&sqlite_path).unwrap();
+
+        store
+            .replace_planned_scoped(
+                Some("profile-a"),
+                &[
+                    sample_planned_block("plan-a-1", "2026-03-26", PlannedTimeBlockType::Work, 1),
+                    sample_planned_block("plan-a-2", "2026-03-27", PlannedTimeBlockType::Rest, 2),
+                ],
+            )
+            .unwrap();
+        store
+            .replace_planned_scoped(
+                Some("profile-b"),
+                &[sample_planned_block(
+                    "plan-b-1",
+                    "2026-03-26",
+                    PlannedTimeBlockType::Rest,
+                    1,
+                )],
+            )
+            .unwrap();
+
+        let scoped_a_today = store
+            .list_planned_for_date_scoped(Some("profile-a"), "2026-03-26")
+            .unwrap();
+        let scoped_a_other_day = store
+            .list_planned_for_date_scoped(Some("profile-a"), "2026-03-27")
+            .unwrap();
+        let scoped_b_today = store
+            .list_planned_for_date_scoped(Some("profile-b"), "2026-03-26")
+            .unwrap();
+        let anonymous_today = store
+            .list_planned_for_date_scoped(None, "2026-03-26")
+            .unwrap();
+
+        assert_eq!(scoped_a_today.len(), 1);
+        assert_eq!(scoped_a_today[0].id, "plan-a-1");
+        assert_eq!(scoped_a_today[0].block_type, PlannedTimeBlockType::Work);
+        assert_eq!(scoped_a_other_day.len(), 1);
+        assert_eq!(scoped_a_other_day[0].id, "plan-a-2");
+        assert_eq!(scoped_b_today.len(), 1);
+        assert_eq!(scoped_b_today[0].id, "plan-b-1");
+        assert!(anonymous_today.is_empty());
+    }
+
+    #[test]
+    fn planned_block_provenance_round_trips_through_json() {
+        let active_block: ActiveBlockData = serde_json::from_value(json!({
+            "startId": "active-1",
+            "name": "Deep Work",
+            "mode": "countdown",
+            "targetMinutes": 50,
+            "elapsed": 120000,
+            "paused": false,
+            "startTime": 1_700_000_000_000u64,
+            "taskIds": ["task-a"],
+            "taskAssociationLog": [],
+            "sourcePlannedBlockId": "plan-1"
+        }))
+        .unwrap();
+        let completed_block: TimeBlockData = serde_json::from_value(json!({
+            "id": "tb-1",
+            "name": "Deep Work",
+            "startId": "active-1",
+            "endId": "end-1",
+            "tags": ["block_feedback"],
+            "startTime": 1_700_000_000_000u64,
+            "endTime": 1_700_000_300_000u64,
+            "taskIds": ["task-a"],
+            "taskAssociationLog": [],
+            "sourcePlannedBlockId": "plan-1"
+        }))
+        .unwrap();
+
+        let active_json = serde_json::to_value(active_block).unwrap();
+        let completed_json = serde_json::to_value(completed_block).unwrap();
+
+        assert_eq!(active_json["sourcePlannedBlockId"], json!("plan-1"));
+        assert_eq!(completed_json["sourcePlannedBlockId"], json!("plan-1"));
     }
 }

--- a/crates/exomind-runtime/src/timeblock.rs
+++ b/crates/exomind-runtime/src/timeblock.rs
@@ -58,6 +58,65 @@ pub struct PlannedTimeBlockData {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct RhythmPresetData {
+    pub key: String,
+    pub label: String,
+    pub work_minutes: u64,
+    pub short_break_minutes: u64,
+    pub long_break_minutes: u64,
+    pub long_break_after_work_segments: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PlannedSegmentKind {
+    Work,
+    Break,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum BreakWindowKind {
+    Short,
+    Long,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PlannedSegmentData {
+    pub id: String,
+    pub window_id: String,
+    pub kind: PlannedSegmentKind,
+    #[serde(default)]
+    pub break_kind: Option<BreakWindowKind>,
+    pub title: String,
+    pub planned_start_at: u64,
+    pub planned_end_at: u64,
+    #[serde(default)]
+    pub linked_task_ids: Vec<String>,
+    pub order: i64,
+    pub created_at: u64,
+    pub updated_at: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SchedulingWindowData {
+    pub id: String,
+    pub date: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    pub planned_start_at: u64,
+    pub planned_end_at: u64,
+    pub rhythm_preset: RhythmPresetData,
+    #[serde(default)]
+    pub segments: Vec<PlannedSegmentData>,
+    pub created_at: u64,
+    pub updated_at: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct BlockTaskAssociationEvent {
     pub block_id: String,
     pub task_id: String,
@@ -167,6 +226,7 @@ struct TimeBlockScopeState {
     completed: Vec<TimeBlockData>,
     active: Option<ActiveBlockData>,
     planned: Vec<PlannedTimeBlockData>,
+    windows: Vec<SchedulingWindowData>,
 }
 
 enum TimeBlockStoreBackend {
@@ -323,6 +383,160 @@ impl TimeBlockStore {
                 store.delete_planned_scoped(normalize_scope_key(scope_key), block_id)
             }
         }
+    }
+
+    pub fn list_windows(&self) -> Result<Vec<SchedulingWindowData>, TimeBlockStoreError> {
+        self.list_windows_scoped(None)
+    }
+
+    pub fn list_windows_scoped(
+        &self,
+        scope_key: Option<&str>,
+    ) -> Result<Vec<SchedulingWindowData>, TimeBlockStoreError> {
+        match &self.backend {
+            TimeBlockStoreBackend::Memory(state) => Ok(sorted_windows(
+                state
+                    .read()
+                    .unwrap()
+                    .get(normalize_scope_key(scope_key))
+                    .map(|scope| scope.windows.clone())
+                    .unwrap_or_default(),
+            )),
+            TimeBlockStoreBackend::Sqlite(store) => {
+                store.list_windows_scoped(normalize_scope_key(scope_key))
+            }
+        }
+    }
+
+    pub fn list_windows_for_date_scoped(
+        &self,
+        scope_key: Option<&str>,
+        date: &str,
+    ) -> Result<Vec<SchedulingWindowData>, TimeBlockStoreError> {
+        let normalized_date = date.trim();
+        Ok(self
+            .list_windows_scoped(scope_key)?
+            .into_iter()
+            .filter(|window| window.date == normalized_date)
+            .collect())
+    }
+
+    pub fn get_window_scoped(
+        &self,
+        scope_key: Option<&str>,
+        window_id: &str,
+    ) -> Result<Option<SchedulingWindowData>, TimeBlockStoreError> {
+        let normalized_window_id = window_id.trim();
+        if normalized_window_id.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(self
+            .list_windows_scoped(scope_key)?
+            .into_iter()
+            .find(|window| window.id == normalized_window_id))
+    }
+
+    pub fn replace_windows_scoped(
+        &self,
+        scope_key: Option<&str>,
+        windows: &[SchedulingWindowData],
+    ) -> Result<(), TimeBlockStoreError> {
+        let sorted = sorted_windows(windows.to_vec());
+        match &self.backend {
+            TimeBlockStoreBackend::Memory(state) => {
+                state
+                    .write()
+                    .unwrap()
+                    .entry(normalize_scope_key(scope_key).to_string())
+                    .or_default()
+                    .windows = sorted;
+                Ok(())
+            }
+            TimeBlockStoreBackend::Sqlite(store) => {
+                store.replace_windows_scoped(normalize_scope_key(scope_key), &sorted)
+            }
+        }
+    }
+
+    pub fn put_window_scoped(
+        &self,
+        scope_key: Option<&str>,
+        window: SchedulingWindowData,
+    ) -> Result<(), TimeBlockStoreError> {
+        match &self.backend {
+            TimeBlockStoreBackend::Memory(state) => {
+                let mut guard = state.write().unwrap();
+                let scope = guard
+                    .entry(normalize_scope_key(scope_key).to_string())
+                    .or_default();
+                if let Some(index) = scope.windows.iter().position(|item| item.id == window.id) {
+                    scope.windows[index] = normalize_window(window);
+                } else {
+                    scope.windows.push(normalize_window(window));
+                }
+                scope.windows = sorted_windows(scope.windows.clone());
+                Ok(())
+            }
+            TimeBlockStoreBackend::Sqlite(store) => {
+                store.put_window_scoped(normalize_scope_key(scope_key), &normalize_window(window))
+            }
+        }
+    }
+
+    pub fn delete_window_scoped(
+        &self,
+        scope_key: Option<&str>,
+        window_id: &str,
+    ) -> Result<(), TimeBlockStoreError> {
+        match &self.backend {
+            TimeBlockStoreBackend::Memory(state) => {
+                if let Some(scope) = state
+                    .write()
+                    .unwrap()
+                    .get_mut(normalize_scope_key(scope_key))
+                {
+                    scope.windows.retain(|window| window.id != window_id);
+                }
+                Ok(())
+            }
+            TimeBlockStoreBackend::Sqlite(store) => {
+                store.delete_window_scoped(normalize_scope_key(scope_key), window_id)
+            }
+        }
+    }
+
+    pub fn get_segment_scoped(
+        &self,
+        scope_key: Option<&str>,
+        segment_id: &str,
+    ) -> Result<Option<PlannedSegmentData>, TimeBlockStoreError> {
+        let normalized_segment_id = segment_id.trim();
+        if normalized_segment_id.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(self
+            .list_windows_scoped(scope_key)?
+            .into_iter()
+            .flat_map(|window| window.segments.into_iter())
+            .find(|segment| segment.id == normalized_segment_id))
+    }
+
+    pub fn get_window_by_segment_scoped(
+        &self,
+        scope_key: Option<&str>,
+        segment_id: &str,
+    ) -> Result<Option<SchedulingWindowData>, TimeBlockStoreError> {
+        let normalized_segment_id = segment_id.trim();
+        if normalized_segment_id.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(self
+            .list_windows_scoped(scope_key)?
+            .into_iter()
+            .find(|window| window.segments.iter().any(|segment| segment.id == normalized_segment_id)))
     }
 
     pub fn list_completed_scoped(
@@ -531,6 +745,38 @@ fn sorted_planned_blocks(mut blocks: Vec<PlannedTimeBlockData>) -> Vec<PlannedTi
     blocks
 }
 
+fn normalize_segment(mut segment: PlannedSegmentData) -> PlannedSegmentData {
+    segment.linked_task_ids.retain(|task_id| !task_id.trim().is_empty());
+    segment
+}
+
+fn sorted_segments(mut segments: Vec<PlannedSegmentData>) -> Vec<PlannedSegmentData> {
+    segments = segments.into_iter().map(normalize_segment).collect();
+    segments.sort_by(|left, right| {
+        left.order
+            .cmp(&right.order)
+            .then_with(|| left.planned_start_at.cmp(&right.planned_start_at))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    segments
+}
+
+fn normalize_window(mut window: SchedulingWindowData) -> SchedulingWindowData {
+    window.segments = sorted_segments(window.segments);
+    window
+}
+
+fn sorted_windows(mut windows: Vec<SchedulingWindowData>) -> Vec<SchedulingWindowData> {
+    windows = windows.into_iter().map(normalize_window).collect();
+    windows.sort_by(|left, right| {
+        left.date
+            .cmp(&right.date)
+            .then_with(|| left.planned_start_at.cmp(&right.planned_start_at))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    windows
+}
+
 impl Default for TimeBlockStore {
     fn default() -> Self {
         Self::new()
@@ -561,6 +807,59 @@ mod tests {
             order,
             created_at: 1_700_000_000_000,
             updated_at: 1_700_000_000_000,
+        }
+    }
+
+    fn sample_window(
+        id: &str,
+        date: &str,
+        start_at: u64,
+        end_at: u64,
+    ) -> SchedulingWindowData {
+        SchedulingWindowData {
+            id: id.to_string(),
+            date: date.to_string(),
+            title: Some(format!("window-{id}")),
+            planned_start_at: start_at,
+            planned_end_at: end_at,
+            rhythm_preset: RhythmPresetData {
+                key: "pomodoro_25_5".to_string(),
+                label: "25 / 5".to_string(),
+                work_minutes: 25,
+                short_break_minutes: 5,
+                long_break_minutes: 20,
+                long_break_after_work_segments: 4,
+            },
+            segments: vec![
+                PlannedSegmentData {
+                    id: format!("{id}-work-1"),
+                    window_id: id.to_string(),
+                    kind: PlannedSegmentKind::Work,
+                    break_kind: None,
+                    title: "Work 1".to_string(),
+                    planned_start_at: start_at,
+                    planned_end_at: start_at + 25 * 60_000,
+                    linked_task_ids: vec!["task-a".to_string()],
+                    order: 0,
+                    created_at: start_at,
+                    updated_at: start_at,
+                },
+                PlannedSegmentData {
+                    id: format!("{id}-break-1"),
+                    window_id: id.to_string(),
+                    kind: PlannedSegmentKind::Break,
+                    break_kind: Some(BreakWindowKind::Short),
+                    title: "Short Break".to_string(),
+                    planned_start_at: start_at + 25 * 60_000,
+                    planned_end_at: start_at + 30 * 60_000,
+                    linked_task_ids: vec![],
+                    order: 1,
+                    created_at: start_at,
+                    updated_at: start_at,
+                },
+            ],
+            created_at: start_at,
+            updated_at: start_at,
         }
     }
 
@@ -824,5 +1123,57 @@ mod tests {
 
         assert_eq!(active_json["sourcePlannedBlockId"], json!("plan-1"));
         assert_eq!(completed_json["sourcePlannedBlockId"], json!("plan-1"));
+    }
+
+    #[test]
+    fn sqlite_store_isolates_planner_windows_by_scope() {
+        let dir = tempdir().unwrap();
+        let sqlite_path = dir.path().join("planner-windows.sqlite");
+        let store = TimeBlockStore::with_sqlite_path(&sqlite_path).unwrap();
+
+        store
+            .replace_windows_scoped(
+                Some("profile-a"),
+                &[sample_window(
+                    "window-a",
+                    "2026-03-27",
+                    1_774_570_800_000,
+                    1_774_579_800_000,
+                )],
+            )
+            .unwrap();
+        store
+            .replace_windows_scoped(
+                Some("profile-b"),
+                &[sample_window(
+                    "window-b",
+                    "2026-03-27",
+                    1_774_581_600_000,
+                    1_774_586_100_000,
+                )],
+            )
+            .unwrap();
+
+        let scoped_a = store
+            .list_windows_for_date_scoped(Some("profile-a"), "2026-03-27")
+            .unwrap();
+        let scoped_b = store
+            .list_windows_for_date_scoped(Some("profile-b"), "2026-03-27")
+            .unwrap();
+        let anonymous = store
+            .list_windows_for_date_scoped(None, "2026-03-27")
+            .unwrap();
+
+        assert_eq!(scoped_a.len(), 1);
+        assert_eq!(scoped_a[0].id, "window-a");
+        assert_eq!(scoped_a[0].segments.len(), 2);
+        assert_eq!(scoped_a[0].segments[0].kind, PlannedSegmentKind::Work);
+        assert_eq!(
+            scoped_a[0].segments[1].break_kind,
+            Some(BreakWindowKind::Short)
+        );
+        assert_eq!(scoped_b.len(), 1);
+        assert_eq!(scoped_b[0].id, "window-b");
+        assert!(anonymous.is_empty());
     }
 }

--- a/crates/exomind-runtime/src/timeblock_sqlite.rs
+++ b/crates/exomind-runtime/src/timeblock_sqlite.rs
@@ -3,7 +3,10 @@ use std::sync::Mutex;
 
 use rusqlite::{Connection, OptionalExtension, params};
 
-use crate::timeblock::{ActiveBlockData, TimeBlockData, TimeBlockStoreError};
+use crate::timeblock::{
+    ActiveBlockData, PlannedTimeBlockData, PlannedTimeBlockType, TimeBlockData,
+    TimeBlockStoreError,
+};
 
 const ACTIVE_BLOCK_SINGLETON_KEY: &str = "current";
 const DEFAULT_SCOPE_KEY: &str = "anonymous";
@@ -39,7 +42,8 @@ impl SqliteTimeBlockStore {
         let connection = self.connection();
         let mut statement = connection.prepare(
             "SELECT id, name, start_id, end_id, note, tags_json, start_time, end_time,
-                    task_ids_json, task_status_outcomes_json, task_association_log_json
+                    task_ids_json, task_status_outcomes_json, task_association_log_json,
+                    source_planned_block_id
              FROM completed_timeblocks
              WHERE scope_key = ?1
              ORDER BY end_time DESC, id DESC",
@@ -64,6 +68,7 @@ impl SqliteTimeBlockStore {
                     .transpose()?,
                 task_association_log: serde_json::from_str(&row.get::<_, String>(10)?)
                     .map_err(to_sqlite_conversion_error)?,
+                source_planned_block_id: row.get(11)?,
             })
         })?;
 
@@ -90,8 +95,9 @@ impl SqliteTimeBlockStore {
             tx.execute(
                 "INSERT OR REPLACE INTO completed_timeblocks (
                     scope_key, id, name, start_id, end_id, note, tags_json, start_time, end_time,
-                    task_ids_json, task_status_outcomes_json, task_association_log_json
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                    task_ids_json, task_status_outcomes_json, task_association_log_json,
+                    source_planned_block_id
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
                 params![
                     normalize_scope_key(scope_key),
                     block.id,
@@ -109,10 +115,86 @@ impl SqliteTimeBlockStore {
                         .map(serde_json::to_string)
                         .transpose()?,
                     serde_json::to_string(&block.task_association_log)?,
+                    block.source_planned_block_id,
                 ],
             )?;
         }
         tx.commit()?;
+        Ok(())
+    }
+
+    pub fn list_planned_scoped(
+        &self,
+        scope_key: &str,
+    ) -> Result<Vec<PlannedTimeBlockData>, TimeBlockStoreError> {
+        let connection = self.connection();
+        let mut statement = connection.prepare(
+            "SELECT id, date, block_type, title, planned_start_at, planned_duration_minutes, note,
+                    linked_task_ids_json, block_order, created_at, updated_at
+             FROM planned_timeblocks
+             WHERE scope_key = ?1
+             ORDER BY date ASC, block_order ASC, planned_start_at ASC, id ASC",
+        )?;
+
+        let rows = statement.query_map(params![normalize_scope_key(scope_key)], |row| {
+            let block_type: String = row.get(2)?;
+            Ok(PlannedTimeBlockData {
+                id: row.get(0)?,
+                date: row.get(1)?,
+                block_type: parse_planned_block_type(&block_type)?,
+                title: row.get(3)?,
+                planned_start_at: row.get(4)?,
+                planned_duration_minutes: row.get(5)?,
+                note: row.get(6)?,
+                linked_task_ids: serde_json::from_str::<Vec<String>>(&row.get::<_, String>(7)?)
+                    .map_err(to_sqlite_conversion_error)?,
+                order: row.get(8)?,
+                created_at: row.get(9)?,
+                updated_at: row.get(10)?,
+            })
+        })?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(TimeBlockStoreError::from)
+    }
+
+    pub fn replace_planned_scoped(
+        &self,
+        scope_key: &str,
+        blocks: &[PlannedTimeBlockData],
+    ) -> Result<(), TimeBlockStoreError> {
+        let mut connection = self.connection();
+        let tx = connection.transaction()?;
+        tx.execute(
+            "DELETE FROM planned_timeblocks WHERE scope_key = ?1",
+            params![normalize_scope_key(scope_key)],
+        )?;
+        for block in blocks {
+            insert_or_replace_planned_block(&tx, scope_key, block)?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn put_planned_scoped(
+        &self,
+        scope_key: &str,
+        block: &PlannedTimeBlockData,
+    ) -> Result<(), TimeBlockStoreError> {
+        let connection = self.connection();
+        insert_or_replace_planned_block(&connection, scope_key, block)
+    }
+
+    pub fn delete_planned_scoped(
+        &self,
+        scope_key: &str,
+        block_id: &str,
+    ) -> Result<(), TimeBlockStoreError> {
+        let connection = self.connection();
+        connection.execute(
+            "DELETE FROM planned_timeblocks WHERE scope_key = ?1 AND id = ?2",
+            params![normalize_scope_key(scope_key), block_id],
+        )?;
         Ok(())
     }
 
@@ -279,6 +361,16 @@ impl SqliteTimeBlockStore {
                     [],
                 )?;
             }
+
+            if !columns
+                .iter()
+                .any(|column| column == "source_planned_block_id")
+            {
+                connection.execute(
+                    "ALTER TABLE completed_timeblocks ADD COLUMN source_planned_block_id TEXT NULL",
+                    [],
+                )?;
+            }
         }
 
         let has_active_table: bool = connection.query_row(
@@ -324,6 +416,7 @@ impl SqliteTimeBlockStore {
                 task_ids_json TEXT NOT NULL DEFAULT '[]',
                 task_status_outcomes_json TEXT NULL,
                 task_association_log_json TEXT NOT NULL DEFAULT '[]',
+                source_planned_block_id TEXT NULL,
                 PRIMARY KEY (scope_key, id)
              );
              CREATE TABLE IF NOT EXISTS active_timeblock (
@@ -331,6 +424,21 @@ impl SqliteTimeBlockStore {
                 singleton_key TEXT NOT NULL,
                 payload_json TEXT NOT NULL,
                 PRIMARY KEY (scope_key, singleton_key)
+             );
+             CREATE TABLE IF NOT EXISTS planned_timeblocks (
+                scope_key TEXT NOT NULL,
+                id TEXT NOT NULL,
+                date TEXT NOT NULL,
+                block_type TEXT NOT NULL,
+                title TEXT NOT NULL,
+                planned_start_at INTEGER NOT NULL,
+                planned_duration_minutes INTEGER NOT NULL,
+                note TEXT NULL,
+                linked_task_ids_json TEXT NOT NULL DEFAULT '[]',
+                block_order INTEGER NOT NULL,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (scope_key, id)
              );",
         )?;
         Ok(())
@@ -358,6 +466,66 @@ fn completed_timeblock_columns(
         .query_map([], |row| row.get::<_, String>(1))?
         .collect::<Result<Vec<_>, _>>()
         .map_err(TimeBlockStoreError::from)
+}
+
+fn insert_or_replace_planned_block(
+    connection: &Connection,
+    scope_key: &str,
+    block: &PlannedTimeBlockData,
+) -> Result<(), TimeBlockStoreError> {
+    connection.execute(
+        "INSERT INTO planned_timeblocks (
+            scope_key, id, date, block_type, title, planned_start_at, planned_duration_minutes,
+            note, linked_task_ids_json, block_order, created_at, updated_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+         ON CONFLICT(scope_key, id) DO UPDATE SET
+            date = excluded.date,
+            block_type = excluded.block_type,
+            title = excluded.title,
+            planned_start_at = excluded.planned_start_at,
+            planned_duration_minutes = excluded.planned_duration_minutes,
+            note = excluded.note,
+            linked_task_ids_json = excluded.linked_task_ids_json,
+            block_order = excluded.block_order,
+            created_at = excluded.created_at,
+            updated_at = excluded.updated_at",
+        params![
+            normalize_scope_key(scope_key),
+            block.id,
+            block.date,
+            planned_block_type_to_str(&block.block_type),
+            block.title,
+            block.planned_start_at,
+            block.planned_duration_minutes,
+            block.note,
+            serde_json::to_string(&block.linked_task_ids)?,
+            block.order,
+            block.created_at,
+            block.updated_at,
+        ],
+    )?;
+    Ok(())
+}
+
+fn planned_block_type_to_str(value: &PlannedTimeBlockType) -> &'static str {
+    match value {
+        PlannedTimeBlockType::Work => "work",
+        PlannedTimeBlockType::Rest => "rest",
+    }
+}
+
+fn parse_planned_block_type(value: &str) -> Result<PlannedTimeBlockType, rusqlite::Error> {
+    match value {
+        "work" => Ok(PlannedTimeBlockType::Work),
+        "rest" => Ok(PlannedTimeBlockType::Rest),
+        other => Err(rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::other(format!(
+                "invalid planned block type: {other}"
+            ))),
+        )),
+    }
 }
 
 fn to_sqlite_conversion_error(error: serde_json::Error) -> rusqlite::Error {

--- a/crates/exomind-runtime/src/timeblock_sqlite.rs
+++ b/crates/exomind-runtime/src/timeblock_sqlite.rs
@@ -4,8 +4,8 @@ use std::sync::Mutex;
 use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::timeblock::{
-    ActiveBlockData, PlannedTimeBlockData, PlannedTimeBlockType, TimeBlockData,
-    TimeBlockStoreError,
+    ActiveBlockData, PlannedTimeBlockData, PlannedTimeBlockType, SchedulingWindowData,
+    TimeBlockData, TimeBlockStoreError,
 };
 
 const ACTIVE_BLOCK_SINGLETON_KEY: &str = "current";
@@ -194,6 +194,78 @@ impl SqliteTimeBlockStore {
         connection.execute(
             "DELETE FROM planned_timeblocks WHERE scope_key = ?1 AND id = ?2",
             params![normalize_scope_key(scope_key), block_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn list_windows_scoped(
+        &self,
+        scope_key: &str,
+    ) -> Result<Vec<SchedulingWindowData>, TimeBlockStoreError> {
+        let connection = self.connection();
+        let mut statement = connection.prepare(
+            "SELECT id, date, title, planned_start_at, planned_end_at, preset_json, segments_json, created_at, updated_at
+             FROM planner_windows
+             WHERE scope_key = ?1
+             ORDER BY date ASC, planned_start_at ASC, id ASC",
+        )?;
+
+        let rows = statement.query_map(params![normalize_scope_key(scope_key)], |row| {
+            Ok(SchedulingWindowData {
+                id: row.get(0)?,
+                date: row.get(1)?,
+                title: row.get(2)?,
+                planned_start_at: row.get(3)?,
+                planned_end_at: row.get(4)?,
+                rhythm_preset: serde_json::from_str(&row.get::<_, String>(5)?)
+                    .map_err(to_sqlite_conversion_error)?,
+                segments: serde_json::from_str(&row.get::<_, String>(6)?)
+                    .map_err(to_sqlite_conversion_error)?,
+                created_at: row.get(7)?,
+                updated_at: row.get(8)?,
+            })
+        })?;
+
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(TimeBlockStoreError::from)
+    }
+
+    pub fn replace_windows_scoped(
+        &self,
+        scope_key: &str,
+        windows: &[SchedulingWindowData],
+    ) -> Result<(), TimeBlockStoreError> {
+        let mut connection = self.connection();
+        let tx = connection.transaction()?;
+        tx.execute(
+            "DELETE FROM planner_windows WHERE scope_key = ?1",
+            params![normalize_scope_key(scope_key)],
+        )?;
+        for window in windows {
+            insert_or_replace_window(&tx, scope_key, window)?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn put_window_scoped(
+        &self,
+        scope_key: &str,
+        window: &SchedulingWindowData,
+    ) -> Result<(), TimeBlockStoreError> {
+        let connection = self.connection();
+        insert_or_replace_window(&connection, scope_key, window)
+    }
+
+    pub fn delete_window_scoped(
+        &self,
+        scope_key: &str,
+        window_id: &str,
+    ) -> Result<(), TimeBlockStoreError> {
+        let connection = self.connection();
+        connection.execute(
+            "DELETE FROM planner_windows WHERE scope_key = ?1 AND id = ?2",
+            params![normalize_scope_key(scope_key), window_id],
         )?;
         Ok(())
     }
@@ -439,6 +511,19 @@ impl SqliteTimeBlockStore {
                 created_at INTEGER NOT NULL,
                 updated_at INTEGER NOT NULL,
                 PRIMARY KEY (scope_key, id)
+             );
+             CREATE TABLE IF NOT EXISTS planner_windows (
+                scope_key TEXT NOT NULL,
+                id TEXT NOT NULL,
+                date TEXT NOT NULL,
+                title TEXT NULL,
+                planned_start_at INTEGER NOT NULL,
+                planned_end_at INTEGER NOT NULL,
+                preset_json TEXT NOT NULL,
+                segments_json TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (scope_key, id)
              );",
         )?;
         Ok(())
@@ -502,6 +587,40 @@ fn insert_or_replace_planned_block(
             block.order,
             block.created_at,
             block.updated_at,
+        ],
+    )?;
+    Ok(())
+}
+
+fn insert_or_replace_window(
+    connection: &Connection,
+    scope_key: &str,
+    window: &SchedulingWindowData,
+) -> Result<(), TimeBlockStoreError> {
+    connection.execute(
+        "INSERT INTO planner_windows (
+            scope_key, id, date, title, planned_start_at, planned_end_at, preset_json, segments_json, created_at, updated_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+         ON CONFLICT(scope_key, id) DO UPDATE SET
+            date = excluded.date,
+            title = excluded.title,
+            planned_start_at = excluded.planned_start_at,
+            planned_end_at = excluded.planned_end_at,
+            preset_json = excluded.preset_json,
+            segments_json = excluded.segments_json,
+            created_at = excluded.created_at,
+            updated_at = excluded.updated_at",
+        params![
+            normalize_scope_key(scope_key),
+            window.id,
+            window.date,
+            window.title,
+            window.planned_start_at,
+            window.planned_end_at,
+            serde_json::to_string(&window.rhythm_preset)?,
+            serde_json::to_string(&window.segments)?,
+            window.created_at,
+            window.updated_at,
         ],
     )?;
     Ok(())

--- a/crates/exomind-runtime/tests/timeblock_routes.rs
+++ b/crates/exomind-runtime/tests/timeblock_routes.rs
@@ -176,6 +176,7 @@ async fn exports_sqlite_snapshot_and_backend_status() {
                 timestamp: 1700000000000,
                 source: "block_start".to_string(),
             }],
+            source_planned_block_id: None,
         }])
         .unwrap();
     let app = test_router(test_state_with_timeblock_store(store));
@@ -250,6 +251,7 @@ async fn imports_json_backup_with_overwrite() {
             task_ids: vec![],
             task_status_outcomes: None,
             task_association_log: vec![],
+            source_planned_block_id: None,
         }])
         .unwrap();
 

--- a/crates/exomind-runtime/tests/timeblock_runtime_sqlite_persistence.rs
+++ b/crates/exomind-runtime/tests/timeblock_runtime_sqlite_persistence.rs
@@ -51,6 +51,7 @@ fn app_state_runtime_reuses_timeblock_sqlite_storage_for_completed_and_active() 
                 timestamp: 1_700_000_000_000,
                 source: "block_start".to_string(),
             }],
+            source_planned_block_id: None,
         }])
         .unwrap();
 
@@ -84,6 +85,7 @@ fn app_state_runtime_reuses_timeblock_sqlite_storage_for_completed_and_active() 
                 timestamp: 1_700_000_000_000,
                 source: "block_start".to_string(),
             }],
+            source_planned_block_id: None,
             task_id: Some("task-1".to_string()),
         })
         .unwrap();
@@ -156,6 +158,7 @@ fn app_state_runtime_reuses_timeblock_sqlite_storage_with_profile_scope() {
             task_ids: vec![],
             task_status_outcomes: None,
             task_association_log: vec![],
+            source_planned_block_id: None,
         }])
         .unwrap();
 
@@ -184,6 +187,7 @@ fn app_state_runtime_reuses_timeblock_sqlite_storage_with_profile_scope() {
                     timestamp: 1_700_000_100_000,
                     source: "block_start".to_string(),
                 }],
+                source_planned_block_id: None,
             }],
         )
         .unwrap();
@@ -220,6 +224,7 @@ fn app_state_runtime_reuses_timeblock_sqlite_storage_with_profile_scope() {
                     timestamp: 1_700_000_100_000,
                     source: "block_start".to_string(),
                 }],
+                source_planned_block_id: None,
                 task_id: Some("task-profile-a".to_string()),
             },
         )
@@ -301,6 +306,7 @@ fn timeblock_store_clearing_active_block_preserves_completed_blocks() {
             task_ids: vec![],
             task_status_outcomes: None,
             task_association_log: vec![],
+            source_planned_block_id: None,
         }])
         .unwrap();
 
@@ -327,6 +333,7 @@ fn timeblock_store_clearing_active_block_preserves_completed_blocks() {
             paused_at: Some(1_700_000_120_000),
             task_ids: vec![],
             task_association_log: vec![],
+            source_planned_block_id: None,
             task_id: None,
         })
         .unwrap();

--- a/crates/exomind-runtime/tests/today_planner_routes.rs
+++ b/crates/exomind-runtime/tests/today_planner_routes.rs
@@ -1,0 +1,267 @@
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use exomind_runtime::AppState;
+use exomind_runtime::mesh::MeshState;
+use exomind_runtime::routes;
+use exomind_runtime::signal::SignalPool;
+use exomind_runtime::timeblock::TimeBlockStore;
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tempfile::tempdir;
+use tower::ServiceExt;
+
+fn test_state_with_timeblock_store(timeblock_store: Arc<TimeBlockStore>) -> AppState {
+    let signal_pool = Arc::new(SignalPool::new(None));
+    let host_id = "today-planner-test-host".to_string();
+    let registry = exomind_runtime::agent::AgentRegistry::new();
+    let energy_registry = exomind_runtime::energy::EnergyRegistry::new();
+    AppState {
+        port: 0,
+        host_id: host_id.clone(),
+        registry: registry.clone(),
+        signal_pool: Arc::clone(&signal_pool),
+        mesh: Arc::new(MeshState::new(
+            host_id.clone(),
+            Arc::clone(&signal_pool),
+            None,
+        )),
+        mesh_relay: None,
+        auth_secret: None,
+        mdns: None,
+        pairing: Arc::new(exomind_runtime::pairing::PairingManager::new()),
+        task_store: Arc::new(exomind_runtime::task::TaskStore::new()),
+        session_store: Arc::new(exomind_runtime::session::SessionStore::new()),
+        session_event_tx: None,
+        eventlog_watch_tx: {
+            let (tx, _rx) = exomind_runtime::routes::eventlog::eventlog_watch_channel();
+            tx
+        },
+        timeblock_store,
+        energy_registry: energy_registry.clone(),
+        tick_manager: Arc::new(exomind_runtime::tick::TickManager::new(
+            host_id.clone(),
+            registry,
+            energy_registry,
+            Arc::clone(&signal_pool),
+        )),
+        life_agents: std::collections::HashMap::new(),
+        eventlog_store: Arc::new(exomind_runtime::eventlog::EventLogStore::new(
+            std::env::temp_dir().join("exomind-test-today-planner"),
+        )),
+        #[cfg(not(target_os = "android"))]
+        pty_manager: Arc::new(exomind_runtime::pty::PtyManager::new(
+            Arc::clone(&signal_pool),
+            host_id,
+        )),
+    }
+}
+
+fn test_router(state: AppState) -> Router {
+    routes::router().with_state(state)
+}
+
+#[tokio::test]
+async fn today_planner_routes_create_reorder_and_start_blocks() {
+    let dir = tempdir().unwrap();
+    let sqlite_path = dir.path().join("today-planner.sqlite");
+    let store = Arc::new(TimeBlockStore::with_sqlite_path(&sqlite_path).unwrap());
+    let app = test_router(test_state_with_timeblock_store(store));
+
+    let create_work_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/act/today-planner/blocks?user_id=user-a")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "date": "2026-03-26",
+                        "type": "work",
+                        "title": "Deep Work",
+                        "plannedStartAt": 1774490400000u64,
+                        "plannedDurationMinutes": 50,
+                        "note": "ship vertical slice",
+                        "linkedTaskIds": ["task-a"],
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(create_work_response.status(), StatusCode::CREATED);
+    let work_body = create_work_response
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes();
+    let work_payload: Value = serde_json::from_slice(&work_body).unwrap();
+    let work_id = work_payload["id"].as_str().unwrap().to_string();
+    assert_eq!(work_payload["type"], "work");
+    assert_eq!(work_payload["status"], "pending");
+
+    let create_rest_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/act/today-planner/blocks?user_id=user-a")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "date": "2026-03-26",
+                        "type": "rest",
+                        "title": "Lunch Reset",
+                        "plannedStartAt": 1774494000000u64,
+                        "plannedDurationMinutes": 30,
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(create_rest_response.status(), StatusCode::CREATED);
+    let rest_body = create_rest_response
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes();
+    let rest_payload: Value = serde_json::from_slice(&rest_body).unwrap();
+    let rest_id = rest_payload["id"].as_str().unwrap().to_string();
+
+    let list_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/act/today-planner?date=2026-03-26&user_id=user-a")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(list_response.status(), StatusCode::OK);
+    let list_body = list_response.into_body().collect().await.unwrap().to_bytes();
+    let list_payload: Value = serde_json::from_slice(&list_body).unwrap();
+    assert_eq!(list_payload["date"], "2026-03-26");
+    assert_eq!(list_payload["blocks"][0]["id"], work_id);
+    assert_eq!(list_payload["blocks"][1]["id"], rest_id);
+
+    let reorder_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/act/today-planner/blocks/reorder?user_id=user-a")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "date": "2026-03-26",
+                        "orderedIds": [rest_id, work_id],
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(reorder_response.status(), StatusCode::OK);
+
+    let update_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(&format!(
+                    "/act/today-planner/blocks/{rest_id}?user_id=user-a"
+                ))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "title": "Lunch + Walk",
+                        "plannedDurationMinutes": 40,
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(update_response.status(), StatusCode::OK);
+    let update_body = update_response
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes();
+    let update_payload: Value = serde_json::from_slice(&update_body).unwrap();
+    assert_eq!(update_payload["title"], "Lunch + Walk");
+    assert_eq!(update_payload["plannedDurationMinutes"], 40);
+
+    let start_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!(
+                    "/act/today-planner/blocks/{rest_id}/start?user_id=user-a"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(start_response.status(), StatusCode::OK);
+    let start_body = start_response
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes();
+    let start_payload: Value = serde_json::from_slice(&start_body).unwrap();
+    assert_eq!(start_payload["sourcePlannedBlockId"], rest_id);
+    assert_eq!(start_payload["targetMinutes"], 40);
+
+    let after_start_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/act/today-planner?date=2026-03-26&user_id=user-a")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(after_start_response.status(), StatusCode::OK);
+    let after_start_body = after_start_response
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes();
+    let after_start_payload: Value = serde_json::from_slice(&after_start_body).unwrap();
+    assert_eq!(after_start_payload["blocks"][0]["id"], rest_id);
+    assert_eq!(after_start_payload["blocks"][0]["status"], "active");
+
+    let delete_response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(&format!(
+                    "/act/today-planner/blocks/{work_id}?user_id=user-a"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(delete_response.status(), StatusCode::NO_CONTENT);
+}

--- a/crates/exomind-runtime/tests/today_planner_routes.rs
+++ b/crates/exomind-runtime/tests/today_planner_routes.rs
@@ -211,3 +211,68 @@ async fn today_planner_windows_create_start_and_reflow() {
     assert_eq!(list_payload["windows"][0]["id"], window_id);
     assert_eq!(list_payload["windows"][0]["segments"][0]["status"], "active");
 }
+
+#[tokio::test]
+async fn today_planner_work_segment_inherits_window_title_before_edit() {
+    let dir = tempdir().unwrap();
+    let sqlite_path = dir.path().join("today-planner-title.sqlite");
+    let store = Arc::new(TimeBlockStore::with_sqlite_path(&sqlite_path).unwrap());
+    let app = test_router(test_state_with_timeblock_store(store));
+
+    let create_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/act/today-planner/windows?user_id=user-a")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "date": "2026-03-27",
+                        "title": "Morning Focus",
+                        "plannedStartAt": 1_774_573_600_000u64,
+                        "plannedEndAt": 1_774_577_200_000u64,
+                        "rhythmPresetKey": "pomodoro_25_5",
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(create_response.status(), StatusCode::CREATED);
+    let create_body = create_response
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes();
+    let create_payload: Value = serde_json::from_slice(&create_body).unwrap();
+    let work_segment_id = create_payload["segments"][0]["id"].as_str().unwrap().to_string();
+    assert_eq!(create_payload["segments"][0]["title"], "Morning Focus");
+
+    let start_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!(
+                    "/act/today-planner/segments/{work_segment_id}/start?user_id=user-a"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(start_response.status(), StatusCode::OK);
+    let start_body = start_response
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes();
+    let start_payload: Value = serde_json::from_slice(&start_body).unwrap();
+    assert_eq!(start_payload["name"], "Morning Focus");
+}

--- a/crates/exomind-runtime/tests/today_planner_routes.rs
+++ b/crates/exomind-runtime/tests/today_planner_routes.rs
@@ -64,28 +64,26 @@ fn test_router(state: AppState) -> Router {
 }
 
 #[tokio::test]
-async fn today_planner_routes_create_reorder_and_start_blocks() {
+async fn today_planner_windows_create_start_and_reflow() {
     let dir = tempdir().unwrap();
     let sqlite_path = dir.path().join("today-planner.sqlite");
     let store = Arc::new(TimeBlockStore::with_sqlite_path(&sqlite_path).unwrap());
     let app = test_router(test_state_with_timeblock_store(store));
 
-    let create_work_response = app
+    let create_response = app
         .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/act/today-planner/blocks?user_id=user-a")
+                .uri("/act/today-planner/windows?user_id=user-a")
                 .header("content-type", "application/json")
                 .body(Body::from(
                     json!({
-                        "date": "2026-03-26",
-                        "type": "work",
-                        "title": "Deep Work",
-                        "plannedStartAt": 1774490400000u64,
-                        "plannedDurationMinutes": 50,
-                        "note": "ship vertical slice",
-                        "linkedTaskIds": ["task-a"],
+                        "date": "2026-03-27",
+                        "title": "Morning Focus",
+                        "plannedStartAt": 1_774_573_600_000u64,
+                        "plannedEndAt": 1_774_577_200_000u64,
+                        "rhythmPresetKey": "pomodoro_25_5",
                     })
                     .to_string(),
                 ))
@@ -94,100 +92,34 @@ async fn today_planner_routes_create_reorder_and_start_blocks() {
         .await
         .unwrap();
 
-    assert_eq!(create_work_response.status(), StatusCode::CREATED);
-    let work_body = create_work_response
+    assert_eq!(create_response.status(), StatusCode::CREATED);
+    let create_body = create_response
         .into_body()
         .collect()
         .await
         .unwrap()
         .to_bytes();
-    let work_payload: Value = serde_json::from_slice(&work_body).unwrap();
-    let work_id = work_payload["id"].as_str().unwrap().to_string();
-    assert_eq!(work_payload["type"], "work");
-    assert_eq!(work_payload["status"], "pending");
+    let create_payload: Value = serde_json::from_slice(&create_body).unwrap();
+    let window_id = create_payload["id"].as_str().unwrap().to_string();
+    assert_eq!(create_payload["date"], "2026-03-27");
+    assert_eq!(create_payload["segments"].as_array().unwrap().len(), 3);
 
-    let create_rest_response = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/act/today-planner/blocks?user_id=user-a")
-                .header("content-type", "application/json")
-                .body(Body::from(
-                    json!({
-                        "date": "2026-03-26",
-                        "type": "rest",
-                        "title": "Lunch Reset",
-                        "plannedStartAt": 1774494000000u64,
-                        "plannedDurationMinutes": 30,
-                    })
-                    .to_string(),
-                ))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let work_segment_id = create_payload["segments"][0]["id"].as_str().unwrap().to_string();
+    let break_segment_id = create_payload["segments"][1]["id"].as_str().unwrap().to_string();
 
-    assert_eq!(create_rest_response.status(), StatusCode::CREATED);
-    let rest_body = create_rest_response
-        .into_body()
-        .collect()
-        .await
-        .unwrap()
-        .to_bytes();
-    let rest_payload: Value = serde_json::from_slice(&rest_body).unwrap();
-    let rest_id = rest_payload["id"].as_str().unwrap().to_string();
-
-    let list_response = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .uri("/act/today-planner?date=2026-03-26&user_id=user-a")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(list_response.status(), StatusCode::OK);
-    let list_body = list_response.into_body().collect().await.unwrap().to_bytes();
-    let list_payload: Value = serde_json::from_slice(&list_body).unwrap();
-    assert_eq!(list_payload["date"], "2026-03-26");
-    assert_eq!(list_payload["blocks"][0]["id"], work_id);
-    assert_eq!(list_payload["blocks"][1]["id"], rest_id);
-
-    let reorder_response = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/act/today-planner/blocks/reorder?user_id=user-a")
-                .header("content-type", "application/json")
-                .body(Body::from(
-                    json!({
-                        "date": "2026-03-26",
-                        "orderedIds": [rest_id, work_id],
-                    })
-                    .to_string(),
-                ))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(reorder_response.status(), StatusCode::OK);
-
-    let update_response = app
+    let update_segment_response = app
         .clone()
         .oneshot(
             Request::builder()
                 .method("PATCH")
                 .uri(&format!(
-                    "/act/today-planner/blocks/{rest_id}?user_id=user-a"
+                    "/act/today-planner/segments/{work_segment_id}?user_id=user-a"
                 ))
                 .header("content-type", "application/json")
                 .body(Body::from(
                     json!({
-                        "title": "Lunch + Walk",
-                        "plannedDurationMinutes": 40,
+                        "title": "Deep Work A",
+                        "linkedTaskIds": ["task-a", "task-b"],
                     })
                     .to_string(),
                 ))
@@ -195,16 +127,16 @@ async fn today_planner_routes_create_reorder_and_start_blocks() {
         )
         .await
         .unwrap();
-    assert_eq!(update_response.status(), StatusCode::OK);
-    let update_body = update_response
+    assert_eq!(update_segment_response.status(), StatusCode::OK);
+    let update_segment_body = update_segment_response
         .into_body()
         .collect()
         .await
         .unwrap()
         .to_bytes();
-    let update_payload: Value = serde_json::from_slice(&update_body).unwrap();
-    assert_eq!(update_payload["title"], "Lunch + Walk");
-    assert_eq!(update_payload["plannedDurationMinutes"], 40);
+    let update_segment_payload: Value = serde_json::from_slice(&update_segment_body).unwrap();
+    assert_eq!(update_segment_payload["title"], "Deep Work A");
+    assert_eq!(update_segment_payload["linkedTaskIds"], json!(["task-a", "task-b"]));
 
     let start_response = app
         .clone()
@@ -212,7 +144,7 @@ async fn today_planner_routes_create_reorder_and_start_blocks() {
             Request::builder()
                 .method("POST")
                 .uri(&format!(
-                    "/act/today-planner/blocks/{rest_id}/start?user_id=user-a"
+                    "/act/today-planner/segments/{work_segment_id}/start?user_id=user-a"
                 ))
                 .body(Body::empty())
                 .unwrap(),
@@ -227,41 +159,55 @@ async fn today_planner_routes_create_reorder_and_start_blocks() {
         .unwrap()
         .to_bytes();
     let start_payload: Value = serde_json::from_slice(&start_body).unwrap();
-    assert_eq!(start_payload["sourcePlannedBlockId"], rest_id);
-    assert_eq!(start_payload["targetMinutes"], 40);
+    assert_eq!(start_payload["sourcePlannedBlockId"], work_segment_id);
+    assert_eq!(start_payload["taskIds"], json!(["task-a", "task-b"]));
 
-    let after_start_response = app
+    let reflow_response = app
         .clone()
         .oneshot(
             Request::builder()
-                .uri("/act/today-planner?date=2026-03-26&user_id=user-a")
-                .body(Body::empty())
+                .method("POST")
+                .uri(&format!(
+                    "/act/today-planner/windows/{window_id}/reflow?user_id=user-a"
+                ))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "anchorSegmentId": work_segment_id,
+                        "actualEndAt": 1_774_575_300_000u64,
+                    })
+                    .to_string(),
+                ))
                 .unwrap(),
         )
         .await
         .unwrap();
-    assert_eq!(after_start_response.status(), StatusCode::OK);
-    let after_start_body = after_start_response
+    assert_eq!(reflow_response.status(), StatusCode::OK);
+    let reflow_body = reflow_response
         .into_body()
         .collect()
         .await
         .unwrap()
         .to_bytes();
-    let after_start_payload: Value = serde_json::from_slice(&after_start_body).unwrap();
-    assert_eq!(after_start_payload["blocks"][0]["id"], rest_id);
-    assert_eq!(after_start_payload["blocks"][0]["status"], "active");
+    let reflow_payload: Value = serde_json::from_slice(&reflow_body).unwrap();
+    assert_eq!(reflow_payload["id"], window_id);
+    assert_eq!(reflow_payload["segments"][1]["id"], break_segment_id);
+    assert_eq!(reflow_payload["segments"][1]["plannedStartAt"], json!(1_774_575_300_000u64));
 
-    let delete_response = app
+    let list_response = app
+        .clone()
         .oneshot(
             Request::builder()
-                .method("DELETE")
-                .uri(&format!(
-                    "/act/today-planner/blocks/{work_id}?user_id=user-a"
-                ))
+                .uri("/act/today-planner?date=2026-03-27&user_id=user-a")
                 .body(Body::empty())
                 .unwrap(),
         )
         .await
         .unwrap();
-    assert_eq!(delete_response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(list_response.status(), StatusCode::OK);
+    let list_body = list_response.into_body().collect().await.unwrap().to_bytes();
+    let list_payload: Value = serde_json::from_slice(&list_body).unwrap();
+    assert_eq!(list_payload["date"], "2026-03-27");
+    assert_eq!(list_payload["windows"][0]["id"], window_id);
+    assert_eq!(list_payload["windows"][0]["segments"][0]["status"], "active");
 }

--- a/crates/exomind-runtime/tests/today_planner_routes.rs
+++ b/crates/exomind-runtime/tests/today_planner_routes.rs
@@ -7,7 +7,7 @@ use exomind_runtime::AppState;
 use exomind_runtime::mesh::MeshState;
 use exomind_runtime::routes;
 use exomind_runtime::signal::SignalPool;
-use exomind_runtime::timeblock::TimeBlockStore;
+use exomind_runtime::timeblock::{ActiveBlockData, TimeBlockStore};
 use http_body_util::BodyExt;
 use serde_json::{Value, json};
 use tempfile::tempdir;
@@ -99,7 +99,9 @@ async fn today_planner_windows_create_start_and_reflow() {
         .await
         .unwrap()
         .to_bytes();
-    let create_payload: Value = serde_json::from_slice(&create_body).unwrap();
+    let create_body_text = String::from_utf8(create_body.to_vec()).unwrap();
+    assert_eq!(create_body_text.matches("\"segments\"").count(), 1);
+    let create_payload: Value = serde_json::from_str(&create_body_text).unwrap();
     let window_id = create_payload["id"].as_str().unwrap().to_string();
     assert_eq!(create_payload["date"], "2026-03-27");
     assert_eq!(create_payload["segments"].as_array().unwrap().len(), 3);
@@ -191,6 +193,7 @@ async fn today_planner_windows_create_start_and_reflow() {
         .to_bytes();
     let reflow_payload: Value = serde_json::from_slice(&reflow_body).unwrap();
     assert_eq!(reflow_payload["id"], window_id);
+    assert_eq!(reflow_payload["segments"][0]["plannedEndAt"], json!(1_774_575_300_000u64));
     assert_eq!(reflow_payload["segments"][1]["id"], break_segment_id);
     assert_eq!(reflow_payload["segments"][1]["plannedStartAt"], json!(1_774_575_300_000u64));
 
@@ -275,4 +278,91 @@ async fn today_planner_work_segment_inherits_window_title_before_edit() {
         .to_bytes();
     let start_payload: Value = serde_json::from_slice(&start_body).unwrap();
     assert_eq!(start_payload["name"], "Morning Focus");
+}
+
+#[tokio::test]
+async fn today_planner_start_conflicts_while_feedback_is_still_in_progress() {
+    let dir = tempdir().unwrap();
+    let sqlite_path = dir.path().join("today-planner-feedback-conflict.sqlite");
+    let store = Arc::new(TimeBlockStore::with_sqlite_path(&sqlite_path).unwrap());
+    let app = test_router(test_state_with_timeblock_store(Arc::clone(&store)));
+
+    let create_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/act/today-planner/windows?user_id=user-a")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "date": "2026-03-27",
+                        "title": "Evening Focus",
+                        "plannedStartAt": 1_774_624_000_000u64,
+                        "plannedEndAt": 1_774_627_600_000u64,
+                        "rhythmPresetKey": "pomodoro_25_5",
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(create_response.status(), StatusCode::CREATED);
+    let create_body = create_response
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes();
+    let create_payload: Value = serde_json::from_slice(&create_body).unwrap();
+    let work_segment_id = create_payload["segments"][0]["id"].as_str().unwrap().to_string();
+
+    store
+        .put_active_scoped(
+            Some("user-a"),
+            ActiveBlockData {
+                start_id: "active-feedback-pending".to_string(),
+                name: "Pending Feedback".to_string(),
+                mode: "countdown".to_string(),
+                target_minutes: Some(25),
+                elapsed: 25 * 60 * 1000,
+                updated_at: Some(1_774_624_600_000u64),
+                phase: Some("feedback_in_progress".to_string()),
+                version: Some(3),
+                actor_id: Some("test".to_string()),
+                last_transition_at: Some(1_774_624_600_000u64),
+                last_resumed_at: Some(1_774_624_000_000u64),
+                accumulated_run_ms: Some(25 * 60 * 1000),
+                start_time: 1_774_624_000_000u64,
+                action_ended_at: Some(1_774_624_600_000u64),
+                feedback_started_at: Some(1_774_624_600_000u64),
+                feedback_submitted_at: None,
+                pause_accumulated_ms: Some(0),
+                paused: false,
+                paused_at: None,
+                task_ids: vec![],
+                task_association_log: vec![],
+                source_planned_block_id: Some("finished-segment".to_string()),
+                task_id: None,
+            },
+        )
+        .unwrap();
+
+    let start_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&format!(
+                    "/act/today-planner/segments/{work_segment_id}/start?user_id=user-a"
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(start_response.status(), StatusCode::CONFLICT);
 }

--- a/docs/development/today-planner-api.md
+++ b/docs/development/today-planner-api.md
@@ -1,0 +1,159 @@
+# Today Planner API（今日计划器接口）
+
+本文件记录本轮 `Today Planner（今日计划器）` 的最小可用 RT feature API。
+
+范围只覆盖：
+
+- 手动创建今日计划块
+- 计划块类型：`work` / `rest`
+- 编辑 / 删除 / 重排
+- 从计划块直接开始执行
+
+不覆盖：
+
+- 自动排程
+- 自动插入休息
+- 通知 / 提醒
+- 任务 `plannedStartAt` 大范围建模
+
+## 1. 获取某天计划
+
+```text
+GET /act/today-planner?date=YYYY-MM-DD&user_id=<profile-id>
+```
+
+示例：
+
+```powershell
+curl.exe -sS "http://127.0.0.1:9124/act/today-planner?date=2026-03-26&user_id=profile-argon"
+```
+
+返回示例：
+
+```json
+{
+  "date": "2026-03-26",
+  "blocks": [
+    {
+      "id": "plan-1",
+      "date": "2026-03-26",
+      "type": "work",
+      "title": "Deep Work",
+      "plannedStartAt": 1774490400000,
+      "plannedDurationMinutes": 50,
+      "linkedTaskIds": ["task-a"],
+      "order": 0,
+      "createdAt": 1774489000000,
+      "updatedAt": 1774489000000,
+      "status": "pending"
+    }
+  ]
+}
+```
+
+`status` 目前有三种：
+
+- `pending`：还没开始
+- `active`：已经进入当前执行时间块
+- `completed`：已经完成并留下历史时间块
+
+## 2. 创建计划块
+
+```text
+POST /act/today-planner/blocks?user_id=<profile-id>
+```
+
+示例：
+
+```powershell
+curl.exe -sS -X POST "http://127.0.0.1:9124/act/today-planner/blocks?user_id=profile-argon" ^
+  -H "Content-Type: application/json" ^
+  -d "{\"date\":\"2026-03-26\",\"type\":\"work\",\"title\":\"Deep Work\",\"plannedStartAt\":1774490400000,\"plannedDurationMinutes\":50,\"note\":\"ship vertical slice\",\"linkedTaskIds\":[\"task-a\"]}"
+```
+
+`type` 只支持：
+
+- `work`
+- `rest`
+
+## 3. 更新计划块
+
+```text
+PATCH /act/today-planner/blocks/:blockId?user_id=<profile-id>
+```
+
+示例：
+
+```powershell
+curl.exe -sS -X PATCH "http://127.0.0.1:9124/act/today-planner/blocks/plan-1?user_id=profile-argon" ^
+  -H "Content-Type: application/json" ^
+  -d "{\"title\":\"Lunch + Walk\",\"plannedDurationMinutes\":40,\"note\":null}"
+```
+
+说明：
+
+- `note: null` 表示清空备注
+- 不传某个字段则保持原值
+
+## 4. 重排计划块
+
+```text
+POST /act/today-planner/blocks/reorder?user_id=<profile-id>
+```
+
+示例：
+
+```powershell
+curl.exe -sS -X POST "http://127.0.0.1:9124/act/today-planner/blocks/reorder?user_id=profile-argon" ^
+  -H "Content-Type: application/json" ^
+  -d "{\"date\":\"2026-03-26\",\"orderedIds\":[\"plan-2\",\"plan-1\",\"plan-3\"]}"
+```
+
+当前前端默认使用“上移 / 下移”按钮，本质也是调用这个接口。
+
+## 5. 从计划块开始执行
+
+```text
+POST /act/today-planner/blocks/:blockId/start?user_id=<profile-id>
+```
+
+示例：
+
+```powershell
+curl.exe -sS -X POST "http://127.0.0.1:9124/act/today-planner/blocks/plan-1/start?user_id=profile-argon"
+```
+
+返回值是当前 `active time block（进行中时间块）`，并带上：
+
+- `sourcePlannedBlockId`
+
+这意味着：
+
+- Today Planner 能知道它是从哪个计划块启动的
+- 后续结束反馈写回 completed block 时，也能保留这条溯源链
+
+## 6. 删除计划块
+
+```text
+DELETE /act/today-planner/blocks/:blockId?user_id=<profile-id>
+```
+
+示例：
+
+```powershell
+curl.exe -sS -X DELETE "http://127.0.0.1:9124/act/today-planner/blocks/plan-1?user_id=profile-argon"
+```
+
+成功返回：
+
+- `204 No Content`
+
+## 7. 当前约束
+
+本轮最重要的契约约束：
+
+- UI 走这套 API
+- `curl.exe` 走这套 API
+- 后续 ExoMind RT skill / Agent 也走这套 API
+
+也就是说，Today Planner 的核心业务语义已经不再是前端私有逻辑，而是 runtime 的正式 feature API。

--- a/docs/development/today-planner-api.md
+++ b/docs/development/today-planner-api.md
@@ -1,22 +1,21 @@
 # Today Planner API（今日计划器接口）
 
-本文件记录本轮 `Today Planner（今日计划器）` 的最小可用 RT feature API。
+本文件记录本轮 `Today Planner / 今日计划` 的 runtime API 合同。
 
-范围只覆盖：
+本轮范围只覆盖：
 
-- 手动创建今日计划块
-- 计划块类型：`work` / `rest`
-- 编辑 / 删除 / 重排
-- 从计划块直接开始执行
+- 手动框选一个 `Scheduling Window / 可调度区间`
+- 按 `Rhythm Preset / 节奏预设` 自动生成工作片段与休息窗
+- 只允许 `work / 工作片段` 关联任务、开始执行
+- 只对当前区间做 `reflow / 重算`
 
-不覆盖：
+本轮不覆盖：
 
-- 自动排程
-- 自动插入休息
-- 通知 / 提醒
-- 任务 `plannedStartAt` 大范围建模
+- MCP skill 接线
+- AI 自动排整天日程
+- 多个区间之间的全局重排
 
-## 1. 获取某天计划
+## 1. 获取某天计划快照
 
 ```text
 GET /act/today-planner?date=YYYY-MM-DD&user_id=<profile-id>
@@ -25,135 +24,163 @@ GET /act/today-planner?date=YYYY-MM-DD&user_id=<profile-id>
 示例：
 
 ```powershell
-curl.exe -sS "http://127.0.0.1:9124/act/today-planner?date=2026-03-26&user_id=profile-argon"
+curl.exe -sS "http://127.0.0.1:9124/act/today-planner?date=2026-03-27&user_id=profile-argon"
 ```
 
 返回示例：
 
 ```json
 {
-  "date": "2026-03-26",
-  "blocks": [
+  "date": "2026-03-27",
+  "windows": [
     {
-      "id": "plan-1",
-      "date": "2026-03-26",
-      "type": "work",
-      "title": "Deep Work",
-      "plannedStartAt": 1774490400000,
-      "plannedDurationMinutes": 50,
-      "linkedTaskIds": ["task-a"],
-      "order": 0,
-      "createdAt": 1774489000000,
-      "updatedAt": 1774489000000,
-      "status": "pending"
+      "id": "window-1",
+      "date": "2026-03-27",
+      "title": "Morning Focus",
+      "plannedStartAt": 1774573600000,
+      "plannedEndAt": 1774577200000,
+      "rhythmPreset": {
+        "key": "pomodoro_25_5",
+        "label": "25 / 5",
+        "workMinutes": 25,
+        "shortBreakMinutes": 5,
+        "longBreakMinutes": 20,
+        "longBreakAfterWorkSegments": 4
+      },
+      "segments": [
+        {
+          "id": "segment-work-1",
+          "windowId": "window-1",
+          "kind": "work",
+          "title": "Work 1",
+          "plannedStartAt": 1774573600000,
+          "plannedEndAt": 1774575100000,
+          "linkedTaskIds": [],
+          "order": 0,
+          "createdAt": 1774570000000,
+          "updatedAt": 1774570000000,
+          "status": "pending"
+        },
+        {
+          "id": "segment-break-1",
+          "windowId": "window-1",
+          "kind": "break",
+          "breakKind": "short",
+          "title": "Short Break",
+          "plannedStartAt": 1774575100000,
+          "plannedEndAt": 1774575400000,
+          "linkedTaskIds": [],
+          "order": 1,
+          "createdAt": 1774570000000,
+          "updatedAt": 1774570000000,
+          "status": "pending"
+        }
+      ],
+      "createdAt": 1774570000000,
+      "updatedAt": 1774570000000
     }
   ]
 }
 ```
 
-`status` 目前有三种：
+`status` 当前有三种：
 
 - `pending`：还没开始
-- `active`：已经进入当前执行时间块
-- `completed`：已经完成并留下历史时间块
+- `active`：已经开始执行，对应 runtime 里存在 active time block
+- `completed`：已完成，并能回溯到历史 time block
 
-## 2. 创建计划块
+## 2. 创建可调度区间
 
 ```text
-POST /act/today-planner/blocks?user_id=<profile-id>
+POST /act/today-planner/windows?user_id=<profile-id>
 ```
 
 示例：
 
 ```powershell
-curl.exe -sS -X POST "http://127.0.0.1:9124/act/today-planner/blocks?user_id=profile-argon" ^
+curl.exe -sS -X POST "http://127.0.0.1:9124/act/today-planner/windows?user_id=profile-argon" ^
   -H "Content-Type: application/json" ^
-  -d "{\"date\":\"2026-03-26\",\"type\":\"work\",\"title\":\"Deep Work\",\"plannedStartAt\":1774490400000,\"plannedDurationMinutes\":50,\"note\":\"ship vertical slice\",\"linkedTaskIds\":[\"task-a\"]}"
-```
-
-`type` 只支持：
-
-- `work`
-- `rest`
-
-## 3. 更新计划块
-
-```text
-PATCH /act/today-planner/blocks/:blockId?user_id=<profile-id>
-```
-
-示例：
-
-```powershell
-curl.exe -sS -X PATCH "http://127.0.0.1:9124/act/today-planner/blocks/plan-1?user_id=profile-argon" ^
-  -H "Content-Type: application/json" ^
-  -d "{\"title\":\"Lunch + Walk\",\"plannedDurationMinutes\":40,\"note\":null}"
+  -d "{\"date\":\"2026-03-27\",\"title\":\"Morning Focus\",\"plannedStartAt\":1774573600000,\"plannedEndAt\":1774577200000,\"rhythmPresetKey\":\"pomodoro_25_5\"}"
 ```
 
 说明：
 
-- `note: null` 表示清空备注
-- 不传某个字段则保持原值
+- 创建的是一个大区间，不是单个工作块
+- runtime 会立刻根据预设自动生成内部 `segments`
+- 当前支持的 `rhythmPresetKey`：
+  - `pomodoro_25_5`
+  - `focus_45_10`
+  - `focus_45_15`
 
-## 4. 重排计划块
+## 3. 更新工作片段
 
 ```text
-POST /act/today-planner/blocks/reorder?user_id=<profile-id>
+PATCH /act/today-planner/segments/:segmentId?user_id=<profile-id>
 ```
 
 示例：
 
 ```powershell
-curl.exe -sS -X POST "http://127.0.0.1:9124/act/today-planner/blocks/reorder?user_id=profile-argon" ^
+curl.exe -sS -X PATCH "http://127.0.0.1:9124/act/today-planner/segments/segment-work-1?user_id=profile-argon" ^
   -H "Content-Type: application/json" ^
-  -d "{\"date\":\"2026-03-26\",\"orderedIds\":[\"plan-2\",\"plan-1\",\"plan-3\"]}"
+  -d "{\"title\":\"Deep Work A\",\"linkedTaskIds\":[\"task-a\",\"task-b\"]}"
 ```
 
-当前前端默认使用“上移 / 下移”按钮，本质也是调用这个接口。
+说明：
 
-## 5. 从计划块开始执行
+- 只允许更新 `work / 工作片段`
+- `break / 休息窗` 不允许挂任务
+- 不传字段就保持原值
+
+## 4. 从工作片段开始执行
 
 ```text
-POST /act/today-planner/blocks/:blockId/start?user_id=<profile-id>
+POST /act/today-planner/segments/:segmentId/start?user_id=<profile-id>
 ```
 
 示例：
 
 ```powershell
-curl.exe -sS -X POST "http://127.0.0.1:9124/act/today-planner/blocks/plan-1/start?user_id=profile-argon"
+curl.exe -sS -X POST "http://127.0.0.1:9124/act/today-planner/segments/segment-work-1/start?user_id=profile-argon"
 ```
 
-返回值是当前 `active time block（进行中时间块）`，并带上：
+返回值是当前 `active time block / 进行中时间块`，并带上：
 
 - `sourcePlannedBlockId`
+- `taskIds`
 
 这意味着：
 
-- Today Planner 能知道它是从哪个计划块启动的
-- 后续结束反馈写回 completed block 时，也能保留这条溯源链
+- Today Planner 的工作片段能和真实执行中的 time block 建立来源链
+- 后续完成后的历史时间块也能继续追溯回这个片段
 
-## 6. 删除计划块
+## 5. 重算当前可调度区间
 
 ```text
-DELETE /act/today-planner/blocks/:blockId?user_id=<profile-id>
+POST /act/today-planner/windows/:windowId/reflow?user_id=<profile-id>
 ```
 
 示例：
 
 ```powershell
-curl.exe -sS -X DELETE "http://127.0.0.1:9124/act/today-planner/blocks/plan-1?user_id=profile-argon"
+curl.exe -sS -X POST "http://127.0.0.1:9124/act/today-planner/windows/window-1/reflow?user_id=profile-argon" ^
+  -H "Content-Type: application/json" ^
+  -d "{\"anchorSegmentId\":\"segment-work-1\",\"actualEndAt\":1774575300000}"
 ```
 
-成功返回：
+说明：
 
-- `204 No Content`
+- `anchorSegmentId` 是你刚刚实际结束的那个工作片段
+- `actualEndAt` 是实际结束时刻（毫秒时间戳）
+- 当前实现只平移这个 `window / 可调度区间` 里后续剩余片段
+- 不会影响其他区间
 
-## 7. 当前约束
+## 6. 当前契约约束
 
-本轮最重要的契约约束：
+本轮最重要的接口约束：
 
-- UI 走这套 API
+- 前端 Today Planner 走这套 API
 - `curl.exe` 走这套 API
-- 后续 ExoMind RT skill / Agent 也走这套 API
+- 后续 MCP/Skill 接线也应该复用这套 runtime contract
 
-也就是说，Today Planner 的核心业务语义已经不再是前端私有逻辑，而是 runtime 的正式 feature API。
+也就是说，Today Planner 已经不是前端私有排表逻辑，而是 runtime 的正式 feature API。

--- a/docs/plans/2026-03-26-today-planner-implementation.md
+++ b/docs/plans/2026-03-26-today-planner-implementation.md
@@ -1,0 +1,269 @@
+# Today Planner Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a minimal manual Today Planner that lets users create, edit, delete, reorder, and start today's planned work/rest blocks through shared runtime APIs.
+
+**Architecture:** Extend the runtime timeblock store with `PlannedTimeBlockData` plus `sourcePlannedBlockId` provenance on active/completed blocks, expose a new `/act/today-planner/*` feature API, and add a thin frontend planner service + Today UI that consumes that API. Keep the implementation vertical and minimal: manual planning only, two block types only, up/down reorder only, and reuse the existing active/completed timeblock execution flow.
+
+**Tech Stack:** Rust `axum` runtime routes, SQLite-backed runtime store, React 18 + TypeScript UI, Vitest unit tests, `gh` CLI, `curl`
+
+---
+
+### Task 1: Runtime Model And Store
+
+**Files:**
+- Modify: `crates/exomind-runtime/src/timeblock.rs`
+- Modify: `crates/exomind-runtime/src/timeblock_sqlite.rs`
+- Test: `crates/exomind-runtime/src/timeblock.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that prove:
+- planned blocks are isolated by `scope_key`
+- planned blocks can be listed per `date`
+- `sourcePlannedBlockId` round-trips on active/completed timeblocks
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+cargo test -p exomind-runtime sqlite_store_isolates_planned_timeblocks_by_scope
+```
+
+Expected: FAIL because planned block model/store methods do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+- `PlannedTimeBlockData`
+- `PlannedTimeBlockType`
+- `source_planned_block_id` on `ActiveBlockData` and `TimeBlockData`
+- in-memory planned-block storage
+- SQLite planned-block table and migration helpers
+- scoped CRUD/list helpers needed by Today Planner routes
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```powershell
+cargo test -p exomind-runtime sqlite_store_isolates_planned_timeblocks_by_scope
+```
+
+Expected: PASS
+
+### Task 2: Runtime Today Planner API
+
+**Files:**
+- Create: `crates/exomind-runtime/src/routes/today_planner.rs`
+- Modify: `crates/exomind-runtime/src/routes/mod.rs`
+- Modify: `crates/exomind-runtime/src/routes/timeblocks.rs`
+- Test: `crates/exomind-runtime/src/routes/today_planner.rs`
+
+**Step 1: Write the failing test**
+
+Add route tests that prove:
+- `GET /act/today-planner?date=YYYY-MM-DD` returns today's planned blocks with derived status
+- `POST /act/today-planner/blocks` creates a `work/rest` block
+- `PATCH /act/today-planner/blocks/:id` updates fields
+- `POST /act/today-planner/blocks/reorder` updates `order`
+- `POST /act/today-planner/blocks/:id/start` creates an active block with `sourcePlannedBlockId`
+- `DELETE /act/today-planner/blocks/:id` removes a planned block
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+cargo test -p exomind-runtime today_planner_routes_create_reorder_and_start_blocks
+```
+
+Expected: FAIL because route module does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+- `GET /act/today-planner`
+- `POST /act/today-planner/blocks`
+- `PATCH /act/today-planner/blocks/:block_id`
+- `POST /act/today-planner/blocks/reorder`
+- `POST /act/today-planner/blocks/:block_id/start`
+- `DELETE /act/today-planner/blocks/:block_id`
+
+Rules:
+- planned block start always bridges to current active timeblock flow
+- runtime owns side effects, not the frontend
+- return enough fields for frontend/curl to render status
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```powershell
+cargo test -p exomind-runtime today_planner_routes_create_reorder_and_start_blocks
+```
+
+Expected: PASS
+
+### Task 3: Frontend Planner Adapter And Service
+
+**Files:**
+- Create: `src/lib/adapters/today-planner-rt-adapter.ts`
+- Create: `src/lib/services/today-planner.service.ts`
+- Modify: `src/lib/types/event.ts`
+- Test: `tests/unit/adapters/today-planner-rt-adapter.test.ts`
+
+**Step 1: Write the failing test**
+
+Add adapter tests that prove:
+- requests go to `/act/today-planner/*`
+- active profile scope is appended
+- create/update/reorder/start/delete use expected HTTP methods and payloads
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+bunx vitest run tests/unit/adapters/today-planner-rt-adapter.test.ts
+```
+
+Expected: FAIL because adapter/service do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+- planner DTO types in `event.ts`
+- RT adapter
+- singleton planner service wrapping the adapter
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```powershell
+bunx vitest run tests/unit/adapters/today-planner-rt-adapter.test.ts
+```
+
+Expected: PASS
+
+### Task 4: Today UI
+
+**Files:**
+- Modify: `src/ui/app/components/NowTodayTab.tsx`
+- Create: `tests/unit/ui/now-today-planner.test.tsx`
+- Optionally modify: `src/ui/app/pages/now-today-blocks-view.ts`
+
+**Step 1: Write the failing test**
+
+Add UI tests that prove:
+- Today tab renders planned work/rest blocks
+- user can create a block
+- user can edit and delete a block
+- user can reorder blocks with up/down actions
+- user can start a planned block
+- current active block and today's history still remain visible enough for continuity
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+bunx vitest run tests/unit/ui/now-today-planner.test.tsx tests/unit/ui/now-today-tab.issue605.test.tsx
+```
+
+Expected: FAIL because planner UI does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+- compact planner form
+- planned block cards with work/rest badges
+- edit/delete/up/down/start actions
+- planner list above the existing today history list
+
+Non-goals for this round:
+- no auto scheduling
+- no drag-and-drop
+- no task picker UI
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```powershell
+bunx vitest run tests/unit/ui/now-today-planner.test.tsx tests/unit/ui/now-today-tab.issue605.test.tsx tests/unit/ui/now-today-blocks-view.issue516.test.ts
+```
+
+Expected: PASS
+
+### Task 5: Curl Contract And Final Verification
+
+**Files:**
+- Create: `docs/development/today-planner-api.md`
+
+**Step 1: Write the doc**
+
+Document:
+- create block
+- list blocks
+- reorder blocks
+- start block
+- delete block
+
+Include Windows-friendly `curl.exe` examples with `user_id`.
+
+**Step 2: Run verification**
+
+Run:
+
+```powershell
+bunx tsc --noEmit
+bunx vitest run tests/unit/adapters/today-planner-rt-adapter.test.ts tests/unit/ui/now-today-planner.test.tsx tests/unit/ui/now-today-tab.issue605.test.tsx tests/unit/ui/now-today-blocks-view.issue516.test.ts tests/unit/services/timeblock.service.rt-sqlite.test.ts
+cargo test -p exomind-runtime today_planner
+```
+
+If runtime test naming differs after implementation, run the matching `today_planner` subset or the full `exomind-runtime` crate tests touched by this change.
+
+**Step 3: Manual curl verification**
+
+Run representative commands:
+
+```powershell
+curl.exe -sS "http://127.0.0.1:9124/act/today-planner?date=2026-03-26&user_id=profile-argon"
+curl.exe -sS -X POST "http://127.0.0.1:9124/act/today-planner/blocks?user_id=profile-argon" -H "Content-Type: application/json" -d "{\"date\":\"2026-03-26\",\"type\":\"work\",\"title\":\"Deep Work\",\"plannedStartAt\":1774490400000,\"plannedDurationMinutes\":50}"
+```
+
+Expected: JSON response with created/listed planned blocks.
+
+### Task 6: Branch And PR
+
+**Files:**
+- No code changes required
+
+**Step 1: Check diff**
+
+Run:
+
+```powershell
+git status --short
+git diff --stat
+```
+
+**Step 2: Commit**
+
+```powershell
+git add .
+git commit -m "feat: add today planner runtime api and ui"
+```
+
+**Step 3: Push and create PR**
+
+```powershell
+git push -u origin feature/issue-751-today-planner
+gh pr create --base dev --head feature/issue-751-today-planner --title "feat: add manual today planner" --body-file .github/pull_request_template.md
+```
+
+Expected: open PR linked to `#751 #752 #753 #754`

--- a/docs/plans/2026-03-27-today-planner-timeline-windows.md
+++ b/docs/plans/2026-03-27-today-planner-timeline-windows.md
@@ -1,0 +1,225 @@
+# Today Planner Timeline Windows Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the current form-based Today Planner with a timeline-based scheduling window planner that auto-generates work and break segments inside each draggable window.
+
+**Architecture:** Extend the runtime planner model from flat planned blocks to `Scheduling Window / 可调度区间` plus nested `Planned Segment / 计划片段`, where work segments can link tasks and break segments remain non-task soft guidance. Keep execution on the existing actual timeblock flow, and add a window-local reflow endpoint so frontend and `curl.exe` can re-align only the current scheduling window after actual progress diverges from plan.
+
+**Tech Stack:** Rust `axum`, SQLite runtime store, React 18 + TypeScript, Vitest, `cargo test`, `curl.exe`
+
+---
+
+### Task 1: Runtime Window Model And Persistence
+
+**Files:**
+- Modify: `crates/exomind-runtime/src/timeblock.rs`
+- Modify: `crates/exomind-runtime/src/timeblock_sqlite.rs`
+- Test: `crates/exomind-runtime/src/timeblock.rs`
+
+**Step 1: Write the failing test**
+
+Add tests that prove:
+- scheduling windows are isolated by `scope_key`
+- a window stores nested generated segments
+- segment provenance (`sourcePlannedBlockId`) still round-trips on active/completed timeblocks
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+cargo test -p exomind-runtime sqlite_store_isolates_planner_windows_by_scope
+```
+
+Expected: FAIL because window persistence does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+- `SchedulingWindowData`
+- `RhythmPresetData`
+- `PlannedSegmentData`
+- `PlannedSegmentKind`
+- SQLite table and CRUD helpers for scoped planner windows
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```powershell
+cargo test -p exomind-runtime sqlite_store_isolates_planner_windows_by_scope
+```
+
+Expected: PASS
+
+### Task 2: Runtime Timeline API
+
+**Files:**
+- Modify: `crates/exomind-runtime/src/routes/today_planner.rs`
+- Modify: `crates/exomind-runtime/src/routes/mod.rs`
+- Test: `crates/exomind-runtime/tests/today_planner_routes.rs`
+
+**Step 1: Write the failing test**
+
+Add route tests that prove:
+- `GET /act/today-planner?date=YYYY-MM-DD` returns scheduling windows and nested segments
+- `POST /act/today-planner/windows` creates a window and auto-generates work/break segments from preset
+- `PATCH /act/today-planner/segments/:segment_id` updates work-segment title/task links
+- `POST /act/today-planner/segments/:segment_id/start` starts only work segments
+- `POST /act/today-planner/windows/:window_id/reflow` re-aligns only remaining segments in that window
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+cargo test -p exomind-runtime today_planner_windows_create_start_and_reflow --test today_planner_routes
+```
+
+Expected: FAIL because API contract still uses flat planned blocks.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+- window snapshot response
+- create window endpoint
+- update work segment endpoint
+- start work segment endpoint
+- window-local reflow endpoint
+
+Keep:
+- break segments non-startable
+- reflow scoped to one window only
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```powershell
+cargo test -p exomind-runtime today_planner_windows_create_start_and_reflow --test today_planner_routes
+```
+
+Expected: PASS
+
+### Task 3: Frontend Planner Types And Adapter
+
+**Files:**
+- Modify: `src/lib/types/event.ts`
+- Modify: `src/lib/adapters/today-planner-rt-adapter.ts`
+- Modify: `src/lib/services/today-planner.service.ts`
+- Test: `tests/unit/adapters/today-planner-rt-adapter.test.ts`
+
+**Step 1: Write the failing test**
+
+Add adapter tests that prove:
+- window create goes to `/act/today-planner/windows`
+- work segment update goes to `/act/today-planner/segments/:id`
+- work segment start goes to `/act/today-planner/segments/:id/start`
+- window reflow goes to `/act/today-planner/windows/:id/reflow`
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+bunx vitest run tests/unit/adapters/today-planner-rt-adapter.test.ts
+```
+
+Expected: FAIL because adapter contract still targets flat blocks.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+- scheduling window DTOs
+- planner adapter methods for windows / segments / reflow
+- service facade updates
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```powershell
+bunx vitest run tests/unit/adapters/today-planner-rt-adapter.test.ts
+```
+
+Expected: PASS
+
+### Task 4: Timeline UI
+
+**Files:**
+- Modify: `src/ui/app/components/NowTodayTab.tsx`
+- Create: `tests/unit/ui/now-today-planner.test.tsx`
+
+**Step 1: Write the failing test**
+
+Add UI tests that prove:
+- Today renders a 15-minute timeline
+- dragging a time range creates a scheduling window draft
+- confirming the draft creates a window via service
+- generated work and break segments render inside the window
+- clicking a work segment can start execution
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```powershell
+bunx vitest run tests/unit/ui/now-today-planner.test.tsx tests/unit/ui/now-today-tab.issue605.test.tsx
+```
+
+Expected: FAIL because UI is still form/list based.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+- 15-minute timeline grid
+- drag selection to create a scheduling window
+- preset chooser with default `25/5`
+- nested work/break segment rendering
+- work-segment actions: assign task later, start now
+
+Non-goals for this round:
+- full drag-resize after creation
+- multi-window day auto-reschedule
+- MCP skill wiring
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```powershell
+bunx vitest run tests/unit/ui/now-today-planner.test.tsx tests/unit/ui/now-today-tab.issue605.test.tsx tests/unit/ui/now-today-blocks-view.issue516.test.ts
+```
+
+Expected: PASS
+
+### Task 5: Curl Contract And Completion
+
+**Files:**
+- Modify: `docs/development/today-planner-api.md`
+
+**Step 1: Update the doc**
+
+Document:
+- get today planner snapshot
+- create scheduling window
+- update work segment
+- start work segment
+- reflow one scheduling window
+
+Use Windows-friendly `curl.exe` examples.
+
+**Step 2: Run verification**
+
+Run:
+
+```powershell
+bunx tsc --noEmit
+bunx vitest run tests/unit/adapters/today-planner-rt-adapter.test.ts tests/unit/ui/now-today-planner.test.tsx tests/unit/ui/now-today-tab.issue605.test.tsx tests/unit/ui/now-today-blocks-view.issue516.test.ts tests/unit/services/timeblock.service.rt-sqlite.test.ts
+cargo test -p exomind-runtime today_planner_windows_create_start_and_reflow --test today_planner_routes
+cargo test -p exomind-runtime sqlite_store_isolates_planner_windows_by_scope
+bun run build
+```
+
+Expected: all PASS

--- a/src/lib/adapters/today-planner-rt-adapter.ts
+++ b/src/lib/adapters/today-planner-rt-adapter.ts
@@ -1,0 +1,114 @@
+import {
+  buildRuntimeAuthHeaders,
+  getSelectedRuntimeTarget,
+  type RuntimeTarget,
+} from '@/config/runtime-target';
+import type {
+  ActiveBlockData,
+  CreatePlannedTimeBlockInput,
+  TodayPlannerBlock,
+  TodayPlannerSnapshot,
+  UpdatePlannedTimeBlockInput,
+} from '@/lib/types/event';
+import { appendRuntimeProfileScope } from './runtime-profile-scope';
+
+type RuntimeFetch = typeof fetch;
+
+export interface TodayPlannerRtAdapterOptions {
+  fetchImpl?: RuntimeFetch;
+  resolveTarget?: () => RuntimeTarget;
+}
+
+function formatHostForUrl(host: string): string {
+  if (host.includes(':') && !host.startsWith('[')) {
+    return `[${host}]`;
+  }
+  return host;
+}
+
+function buildBaseUrl(target: RuntimeTarget): string {
+  return `http://${formatHostForUrl(target.host)}:${target.port}`;
+}
+
+export class TodayPlannerRtAdapter {
+  private readonly fetchImpl: RuntimeFetch;
+  private readonly resolveTarget: () => RuntimeTarget;
+
+  constructor(options: TodayPlannerRtAdapterOptions = {}) {
+    this.fetchImpl = options.fetchImpl ?? ((input, init) => globalThis.fetch(input, init));
+    this.resolveTarget = options.resolveTarget ?? (() => getSelectedRuntimeTarget());
+  }
+
+  async getTodayPlanner(date: string): Promise<TodayPlannerSnapshot> {
+    return this.requestJson<TodayPlannerSnapshot>(`/act/today-planner?date=${encodeURIComponent(date)}`);
+  }
+
+  async createPlannedBlock(input: CreatePlannedTimeBlockInput): Promise<TodayPlannerBlock> {
+    return this.requestJsonWithBody<TodayPlannerBlock>('/act/today-planner/blocks', 'POST', {
+      ...input,
+      linkedTaskIds: input.linkedTaskIds ?? [],
+    });
+  }
+
+  async updatePlannedBlock(blockId: string, input: UpdatePlannedTimeBlockInput): Promise<TodayPlannerBlock> {
+    return this.requestJsonWithBody<TodayPlannerBlock>(`/act/today-planner/blocks/${encodeURIComponent(blockId)}`, 'PATCH', input);
+  }
+
+  async reorderPlannedBlocks(date: string, orderedIds: string[]): Promise<TodayPlannerSnapshot> {
+    return this.requestJsonWithBody<TodayPlannerSnapshot>('/act/today-planner/blocks/reorder', 'POST', {
+      date,
+      orderedIds,
+    });
+  }
+
+  async startPlannedBlock(blockId: string): Promise<ActiveBlockData> {
+    return this.requestJsonWithBody<ActiveBlockData>(`/act/today-planner/blocks/${encodeURIComponent(blockId)}/start`, 'POST');
+  }
+
+  async deletePlannedBlock(blockId: string): Promise<void> {
+    const target = this.resolveTarget();
+    const response = await this.fetchImpl(this.url(`/act/today-planner/blocks/${encodeURIComponent(blockId)}`, target), {
+      method: 'DELETE',
+      headers: buildRuntimeAuthHeaders(target, { Accept: 'application/json' }),
+    });
+    if (!response.ok && response.status !== 204) {
+      throw new Error(`RT today planner delete failed: ${response.status}`);
+    }
+  }
+
+  private async requestJson<T>(path: string): Promise<T> {
+    const target = this.resolveTarget();
+    const response = await this.fetchImpl(this.url(path, target), {
+      method: 'GET',
+      headers: buildRuntimeAuthHeaders(target, { Accept: 'application/json' }),
+    });
+    if (!response.ok) {
+      throw new Error(`RT today planner request failed: ${response.status}`);
+    }
+    return response.json() as Promise<T>;
+  }
+
+  private async requestJsonWithBody<T>(path: string, method: 'POST' | 'PATCH', body?: unknown): Promise<T> {
+    const target = this.resolveTarget();
+    const response = await this.fetchImpl(this.url(path, target), {
+      method,
+      headers: buildRuntimeAuthHeaders(target, {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      }),
+      body: JSON.stringify(body ?? {}),
+    });
+    if (!response.ok) {
+      throw new Error(`RT today planner ${method} failed: ${response.status}`);
+    }
+    return response.json() as Promise<T>;
+  }
+
+  private baseUrl(target = this.resolveTarget()): string {
+    return buildBaseUrl(target);
+  }
+
+  private url(path: string, target = this.resolveTarget()): string {
+    return `${this.baseUrl(target)}${appendRuntimeProfileScope(path)}`;
+  }
+}

--- a/src/lib/adapters/today-planner-rt-adapter.ts
+++ b/src/lib/adapters/today-planner-rt-adapter.ts
@@ -5,10 +5,12 @@ import {
 } from '@/config/runtime-target';
 import type {
   ActiveBlockData,
-  CreatePlannedTimeBlockInput,
-  TodayPlannerBlock,
+  CreateSchedulingWindowInput,
+  ReflowSchedulingWindowInput,
   TodayPlannerSnapshot,
-  UpdatePlannedTimeBlockInput,
+  TodayPlannerSegment,
+  TodayPlannerWindow,
+  UpdatePlannedSegmentInput,
 } from '@/lib/types/event';
 import { appendRuntimeProfileScope } from './runtime-profile-scope';
 
@@ -43,37 +45,34 @@ export class TodayPlannerRtAdapter {
     return this.requestJson<TodayPlannerSnapshot>(`/act/today-planner?date=${encodeURIComponent(date)}`);
   }
 
-  async createPlannedBlock(input: CreatePlannedTimeBlockInput): Promise<TodayPlannerBlock> {
-    return this.requestJsonWithBody<TodayPlannerBlock>('/act/today-planner/blocks', 'POST', {
-      ...input,
-      linkedTaskIds: input.linkedTaskIds ?? [],
-    });
+  async createSchedulingWindow(input: CreateSchedulingWindowInput): Promise<TodayPlannerWindow> {
+    return this.requestJsonWithBody<TodayPlannerWindow>('/act/today-planner/windows', 'POST', input);
   }
 
-  async updatePlannedBlock(blockId: string, input: UpdatePlannedTimeBlockInput): Promise<TodayPlannerBlock> {
-    return this.requestJsonWithBody<TodayPlannerBlock>(`/act/today-planner/blocks/${encodeURIComponent(blockId)}`, 'PATCH', input);
+  async updatePlannedSegment(segmentId: string, input: UpdatePlannedSegmentInput): Promise<TodayPlannerSegment> {
+    return this.requestJsonWithBody<TodayPlannerSegment>(
+      `/act/today-planner/segments/${encodeURIComponent(segmentId)}`,
+      'PATCH',
+      {
+        ...input,
+        linkedTaskIds: input.linkedTaskIds ?? [],
+      },
+    );
   }
 
-  async reorderPlannedBlocks(date: string, orderedIds: string[]): Promise<TodayPlannerSnapshot> {
-    return this.requestJsonWithBody<TodayPlannerSnapshot>('/act/today-planner/blocks/reorder', 'POST', {
-      date,
-      orderedIds,
-    });
+  async startWorkSegment(segmentId: string): Promise<ActiveBlockData> {
+    return this.requestJsonWithBody<ActiveBlockData>(
+      `/act/today-planner/segments/${encodeURIComponent(segmentId)}/start`,
+      'POST',
+    );
   }
 
-  async startPlannedBlock(blockId: string): Promise<ActiveBlockData> {
-    return this.requestJsonWithBody<ActiveBlockData>(`/act/today-planner/blocks/${encodeURIComponent(blockId)}/start`, 'POST');
-  }
-
-  async deletePlannedBlock(blockId: string): Promise<void> {
-    const target = this.resolveTarget();
-    const response = await this.fetchImpl(this.url(`/act/today-planner/blocks/${encodeURIComponent(blockId)}`, target), {
-      method: 'DELETE',
-      headers: buildRuntimeAuthHeaders(target, { Accept: 'application/json' }),
-    });
-    if (!response.ok && response.status !== 204) {
-      throw new Error(`RT today planner delete failed: ${response.status}`);
-    }
+  async reflowSchedulingWindow(windowId: string, input: ReflowSchedulingWindowInput): Promise<TodayPlannerWindow> {
+    return this.requestJsonWithBody<TodayPlannerWindow>(
+      `/act/today-planner/windows/${encodeURIComponent(windowId)}/reflow`,
+      'POST',
+      input,
+    );
   }
 
   private async requestJson<T>(path: string): Promise<T> {

--- a/src/lib/adapters/today-planner-rt-adapter.ts
+++ b/src/lib/adapters/today-planner-rt-adapter.ts
@@ -50,13 +50,14 @@ export class TodayPlannerRtAdapter {
   }
 
   async updatePlannedSegment(segmentId: string, input: UpdatePlannedSegmentInput): Promise<TodayPlannerSegment> {
+    const payload = {
+      ...(input.title !== undefined ? { title: input.title } : {}),
+      ...(input.linkedTaskIds !== undefined ? { linkedTaskIds: input.linkedTaskIds } : {}),
+    };
     return this.requestJsonWithBody<TodayPlannerSegment>(
       `/act/today-planner/segments/${encodeURIComponent(segmentId)}`,
       'PATCH',
-      {
-        ...input,
-        linkedTaskIds: input.linkedTaskIds ?? [],
-      },
+      payload,
     );
   }
 

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -19,6 +19,8 @@ export type {
 
 export { TimeBlockServiceImpl, getTimeBlockService } from './timeblock.service';
 export type { TimeBlockService } from './timeblock.service';
+export { TodayPlannerServiceImpl, getTodayPlannerService } from './today-planner.service';
+export type { TodayPlannerService } from './today-planner.service';
 export {
   TimeBlockBackupServiceImpl,
   getTimeBlockBackupService,

--- a/src/lib/services/timeblock.service.ts
+++ b/src/lib/services/timeblock.service.ts
@@ -520,6 +520,7 @@ export class TimeBlockServiceImpl implements TimeBlockService {
       taskIds: activeData.taskIds ?? [],
       taskStatusOutcomes: options?.taskStatusOutcomes,
       taskAssociationLog: activeData.taskAssociationLog ?? [],
+      sourcePlannedBlockId: activeData.sourcePlannedBlockId,
     };
 
     // 追加到已完成列表

--- a/src/lib/services/today-planner.service.ts
+++ b/src/lib/services/today-planner.service.ts
@@ -1,19 +1,20 @@
 import { TodayPlannerRtAdapter } from '@/lib/adapters/today-planner-rt-adapter';
 import type {
   ActiveBlockData,
-  CreatePlannedTimeBlockInput,
-  TodayPlannerBlock,
+  CreateSchedulingWindowInput,
+  ReflowSchedulingWindowInput,
   TodayPlannerSnapshot,
-  UpdatePlannedTimeBlockInput,
+  TodayPlannerSegment,
+  TodayPlannerWindow,
+  UpdatePlannedSegmentInput,
 } from '@/lib/types/event';
 
 export interface TodayPlannerService {
   getTodayPlanner(date: string): Promise<TodayPlannerSnapshot>;
-  createPlannedBlock(input: CreatePlannedTimeBlockInput): Promise<TodayPlannerBlock>;
-  updatePlannedBlock(blockId: string, input: UpdatePlannedTimeBlockInput): Promise<TodayPlannerBlock>;
-  reorderPlannedBlocks(date: string, orderedIds: string[]): Promise<TodayPlannerSnapshot>;
-  startPlannedBlock(blockId: string): Promise<ActiveBlockData>;
-  deletePlannedBlock(blockId: string): Promise<void>;
+  createSchedulingWindow(input: CreateSchedulingWindowInput): Promise<TodayPlannerWindow>;
+  updatePlannedSegment(segmentId: string, input: UpdatePlannedSegmentInput): Promise<TodayPlannerSegment>;
+  startWorkSegment(segmentId: string): Promise<ActiveBlockData>;
+  reflowSchedulingWindow(windowId: string, input: ReflowSchedulingWindowInput): Promise<TodayPlannerWindow>;
 }
 
 export class TodayPlannerServiceImpl implements TodayPlannerService {
@@ -23,24 +24,20 @@ export class TodayPlannerServiceImpl implements TodayPlannerService {
     return this.rtAdapter.getTodayPlanner(date);
   }
 
-  createPlannedBlock(input: CreatePlannedTimeBlockInput): Promise<TodayPlannerBlock> {
-    return this.rtAdapter.createPlannedBlock(input);
+  createSchedulingWindow(input: CreateSchedulingWindowInput): Promise<TodayPlannerWindow> {
+    return this.rtAdapter.createSchedulingWindow(input);
   }
 
-  updatePlannedBlock(blockId: string, input: UpdatePlannedTimeBlockInput): Promise<TodayPlannerBlock> {
-    return this.rtAdapter.updatePlannedBlock(blockId, input);
+  updatePlannedSegment(segmentId: string, input: UpdatePlannedSegmentInput): Promise<TodayPlannerSegment> {
+    return this.rtAdapter.updatePlannedSegment(segmentId, input);
   }
 
-  reorderPlannedBlocks(date: string, orderedIds: string[]): Promise<TodayPlannerSnapshot> {
-    return this.rtAdapter.reorderPlannedBlocks(date, orderedIds);
+  startWorkSegment(segmentId: string): Promise<ActiveBlockData> {
+    return this.rtAdapter.startWorkSegment(segmentId);
   }
 
-  startPlannedBlock(blockId: string): Promise<ActiveBlockData> {
-    return this.rtAdapter.startPlannedBlock(blockId);
-  }
-
-  deletePlannedBlock(blockId: string): Promise<void> {
-    return this.rtAdapter.deletePlannedBlock(blockId);
+  reflowSchedulingWindow(windowId: string, input: ReflowSchedulingWindowInput): Promise<TodayPlannerWindow> {
+    return this.rtAdapter.reflowSchedulingWindow(windowId, input);
   }
 }
 

--- a/src/lib/services/today-planner.service.ts
+++ b/src/lib/services/today-planner.service.ts
@@ -1,0 +1,54 @@
+import { TodayPlannerRtAdapter } from '@/lib/adapters/today-planner-rt-adapter';
+import type {
+  ActiveBlockData,
+  CreatePlannedTimeBlockInput,
+  TodayPlannerBlock,
+  TodayPlannerSnapshot,
+  UpdatePlannedTimeBlockInput,
+} from '@/lib/types/event';
+
+export interface TodayPlannerService {
+  getTodayPlanner(date: string): Promise<TodayPlannerSnapshot>;
+  createPlannedBlock(input: CreatePlannedTimeBlockInput): Promise<TodayPlannerBlock>;
+  updatePlannedBlock(blockId: string, input: UpdatePlannedTimeBlockInput): Promise<TodayPlannerBlock>;
+  reorderPlannedBlocks(date: string, orderedIds: string[]): Promise<TodayPlannerSnapshot>;
+  startPlannedBlock(blockId: string): Promise<ActiveBlockData>;
+  deletePlannedBlock(blockId: string): Promise<void>;
+}
+
+export class TodayPlannerServiceImpl implements TodayPlannerService {
+  constructor(private readonly rtAdapter: TodayPlannerRtAdapter = new TodayPlannerRtAdapter()) {}
+
+  getTodayPlanner(date: string): Promise<TodayPlannerSnapshot> {
+    return this.rtAdapter.getTodayPlanner(date);
+  }
+
+  createPlannedBlock(input: CreatePlannedTimeBlockInput): Promise<TodayPlannerBlock> {
+    return this.rtAdapter.createPlannedBlock(input);
+  }
+
+  updatePlannedBlock(blockId: string, input: UpdatePlannedTimeBlockInput): Promise<TodayPlannerBlock> {
+    return this.rtAdapter.updatePlannedBlock(blockId, input);
+  }
+
+  reorderPlannedBlocks(date: string, orderedIds: string[]): Promise<TodayPlannerSnapshot> {
+    return this.rtAdapter.reorderPlannedBlocks(date, orderedIds);
+  }
+
+  startPlannedBlock(blockId: string): Promise<ActiveBlockData> {
+    return this.rtAdapter.startPlannedBlock(blockId);
+  }
+
+  deletePlannedBlock(blockId: string): Promise<void> {
+    return this.rtAdapter.deletePlannedBlock(blockId);
+  }
+}
+
+let todayPlannerServiceInstance: TodayPlannerService | null = null;
+
+export function getTodayPlannerService(): TodayPlannerService {
+  if (!todayPlannerServiceInstance) {
+    todayPlannerServiceInstance = new TodayPlannerServiceImpl();
+  }
+  return todayPlannerServiceInstance;
+}

--- a/src/lib/services/today-planner.service.ts
+++ b/src/lib/services/today-planner.service.ts
@@ -1,4 +1,5 @@
 import { TodayPlannerRtAdapter } from '@/lib/adapters/today-planner-rt-adapter';
+import { getTimeBlockService } from './timeblock.service';
 import type {
   ActiveBlockData,
   CreateSchedulingWindowInput,
@@ -32,8 +33,10 @@ export class TodayPlannerServiceImpl implements TodayPlannerService {
     return this.rtAdapter.updatePlannedSegment(segmentId, input);
   }
 
-  startWorkSegment(segmentId: string): Promise<ActiveBlockData> {
-    return this.rtAdapter.startWorkSegment(segmentId);
+  async startWorkSegment(segmentId: string): Promise<ActiveBlockData> {
+    const activeBlock = await this.rtAdapter.startWorkSegment(segmentId);
+    await getTimeBlockService().applyReplicatedActiveBlock(activeBlock);
+    return activeBlock;
   }
 
   reflowSchedulingWindow(windowId: string, input: ReflowSchedulingWindowInput): Promise<TodayPlannerWindow> {

--- a/src/lib/types/event.ts
+++ b/src/lib/types/event.ts
@@ -97,6 +97,7 @@ export interface TimeBlockData {
   taskStatusOutcomes?: Record<string, string>;
   /** 关联历史日志：可回放“曾关联过哪些任务”以及后续计算任务出现程度 */
   taskAssociationLog?: BlockTaskAssociationEvent[];
+  sourcePlannedBlockId?: UUID;
 }
 
 // 时间块类型（UI 使用）
@@ -114,6 +115,7 @@ export interface TimeBlock {
   taskStatusOutcomes?: Record<string, string>;
   /** 关联历史日志：可回放“曾关联过哪些任务”以及后续计算任务出现程度 */
   taskAssociationLog?: BlockTaskAssociationEvent[];
+  sourcePlannedBlockId?: UUID;
 }
 
 // 活跃时间块（进行中）
@@ -161,8 +163,56 @@ export interface ActiveBlockData {
   taskIds: UUID[];
   /** 运行期关联历史：不仅能恢复当前关联，也能保留“曾经关联过”的任务全集 */
   taskAssociationLog: BlockTaskAssociationEvent[];
+  sourcePlannedBlockId?: UUID;
   /** @deprecated Use taskIds. Kept for deserialization compat only. */
   taskId?: UUID;
+}
+
+export type PlannedTimeBlockType = 'work' | 'rest';
+export type PlannedTimeBlockStatus = 'pending' | 'active' | 'completed';
+
+export interface PlannedTimeBlockData {
+  id: UUID;
+  date: string;
+  type: PlannedTimeBlockType;
+  title: string;
+  plannedStartAt: Timestamp;
+  plannedDurationMinutes: number;
+  note?: string;
+  linkedTaskIds: UUID[];
+  order: number;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+}
+
+export interface TodayPlannerBlock extends PlannedTimeBlockData {
+  status: PlannedTimeBlockStatus;
+  sourceTimeBlockId?: UUID;
+}
+
+export interface TodayPlannerSnapshot {
+  date: string;
+  blocks: TodayPlannerBlock[];
+}
+
+export interface CreatePlannedTimeBlockInput {
+  date: string;
+  type: PlannedTimeBlockType;
+  title: string;
+  plannedStartAt: Timestamp;
+  plannedDurationMinutes: number;
+  note?: string;
+  linkedTaskIds?: UUID[];
+}
+
+export interface UpdatePlannedTimeBlockInput {
+  date?: string;
+  type?: PlannedTimeBlockType;
+  title?: string;
+  plannedStartAt?: Timestamp;
+  plannedDurationMinutes?: number;
+  note?: string | null;
+  linkedTaskIds?: UUID[];
 }
 
 // 计时器配置

--- a/src/lib/types/event.ts
+++ b/src/lib/types/event.ts
@@ -168,51 +168,73 @@ export interface ActiveBlockData {
   taskId?: UUID;
 }
 
-export type PlannedTimeBlockType = 'work' | 'rest';
-export type PlannedTimeBlockStatus = 'pending' | 'active' | 'completed';
+export type RhythmPresetKey = 'pomodoro_25_5' | 'focus_45_10' | 'focus_45_15';
 
-export interface PlannedTimeBlockData {
+export interface RhythmPresetData {
+  key: RhythmPresetKey;
+  label: string;
+  workMinutes: number;
+  shortBreakMinutes: number;
+  longBreakMinutes: number;
+  longBreakAfterWorkSegments: number;
+}
+
+export type PlannedSegmentKind = 'work' | 'break';
+export type BreakWindowKind = 'short' | 'long';
+export type TodayPlannerSegmentStatus = 'pending' | 'active' | 'completed';
+
+export interface PlannedSegmentData {
   id: UUID;
-  date: string;
-  type: PlannedTimeBlockType;
+  windowId: UUID;
+  kind: PlannedSegmentKind;
+  breakKind?: BreakWindowKind;
   title: string;
   plannedStartAt: Timestamp;
-  plannedDurationMinutes: number;
-  note?: string;
+  plannedEndAt: Timestamp;
   linkedTaskIds: UUID[];
   order: number;
   createdAt: Timestamp;
   updatedAt: Timestamp;
 }
 
-export interface TodayPlannerBlock extends PlannedTimeBlockData {
-  status: PlannedTimeBlockStatus;
+export interface TodayPlannerSegment extends PlannedSegmentData {
+  status: TodayPlannerSegmentStatus;
   sourceTimeBlockId?: UUID;
+}
+
+export interface TodayPlannerWindow {
+  id: UUID;
+  date: string;
+  title?: string;
+  plannedStartAt: Timestamp;
+  plannedEndAt: Timestamp;
+  rhythmPreset: RhythmPresetData;
+  segments: TodayPlannerSegment[];
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
 }
 
 export interface TodayPlannerSnapshot {
   date: string;
-  blocks: TodayPlannerBlock[];
+  windows: TodayPlannerWindow[];
 }
 
-export interface CreatePlannedTimeBlockInput {
+export interface CreateSchedulingWindowInput {
   date: string;
-  type: PlannedTimeBlockType;
-  title: string;
+  title?: string;
   plannedStartAt: Timestamp;
-  plannedDurationMinutes: number;
-  note?: string;
+  plannedEndAt: Timestamp;
+  rhythmPresetKey: RhythmPresetKey;
+}
+
+export interface UpdatePlannedSegmentInput {
+  title?: string;
   linkedTaskIds?: UUID[];
 }
 
-export interface UpdatePlannedTimeBlockInput {
-  date?: string;
-  type?: PlannedTimeBlockType;
-  title?: string;
-  plannedStartAt?: Timestamp;
-  plannedDurationMinutes?: number;
-  note?: string | null;
-  linkedTaskIds?: UUID[];
+export interface ReflowSchedulingWindowInput {
+  anchorSegmentId: UUID;
+  actualEndAt: Timestamp;
 }
 
 // 计时器配置

--- a/src/ui/app/components/NowTodayPlannerTimeline.tsx
+++ b/src/ui/app/components/NowTodayPlannerTimeline.tsx
@@ -1,0 +1,430 @@
+import { useEffect, useMemo, useState } from 'react';
+import { getTodayPlannerService } from '@/lib/services';
+import type { RhythmPresetKey, TodayPlannerSegment, TodayPlannerSnapshot, TodayPlannerWindow } from '@/lib/types/event';
+import { PrestartTaskSelectionList, usePrestartSelectableTasks } from './prestart-task-selection';
+
+const SLOT_MINUTES = 15;
+const SLOT_MS = SLOT_MINUTES * 60_000;
+const SLOT_HEIGHT = 24;
+const SLOT_COUNT = (24 * 60) / SLOT_MINUTES;
+
+const RHYTHM_OPTIONS: Array<{ key: RhythmPresetKey; label: string }> = [
+  { key: 'pomodoro_25_5', label: '25 / 5 · Pomodoro' },
+  { key: 'focus_45_10', label: '45 / 10 · Focus' },
+  { key: 'focus_45_15', label: '45 / 15 · Long Break' },
+];
+
+interface SlotRange {
+  startIndex: number;
+  endIndex: number;
+}
+
+interface DraftState extends SlotRange {
+  title: string;
+  rhythmPresetKey: RhythmPresetKey;
+}
+
+interface NowTodayPlannerTimelineProps {
+  dateKey: string;
+  snapshot: TodayPlannerSnapshot | null;
+  loading: boolean;
+  error: string | null;
+  setError(message: string | null): void;
+  refreshPlanner(): Promise<void>;
+  refreshHistory(forceRefreshTasks?: boolean): Promise<void>;
+}
+
+function normalizeRange(startIndex: number, endIndex: number): SlotRange {
+  return { startIndex: Math.min(startIndex, endIndex), endIndex: Math.max(startIndex, endIndex) };
+}
+
+function buildTs(dateKey: string, timeValue: string): number {
+  const [year, month, day] = dateKey.split('-').map((part) => Number.parseInt(part, 10));
+  const [hours, minutes] = timeValue.split(':').map((part) => Number.parseInt(part, 10));
+  return new Date(year, (month ?? 1) - 1, day ?? 1, hours ?? 0, minutes ?? 0, 0, 0).getTime();
+}
+
+function dayStart(dateKey: string): number {
+  return buildTs(dateKey, '00:00');
+}
+
+function clock(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', hour12: false });
+}
+
+function timeValue(timestamp: number): string {
+  const date = new Date(timestamp);
+  return `${`${date.getHours()}`.padStart(2, '0')}:${`${date.getMinutes()}`.padStart(2, '0')}`;
+}
+
+function selectionRange(dateKey: string, range: SlotRange): { startAt: number; endAt: number } {
+  const start = dayStart(dateKey);
+  return {
+    startAt: start + range.startIndex * SLOT_MS,
+    endAt: start + (range.endIndex + 1) * SLOT_MS,
+  };
+}
+
+function rangeLabel(startAt: number, endAt: number): string {
+  return `${clock(startAt)} - ${clock(endAt)} · ${Math.max(1, Math.round((endAt - startAt) / 60_000))} 分钟`;
+}
+
+function topFor(dateKey: string, timestamp: number): number {
+  return ((timestamp - dayStart(dateKey)) / SLOT_MS) * SLOT_HEIGHT;
+}
+
+function heightFor(window: TodayPlannerWindow): number {
+  return ((window.plannedEndAt - window.plannedStartAt) / SLOT_MS) * SLOT_HEIGHT;
+}
+
+function segmentTone(segment: TodayPlannerSegment, selected: boolean): string {
+  if (segment.kind === 'break') return 'border-dashed border-sky-300 bg-sky-50 text-sky-800 dark:border-sky-700 dark:bg-sky-950 dark:text-sky-200';
+  if (segment.status === 'active') return 'border-orange-600 bg-orange-600 text-white';
+  if (segment.status === 'completed') return 'border-stone-300 bg-stone-100 text-stone-700 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-100';
+  return `${selected ? 'ring-2 ring-stone-950 dark:ring-stone-50 ' : ''}border-orange-200 bg-orange-50 text-orange-900 dark:border-orange-900 dark:bg-[#2A231B] dark:text-orange-200`;
+}
+
+export function NowTodayPlannerTimeline({
+  dateKey,
+  snapshot,
+  loading,
+  error,
+  setError,
+  refreshPlanner,
+  refreshHistory,
+}: NowTodayPlannerTimelineProps) {
+  const [dragRange, setDragRange] = useState<SlotRange | null>(null);
+  const [draft, setDraft] = useState<DraftState | null>(null);
+  const [selectedSegmentId, setSelectedSegmentId] = useState<string | null>(null);
+  const [editorTitle, setEditorTitle] = useState('');
+  const [editorTaskIds, setEditorTaskIds] = useState<string[]>([]);
+  const [actualEndTime, setActualEndTime] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const selectableTasks = usePrestartSelectableTasks();
+
+  useEffect(() => {
+    if (!dragRange) return;
+    const handleMouseUp = () => {
+      const next = normalizeRange(dragRange.startIndex, dragRange.endIndex);
+      setDraft({ ...next, title: '', rhythmPresetKey: 'pomodoro_25_5' });
+      setDragRange(null);
+    };
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => window.removeEventListener('mouseup', handleMouseUp);
+  }, [dragRange]);
+
+  const slots = useMemo(() => Array.from({ length: SLOT_COUNT }, (_, index) => {
+    const minutes = index * SLOT_MINUTES;
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    return { index, label: `${`${hours}`.padStart(2, '0')}:${`${mins}`.padStart(2, '0')}`, isHour: mins === 0 };
+  }), []);
+
+  const windows = useMemo(
+    () => [...(snapshot?.windows ?? [])].sort((left, right) => left.plannedStartAt - right.plannedStartAt),
+    [snapshot],
+  );
+
+  const selectedContext = useMemo(() => {
+    for (const window of windows) {
+      const segment = window.segments.find((candidate) => candidate.id === selectedSegmentId);
+      if (segment) return { window, segment };
+    }
+    return null;
+  }, [selectedSegmentId, windows]);
+
+  const selectedWork = selectedContext?.segment.kind === 'work' ? selectedContext : null;
+
+  useEffect(() => {
+    if (!selectedWork) {
+      setEditorTitle('');
+      setEditorTaskIds([]);
+      setActualEndTime('');
+      return;
+    }
+    setEditorTitle(selectedWork.segment.title);
+    setEditorTaskIds(selectedWork.segment.linkedTaskIds);
+    setActualEndTime(timeValue(selectedWork.segment.plannedEndAt));
+  }, [selectedWork]);
+
+  const preview = draft ?? (dragRange ? normalizeRange(dragRange.startIndex, dragRange.endIndex) : null);
+  const previewRect = preview ? (() => {
+    const { startAt, endAt } = selectionRange(dateKey, preview);
+    return { top: topFor(dateKey, startAt), height: ((endAt - startAt) / SLOT_MS) * SLOT_HEIGHT };
+  })() : null;
+
+  async function createWindow(): Promise<void> {
+    if (!draft) return;
+    const { startAt, endAt } = selectionRange(dateKey, draft);
+    setSubmitting(true);
+    setError(null);
+    try {
+      await getTodayPlannerService().createSchedulingWindow({
+        date: dateKey,
+        title: draft.title.trim() || undefined,
+        plannedStartAt: startAt,
+        plannedEndAt: endAt,
+        rhythmPresetKey: draft.rhythmPresetKey,
+      });
+      await refreshPlanner();
+      setDraft(null);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : '创建可调度区间失败');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function saveSegment(): Promise<void> {
+    if (!selectedWork) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await getTodayPlannerService().updatePlannedSegment(selectedWork.segment.id, {
+        ...(editorTitle.trim() && editorTitle.trim() !== selectedWork.segment.title ? { title: editorTitle.trim() } : {}),
+        linkedTaskIds: editorTaskIds,
+      });
+      await refreshPlanner();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : '保存工作片段失败');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function startSegment(): Promise<void> {
+    if (!selectedWork) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await getTodayPlannerService().startWorkSegment(selectedWork.segment.id);
+      await Promise.all([refreshPlanner(), refreshHistory(true)]);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : '开始工作片段失败');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function reflowWindow(): Promise<void> {
+    if (!selectedWork) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await getTodayPlannerService().reflowSchedulingWindow(selectedWork.window.id, {
+        anchorSegmentId: selectedWork.segment.id,
+        actualEndAt: buildTs(dateKey, actualEndTime),
+      });
+      await refreshPlanner();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : '重算当前区间失败');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="rounded-3xl border border-[#E7E5E4] bg-white/90 p-4 shadow-sm dark:border-[#292524] dark:bg-[#1C1917]">
+      <div className="flex flex-col gap-1">
+        <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">Today Planner / 今日计划</p>
+        <p className="text-xs text-[#78716C] dark:text-[#A8A29E]">拖出可调度区间，再自动切成工作片段与休息窗。</p>
+      </div>
+      {error ? <p className="mt-3 text-xs text-[#C75B3A]" role="alert">{error}</p> : null}
+      <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="rounded-3xl border border-[#E7E5E4] bg-[#FCFBFA] p-3 dark:border-[#292524] dark:bg-[#120F0D]">
+          <div className="mb-3 flex items-center justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[#A8A29E]">Timeline / 时间线</p>
+              <p className="mt-1 text-sm text-[#57534E] dark:text-[#D6D3D1]">15 分钟一格，拖拽创建可调度区间。</p>
+            </div>
+            <span className="rounded-full bg-[#F5F0ED] px-3 py-1 text-[11px] text-[#78716C] dark:bg-[#292524] dark:text-[#D6D3D1]">
+              {loading ? '同步中...' : `${windows.length} 个区间`}
+            </span>
+          </div>
+          <div className="max-h-[720px] overflow-y-auto rounded-2xl border border-[#E7E5E4] bg-white dark:border-[#292524] dark:bg-[#1C1917]">
+            <div className="relative" style={{ height: `${SLOT_COUNT * SLOT_HEIGHT}px` }}>
+              {slots.map((slot) => (
+                <div
+                  key={slot.label}
+                  data-testid={`planner-slot-${slot.label}`}
+                  className="absolute inset-x-0 select-none"
+                  style={{ top: `${slot.index * SLOT_HEIGHT}px`, height: `${SLOT_HEIGHT}px` }}
+                  onMouseDown={() => { setSelectedSegmentId(null); setDraft(null); setDragRange({ startIndex: slot.index, endIndex: slot.index }); }}
+                  onMouseEnter={() => setDragRange((current) => current ? { ...current, endIndex: slot.index } : current)}
+                  onMouseUp={() => {
+                    if (!dragRange) return;
+                    setDraft({ ...normalizeRange(dragRange.startIndex, slot.index), title: '', rhythmPresetKey: 'pomodoro_25_5' });
+                    setDragRange(null);
+                  }}
+                >
+                  <div className="flex h-full">
+                    <div className="w-16 px-3 pt-1 text-[10px] text-[#A8A29E]">{slot.isHour ? slot.label : ''}</div>
+                    <div className={`h-full flex-1 border-t ${slot.isHour ? 'border-[#D6D3D1] dark:border-[#44403C]' : 'border-[#F5F0ED] dark:border-[#292524]'}`} />
+                  </div>
+                </div>
+              ))}
+              {previewRect ? (
+                <div
+                  className="pointer-events-none absolute left-16 right-3 z-[5] rounded-2xl border border-dashed border-[#C75B3A] bg-[#FFF7ED]/70"
+                  data-testid="today-planner-selection-preview"
+                  style={previewRect}
+                />
+              ) : null}
+              {windows.map((window) => (
+                <div
+                  key={window.id}
+                  data-testid={`planner-window-${window.id}`}
+                  className="absolute left-16 right-3 z-10 overflow-hidden rounded-2xl border border-[#E7E5E4] bg-white shadow-sm dark:border-[#44403C] dark:bg-[#1F1B18]"
+                  style={{ top: `${topFor(dateKey, window.plannedStartAt)}px`, height: `${heightFor(window)}px` }}
+                >
+                  <div className="pointer-events-none absolute left-2 right-2 top-2 z-20 flex items-center justify-between gap-2">
+                    <div className="truncate rounded-full bg-white/80 px-2 py-1 text-[10px] font-medium text-[#57534E] shadow-sm dark:bg-[#120F0D]/80 dark:text-[#E7E5E4]">
+                      {window.title?.trim() || '可调度区间'}
+                    </div>
+                    <div className="rounded-full bg-[#1C1917]/80 px-2 py-1 text-[10px] text-white dark:bg-[#FAFAF9]/80 dark:text-[#1C1917]">
+                      {window.rhythmPreset.label}
+                    </div>
+                  </div>
+                  <div className="flex h-full flex-col">
+                    {window.segments.map((segment) => {
+                      const flexValue = Math.max(1, segment.plannedEndAt - segment.plannedStartAt);
+                      const selected = selectedSegmentId === segment.id;
+                      return segment.kind === 'work' ? (
+                        <button
+                          key={segment.id}
+                          type="button"
+                          data-testid={`planner-segment-${segment.id}`}
+                          aria-label={`选择工作片段：${segment.title}`}
+                          onClick={() => setSelectedSegmentId(segment.id)}
+                          className={`relative flex min-h-0 flex-col items-start justify-end overflow-hidden border px-3 py-2 text-left transition-colors ${segmentTone(segment, selected)}`}
+                          style={{ flex: `${flexValue} 1 0` }}
+                        >
+                          <span className="text-[11px] font-semibold leading-tight">{segment.title}</span>
+                          <span className="mt-1 text-[10px] opacity-80">
+                            {clock(segment.plannedStartAt)} - {clock(segment.plannedEndAt)}
+                            {segment.linkedTaskIds.length > 0 ? ` · ${segment.linkedTaskIds.length} 个任务` : ''}
+                          </span>
+                        </button>
+                      ) : (
+                        <div
+                          key={segment.id}
+                          className={`relative flex min-h-0 items-center border px-3 py-1 text-[10px] ${segmentTone(segment, false)}`}
+                          style={{ flex: `${flexValue} 1 0` }}
+                        >
+                          <span className="truncate">{segment.title}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+        <aside className="rounded-3xl border border-[#E7E5E4] bg-[#FCFBFA] p-4 dark:border-[#292524] dark:bg-[#120F0D]">
+          {draft ? (
+            <div data-testid="today-planner-window-draft" className="space-y-4">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[#A8A29E]">Draft / 区间草稿</p>
+                <p className="mt-1 text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">
+                  {(() => {
+                    const { startAt, endAt } = selectionRange(dateKey, draft);
+                    return rangeLabel(startAt, endAt);
+                  })()}
+                </p>
+                <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">创建的是“可调度区间”，内部会自动切成工作和休息。</p>
+              </div>
+              <label className="space-y-1 text-xs text-[#57534E] dark:text-[#D6D3D1]">
+                <span>区间标题</span>
+                <input
+                  aria-label="区间标题"
+                  value={draft.title}
+                  onChange={(event) => setDraft((current) => current ? { ...current, title: event.target.value } : current)}
+                  className="w-full rounded-2xl border border-[#E7E5E4] bg-white px-3 py-2 text-sm outline-none focus:border-[#C75B3A] dark:border-[#292524] dark:bg-[#1C1917]"
+                  placeholder="例如：上午深度工作"
+                />
+              </label>
+              <label className="space-y-1 text-xs text-[#57534E] dark:text-[#D6D3D1]">
+                <span>节奏预设</span>
+                <select
+                  aria-label="节奏预设"
+                  value={draft.rhythmPresetKey}
+                  onChange={(event) => setDraft((current) => current ? { ...current, rhythmPresetKey: event.target.value as RhythmPresetKey } : current)}
+                  className="w-full rounded-2xl border border-[#E7E5E4] bg-white px-3 py-2 text-sm outline-none focus:border-[#C75B3A] dark:border-[#292524] dark:bg-[#1C1917]"
+                >
+                  {RHYTHM_OPTIONS.map((option) => <option key={option.key} value={option.key}>{option.label}</option>)}
+                </select>
+              </label>
+              <div className="flex flex-wrap gap-2">
+                <button type="button" disabled={submitting} onClick={() => void createWindow()} className="rounded-full bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white hover:bg-[#B14D2F] disabled:cursor-not-allowed disabled:opacity-60">
+                  创建可调度区间
+                </button>
+                <button type="button" onClick={() => setDraft(null)} className="rounded-full border border-[#E7E5E4] px-4 py-2 text-sm text-[#57534E] hover:bg-[#F5F0ED] dark:border-[#292524] dark:text-[#D6D3D1] dark:hover:bg-[#292524]">
+                  取消
+                </button>
+              </div>
+            </div>
+          ) : selectedWork ? (
+            <div data-testid="planner-segment-inspector" className="space-y-4">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[#A8A29E]">Inspector / 工作片段</p>
+                <div className="mt-1 flex items-center gap-2">
+                  <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{selectedWork.segment.title}</p>
+                  <span className="rounded-full bg-[#F5F0ED] px-2 py-1 text-[11px] text-[#78716C] dark:bg-[#292524] dark:text-[#D6D3D1]">
+                    {selectedWork.segment.status === 'active' ? '进行中' : selectedWork.segment.status === 'completed' ? '已完成' : '待开始'}
+                  </span>
+                </div>
+                <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">{rangeLabel(selectedWork.segment.plannedStartAt, selectedWork.segment.plannedEndAt)}</p>
+              </div>
+              <label className="space-y-1 text-xs text-[#57534E] dark:text-[#D6D3D1]">
+                <span>工作标题</span>
+                <input
+                  aria-label="工作标题"
+                  value={editorTitle}
+                  onChange={(event) => setEditorTitle(event.target.value)}
+                  className="w-full rounded-2xl border border-[#E7E5E4] bg-white px-3 py-2 text-sm outline-none focus:border-[#C75B3A] dark:border-[#292524] dark:bg-[#1C1917]"
+                />
+              </label>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <p className="text-xs font-semibold uppercase tracking-[0.08em] text-[#A8A29E]">Tasks / 关联任务</p>
+                  <span className="text-[11px] text-[#78716C] dark:text-[#A8A29E]">只有工作片段可以挂任务</span>
+                </div>
+                <PrestartTaskSelectionList tasks={selectableTasks} selectedTaskIds={editorTaskIds} onSelectedTaskIdsChange={setEditorTaskIds} listTestId="planner-segment-task-list" itemTestIdPrefix="planner-segment-task-" emptyLabel="当前没有可关联的任务。" />
+              </div>
+              <div className="space-y-1">
+                <p className="text-xs font-semibold uppercase tracking-[0.08em] text-[#A8A29E]">Reflow / 当前区间重算</p>
+                <div className="flex gap-2">
+                  <input
+                    aria-label="实际结束时间"
+                    type="time"
+                    value={actualEndTime}
+                    onChange={(event) => setActualEndTime(event.target.value)}
+                    className="min-w-0 flex-1 rounded-2xl border border-[#E7E5E4] bg-white px-3 py-2 text-sm outline-none focus:border-[#C75B3A] dark:border-[#292524] dark:bg-[#1C1917]"
+                  />
+                  <button type="button" disabled={submitting} onClick={() => void reflowWindow()} className="rounded-full border border-[#E7E5E4] px-3 py-2 text-xs text-[#57534E] hover:bg-[#F5F0ED] disabled:cursor-not-allowed disabled:opacity-60 dark:border-[#292524] dark:text-[#D6D3D1] dark:hover:bg-[#292524]">
+                    重算当前区间
+                  </button>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <button type="button" disabled={submitting} onClick={() => void saveSegment()} className="rounded-full border border-[#E7E5E4] px-4 py-2 text-sm text-[#57534E] hover:bg-[#F5F0ED] disabled:cursor-not-allowed disabled:opacity-60 dark:border-[#292524] dark:text-[#D6D3D1] dark:hover:bg-[#292524]">
+                  保存工作片段
+                </button>
+                <button type="button" disabled={submitting || selectedWork.segment.status === 'active'} onClick={() => void startSegment()} className="rounded-full bg-[#1C1917] px-4 py-2 text-sm font-medium text-white hover:bg-[#292524] disabled:cursor-not-allowed disabled:opacity-60 dark:bg-[#FAFAF9] dark:text-[#1C1917] dark:hover:bg-[#E7E5E4]">
+                  开始这个工作片段
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-2xl border border-dashed border-[#E7E5E4] bg-white/70 p-4 text-sm text-[#57534E] dark:border-[#292524] dark:bg-[#1C1917] dark:text-[#D6D3D1]">
+              <p>1. 在左侧时间线上拖出一个可调度区间。</p>
+              <p className="mt-2">2. 选节奏预设，让系统自动切分工作片段和休息窗。</p>
+              <p className="mt-2">3. 点击工作片段，挂任务、开始执行，必要时只重算当前区间。</p>
+            </div>
+          )}
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/src/ui/app/components/NowTodayPlannerTimeline.tsx
+++ b/src/ui/app/components/NowTodayPlannerTimeline.tsx
@@ -48,6 +48,15 @@ function dayStart(dateKey: string): number {
   return buildTs(dateKey, '00:00');
 }
 
+function resolveActualEndAt(dateKey: string, segment: TodayPlannerSegment, timeInput: string): number {
+  const resolved = buildTs(dateKey, timeInput);
+  const dayEnd = dayStart(dateKey) + 86_400_000;
+  if (segment.plannedEndAt >= dayEnd && resolved <= segment.plannedStartAt) {
+    return resolved + 86_400_000;
+  }
+  return resolved;
+}
+
 function clock(timestamp: number): string {
   return new Date(timestamp).toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', hour12: false });
 }
@@ -213,7 +222,7 @@ export function NowTodayPlannerTimeline({
     try {
       await getTodayPlannerService().reflowSchedulingWindow(selectedWork.window.id, {
         anchorSegmentId: selectedWork.segment.id,
-        actualEndAt: buildTs(dateKey, actualEndTime),
+        actualEndAt: resolveActualEndAt(dateKey, selectedWork.segment, actualEndTime),
       });
       await refreshPlanner();
     } catch (cause) {

--- a/src/ui/app/components/NowTodayPlannerTimeline.tsx
+++ b/src/ui/app/components/NowTodayPlannerTimeline.tsx
@@ -390,7 +390,16 @@ export function NowTodayPlannerTimeline({
                   <p className="text-xs font-semibold uppercase tracking-[0.08em] text-[#A8A29E]">Tasks / 关联任务</p>
                   <span className="text-[11px] text-[#78716C] dark:text-[#A8A29E]">只有工作片段可以挂任务</span>
                 </div>
-                <PrestartTaskSelectionList tasks={selectableTasks} selectedTaskIds={editorTaskIds} onSelectedTaskIdsChange={setEditorTaskIds} listTestId="planner-segment-task-list" itemTestIdPrefix="planner-segment-task-" emptyLabel="当前没有可关联的任务。" />
+                <PrestartTaskSelectionList
+                  tasks={selectableTasks}
+                  selectedTaskIds={editorTaskIds}
+                  onSelectedTaskIdsChange={setEditorTaskIds}
+                  listTestId="planner-segment-task-list"
+                  itemTestIdPrefix="planner-segment-task-"
+                  emptyLabel="当前没有可关联的任务。"
+                  maxVisibleTasks={10}
+                  overflowSelectLabel="更多任务"
+                />
               </div>
               <div className="space-y-1">
                 <p className="text-xs font-semibold uppercase tracking-[0.08em] text-[#A8A29E]">Reflow / 当前区间重算</p>

--- a/src/ui/app/components/NowTodayTab.tsx
+++ b/src/ui/app/components/NowTodayTab.tsx
@@ -5,15 +5,12 @@ import {
   resolveActiveBlockTaskIds,
   resolveTimeBlockRelatedTaskIds,
   type ActiveBlockData,
-  type CreatePlannedTimeBlockInput,
-  type PlannedTimeBlockType,
   type TimeBlock,
-  type TodayPlannerBlock,
   type TodayPlannerSnapshot,
-  type UpdatePlannedTimeBlockInput,
 } from '@/lib/types/event';
 import type { TaskNode } from '@/lib/types/task';
 import { buildNowTodayBlocksView } from '@/ui/app/pages/now-today-blocks-view';
+import { NowTodayPlannerTimeline } from './NowTodayPlannerTimeline';
 
 function isToday(timestamp: number, now: Date): boolean {
   const start = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
@@ -97,74 +94,10 @@ function formatDateKey(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
-function formatTimeValue(timestamp: number): string {
-  const date = new Date(timestamp);
-  return `${`${date.getHours()}`.padStart(2, '0')}:${`${date.getMinutes()}`.padStart(2, '0')}`;
-}
-
-function formatPlannerClock(timestamp: number): string {
-  return new Date(timestamp).toLocaleTimeString('zh-CN', {
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  });
-}
-
-function buildPlannerTimestamp(dateKey: string, timeValue: string): number {
-  const [year, month, day] = dateKey.split('-').map((part) => Number.parseInt(part, 10));
-  const [hours, minutes] = timeValue.split(':').map((part) => Number.parseInt(part, 10));
-  return new Date(year, (month ?? 1) - 1, day ?? 1, hours ?? 0, minutes ?? 0, 0, 0).getTime();
-}
-
-function buildDefaultTimeValue(now: Date): string {
-  const rounded = new Date(now.getTime());
-  rounded.setSeconds(0, 0);
-  const minutes = rounded.getMinutes();
-  const nextMinutes = minutes <= 30 ? 30 : 60;
-  rounded.setMinutes(nextMinutes, 0, 0);
-  return formatTimeValue(rounded.getTime());
-}
-
-function formatPlannerRange(block: TodayPlannerBlock): string {
-  const end = block.plannedStartAt + (block.plannedDurationMinutes * 60_000);
-  return `${formatPlannerClock(block.plannedStartAt)} - ${formatPlannerClock(end)} · ${block.plannedDurationMinutes} 分钟`;
-}
-
-function resolvePlannerTypeLabel(blockType: PlannedTimeBlockType): string {
-  return blockType === 'work' ? '工作块' : '休息块';
-}
-
-function resolvePlannerStatusLabel(status: TodayPlannerBlock['status']): string {
-  if (status === 'active') return '进行中';
-  if (status === 'completed') return '已完成';
-  return '待开始';
-}
-
-interface PlannerFormState {
-  title: string;
-  type: PlannedTimeBlockType;
-  timeValue: string;
-  durationMinutes: string;
-  note: string;
-}
-
-function buildDefaultPlannerForm(now: Date): PlannerFormState {
-  return {
-    title: '',
-    type: 'work',
-    timeValue: buildDefaultTimeValue(now),
-    durationMinutes: '50',
-    note: '',
-  };
-}
-
 export function NowTodayTab() {
   const [plannerSnapshot, setPlannerSnapshot] = useState<TodayPlannerSnapshot | null>(null);
   const [plannerLoading, setPlannerLoading] = useState(true);
   const [plannerError, setPlannerError] = useState<string | null>(null);
-  const [plannerForm, setPlannerForm] = useState<PlannerFormState>(() => buildDefaultPlannerForm(new Date()));
-  const [editingBlockId, setEditingBlockId] = useState<string | null>(null);
-  const [plannerSubmitting, setPlannerSubmitting] = useState(false);
   const [completedBlocks, setCompletedBlocks] = useState<TimeBlock[]>([]);
   const [activeBlock, setActiveBlock] = useState<ActiveBlockData | null>(null);
   const [tasksById, setTasksById] = useState<Map<string, TaskNode>>(new Map());
@@ -334,290 +267,23 @@ export function NowTodayTab() {
     now,
   }), [blocks, now, tasksById]);
 
-  const plannerBlocks = plannerSnapshot?.blocks ?? [];
-
-  const resetPlannerForm = () => {
-    setPlannerForm(buildDefaultPlannerForm(new Date()));
-    setEditingBlockId(null);
-  };
-
   const refreshPlanner = async () => {
     setPlannerError(null);
     const snapshot = await getTodayPlannerService().getTodayPlanner(todayDate);
     setPlannerSnapshot(snapshot);
   };
 
-  const handlePlannerSubmit = async () => {
-    const trimmedTitle = plannerForm.title.trim();
-    const durationMinutes = Number.parseInt(plannerForm.durationMinutes, 10);
-    if (!trimmedTitle) {
-      setPlannerError('标题不能为空');
-      return;
-    }
-    if (!Number.isFinite(durationMinutes) || durationMinutes <= 0) {
-      setPlannerError('时长必须大于 0');
-      return;
-    }
-
-    const basePayload = {
-      date: todayDate,
-      type: plannerForm.type,
-      title: trimmedTitle,
-      plannedStartAt: buildPlannerTimestamp(todayDate, plannerForm.timeValue),
-      plannedDurationMinutes: durationMinutes,
-      linkedTaskIds: [],
-    };
-
-    setPlannerSubmitting(true);
-    setPlannerError(null);
-    try {
-      if (editingBlockId) {
-        await getTodayPlannerService().updatePlannedBlock(editingBlockId, {
-          ...basePayload,
-          note: plannerForm.note.trim() || null,
-        } satisfies UpdatePlannedTimeBlockInput);
-      } else {
-        await getTodayPlannerService().createPlannedBlock({
-          ...basePayload,
-          note: plannerForm.note.trim() || undefined,
-        } satisfies CreatePlannedTimeBlockInput);
-      }
-      await refreshPlanner();
-      resetPlannerForm();
-    } catch (error) {
-      setPlannerError(error instanceof Error ? error.message : '保存今日计划失败');
-    } finally {
-      setPlannerSubmitting(false);
-    }
-  };
-
-  const handleEditBlock = (block: TodayPlannerBlock) => {
-    setEditingBlockId(block.id);
-    setPlannerForm({
-      title: block.title,
-      type: block.type,
-      timeValue: formatTimeValue(block.plannedStartAt),
-      durationMinutes: String(block.plannedDurationMinutes),
-      note: block.note ?? '',
-    });
-  };
-
-  const handleMoveBlock = async (blockId: string, direction: -1 | 1) => {
-    const currentIndex = plannerBlocks.findIndex((block) => block.id === blockId);
-    const targetIndex = currentIndex + direction;
-    if (currentIndex < 0 || targetIndex < 0 || targetIndex >= plannerBlocks.length) {
-      return;
-    }
-
-    const nextIds = plannerBlocks.map((block) => block.id);
-    const [moved] = nextIds.splice(currentIndex, 1);
-    nextIds.splice(targetIndex, 0, moved);
-    try {
-      await getTodayPlannerService().reorderPlannedBlocks(todayDate, nextIds);
-      await refreshPlanner();
-    } catch (error) {
-      setPlannerError(error instanceof Error ? error.message : '重排今日计划失败');
-    }
-  };
-
-  const handleStartBlock = async (blockId: string) => {
-    try {
-      await getTodayPlannerService().startPlannedBlock(blockId);
-      await Promise.all([
-        refreshPlanner(),
-        refreshHistoryRef.current?.(true) ?? Promise.resolve(),
-      ]);
-    } catch (error) {
-      setPlannerError(error instanceof Error ? error.message : '开始计划块失败');
-    }
-  };
-
-  const handleDeleteBlock = async (blockId: string) => {
-    try {
-      await getTodayPlannerService().deletePlannedBlock(blockId);
-      await refreshPlanner();
-      if (editingBlockId === blockId) {
-        resetPlannerForm();
-      }
-    } catch (error) {
-      setPlannerError(error instanceof Error ? error.message : '删除计划块失败');
-    }
-  };
-
   return (
     <div className="space-y-6">
-      <section className="rounded-3xl border border-[#E7E5E4] bg-white/90 p-4 shadow-sm dark:border-[#292524] dark:bg-[#1C1917]">
-        <div className="flex flex-col gap-1">
-          <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">今日计划</p>
-          <p className="text-xs text-[#78716C] dark:text-[#A8A29E]">手动安排今天的工作块和休息块，然后直接开始执行。</p>
-        </div>
-
-        <div className="mt-4 grid gap-3 md:grid-cols-2">
-          <label className="space-y-1 text-xs text-[#57534E] dark:text-[#D6D3D1]">
-            <span>标题</span>
-            <input
-              aria-label="标题"
-              value={plannerForm.title}
-              onChange={(event) => setPlannerForm((prev) => ({ ...prev, title: event.target.value }))}
-              className="w-full rounded-2xl border border-[#E7E5E4] bg-white px-3 py-2 text-sm outline-none transition-colors focus:border-[#C75B3A] dark:border-[#292524] dark:bg-[#120F0D]"
-              placeholder="例如：Deep Work / 午休"
-            />
-          </label>
-
-          <label className="space-y-1 text-xs text-[#57534E] dark:text-[#D6D3D1]">
-            <span>类型</span>
-            <select
-              aria-label="类型"
-              value={plannerForm.type}
-              onChange={(event) => setPlannerForm((prev) => ({ ...prev, type: event.target.value as PlannedTimeBlockType }))}
-              className="w-full rounded-2xl border border-[#E7E5E4] bg-white px-3 py-2 text-sm outline-none transition-colors focus:border-[#C75B3A] dark:border-[#292524] dark:bg-[#120F0D]"
-            >
-              <option value="work">工作块</option>
-              <option value="rest">休息块</option>
-            </select>
-          </label>
-
-          <label className="space-y-1 text-xs text-[#57534E] dark:text-[#D6D3D1]">
-            <span>开始时间</span>
-            <input
-              aria-label="开始时间"
-              type="time"
-              value={plannerForm.timeValue}
-              onChange={(event) => setPlannerForm((prev) => ({ ...prev, timeValue: event.target.value }))}
-              className="w-full rounded-2xl border border-[#E7E5E4] bg-white px-3 py-2 text-sm outline-none transition-colors focus:border-[#C75B3A] dark:border-[#292524] dark:bg-[#120F0D]"
-            />
-          </label>
-
-          <label className="space-y-1 text-xs text-[#57534E] dark:text-[#D6D3D1]">
-            <span>时长（分钟）</span>
-            <input
-              aria-label="时长（分钟）"
-              type="number"
-              min={1}
-              value={plannerForm.durationMinutes}
-              onChange={(event) => setPlannerForm((prev) => ({ ...prev, durationMinutes: event.target.value }))}
-              className="w-full rounded-2xl border border-[#E7E5E4] bg-white px-3 py-2 text-sm outline-none transition-colors focus:border-[#C75B3A] dark:border-[#292524] dark:bg-[#120F0D]"
-            />
-          </label>
-        </div>
-
-        <label className="mt-3 block space-y-1 text-xs text-[#57534E] dark:text-[#D6D3D1]">
-          <span>备注</span>
-          <textarea
-            value={plannerForm.note}
-            onChange={(event) => setPlannerForm((prev) => ({ ...prev, note: event.target.value }))}
-            className="min-h-[84px] w-full rounded-2xl border border-[#E7E5E4] bg-white px-3 py-2 text-sm outline-none transition-colors focus:border-[#C75B3A] dark:border-[#292524] dark:bg-[#120F0D]"
-            placeholder="可选：记录这个块的目的或边界"
-          />
-        </label>
-
-        <div className="mt-3 flex flex-wrap gap-2">
-          <button
-            type="button"
-            disabled={plannerSubmitting}
-            onClick={() => void handlePlannerSubmit()}
-            className="rounded-full bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#B14D2F] disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {editingBlockId ? '保存修改' : '添加计划块'}
-          </button>
-          {editingBlockId ? (
-            <button
-              type="button"
-              onClick={resetPlannerForm}
-              className="rounded-full border border-[#E7E5E4] px-4 py-2 text-sm text-[#57534E] transition-colors hover:bg-[#F5F0ED] dark:border-[#292524] dark:text-[#D6D3D1] dark:hover:bg-[#292524]"
-            >
-              取消编辑
-            </button>
-          ) : null}
-        </div>
-
-        {plannerError ? (
-          <p className="mt-3 text-xs text-[#C75B3A]" role="alert">{plannerError}</p>
-        ) : null}
-
-        <div className="mt-4 space-y-3">
-          {plannerLoading ? (
-            <p className="text-sm text-[#78716C] dark:text-[#A8A29E]">加载今日计划...</p>
-          ) : plannerBlocks.length === 0 ? (
-            <p className="text-sm text-[#78716C] dark:text-[#A8A29E]">今天还没有计划块。</p>
-          ) : (
-            plannerBlocks.map((block, index) => (
-              <div
-                key={block.id}
-                className="rounded-2xl border border-[#E7E5E4] bg-[#FCFBFA] p-4 dark:border-[#292524] dark:bg-[#120F0D]"
-              >
-                <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                  <div className="min-w-0">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{block.title}</p>
-                      <span className={`rounded-full px-2 py-1 text-[11px] ${
-                        block.type === 'work'
-                          ? 'bg-[#FFF7ED] text-[#C75B3A] dark:bg-[#2A231B] dark:text-[#FDBA74]'
-                          : 'bg-[#ECFDF5] text-[#047857] dark:bg-[#10261D] dark:text-[#6EE7B7]'
-                      }`}>
-                        {resolvePlannerTypeLabel(block.type)}
-                      </span>
-                      <span className="rounded-full bg-[#F5F0ED] px-2 py-1 text-[11px] text-[#78716C] dark:bg-[#292524] dark:text-[#D6D3D1]">
-                        {resolvePlannerStatusLabel(block.status)}
-                      </span>
-                    </div>
-                    <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">{formatPlannerRange(block)}</p>
-                    {block.note ? (
-                      <p className="mt-2 text-xs text-[#57534E] dark:text-[#D6D3D1]">{block.note}</p>
-                    ) : null}
-                  </div>
-
-                  <div className="flex flex-wrap gap-2">
-                    <button
-                      type="button"
-                      aria-label={`编辑计划块：${block.title}`}
-                      onClick={() => handleEditBlock(block)}
-                      className="rounded-full border border-[#E7E5E4] px-3 py-1.5 text-xs text-[#57534E] transition-colors hover:bg-[#F5F0ED] dark:border-[#292524] dark:text-[#D6D3D1] dark:hover:bg-[#292524]"
-                    >
-                      编辑
-                    </button>
-                    <button
-                      type="button"
-                      aria-label={`上移计划块：${block.title}`}
-                      disabled={index === 0}
-                      onClick={() => void handleMoveBlock(block.id, -1)}
-                      className="rounded-full border border-[#E7E5E4] px-3 py-1.5 text-xs text-[#57534E] transition-colors hover:bg-[#F5F0ED] disabled:cursor-not-allowed disabled:opacity-50 dark:border-[#292524] dark:text-[#D6D3D1] dark:hover:bg-[#292524]"
-                    >
-                      上移
-                    </button>
-                    <button
-                      type="button"
-                      aria-label={`下移计划块：${block.title}`}
-                      disabled={index === plannerBlocks.length - 1}
-                      onClick={() => void handleMoveBlock(block.id, 1)}
-                      className="rounded-full border border-[#E7E5E4] px-3 py-1.5 text-xs text-[#57534E] transition-colors hover:bg-[#F5F0ED] disabled:cursor-not-allowed disabled:opacity-50 dark:border-[#292524] dark:text-[#D6D3D1] dark:hover:bg-[#292524]"
-                    >
-                      下移
-                    </button>
-                    <button
-                      type="button"
-                      aria-label={`开始计划块：${block.title}`}
-                      disabled={block.status === 'active'}
-                      onClick={() => void handleStartBlock(block.id)}
-                      className="rounded-full bg-[#1C1917] px-3 py-1.5 text-xs text-white transition-colors hover:bg-[#292524] disabled:cursor-not-allowed disabled:opacity-50 dark:bg-[#FAFAF9] dark:text-[#1C1917] dark:hover:bg-[#E7E5E4]"
-                    >
-                      开始
-                    </button>
-                    <button
-                      type="button"
-                      aria-label={`删除计划块：${block.title}`}
-                      onClick={() => void handleDeleteBlock(block.id)}
-                      className="rounded-full border border-[#F5D0C5] px-3 py-1.5 text-xs text-[#C75B3A] transition-colors hover:bg-[#FFF7ED] dark:border-[#5A2C20] dark:text-[#FDBA74] dark:hover:bg-[#2A231B]"
-                    >
-                      删除
-                    </button>
-                  </div>
-                </div>
-              </div>
-            ))
-          )}
-        </div>
-      </section>
+      <NowTodayPlannerTimeline
+        dateKey={todayDate}
+        snapshot={plannerSnapshot}
+        loading={plannerLoading}
+        error={plannerError}
+        setError={setPlannerError}
+        refreshPlanner={refreshPlanner}
+        refreshHistory={(forceRefreshTasks) => refreshHistoryRef.current?.(forceRefreshTasks) ?? Promise.resolve()}
+      />
 
       <section className="space-y-3">
         <div className="flex items-center justify-between">

--- a/src/ui/app/components/NowTodayTab.tsx
+++ b/src/ui/app/components/NowTodayTab.tsx
@@ -253,6 +253,19 @@ export function NowTodayTab() {
     };
   }, [activeBlock]);
 
+  useEffect(() => {
+    const nextDayStart = new Date();
+    nextDayStart.setHours(24, 0, 0, 0);
+    const delay = Math.max(1, nextDayStart.getTime() - Date.now());
+    const timerId = window.setTimeout(() => {
+      setNow(new Date());
+    }, delay);
+
+    return () => {
+      window.clearTimeout(timerId);
+    };
+  }, [todayDate]);
+
   const blocks = useMemo(() => {
     const nextBlocks = [...completedBlocks];
     if (activeBlock && isToday(activeBlock.startTime, now)) {
@@ -268,9 +281,13 @@ export function NowTodayTab() {
   }), [blocks, now, tasksById]);
 
   const refreshPlanner = async () => {
+    const currentDate = formatDateKey(new Date());
     setPlannerError(null);
-    const snapshot = await getTodayPlannerService().getTodayPlanner(todayDate);
+    const snapshot = await getTodayPlannerService().getTodayPlanner(currentDate);
     setPlannerSnapshot(snapshot);
+    if (currentDate !== todayDate) {
+      setNow(new Date());
+    }
   };
 
   return (

--- a/src/ui/app/components/NowTodayTab.tsx
+++ b/src/ui/app/components/NowTodayTab.tsx
@@ -1,7 +1,17 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from '@tanstack/react-router';
-import { getTaskService, getTimeBlockService } from '@/lib/services';
-import { resolveActiveBlockTaskIds, resolveTimeBlockRelatedTaskIds, type ActiveBlockData, type TimeBlock } from '@/lib/types/event';
+import { getTaskService, getTimeBlockService, getTodayPlannerService } from '@/lib/services';
+import {
+  resolveActiveBlockTaskIds,
+  resolveTimeBlockRelatedTaskIds,
+  type ActiveBlockData,
+  type CreatePlannedTimeBlockInput,
+  type PlannedTimeBlockType,
+  type TimeBlock,
+  type TodayPlannerBlock,
+  type TodayPlannerSnapshot,
+  type UpdatePlannedTimeBlockInput,
+} from '@/lib/types/event';
 import type { TaskNode } from '@/lib/types/task';
 import { buildNowTodayBlocksView } from '@/ui/app/pages/now-today-blocks-view';
 
@@ -80,17 +90,124 @@ function collectRelevantTaskIds(blocks: TimeBlock[], activeBlock: ActiveBlockDat
   return Array.from(ids);
 }
 
+function formatDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function formatTimeValue(timestamp: number): string {
+  const date = new Date(timestamp);
+  return `${`${date.getHours()}`.padStart(2, '0')}:${`${date.getMinutes()}`.padStart(2, '0')}`;
+}
+
+function formatPlannerClock(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString('zh-CN', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+function buildPlannerTimestamp(dateKey: string, timeValue: string): number {
+  const [year, month, day] = dateKey.split('-').map((part) => Number.parseInt(part, 10));
+  const [hours, minutes] = timeValue.split(':').map((part) => Number.parseInt(part, 10));
+  return new Date(year, (month ?? 1) - 1, day ?? 1, hours ?? 0, minutes ?? 0, 0, 0).getTime();
+}
+
+function buildDefaultTimeValue(now: Date): string {
+  const rounded = new Date(now.getTime());
+  rounded.setSeconds(0, 0);
+  const minutes = rounded.getMinutes();
+  const nextMinutes = minutes <= 30 ? 30 : 60;
+  rounded.setMinutes(nextMinutes, 0, 0);
+  return formatTimeValue(rounded.getTime());
+}
+
+function formatPlannerRange(block: TodayPlannerBlock): string {
+  const end = block.plannedStartAt + (block.plannedDurationMinutes * 60_000);
+  return `${formatPlannerClock(block.plannedStartAt)} - ${formatPlannerClock(end)} · ${block.plannedDurationMinutes} 分钟`;
+}
+
+function resolvePlannerTypeLabel(blockType: PlannedTimeBlockType): string {
+  return blockType === 'work' ? '工作块' : '休息块';
+}
+
+function resolvePlannerStatusLabel(status: TodayPlannerBlock['status']): string {
+  if (status === 'active') return '进行中';
+  if (status === 'completed') return '已完成';
+  return '待开始';
+}
+
+interface PlannerFormState {
+  title: string;
+  type: PlannedTimeBlockType;
+  timeValue: string;
+  durationMinutes: string;
+  note: string;
+}
+
+function buildDefaultPlannerForm(now: Date): PlannerFormState {
+  return {
+    title: '',
+    type: 'work',
+    timeValue: buildDefaultTimeValue(now),
+    durationMinutes: '50',
+    note: '',
+  };
+}
+
 export function NowTodayTab() {
+  const [plannerSnapshot, setPlannerSnapshot] = useState<TodayPlannerSnapshot | null>(null);
+  const [plannerLoading, setPlannerLoading] = useState(true);
+  const [plannerError, setPlannerError] = useState<string | null>(null);
+  const [plannerForm, setPlannerForm] = useState<PlannerFormState>(() => buildDefaultPlannerForm(new Date()));
+  const [editingBlockId, setEditingBlockId] = useState<string | null>(null);
+  const [plannerSubmitting, setPlannerSubmitting] = useState(false);
   const [completedBlocks, setCompletedBlocks] = useState<TimeBlock[]>([]);
   const [activeBlock, setActiveBlock] = useState<ActiveBlockData | null>(null);
   const [tasksById, setTasksById] = useState<Map<string, TaskNode>>(new Map());
-  const [loading, setLoading] = useState(true);
+  const [historyLoading, setHistoryLoading] = useState(true);
   const [now, setNow] = useState(() => new Date());
+  const refreshHistoryRef = useRef<((forceRefreshTasks?: boolean) => Promise<void>) | null>(null);
   const completedBlocksRef = useRef<TimeBlock[]>([]);
   const activeBlockRef = useRef<ActiveBlockData | null>(null);
   const completedBlocksSignatureRef = useRef('');
   const activeBlockSignatureRef = useRef('null');
   const taskIdsSignatureRef = useRef('');
+  const todayDate = formatDateKey(now);
+
+  useEffect(() => {
+    const todayPlannerService = getTodayPlannerService();
+    let disposed = false;
+
+    const loadPlanner = async () => {
+      setPlannerLoading(true);
+      setPlannerError(null);
+      try {
+        const snapshot = await todayPlannerService.getTodayPlanner(todayDate);
+        if (disposed) {
+          return;
+        }
+        setPlannerSnapshot(snapshot);
+      } catch (error) {
+        if (disposed) {
+          return;
+        }
+        setPlannerError(error instanceof Error ? error.message : '加载今日计划失败');
+      } finally {
+        if (!disposed) {
+          setPlannerLoading(false);
+        }
+      }
+    };
+
+    void loadPlanner();
+    return () => {
+      disposed = true;
+    };
+  }, [todayDate]);
 
   useEffect(() => {
     let disposed = false;
@@ -158,9 +275,10 @@ export function NowTodayTab() {
       }
 
       setNow(new Date());
-      setLoading(false);
+      setHistoryLoading(false);
     };
 
+    refreshHistoryRef.current = loadSnapshot;
     void loadSnapshot(true);
     const unsubscribeTasks = taskService.onTaskChange(() => {
       void syncTasks(completedBlocksRef.current, activeBlockRef.current, true);
@@ -180,6 +298,7 @@ export function NowTodayTab() {
 
     return () => {
       disposed = true;
+      refreshHistoryRef.current = null;
       unsubscribeTasks();
       unsubscribeBlocks();
     };
@@ -215,51 +334,339 @@ export function NowTodayTab() {
     now,
   }), [blocks, now, tasksById]);
 
-  if (loading) {
-    return <p className="px-1 py-4 text-sm text-[#78716C] dark:text-[#A8A29E]">加载今日时间块...</p>;
-  }
+  const plannerBlocks = plannerSnapshot?.blocks ?? [];
 
-  if (view.items.length === 0) {
-    return <p className="px-1 py-4 text-sm text-[#78716C] dark:text-[#A8A29E]">今天还没有时间块记录。</p>;
-  }
+  const resetPlannerForm = () => {
+    setPlannerForm(buildDefaultPlannerForm(new Date()));
+    setEditingBlockId(null);
+  };
+
+  const refreshPlanner = async () => {
+    setPlannerError(null);
+    const snapshot = await getTodayPlannerService().getTodayPlanner(todayDate);
+    setPlannerSnapshot(snapshot);
+  };
+
+  const handlePlannerSubmit = async () => {
+    const trimmedTitle = plannerForm.title.trim();
+    const durationMinutes = Number.parseInt(plannerForm.durationMinutes, 10);
+    if (!trimmedTitle) {
+      setPlannerError('标题不能为空');
+      return;
+    }
+    if (!Number.isFinite(durationMinutes) || durationMinutes <= 0) {
+      setPlannerError('时长必须大于 0');
+      return;
+    }
+
+    const basePayload = {
+      date: todayDate,
+      type: plannerForm.type,
+      title: trimmedTitle,
+      plannedStartAt: buildPlannerTimestamp(todayDate, plannerForm.timeValue),
+      plannedDurationMinutes: durationMinutes,
+      linkedTaskIds: [],
+    };
+
+    setPlannerSubmitting(true);
+    setPlannerError(null);
+    try {
+      if (editingBlockId) {
+        await getTodayPlannerService().updatePlannedBlock(editingBlockId, {
+          ...basePayload,
+          note: plannerForm.note.trim() || null,
+        } satisfies UpdatePlannedTimeBlockInput);
+      } else {
+        await getTodayPlannerService().createPlannedBlock({
+          ...basePayload,
+          note: plannerForm.note.trim() || undefined,
+        } satisfies CreatePlannedTimeBlockInput);
+      }
+      await refreshPlanner();
+      resetPlannerForm();
+    } catch (error) {
+      setPlannerError(error instanceof Error ? error.message : '保存今日计划失败');
+    } finally {
+      setPlannerSubmitting(false);
+    }
+  };
+
+  const handleEditBlock = (block: TodayPlannerBlock) => {
+    setEditingBlockId(block.id);
+    setPlannerForm({
+      title: block.title,
+      type: block.type,
+      timeValue: formatTimeValue(block.plannedStartAt),
+      durationMinutes: String(block.plannedDurationMinutes),
+      note: block.note ?? '',
+    });
+  };
+
+  const handleMoveBlock = async (blockId: string, direction: -1 | 1) => {
+    const currentIndex = plannerBlocks.findIndex((block) => block.id === blockId);
+    const targetIndex = currentIndex + direction;
+    if (currentIndex < 0 || targetIndex < 0 || targetIndex >= plannerBlocks.length) {
+      return;
+    }
+
+    const nextIds = plannerBlocks.map((block) => block.id);
+    const [moved] = nextIds.splice(currentIndex, 1);
+    nextIds.splice(targetIndex, 0, moved);
+    try {
+      await getTodayPlannerService().reorderPlannedBlocks(todayDate, nextIds);
+      await refreshPlanner();
+    } catch (error) {
+      setPlannerError(error instanceof Error ? error.message : '重排今日计划失败');
+    }
+  };
+
+  const handleStartBlock = async (blockId: string) => {
+    try {
+      await getTodayPlannerService().startPlannedBlock(blockId);
+      await Promise.all([
+        refreshPlanner(),
+        refreshHistoryRef.current?.(true) ?? Promise.resolve(),
+      ]);
+    } catch (error) {
+      setPlannerError(error instanceof Error ? error.message : '开始计划块失败');
+    }
+  };
+
+  const handleDeleteBlock = async (blockId: string) => {
+    try {
+      await getTodayPlannerService().deletePlannedBlock(blockId);
+      await refreshPlanner();
+      if (editingBlockId === blockId) {
+        resetPlannerForm();
+      }
+    } catch (error) {
+      setPlannerError(error instanceof Error ? error.message : '删除计划块失败');
+    }
+  };
 
   return (
-    <div className="space-y-3">
-      {view.items.map((item) => (
-        <Link
-          key={item.blockId}
-          to="/eventlog/timeblocks/$blockId"
-          params={{ blockId: item.blockId }}
-          className="block rounded-2xl border border-[#E7E5E4] bg-white p-4 transition-colors hover:bg-[#FAF7F5] dark:border-[#292524] dark:bg-[#1C1917] dark:hover:bg-[#292524]"
-        >
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0">
-              <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{item.title}</p>
-              <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">{item.timeLabel}</p>
-            </div>
-            <span className="rounded-full bg-[#F5F0ED] px-2 py-1 text-[11px] text-[#78716C] dark:bg-[#292524] dark:text-[#D6D3D1]">
-              {item.linkedTasks.length} 个任务
-            </span>
-          </div>
+    <div className="space-y-6">
+      <section className="rounded-3xl border border-[#E7E5E4] bg-white/90 p-4 shadow-sm dark:border-[#292524] dark:bg-[#1C1917]">
+        <div className="flex flex-col gap-1">
+          <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">今日计划</p>
+          <p className="text-xs text-[#78716C] dark:text-[#A8A29E]">手动安排今天的工作块和休息块，然后直接开始执行。</p>
+        </div>
 
-          {item.linkedTasks.length > 0 ? (
-            <div className="mt-3 flex flex-wrap gap-2">
-              {item.linkedTasks.map((task) => (
-                <span
-                  key={`${item.blockId}-${task.taskId}`}
-                  className="rounded-full bg-[#FFF7ED] px-2 py-1 text-[11px] text-[#C75B3A] dark:bg-[#2A231B] dark:text-[#FDBA74]"
-                >
-                  {task.title}{task.outcome ? ` · ${task.outcome}` : ''}
+        <div className="mt-4 grid gap-3 md:grid-cols-2">
+          <label className="space-y-1 text-xs text-[#57534E] dark:text-[#D6D3D1]">
+            <span>标题</span>
+            <input
+              aria-label="标题"
+              value={plannerForm.title}
+              onChange={(event) => setPlannerForm((prev) => ({ ...prev, title: event.target.value }))}
+              className="w-full rounded-2xl border border-[#E7E5E4] bg-white px-3 py-2 text-sm outline-none transition-colors focus:border-[#C75B3A] dark:border-[#292524] dark:bg-[#120F0D]"
+              placeholder="例如：Deep Work / 午休"
+            />
+          </label>
+
+          <label className="space-y-1 text-xs text-[#57534E] dark:text-[#D6D3D1]">
+            <span>类型</span>
+            <select
+              aria-label="类型"
+              value={plannerForm.type}
+              onChange={(event) => setPlannerForm((prev) => ({ ...prev, type: event.target.value as PlannedTimeBlockType }))}
+              className="w-full rounded-2xl border border-[#E7E5E4] bg-white px-3 py-2 text-sm outline-none transition-colors focus:border-[#C75B3A] dark:border-[#292524] dark:bg-[#120F0D]"
+            >
+              <option value="work">工作块</option>
+              <option value="rest">休息块</option>
+            </select>
+          </label>
+
+          <label className="space-y-1 text-xs text-[#57534E] dark:text-[#D6D3D1]">
+            <span>开始时间</span>
+            <input
+              aria-label="开始时间"
+              type="time"
+              value={plannerForm.timeValue}
+              onChange={(event) => setPlannerForm((prev) => ({ ...prev, timeValue: event.target.value }))}
+              className="w-full rounded-2xl border border-[#E7E5E4] bg-white px-3 py-2 text-sm outline-none transition-colors focus:border-[#C75B3A] dark:border-[#292524] dark:bg-[#120F0D]"
+            />
+          </label>
+
+          <label className="space-y-1 text-xs text-[#57534E] dark:text-[#D6D3D1]">
+            <span>时长（分钟）</span>
+            <input
+              aria-label="时长（分钟）"
+              type="number"
+              min={1}
+              value={plannerForm.durationMinutes}
+              onChange={(event) => setPlannerForm((prev) => ({ ...prev, durationMinutes: event.target.value }))}
+              className="w-full rounded-2xl border border-[#E7E5E4] bg-white px-3 py-2 text-sm outline-none transition-colors focus:border-[#C75B3A] dark:border-[#292524] dark:bg-[#120F0D]"
+            />
+          </label>
+        </div>
+
+        <label className="mt-3 block space-y-1 text-xs text-[#57534E] dark:text-[#D6D3D1]">
+          <span>备注</span>
+          <textarea
+            value={plannerForm.note}
+            onChange={(event) => setPlannerForm((prev) => ({ ...prev, note: event.target.value }))}
+            className="min-h-[84px] w-full rounded-2xl border border-[#E7E5E4] bg-white px-3 py-2 text-sm outline-none transition-colors focus:border-[#C75B3A] dark:border-[#292524] dark:bg-[#120F0D]"
+            placeholder="可选：记录这个块的目的或边界"
+          />
+        </label>
+
+        <div className="mt-3 flex flex-wrap gap-2">
+          <button
+            type="button"
+            disabled={plannerSubmitting}
+            onClick={() => void handlePlannerSubmit()}
+            className="rounded-full bg-[#C75B3A] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#B14D2F] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {editingBlockId ? '保存修改' : '添加计划块'}
+          </button>
+          {editingBlockId ? (
+            <button
+              type="button"
+              onClick={resetPlannerForm}
+              className="rounded-full border border-[#E7E5E4] px-4 py-2 text-sm text-[#57534E] transition-colors hover:bg-[#F5F0ED] dark:border-[#292524] dark:text-[#D6D3D1] dark:hover:bg-[#292524]"
+            >
+              取消编辑
+            </button>
+          ) : null}
+        </div>
+
+        {plannerError ? (
+          <p className="mt-3 text-xs text-[#C75B3A]" role="alert">{plannerError}</p>
+        ) : null}
+
+        <div className="mt-4 space-y-3">
+          {plannerLoading ? (
+            <p className="text-sm text-[#78716C] dark:text-[#A8A29E]">加载今日计划...</p>
+          ) : plannerBlocks.length === 0 ? (
+            <p className="text-sm text-[#78716C] dark:text-[#A8A29E]">今天还没有计划块。</p>
+          ) : (
+            plannerBlocks.map((block, index) => (
+              <div
+                key={block.id}
+                className="rounded-2xl border border-[#E7E5E4] bg-[#FCFBFA] p-4 dark:border-[#292524] dark:bg-[#120F0D]"
+              >
+                <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{block.title}</p>
+                      <span className={`rounded-full px-2 py-1 text-[11px] ${
+                        block.type === 'work'
+                          ? 'bg-[#FFF7ED] text-[#C75B3A] dark:bg-[#2A231B] dark:text-[#FDBA74]'
+                          : 'bg-[#ECFDF5] text-[#047857] dark:bg-[#10261D] dark:text-[#6EE7B7]'
+                      }`}>
+                        {resolvePlannerTypeLabel(block.type)}
+                      </span>
+                      <span className="rounded-full bg-[#F5F0ED] px-2 py-1 text-[11px] text-[#78716C] dark:bg-[#292524] dark:text-[#D6D3D1]">
+                        {resolvePlannerStatusLabel(block.status)}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">{formatPlannerRange(block)}</p>
+                    {block.note ? (
+                      <p className="mt-2 text-xs text-[#57534E] dark:text-[#D6D3D1]">{block.note}</p>
+                    ) : null}
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      aria-label={`编辑计划块：${block.title}`}
+                      onClick={() => handleEditBlock(block)}
+                      className="rounded-full border border-[#E7E5E4] px-3 py-1.5 text-xs text-[#57534E] transition-colors hover:bg-[#F5F0ED] dark:border-[#292524] dark:text-[#D6D3D1] dark:hover:bg-[#292524]"
+                    >
+                      编辑
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`上移计划块：${block.title}`}
+                      disabled={index === 0}
+                      onClick={() => void handleMoveBlock(block.id, -1)}
+                      className="rounded-full border border-[#E7E5E4] px-3 py-1.5 text-xs text-[#57534E] transition-colors hover:bg-[#F5F0ED] disabled:cursor-not-allowed disabled:opacity-50 dark:border-[#292524] dark:text-[#D6D3D1] dark:hover:bg-[#292524]"
+                    >
+                      上移
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`下移计划块：${block.title}`}
+                      disabled={index === plannerBlocks.length - 1}
+                      onClick={() => void handleMoveBlock(block.id, 1)}
+                      className="rounded-full border border-[#E7E5E4] px-3 py-1.5 text-xs text-[#57534E] transition-colors hover:bg-[#F5F0ED] disabled:cursor-not-allowed disabled:opacity-50 dark:border-[#292524] dark:text-[#D6D3D1] dark:hover:bg-[#292524]"
+                    >
+                      下移
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`开始计划块：${block.title}`}
+                      disabled={block.status === 'active'}
+                      onClick={() => void handleStartBlock(block.id)}
+                      className="rounded-full bg-[#1C1917] px-3 py-1.5 text-xs text-white transition-colors hover:bg-[#292524] disabled:cursor-not-allowed disabled:opacity-50 dark:bg-[#FAFAF9] dark:text-[#1C1917] dark:hover:bg-[#E7E5E4]"
+                    >
+                      开始
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`删除计划块：${block.title}`}
+                      onClick={() => void handleDeleteBlock(block.id)}
+                      className="rounded-full border border-[#F5D0C5] px-3 py-1.5 text-xs text-[#C75B3A] transition-colors hover:bg-[#FFF7ED] dark:border-[#5A2C20] dark:text-[#FDBA74] dark:hover:bg-[#2A231B]"
+                    >
+                      删除
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">今日记录</p>
+          <p className="text-xs text-[#78716C] dark:text-[#A8A29E]">执行后的时间块会继续留在这里。</p>
+        </div>
+
+        {historyLoading ? (
+          <p className="px-1 py-4 text-sm text-[#78716C] dark:text-[#A8A29E]">加载今日时间块...</p>
+        ) : view.items.length === 0 ? (
+          <p className="px-1 py-4 text-sm text-[#78716C] dark:text-[#A8A29E]">今天还没有时间块记录。</p>
+        ) : (
+          view.items.map((item) => (
+            <Link
+              key={item.blockId}
+              to="/eventlog/timeblocks/$blockId"
+              params={{ blockId: item.blockId }}
+              className="block rounded-2xl border border-[#E7E5E4] bg-white p-4 transition-colors hover:bg-[#FAF7F5] dark:border-[#292524] dark:bg-[#1C1917] dark:hover:bg-[#292524]"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{item.title}</p>
+                  <p className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">{item.timeLabel}</p>
+                </div>
+                <span className="rounded-full bg-[#F5F0ED] px-2 py-1 text-[11px] text-[#78716C] dark:bg-[#292524] dark:text-[#D6D3D1]">
+                  {item.linkedTasks.length} 个任务
                 </span>
-              ))}
-            </div>
-          ) : null}
+              </div>
 
-          {item.note ? (
-            <p className="mt-3 text-xs text-[#78716C] dark:text-[#A8A29E]">{item.note}</p>
-          ) : null}
-        </Link>
-      ))}
+              {item.linkedTasks.length > 0 ? (
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {item.linkedTasks.map((task) => (
+                    <span
+                      key={`${item.blockId}-${task.taskId}`}
+                      className="rounded-full bg-[#FFF7ED] px-2 py-1 text-[11px] text-[#C75B3A] dark:bg-[#2A231B] dark:text-[#FDBA74]"
+                    >
+                      {task.title}{task.outcome ? ` · ${task.outcome}` : ''}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+
+              {item.note ? (
+                <p className="mt-3 text-xs text-[#78716C] dark:text-[#A8A29E]">{item.note}</p>
+              ) : null}
+            </Link>
+          ))
+        )}
+      </section>
     </div>
   );
 }

--- a/src/ui/app/components/prestart-task-selection.tsx
+++ b/src/ui/app/components/prestart-task-selection.tsx
@@ -58,6 +58,8 @@ interface PrestartTaskSelectionListProps {
   itemTestIdPrefix: string;
   emptyLabel: string;
   className?: string;
+  maxVisibleTasks?: number;
+  overflowSelectLabel?: string;
 }
 
 function resolvePrestartTaskStatusLabel(task: TaskNode, selected: boolean): string {
@@ -81,8 +83,26 @@ export function PrestartTaskSelectionList({
   itemTestIdPrefix,
   emptyLabel,
   className,
+  maxVisibleTasks,
+  overflowSelectLabel,
 }: PrestartTaskSelectionListProps) {
   const selectedTaskIdSet = new Set(selectedTaskIds);
+  const [overflowSelection, setOverflowSelection] = useState('');
+  const visibleTasks = maxVisibleTasks ? tasks.slice(0, maxVisibleTasks) : tasks;
+  const overflowTasks = maxVisibleTasks ? tasks.slice(maxVisibleTasks) : [];
+
+  const toggleTask = (taskId: string) => {
+    const selected = selectedTaskIdSet.has(taskId);
+    onSelectedTaskIdsChange(
+      selected
+        ? selectedTaskIds.filter((value) => value !== taskId)
+        : [...selectedTaskIds, taskId],
+    );
+  };
+
+  useEffect(() => {
+    setOverflowSelection('');
+  }, [selectedTaskIds, tasks]);
 
   if (tasks.length === 0) {
     return (
@@ -97,7 +117,7 @@ export function PrestartTaskSelectionList({
       data-testid={listTestId}
       className={className ?? 'space-y-2 rounded-[12px] border border-[#E7E5E4] bg-white/55 p-2 dark:border-[#FFFFFF20] dark:bg-[#FFFFFF08]'}
     >
-      {tasks.map((task) => {
+      {visibleTasks.map((task) => {
         const selected = selectedTaskIdSet.has(task.id);
         return (
           <button
@@ -105,13 +125,7 @@ export function PrestartTaskSelectionList({
             type="button"
             data-testid={`${itemTestIdPrefix}${task.id}`}
             aria-pressed={selected}
-            onClick={() => {
-              onSelectedTaskIdsChange(
-                selected
-                  ? selectedTaskIds.filter((taskId) => taskId !== task.id)
-                  : [...selectedTaskIds, task.id],
-              );
-            }}
+            onClick={() => toggleTask(task.id)}
             className={`flex w-full items-center justify-between rounded-[10px] px-3 py-2 text-left text-[12px] transition-colors ${
               selected
                 ? 'bg-[#FFF7ED] text-[#C75B3A] dark:bg-[#2A231B] dark:text-[#FDBA74]'
@@ -125,6 +139,39 @@ export function PrestartTaskSelectionList({
           </button>
         );
       })}
+      {overflowTasks.length > 0 ? (
+        <label className="block space-y-1 text-[12px] text-[#57534E] dark:text-[#D6D3D1]">
+          <span className="flex items-center justify-between gap-2">
+            <span>{overflowSelectLabel ?? 'More tasks / 更多任务'}</span>
+            <span className="text-[11px] text-[#A8A29E]">{overflowTasks.length} 个候选</span>
+          </span>
+          <select
+            aria-label={overflowSelectLabel ?? '更多任务'}
+            value={overflowSelection}
+            onChange={(event) => {
+              const nextTaskId = event.target.value;
+              setOverflowSelection(nextTaskId);
+              if (!nextTaskId) {
+                return;
+              }
+              toggleTask(nextTaskId);
+              setOverflowSelection('');
+            }}
+            className="w-full rounded-[10px] border border-[#E7E5E4] bg-white px-3 py-2 text-[12px] outline-none focus:border-[#C75B3A] dark:border-[#FFFFFF20] dark:bg-[#120F0D] dark:text-[#D6D3D1]"
+          >
+            <option value="">从下拉里查看和选择更多任务</option>
+            {overflowTasks.map((task) => {
+              const selected = selectedTaskIdSet.has(task.id);
+              const statusLabel = resolvePrestartTaskStatusLabel(task, selected);
+              return (
+                <option key={task.id} value={task.id}>
+                  {`${selected ? '[已选] ' : ''}${task.title} · ${statusLabel}`}
+                </option>
+              );
+            })}
+          </select>
+        </label>
+      ) : null}
     </div>
   );
 }

--- a/tests/unit/adapters/today-planner-rt-adapter.test.ts
+++ b/tests/unit/adapters/today-planner-rt-adapter.test.ts
@@ -175,4 +175,38 @@ describe('TodayPlannerRtAdapter（Today Planner RT 适配器）', () => {
       actualEndAt: 1774575300000,
     });
   });
+
+  it('omits linkedTaskIds when updating only the title（仅改标题时不覆盖已关联任务）', async () => {
+    activateProfileScope();
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: 'segment-2',
+        windowId: 'window-1',
+        kind: 'work',
+        title: 'Renamed Segment',
+        plannedStartAt: 1774573600000,
+        plannedEndAt: 1774575100000,
+        linkedTaskIds: ['task-a'],
+        order: 0,
+        createdAt: 1774570000000,
+        updatedAt: 1774570100000,
+        status: 'pending',
+      }),
+    });
+    const adapter = new TodayPlannerRtAdapter({
+      fetchImpl,
+      resolveTarget: () => ({ mode: 'embedded', host: '127.0.0.1', port: 9124 }),
+    });
+
+    await adapter.updatePlannedSegment('segment-2', {
+      title: 'Renamed Segment',
+    });
+
+    const [, updateInit] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(updateInit.body))).toEqual({
+      title: 'Renamed Segment',
+    });
+  });
 });

--- a/tests/unit/adapters/today-planner-rt-adapter.test.ts
+++ b/tests/unit/adapters/today-planner-rt-adapter.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createLocalProfile, setProfileSession } from '@/lib/profile/profile-storage';
+import { TodayPlannerRtAdapter } from '@/lib/adapters/today-planner-rt-adapter';
+
+function activateProfileScope(): string {
+  const profile = createLocalProfile({
+    slug: 'exomind',
+    displayName: 'Hailay',
+  });
+  setProfileSession({
+    version: 1,
+    activeProfileId: profile.profileId,
+    unlockedProfileIds: [profile.profileId],
+  });
+  return profile.profileId;
+}
+
+describe('TodayPlannerRtAdapter（Today Planner RT 适配器）', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('uses /act/today-planner routes with scoped query and expected verbs（走 /act/today-planner 且自动带 profile scope）', async () => {
+    const profileId = activateProfileScope();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          date: '2026-03-26',
+          blocks: [],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({
+          id: 'plan-1',
+          date: '2026-03-26',
+          type: 'work',
+          title: 'Deep Work',
+          plannedStartAt: 1774490400000,
+          plannedDurationMinutes: 50,
+          linkedTaskIds: ['task-a'],
+          order: 0,
+          createdAt: 1774489000000,
+          updatedAt: 1774489000000,
+          status: 'pending',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: 'plan-1',
+          date: '2026-03-26',
+          type: 'rest',
+          title: 'Lunch Reset',
+          plannedStartAt: 1774494000000,
+          plannedDurationMinutes: 30,
+          linkedTaskIds: [],
+          order: 0,
+          createdAt: 1774489000000,
+          updatedAt: 1774489100000,
+          status: 'pending',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          date: '2026-03-26',
+          blocks: [],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          startId: 'active-1',
+          name: 'Lunch Reset',
+          mode: 'countdown',
+          targetMinutes: 30,
+          elapsed: 1800000,
+          paused: false,
+          startTime: 1774494000000,
+          taskIds: [],
+          taskAssociationLog: [],
+          sourcePlannedBlockId: 'plan-1',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+        json: async () => ({}),
+      });
+
+    const adapter = new TodayPlannerRtAdapter({
+      fetchImpl,
+      resolveTarget: () => ({ mode: 'embedded', host: '127.0.0.1', port: 9124 }),
+    });
+
+    await adapter.getTodayPlanner('2026-03-26');
+    await adapter.createPlannedBlock({
+      date: '2026-03-26',
+      type: 'work',
+      title: 'Deep Work',
+      plannedStartAt: 1774490400000,
+      plannedDurationMinutes: 50,
+      linkedTaskIds: ['task-a'],
+    });
+    await adapter.updatePlannedBlock('plan-1', {
+      type: 'rest',
+      title: 'Lunch Reset',
+      plannedStartAt: 1774494000000,
+      plannedDurationMinutes: 30,
+      linkedTaskIds: [],
+    });
+    await adapter.reorderPlannedBlocks('2026-03-26', ['plan-2', 'plan-1']);
+    await adapter.startPlannedBlock('plan-1');
+    await adapter.deletePlannedBlock('plan-1');
+
+    const [listUrl, listInit] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const listRequestUrl = new URL(listUrl);
+    expect(`${listRequestUrl.origin}${listRequestUrl.pathname}`).toBe('http://127.0.0.1:9124/act/today-planner');
+    expect(listRequestUrl.searchParams.get('date')).toBe('2026-03-26');
+    expect(listRequestUrl.searchParams.get('user_id')).toBe(profileId);
+    expect(listInit.method).toBe('GET');
+
+    const [createUrl, createInit] = fetchImpl.mock.calls[1] as [string, RequestInit];
+    const createRequestUrl = new URL(createUrl);
+    expect(`${createRequestUrl.origin}${createRequestUrl.pathname}`).toBe('http://127.0.0.1:9124/act/today-planner/blocks');
+    expect(createRequestUrl.searchParams.get('user_id')).toBe(profileId);
+    expect(createInit.method).toBe('POST');
+    expect(JSON.parse(String(createInit.body))).toEqual({
+      date: '2026-03-26',
+      type: 'work',
+      title: 'Deep Work',
+      plannedStartAt: 1774490400000,
+      plannedDurationMinutes: 50,
+      linkedTaskIds: ['task-a'],
+    });
+
+    const [updateUrl, updateInit] = fetchImpl.mock.calls[2] as [string, RequestInit];
+    const updateRequestUrl = new URL(updateUrl);
+    expect(`${updateRequestUrl.origin}${updateRequestUrl.pathname}`).toBe('http://127.0.0.1:9124/act/today-planner/blocks/plan-1');
+    expect(updateRequestUrl.searchParams.get('user_id')).toBe(profileId);
+    expect(updateInit.method).toBe('PATCH');
+
+    const [reorderUrl, reorderInit] = fetchImpl.mock.calls[3] as [string, RequestInit];
+    const reorderRequestUrl = new URL(reorderUrl);
+    expect(`${reorderRequestUrl.origin}${reorderRequestUrl.pathname}`).toBe('http://127.0.0.1:9124/act/today-planner/blocks/reorder');
+    expect(reorderRequestUrl.searchParams.get('user_id')).toBe(profileId);
+    expect(reorderInit.method).toBe('POST');
+    expect(JSON.parse(String(reorderInit.body))).toEqual({
+      date: '2026-03-26',
+      orderedIds: ['plan-2', 'plan-1'],
+    });
+
+    const [startUrl, startInit] = fetchImpl.mock.calls[4] as [string, RequestInit];
+    const startRequestUrl = new URL(startUrl);
+    expect(`${startRequestUrl.origin}${startRequestUrl.pathname}`).toBe('http://127.0.0.1:9124/act/today-planner/blocks/plan-1/start');
+    expect(startRequestUrl.searchParams.get('user_id')).toBe(profileId);
+    expect(startInit.method).toBe('POST');
+
+    const [deleteUrl, deleteInit] = fetchImpl.mock.calls[5] as [string, RequestInit];
+    const deleteRequestUrl = new URL(deleteUrl);
+    expect(`${deleteRequestUrl.origin}${deleteRequestUrl.pathname}`).toBe('http://127.0.0.1:9124/act/today-planner/blocks/plan-1');
+    expect(deleteRequestUrl.searchParams.get('user_id')).toBe(profileId);
+    expect(deleteInit.method).toBe('DELETE');
+  });
+});

--- a/tests/unit/adapters/today-planner-rt-adapter.test.ts
+++ b/tests/unit/adapters/today-planner-rt-adapter.test.ts
@@ -20,7 +20,7 @@ describe('TodayPlannerRtAdapter（Today Planner RT 适配器）', () => {
     window.localStorage.clear();
   });
 
-  it('uses /act/today-planner routes with scoped query and expected verbs（走 /act/today-planner 且自动带 profile scope）', async () => {
+  it('uses scheduling-window and segment routes with scoped query and expected verbs（走窗口/片段路由且自动带 profile scope）', async () => {
     const profileId = activateProfileScope();
     const fetchImpl = vi
       .fn()
@@ -28,50 +28,47 @@ describe('TodayPlannerRtAdapter（Today Planner RT 适配器）', () => {
         ok: true,
         status: 200,
         json: async () => ({
-          date: '2026-03-26',
-          blocks: [],
+          date: '2026-03-27',
+          windows: [],
         }),
       })
       .mockResolvedValueOnce({
         ok: true,
         status: 201,
         json: async () => ({
-          id: 'plan-1',
-          date: '2026-03-26',
-          type: 'work',
-          title: 'Deep Work',
-          plannedStartAt: 1774490400000,
-          plannedDurationMinutes: 50,
+          id: 'window-1',
+          date: '2026-03-27',
+          title: 'Morning Focus',
+          plannedStartAt: 1774573600000,
+          plannedEndAt: 1774577200000,
+          rhythmPreset: {
+            key: 'pomodoro_25_5',
+            label: '25 / 5',
+            workMinutes: 25,
+            shortBreakMinutes: 5,
+            longBreakMinutes: 20,
+            longBreakAfterWorkSegments: 4,
+          },
+          segments: [],
+          createdAt: 1774570000000,
+          updatedAt: 1774570000000,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: 'segment-1',
+          windowId: 'window-1',
+          kind: 'work',
+          title: 'Deep Work A',
+          plannedStartAt: 1774573600000,
+          plannedEndAt: 1774575100000,
           linkedTaskIds: ['task-a'],
           order: 0,
-          createdAt: 1774489000000,
-          updatedAt: 1774489000000,
+          createdAt: 1774570000000,
+          updatedAt: 1774570100000,
           status: 'pending',
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => ({
-          id: 'plan-1',
-          date: '2026-03-26',
-          type: 'rest',
-          title: 'Lunch Reset',
-          plannedStartAt: 1774494000000,
-          plannedDurationMinutes: 30,
-          linkedTaskIds: [],
-          order: 0,
-          createdAt: 1774489000000,
-          updatedAt: 1774489100000,
-          status: 'pending',
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => ({
-          date: '2026-03-26',
-          blocks: [],
         }),
       })
       .mockResolvedValueOnce({
@@ -79,21 +76,38 @@ describe('TodayPlannerRtAdapter（Today Planner RT 适配器）', () => {
         status: 200,
         json: async () => ({
           startId: 'active-1',
-          name: 'Lunch Reset',
+          name: 'Deep Work A',
           mode: 'countdown',
-          targetMinutes: 30,
-          elapsed: 1800000,
+          targetMinutes: 25,
+          elapsed: 1500000,
           paused: false,
-          startTime: 1774494000000,
-          taskIds: [],
+          startTime: 1774573600000,
+          taskIds: ['task-a'],
           taskAssociationLog: [],
-          sourcePlannedBlockId: 'plan-1',
+          sourcePlannedBlockId: 'segment-1',
         }),
       })
       .mockResolvedValueOnce({
         ok: true,
-        status: 204,
-        json: async () => ({}),
+        status: 200,
+        json: async () => ({
+          id: 'window-1',
+          date: '2026-03-27',
+          title: 'Morning Focus',
+          plannedStartAt: 1774573600000,
+          plannedEndAt: 1774577800000,
+          rhythmPreset: {
+            key: 'pomodoro_25_5',
+            label: '25 / 5',
+            workMinutes: 25,
+            shortBreakMinutes: 5,
+            longBreakMinutes: 20,
+            longBreakAfterWorkSegments: 4,
+          },
+          segments: [],
+          createdAt: 1774570000000,
+          updatedAt: 1774570200000,
+        }),
       });
 
     const adapter = new TodayPlannerRtAdapter({
@@ -101,73 +115,64 @@ describe('TodayPlannerRtAdapter（Today Planner RT 适配器）', () => {
       resolveTarget: () => ({ mode: 'embedded', host: '127.0.0.1', port: 9124 }),
     });
 
-    await adapter.getTodayPlanner('2026-03-26');
-    await adapter.createPlannedBlock({
-      date: '2026-03-26',
-      type: 'work',
-      title: 'Deep Work',
-      plannedStartAt: 1774490400000,
-      plannedDurationMinutes: 50,
+    await adapter.getTodayPlanner('2026-03-27');
+    await adapter.createSchedulingWindow({
+      date: '2026-03-27',
+      title: 'Morning Focus',
+      plannedStartAt: 1774573600000,
+      plannedEndAt: 1774577200000,
+      rhythmPresetKey: 'pomodoro_25_5',
+    });
+    await adapter.updatePlannedSegment('segment-1', {
+      title: 'Deep Work A',
       linkedTaskIds: ['task-a'],
     });
-    await adapter.updatePlannedBlock('plan-1', {
-      type: 'rest',
-      title: 'Lunch Reset',
-      plannedStartAt: 1774494000000,
-      plannedDurationMinutes: 30,
-      linkedTaskIds: [],
+    await adapter.startWorkSegment('segment-1');
+    await adapter.reflowSchedulingWindow('window-1', {
+      anchorSegmentId: 'segment-1',
+      actualEndAt: 1774575300000,
     });
-    await adapter.reorderPlannedBlocks('2026-03-26', ['plan-2', 'plan-1']);
-    await adapter.startPlannedBlock('plan-1');
-    await adapter.deletePlannedBlock('plan-1');
 
     const [listUrl, listInit] = fetchImpl.mock.calls[0] as [string, RequestInit];
     const listRequestUrl = new URL(listUrl);
     expect(`${listRequestUrl.origin}${listRequestUrl.pathname}`).toBe('http://127.0.0.1:9124/act/today-planner');
-    expect(listRequestUrl.searchParams.get('date')).toBe('2026-03-26');
+    expect(listRequestUrl.searchParams.get('date')).toBe('2026-03-27');
     expect(listRequestUrl.searchParams.get('user_id')).toBe(profileId);
     expect(listInit.method).toBe('GET');
 
     const [createUrl, createInit] = fetchImpl.mock.calls[1] as [string, RequestInit];
     const createRequestUrl = new URL(createUrl);
-    expect(`${createRequestUrl.origin}${createRequestUrl.pathname}`).toBe('http://127.0.0.1:9124/act/today-planner/blocks');
+    expect(`${createRequestUrl.origin}${createRequestUrl.pathname}`).toBe('http://127.0.0.1:9124/act/today-planner/windows');
     expect(createRequestUrl.searchParams.get('user_id')).toBe(profileId);
     expect(createInit.method).toBe('POST');
     expect(JSON.parse(String(createInit.body))).toEqual({
-      date: '2026-03-26',
-      type: 'work',
-      title: 'Deep Work',
-      plannedStartAt: 1774490400000,
-      plannedDurationMinutes: 50,
-      linkedTaskIds: ['task-a'],
+      date: '2026-03-27',
+      title: 'Morning Focus',
+      plannedStartAt: 1774573600000,
+      plannedEndAt: 1774577200000,
+      rhythmPresetKey: 'pomodoro_25_5',
     });
 
     const [updateUrl, updateInit] = fetchImpl.mock.calls[2] as [string, RequestInit];
     const updateRequestUrl = new URL(updateUrl);
-    expect(`${updateRequestUrl.origin}${updateRequestUrl.pathname}`).toBe('http://127.0.0.1:9124/act/today-planner/blocks/plan-1');
+    expect(`${updateRequestUrl.origin}${updateRequestUrl.pathname}`).toBe('http://127.0.0.1:9124/act/today-planner/segments/segment-1');
     expect(updateRequestUrl.searchParams.get('user_id')).toBe(profileId);
     expect(updateInit.method).toBe('PATCH');
 
-    const [reorderUrl, reorderInit] = fetchImpl.mock.calls[3] as [string, RequestInit];
-    const reorderRequestUrl = new URL(reorderUrl);
-    expect(`${reorderRequestUrl.origin}${reorderRequestUrl.pathname}`).toBe('http://127.0.0.1:9124/act/today-planner/blocks/reorder');
-    expect(reorderRequestUrl.searchParams.get('user_id')).toBe(profileId);
-    expect(reorderInit.method).toBe('POST');
-    expect(JSON.parse(String(reorderInit.body))).toEqual({
-      date: '2026-03-26',
-      orderedIds: ['plan-2', 'plan-1'],
-    });
-
-    const [startUrl, startInit] = fetchImpl.mock.calls[4] as [string, RequestInit];
+    const [startUrl, startInit] = fetchImpl.mock.calls[3] as [string, RequestInit];
     const startRequestUrl = new URL(startUrl);
-    expect(`${startRequestUrl.origin}${startRequestUrl.pathname}`).toBe('http://127.0.0.1:9124/act/today-planner/blocks/plan-1/start');
+    expect(`${startRequestUrl.origin}${startRequestUrl.pathname}`).toBe('http://127.0.0.1:9124/act/today-planner/segments/segment-1/start');
     expect(startRequestUrl.searchParams.get('user_id')).toBe(profileId);
     expect(startInit.method).toBe('POST');
 
-    const [deleteUrl, deleteInit] = fetchImpl.mock.calls[5] as [string, RequestInit];
-    const deleteRequestUrl = new URL(deleteUrl);
-    expect(`${deleteRequestUrl.origin}${deleteRequestUrl.pathname}`).toBe('http://127.0.0.1:9124/act/today-planner/blocks/plan-1');
-    expect(deleteRequestUrl.searchParams.get('user_id')).toBe(profileId);
-    expect(deleteInit.method).toBe('DELETE');
+    const [reflowUrl, reflowInit] = fetchImpl.mock.calls[4] as [string, RequestInit];
+    const reflowRequestUrl = new URL(reflowUrl);
+    expect(`${reflowRequestUrl.origin}${reflowRequestUrl.pathname}`).toBe('http://127.0.0.1:9124/act/today-planner/windows/window-1/reflow');
+    expect(reflowRequestUrl.searchParams.get('user_id')).toBe(profileId);
+    expect(reflowInit.method).toBe('POST');
+    expect(JSON.parse(String(reflowInit.body))).toEqual({
+      anchorSegmentId: 'segment-1',
+      actualEndAt: 1774575300000,
+    });
   });
 });

--- a/tests/unit/services/timeblock.service.rt-sqlite.test.ts
+++ b/tests/unit/services/timeblock.service.rt-sqlite.test.ts
@@ -77,9 +77,12 @@ function createMemoryEnv(initial: Record<string, unknown> = {}): MemoryEnv {
   };
 }
 
-function createRtAdapter(): TimeBlockRtAdapterLike {
-  let completedBlocks: TimeBlockData[] = [];
-  let activeBlock: ActiveBlockData | null = null;
+function createRtAdapter(initial?: {
+  completedBlocks?: TimeBlockData[];
+  activeBlock?: ActiveBlockData | null;
+}): TimeBlockRtAdapterLike {
+  let completedBlocks: TimeBlockData[] = initial?.completedBlocks ?? [];
+  let activeBlock: ActiveBlockData | null = initial?.activeBlock ?? null;
   return {
     listCompletedBlocks: vi.fn(async () => completedBlocks),
     replaceCompletedBlocks: vi.fn(async (blocks: TimeBlockData[]) => {
@@ -219,5 +222,37 @@ describe('TimeBlockServiceImpl rt-sqlite backend', () => {
       ([event]) => (event as { type?: string }).type,
     );
     expect(types).not.toContain('block_end');
+  });
+
+  it('preserves sourcePlannedBlockId when finishing a planned block in rt-sqlite mode', async () => {
+    const env = createMemoryEnv();
+    const rtAdapter = createRtAdapter({
+      activeBlock: {
+        startId: 'active-planned-1',
+        name: 'Lunch Reset',
+        mode: 'countdown',
+        targetMinutes: 30,
+        elapsed: 1_800_000,
+        paused: false,
+        startTime: 1_700_000_000_000,
+        phase: 'running',
+        version: 1,
+        lastTransitionAt: 1_700_000_000_000,
+        taskIds: [],
+        taskAssociationLog: [],
+        sourcePlannedBlockId: 'plan-1',
+      },
+    });
+    const service = new TimeBlockServiceImpl(env as never, {
+      backendMode: 'rt-sqlite',
+      rtAdapter,
+    });
+
+    await service.markEnding();
+    await service.endBlock('rest done');
+
+    expect(rtAdapter.replaceCompletedBlocks).toHaveBeenCalled();
+    const [completedBlocks] = (rtAdapter.replaceCompletedBlocks as ReturnType<typeof vi.fn>).mock.calls.at(-1) ?? [];
+    expect(completedBlocks?.[0]?.sourcePlannedBlockId).toBe('plan-1');
   });
 });

--- a/tests/unit/services/today-planner.service.test.ts
+++ b/tests/unit/services/today-planner.service.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ActiveBlockData } from '@/lib/types/event';
+
+const mocks = vi.hoisted(() => ({
+  applyReplicatedActiveBlock: vi.fn(),
+}));
+
+vi.mock('@/lib/services/timeblock.service', () => ({
+  getTimeBlockService: () => ({
+    applyReplicatedActiveBlock: mocks.applyReplicatedActiveBlock,
+  }),
+}));
+
+import { TodayPlannerServiceImpl } from '@/lib/services/today-planner.service';
+
+describe('TodayPlannerServiceImpl（今日计划服务）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('syncs runtime start results into local TimeBlockService after starting a work segment（开始工作片段后同步本地活跃块）', async () => {
+    const activeBlock: ActiveBlockData = {
+      startId: 'active-segment-1',
+      name: 'Deep Work A',
+      mode: 'countdown',
+      elapsed: 0,
+      startTime: 1_774_573_600_000,
+      paused: false,
+      phase: 'running',
+      version: 1,
+      lastTransitionAt: 1_774_573_600_000,
+      taskIds: ['task-a'],
+      taskAssociationLog: [],
+      targetMinutes: 45,
+      sourcePlannedBlockId: 'segment-1',
+    };
+    const rtAdapter = {
+      startWorkSegment: vi.fn().mockResolvedValue(activeBlock),
+    };
+    const service = new TodayPlannerServiceImpl(rtAdapter as never);
+
+    const result = await service.startWorkSegment('segment-1');
+
+    expect(rtAdapter.startWorkSegment).toHaveBeenCalledWith('segment-1');
+    expect(mocks.applyReplicatedActiveBlock).toHaveBeenCalledWith(activeBlock);
+    expect(result).toEqual(activeBlock);
+  });
+});

--- a/tests/unit/ui/now-today-planner.test.tsx
+++ b/tests/unit/ui/now-today-planner.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NowTodayTab } from '@/ui/app/components/NowTodayTab';
 import type {
@@ -49,6 +49,10 @@ vi.mock('@/lib/services', () => ({
 
 function plannerTs(clock: string): number {
   return new Date(`2026-03-27T${clock}:00+08:00`).getTime();
+}
+
+function plannerTsOn(dateKey: string, clock: string): number {
+  return new Date(`${dateKey}T${clock}:00+08:00`).getTime();
 }
 
 function makeTask(input: Partial<TaskNode> & Pick<TaskNode, 'id' | 'title'>): TaskNode {
@@ -362,6 +366,74 @@ describe('NowTodayTab Today Planner timeline（时间线版今日计划器）', 
       expect(updatePlannedSegmentMock).toHaveBeenCalledWith('segment-work-overflow', {
         linkedTaskIds: ['task-11'],
       });
+    });
+  });
+
+  it('reflows a work segment ending at midnight using the next-day timestamp（跨午夜重算会把 00:00 解释为次日）', async () => {
+    const snapshotWindow = makeWindow({
+      id: 'window-midnight',
+      title: '夜间冲刺',
+      plannedStartAt: plannerTs('23:15'),
+      plannedEndAt: plannerTsOn('2026-03-28', '00:30'),
+      segments: [
+        makeSegment({
+          id: 'segment-work-midnight',
+          windowId: 'window-midnight',
+          kind: 'work',
+          title: '夜间工作块',
+          plannedStartAt: plannerTs('23:15'),
+          plannedEndAt: plannerTsOn('2026-03-28', '00:00'),
+          order: 0,
+        }),
+        makeSegment({
+          id: 'segment-break-midnight',
+          windowId: 'window-midnight',
+          kind: 'break',
+          breakKind: 'short',
+          title: 'Short Break',
+          plannedStartAt: plannerTsOn('2026-03-28', '00:00'),
+          plannedEndAt: plannerTsOn('2026-03-28', '00:30'),
+          order: 1,
+        }),
+      ],
+    });
+
+    getTodayPlannerMock.mockResolvedValue({ date: '2026-03-27', windows: [snapshotWindow] });
+    reflowSchedulingWindowMock.mockResolvedValue(snapshotWindow);
+
+    render(<NowTodayTab />);
+
+    fireEvent.click(await screen.findByTestId('planner-segment-segment-work-midnight'));
+    expect(await screen.findByTestId('planner-segment-inspector')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '重算当前区间' }));
+
+    await waitFor(() => {
+      expect(reflowSchedulingWindowMock).toHaveBeenCalledWith('window-midnight', {
+        anchorSegmentId: 'segment-work-midnight',
+        actualEndAt: plannerTsOn('2026-03-28', '00:00'),
+      });
+    });
+  });
+
+  it('refreshes planner date after midnight even without an active block（无活跃块时跨午夜也会刷新今日日期）', async () => {
+    vi.setSystemTime(new Date('2026-03-27T23:59:00+08:00'));
+    getTodayPlannerMock.mockImplementation(async (date: string) => ({ date, windows: [] }));
+
+    render(<NowTodayTab />);
+
+    await waitFor(() => {
+      expect(getTodayPlannerMock).toHaveBeenCalledWith('2026-03-27');
+    });
+
+    getTodayPlannerMock.mockClear();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(61_000);
+    });
+
+    await waitFor(() => {
+      expect(getTodayPlannerMock).toHaveBeenCalledWith('2026-03-28');
     });
   });
 });

--- a/tests/unit/ui/now-today-planner.test.tsx
+++ b/tests/unit/ui/now-today-planner.test.tsx
@@ -297,4 +297,71 @@ describe('NowTodayTab Today Planner timeline（时间线版今日计划器）', 
       expect(startWorkSegmentMock).toHaveBeenCalledWith('segment-work-3');
     });
   });
+
+  it('shows only the first 10 task chips and uses a dropdown for overflow tasks（任务过多时只平铺前 10 个，其余走下拉）', async () => {
+    const snapshotWindow = makeWindow({
+      id: 'window-overflow',
+      title: '任务太多测试',
+      plannedStartAt: plannerTs('15:00'),
+      plannedEndAt: plannerTs('16:00'),
+      segments: [
+        makeSegment({
+          id: 'segment-work-overflow',
+          windowId: 'window-overflow',
+          kind: 'work',
+          title: '任务过多工作块',
+          plannedStartAt: plannerTs('15:00'),
+          plannedEndAt: plannerTs('15:45'),
+          order: 0,
+        }),
+        makeSegment({
+          id: 'segment-break-overflow',
+          windowId: 'window-overflow',
+          kind: 'break',
+          breakKind: 'short',
+          title: 'Short Break',
+          plannedStartAt: plannerTs('15:45'),
+          plannedEndAt: plannerTs('16:00'),
+          order: 1,
+        }),
+      ],
+    });
+
+    getTodayPlannerMock.mockResolvedValue({ date: '2026-03-27', windows: [snapshotWindow] });
+    listTasksMock.mockResolvedValue(
+      Array.from({ length: 12 }, (_, index) => makeTask({
+        id: `task-${index + 1}`,
+        title: `任务 ${index + 1}`,
+        status: 'pending',
+      })),
+    );
+    updatePlannedSegmentMock.mockResolvedValue({
+      ...snapshotWindow.segments[0],
+      linkedTaskIds: ['task-11'],
+      status: 'pending',
+    });
+
+    render(<NowTodayTab />);
+
+    fireEvent.click(await screen.findByTestId('planner-segment-segment-work-overflow'));
+
+    expect(await screen.findByTestId('planner-segment-inspector')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId(/planner-segment-task-task-/)).toHaveLength(10);
+    });
+    expect(screen.getByTestId('planner-segment-task-task-10')).toBeInTheDocument();
+    expect(screen.queryByTestId('planner-segment-task-task-11')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('更多任务'), {
+      target: { value: 'task-11' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '保存工作片段' }));
+
+    await waitFor(() => {
+      expect(updatePlannedSegmentMock).toHaveBeenCalledWith('segment-work-overflow', {
+        linkedTaskIds: ['task-11'],
+      });
+    });
+  });
 });

--- a/tests/unit/ui/now-today-planner.test.tsx
+++ b/tests/unit/ui/now-today-planner.test.tsx
@@ -2,153 +2,299 @@ import type { ReactNode } from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NowTodayTab } from '@/ui/app/components/NowTodayTab';
-import type { TodayPlannerSnapshot } from '@/lib/types/event';
+import type {
+  ActiveBlockData,
+  TodayPlannerSegment,
+  TodayPlannerWindow,
+} from '@/lib/types/event';
+import type { TaskNode } from '@/lib/types/task';
 
-const getTodayPlannerMock = vi.fn();
-const createPlannedBlockMock = vi.fn();
-const updatePlannedBlockMock = vi.fn();
-const reorderPlannedBlocksMock = vi.fn();
-const startPlannedBlockMock = vi.fn();
-const deletePlannedBlockMock = vi.fn();
+const getTaskMock = vi.fn();
+const listTasksMock = vi.fn();
+const checkDependenciesMetMock = vi.fn();
+const onTaskChangeMock = vi.fn(() => () => {});
 const loadTimeBlocksMock = vi.fn();
 const loadActiveBlockMock = vi.fn();
 const onBlockChangeMock = vi.fn(() => () => {});
-const getTaskMock = vi.fn();
-const onTaskChangeMock = vi.fn(() => () => {});
+const getTodayPlannerMock = vi.fn();
+const createSchedulingWindowMock = vi.fn();
+const updatePlannedSegmentMock = vi.fn();
+const startWorkSegmentMock = vi.fn();
+const reflowSchedulingWindowMock = vi.fn();
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
 }));
 
 vi.mock('@/lib/services', () => ({
-  getTodayPlannerService: () => ({
-    getTodayPlanner: getTodayPlannerMock,
-    createPlannedBlock: createPlannedBlockMock,
-    updatePlannedBlock: updatePlannedBlockMock,
-    reorderPlannedBlocks: reorderPlannedBlocksMock,
-    startPlannedBlock: startPlannedBlockMock,
-    deletePlannedBlock: deletePlannedBlockMock,
+  getTaskService: () => ({
+    getTask: getTaskMock,
+    listTasks: listTasksMock,
+    checkDependenciesMet: checkDependenciesMetMock,
+    onTaskChange: onTaskChangeMock,
   }),
   getTimeBlockService: () => ({
     loadTimeBlocks: loadTimeBlocksMock,
     loadActiveBlock: loadActiveBlockMock,
     onBlockChange: onBlockChangeMock,
   }),
-  getTaskService: () => ({
-    getTask: getTaskMock,
-    onTaskChange: onTaskChangeMock,
+  getTodayPlannerService: () => ({
+    getTodayPlanner: getTodayPlannerMock,
+    createSchedulingWindow: createSchedulingWindowMock,
+    updatePlannedSegment: updatePlannedSegmentMock,
+    startWorkSegment: startWorkSegmentMock,
+    reflowSchedulingWindow: reflowSchedulingWindowMock,
   }),
 }));
 
-function createSnapshot(): TodayPlannerSnapshot {
+function plannerTs(clock: string): number {
+  return new Date(`2026-03-27T${clock}:00+08:00`).getTime();
+}
+
+function makeTask(input: Partial<TaskNode> & Pick<TaskNode, 'id' | 'title'>): TaskNode {
+  const now = plannerTs('08:00');
   return {
-    date: '2026-03-26',
-    blocks: [
-      {
-        id: 'plan-1',
-        date: '2026-03-26',
-        type: 'work',
-        title: 'Deep Work',
-        plannedStartAt: new Date('2026-03-26T09:00:00+08:00').getTime(),
-        plannedDurationMinutes: 50,
-        linkedTaskIds: ['task-a'],
-        order: 0,
-        createdAt: new Date('2026-03-26T08:00:00+08:00').getTime(),
-        updatedAt: new Date('2026-03-26T08:00:00+08:00').getTime(),
-        status: 'pending',
-      },
-      {
-        id: 'plan-2',
-        date: '2026-03-26',
-        type: 'rest',
-        title: 'Lunch Reset',
-        plannedStartAt: new Date('2026-03-26T12:30:00+08:00').getTime(),
-        plannedDurationMinutes: 30,
-        linkedTaskIds: [],
-        order: 1,
-        createdAt: new Date('2026-03-26T08:10:00+08:00').getTime(),
-        updatedAt: new Date('2026-03-26T08:10:00+08:00').getTime(),
-        status: 'pending',
-      },
-    ],
+    id: input.id,
+    title: input.title,
+    status: input.status ?? 'pending',
+    priority: input.priority ?? 'medium',
+    dependsOn: input.dependsOn ?? [],
+    tags: input.tags ?? [],
+    createdAt: input.createdAt ?? now,
+    updatedAt: input.updatedAt ?? now,
+    description: input.description,
+    estimatedMinutes: input.estimatedMinutes,
+    completedAt: input.completedAt,
+    dueAt: input.dueAt,
+    source: input.source,
+    parentId: input.parentId,
+    doneCondition: input.doneCondition,
+    timeBlockIds: input.timeBlockIds,
   };
 }
 
-describe('NowTodayTab Today Planner（今日计划器）', () => {
+function makeSegment(
+  input: Partial<TodayPlannerSegment> & Pick<TodayPlannerSegment, 'id' | 'windowId' | 'kind' | 'title' | 'plannedStartAt' | 'plannedEndAt' | 'order'>,
+): TodayPlannerSegment {
+  return {
+    id: input.id,
+    windowId: input.windowId,
+    kind: input.kind,
+    title: input.title,
+    plannedStartAt: input.plannedStartAt,
+    plannedEndAt: input.plannedEndAt,
+    linkedTaskIds: input.linkedTaskIds ?? [],
+    order: input.order,
+    createdAt: input.createdAt ?? input.plannedStartAt,
+    updatedAt: input.updatedAt ?? input.plannedStartAt,
+    status: input.status ?? 'pending',
+    breakKind: input.breakKind,
+    sourceTimeBlockId: input.sourceTimeBlockId,
+  };
+}
+
+function makeWindow(
+  input: Partial<TodayPlannerWindow> & Pick<TodayPlannerWindow, 'id' | 'plannedStartAt' | 'plannedEndAt' | 'segments'>,
+): TodayPlannerWindow {
+  return {
+    id: input.id,
+    date: input.date ?? '2026-03-27',
+    title: input.title,
+    plannedStartAt: input.plannedStartAt,
+    plannedEndAt: input.plannedEndAt,
+    rhythmPreset: input.rhythmPreset ?? {
+      key: 'pomodoro_25_5',
+      label: '25 / 5',
+      workMinutes: 25,
+      shortBreakMinutes: 5,
+      longBreakMinutes: 20,
+      longBreakAfterWorkSegments: 4,
+    },
+    segments: input.segments,
+    createdAt: input.createdAt ?? input.plannedStartAt,
+    updatedAt: input.updatedAt ?? input.plannedStartAt,
+  };
+}
+
+describe('NowTodayTab Today Planner timeline（时间线版今日计划器）', () => {
   beforeEach(() => {
-    getTodayPlannerMock.mockReset();
-    createPlannedBlockMock.mockReset();
-    updatePlannedBlockMock.mockReset();
-    reorderPlannedBlocksMock.mockReset();
-    startPlannedBlockMock.mockReset();
-    deletePlannedBlockMock.mockReset();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2026-03-27T09:00:00+08:00'));
+
+    getTaskMock.mockReset();
+    listTasksMock.mockReset();
+    checkDependenciesMetMock.mockReset();
+    onTaskChangeMock.mockClear();
     loadTimeBlocksMock.mockReset();
     loadActiveBlockMock.mockReset();
-    onBlockChangeMock.mockClear();
-    getTaskMock.mockReset();
-    onTaskChangeMock.mockClear();
+    onBlockChangeMock.mockReset();
+    getTodayPlannerMock.mockReset();
+    createSchedulingWindowMock.mockReset();
+    updatePlannedSegmentMock.mockReset();
+    startWorkSegmentMock.mockReset();
+    reflowSchedulingWindowMock.mockReset();
 
-    getTodayPlannerMock.mockResolvedValue(createSnapshot());
-    createPlannedBlockMock.mockResolvedValue(undefined);
-    updatePlannedBlockMock.mockResolvedValue(undefined);
-    reorderPlannedBlocksMock.mockResolvedValue(createSnapshot());
-    startPlannedBlockMock.mockResolvedValue(undefined);
-    deletePlannedBlockMock.mockResolvedValue(undefined);
     loadTimeBlocksMock.mockResolvedValue([]);
     loadActiveBlockMock.mockResolvedValue(null);
-    getTaskMock.mockResolvedValue(null);
+    getTodayPlannerMock.mockResolvedValue({ date: '2026-03-27', windows: [] });
+    listTasksMock.mockResolvedValue([]);
+    checkDependenciesMetMock.mockResolvedValue({ met: true, blocking: [] });
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
-  it('lets users create, edit, reorder, start, and delete planned work/rest blocks（支持创建、编辑、重排、开始、删除今日计划块）', async () => {
+  it('renders a 15-minute timeline and creates a scheduling window from drag selection（15 分钟时间线拖拽创建可调度区间）', async () => {
+    const createdWindow = makeWindow({
+      id: 'window-1',
+      title: '上午深度工作',
+      plannedStartAt: plannerTs('08:15'),
+      plannedEndAt: plannerTs('09:15'),
+      segments: [
+        makeSegment({
+          id: 'segment-work-1',
+          windowId: 'window-1',
+          kind: 'work',
+          title: 'Deep Work 1',
+          plannedStartAt: plannerTs('08:15'),
+          plannedEndAt: plannerTs('08:55'),
+          order: 0,
+        }),
+        makeSegment({
+          id: 'segment-break-1',
+          windowId: 'window-1',
+          kind: 'break',
+          breakKind: 'short',
+          title: 'Short Break',
+          plannedStartAt: plannerTs('08:55'),
+          plannedEndAt: plannerTs('09:00'),
+          order: 1,
+        }),
+        makeSegment({
+          id: 'segment-work-2',
+          windowId: 'window-1',
+          kind: 'work',
+          title: 'Deep Work 2',
+          plannedStartAt: plannerTs('09:00'),
+          plannedEndAt: plannerTs('09:15'),
+          order: 2,
+        }),
+      ],
+    });
+
+    getTodayPlannerMock
+      .mockResolvedValueOnce({ date: '2026-03-27', windows: [] })
+      .mockResolvedValue({ date: '2026-03-27', windows: [createdWindow] });
+    createSchedulingWindowMock.mockResolvedValue(createdWindow);
+
     render(<NowTodayTab />);
 
+    const slot0815 = await screen.findByTestId('planner-slot-08:15');
+    const slot0900 = screen.getByTestId('planner-slot-09:00');
+
+    fireEvent.mouseDown(slot0815);
+    fireEvent.mouseEnter(slot0900);
+    fireEvent.mouseUp(slot0900);
+
+    expect(await screen.findByTestId('today-planner-window-draft')).toHaveTextContent('08:15');
+    expect(screen.getByTestId('today-planner-window-draft')).toHaveTextContent('09:15');
+
+    fireEvent.change(screen.getByLabelText('区间标题'), {
+      target: { value: '上午深度工作' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '创建可调度区间' }));
+
     await waitFor(() => {
-      expect(screen.getByText('Deep Work')).toBeInTheDocument();
-      expect(screen.getByText('Lunch Reset')).toBeInTheDocument();
+      expect(createSchedulingWindowMock).toHaveBeenCalledWith({
+        date: '2026-03-27',
+        title: '上午深度工作',
+        plannedStartAt: plannerTs('08:15'),
+        plannedEndAt: plannerTs('09:15'),
+        rhythmPresetKey: 'pomodoro_25_5',
+      });
     });
 
-    fireEvent.change(screen.getByLabelText('标题'), { target: { value: 'Wrap Up' } });
-    fireEvent.change(screen.getByLabelText('类型'), { target: { value: 'rest' } });
-    fireEvent.change(screen.getByLabelText('开始时间'), { target: { value: '18:30' } });
-    fireEvent.change(screen.getByLabelText('时长（分钟）'), { target: { value: '20' } });
-    fireEvent.click(screen.getByRole('button', { name: '添加计划块' }));
+    expect(await screen.findByTestId('planner-window-window-1')).toBeInTheDocument();
+    expect(screen.getByText('Deep Work 1')).toBeInTheDocument();
+    expect(screen.getByText('Short Break')).toBeInTheDocument();
+  });
+
+  it('can link tasks to a work segment and start it（工作片段可关联任务并开始执行）', async () => {
+    const snapshotWindow = makeWindow({
+      id: 'window-2',
+      title: '下午推进',
+      plannedStartAt: plannerTs('13:00'),
+      plannedEndAt: plannerTs('14:00'),
+      segments: [
+        makeSegment({
+          id: 'segment-work-3',
+          windowId: 'window-2',
+          kind: 'work',
+          title: 'Deep Work A',
+          plannedStartAt: plannerTs('13:00'),
+          plannedEndAt: plannerTs('13:45'),
+          order: 0,
+        }),
+        makeSegment({
+          id: 'segment-break-3',
+          windowId: 'window-2',
+          kind: 'break',
+          breakKind: 'short',
+          title: 'Short Break',
+          plannedStartAt: plannerTs('13:45'),
+          plannedEndAt: plannerTs('14:00'),
+          order: 1,
+        }),
+      ],
+    });
+    const activeBlock: ActiveBlockData = {
+      startId: 'active-segment-work-3',
+      name: 'Deep Work A',
+      mode: 'countdown',
+      elapsed: 0,
+      startTime: plannerTs('13:00'),
+      paused: false,
+      phase: 'running',
+      version: 1,
+      lastTransitionAt: plannerTs('13:00'),
+      taskIds: ['task-a'],
+      taskAssociationLog: [],
+      targetMinutes: 45,
+      sourcePlannedBlockId: 'segment-work-3',
+    };
+
+    getTodayPlannerMock.mockResolvedValue({ date: '2026-03-27', windows: [snapshotWindow] });
+    updatePlannedSegmentMock.mockResolvedValue({
+      ...snapshotWindow.segments[0],
+      linkedTaskIds: ['task-a'],
+      status: 'pending',
+    });
+    startWorkSegmentMock.mockResolvedValue(activeBlock);
+    listTasksMock.mockResolvedValue([
+      makeTask({ id: 'task-a', title: '任务甲', status: 'pending' }),
+      makeTask({ id: 'task-b', title: '任务乙', status: 'in_progress' }),
+    ]);
+
+    render(<NowTodayTab />);
+
+    fireEvent.click(await screen.findByTestId('planner-segment-segment-work-3'));
+
+    expect(await screen.findByTestId('planner-segment-inspector')).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByTestId('planner-segment-task-task-a'));
+    fireEvent.click(screen.getByRole('button', { name: '保存工作片段' }));
 
     await waitFor(() => {
-      expect(createPlannedBlockMock).toHaveBeenCalledWith(expect.objectContaining({
-        date: expect.any(String),
-        type: 'rest',
-        title: 'Wrap Up',
-        plannedDurationMinutes: 20,
-      }));
+      expect(updatePlannedSegmentMock).toHaveBeenCalledWith('segment-work-3', {
+        linkedTaskIds: ['task-a'],
+      });
     });
 
-    fireEvent.click(screen.getByRole('button', { name: '编辑计划块：Deep Work' }));
-    fireEvent.change(screen.getByLabelText('标题'), { target: { value: 'Deep Work Revised' } });
-    fireEvent.click(screen.getByRole('button', { name: '保存修改' }));
+    fireEvent.click(screen.getByRole('button', { name: '开始这个工作片段' }));
 
     await waitFor(() => {
-      expect(updatePlannedBlockMock).toHaveBeenCalledWith('plan-1', expect.objectContaining({
-        title: 'Deep Work Revised',
-      }));
-    });
-
-    fireEvent.click(screen.getByRole('button', { name: '上移计划块：Lunch Reset' }));
-    await waitFor(() => {
-      expect(reorderPlannedBlocksMock).toHaveBeenCalledWith('2026-03-26', ['plan-2', 'plan-1']);
-    });
-
-    fireEvent.click(screen.getByRole('button', { name: '开始计划块：Deep Work' }));
-    await waitFor(() => {
-      expect(startPlannedBlockMock).toHaveBeenCalledWith('plan-1');
-    });
-
-    fireEvent.click(screen.getByRole('button', { name: '删除计划块：Lunch Reset' }));
-    await waitFor(() => {
-      expect(deletePlannedBlockMock).toHaveBeenCalledWith('plan-2');
+      expect(startWorkSegmentMock).toHaveBeenCalledWith('segment-work-3');
     });
   });
 });

--- a/tests/unit/ui/now-today-planner.test.tsx
+++ b/tests/unit/ui/now-today-planner.test.tsx
@@ -1,0 +1,154 @@
+import type { ReactNode } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NowTodayTab } from '@/ui/app/components/NowTodayTab';
+import type { TodayPlannerSnapshot } from '@/lib/types/event';
+
+const getTodayPlannerMock = vi.fn();
+const createPlannedBlockMock = vi.fn();
+const updatePlannedBlockMock = vi.fn();
+const reorderPlannedBlocksMock = vi.fn();
+const startPlannedBlockMock = vi.fn();
+const deletePlannedBlockMock = vi.fn();
+const loadTimeBlocksMock = vi.fn();
+const loadActiveBlockMock = vi.fn();
+const onBlockChangeMock = vi.fn(() => () => {});
+const getTaskMock = vi.fn();
+const onTaskChangeMock = vi.fn(() => () => {});
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+vi.mock('@/lib/services', () => ({
+  getTodayPlannerService: () => ({
+    getTodayPlanner: getTodayPlannerMock,
+    createPlannedBlock: createPlannedBlockMock,
+    updatePlannedBlock: updatePlannedBlockMock,
+    reorderPlannedBlocks: reorderPlannedBlocksMock,
+    startPlannedBlock: startPlannedBlockMock,
+    deletePlannedBlock: deletePlannedBlockMock,
+  }),
+  getTimeBlockService: () => ({
+    loadTimeBlocks: loadTimeBlocksMock,
+    loadActiveBlock: loadActiveBlockMock,
+    onBlockChange: onBlockChangeMock,
+  }),
+  getTaskService: () => ({
+    getTask: getTaskMock,
+    onTaskChange: onTaskChangeMock,
+  }),
+}));
+
+function createSnapshot(): TodayPlannerSnapshot {
+  return {
+    date: '2026-03-26',
+    blocks: [
+      {
+        id: 'plan-1',
+        date: '2026-03-26',
+        type: 'work',
+        title: 'Deep Work',
+        plannedStartAt: new Date('2026-03-26T09:00:00+08:00').getTime(),
+        plannedDurationMinutes: 50,
+        linkedTaskIds: ['task-a'],
+        order: 0,
+        createdAt: new Date('2026-03-26T08:00:00+08:00').getTime(),
+        updatedAt: new Date('2026-03-26T08:00:00+08:00').getTime(),
+        status: 'pending',
+      },
+      {
+        id: 'plan-2',
+        date: '2026-03-26',
+        type: 'rest',
+        title: 'Lunch Reset',
+        plannedStartAt: new Date('2026-03-26T12:30:00+08:00').getTime(),
+        plannedDurationMinutes: 30,
+        linkedTaskIds: [],
+        order: 1,
+        createdAt: new Date('2026-03-26T08:10:00+08:00').getTime(),
+        updatedAt: new Date('2026-03-26T08:10:00+08:00').getTime(),
+        status: 'pending',
+      },
+    ],
+  };
+}
+
+describe('NowTodayTab Today Planner（今日计划器）', () => {
+  beforeEach(() => {
+    getTodayPlannerMock.mockReset();
+    createPlannedBlockMock.mockReset();
+    updatePlannedBlockMock.mockReset();
+    reorderPlannedBlocksMock.mockReset();
+    startPlannedBlockMock.mockReset();
+    deletePlannedBlockMock.mockReset();
+    loadTimeBlocksMock.mockReset();
+    loadActiveBlockMock.mockReset();
+    onBlockChangeMock.mockClear();
+    getTaskMock.mockReset();
+    onTaskChangeMock.mockClear();
+
+    getTodayPlannerMock.mockResolvedValue(createSnapshot());
+    createPlannedBlockMock.mockResolvedValue(undefined);
+    updatePlannedBlockMock.mockResolvedValue(undefined);
+    reorderPlannedBlocksMock.mockResolvedValue(createSnapshot());
+    startPlannedBlockMock.mockResolvedValue(undefined);
+    deletePlannedBlockMock.mockResolvedValue(undefined);
+    loadTimeBlocksMock.mockResolvedValue([]);
+    loadActiveBlockMock.mockResolvedValue(null);
+    getTaskMock.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('lets users create, edit, reorder, start, and delete planned work/rest blocks（支持创建、编辑、重排、开始、删除今日计划块）', async () => {
+    render(<NowTodayTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Deep Work')).toBeInTheDocument();
+      expect(screen.getByText('Lunch Reset')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('标题'), { target: { value: 'Wrap Up' } });
+    fireEvent.change(screen.getByLabelText('类型'), { target: { value: 'rest' } });
+    fireEvent.change(screen.getByLabelText('开始时间'), { target: { value: '18:30' } });
+    fireEvent.change(screen.getByLabelText('时长（分钟）'), { target: { value: '20' } });
+    fireEvent.click(screen.getByRole('button', { name: '添加计划块' }));
+
+    await waitFor(() => {
+      expect(createPlannedBlockMock).toHaveBeenCalledWith(expect.objectContaining({
+        date: expect.any(String),
+        type: 'rest',
+        title: 'Wrap Up',
+        plannedDurationMinutes: 20,
+      }));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '编辑计划块：Deep Work' }));
+    fireEvent.change(screen.getByLabelText('标题'), { target: { value: 'Deep Work Revised' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存修改' }));
+
+    await waitFor(() => {
+      expect(updatePlannedBlockMock).toHaveBeenCalledWith('plan-1', expect.objectContaining({
+        title: 'Deep Work Revised',
+      }));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '上移计划块：Lunch Reset' }));
+    await waitFor(() => {
+      expect(reorderPlannedBlocksMock).toHaveBeenCalledWith('2026-03-26', ['plan-2', 'plan-1']);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '开始计划块：Deep Work' }));
+    await waitFor(() => {
+      expect(startPlannedBlockMock).toHaveBeenCalledWith('plan-1');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '删除计划块：Lunch Reset' }));
+    await waitFor(() => {
+      expect(deletePlannedBlockMock).toHaveBeenCalledWith('plan-2');
+    });
+  });
+});

--- a/tests/unit/ui/now-today-tab.issue605.test.tsx
+++ b/tests/unit/ui/now-today-tab.issue605.test.tsx
@@ -6,11 +6,17 @@ import type { ActiveBlockData, TimeBlock } from '@/lib/types/event';
 import type { TaskNode } from '@/lib/types/task';
 
 const getTaskMock = vi.fn();
+const listTasksMock = vi.fn();
+const checkDependenciesMetMock = vi.fn();
 const onTaskChangeMock = vi.fn(() => () => {});
 const loadTimeBlocksMock = vi.fn();
 const loadActiveBlockMock = vi.fn();
 const onBlockChangeMock = vi.fn();
 const getTodayPlannerMock = vi.fn();
+const createSchedulingWindowMock = vi.fn();
+const updatePlannedSegmentMock = vi.fn();
+const startWorkSegmentMock = vi.fn();
+const reflowSchedulingWindowMock = vi.fn();
 
 let blockChangeHandler: ((block: ActiveBlockData | null) => void) | null = null;
 
@@ -21,6 +27,8 @@ vi.mock('@tanstack/react-router', () => ({
 vi.mock('@/lib/services', () => ({
   getTaskService: () => ({
     getTask: getTaskMock,
+    listTasks: listTasksMock,
+    checkDependenciesMet: checkDependenciesMetMock,
     onTaskChange: onTaskChangeMock,
   }),
   getTimeBlockService: () => ({
@@ -30,11 +38,10 @@ vi.mock('@/lib/services', () => ({
   }),
   getTodayPlannerService: () => ({
     getTodayPlanner: getTodayPlannerMock,
-    createPlannedBlock: vi.fn(),
-    updatePlannedBlock: vi.fn(),
-    reorderPlannedBlocks: vi.fn(),
-    startPlannedBlock: vi.fn(),
-    deletePlannedBlock: vi.fn(),
+    createSchedulingWindow: createSchedulingWindowMock,
+    updatePlannedSegment: updatePlannedSegmentMock,
+    startWorkSegment: startWorkSegmentMock,
+    reflowSchedulingWindow: reflowSchedulingWindowMock,
   }),
 }));
 
@@ -79,16 +86,24 @@ function makeBlock(input: Partial<TimeBlock> & Pick<TimeBlock, 'id' | 'name' | '
 describe('NowTodayTab issue-605（活跃时间块快照闪烁修复）', () => {
   beforeEach(() => {
     getTaskMock.mockReset();
+    listTasksMock.mockReset();
+    checkDependenciesMetMock.mockReset();
     onTaskChangeMock.mockClear();
     loadTimeBlocksMock.mockReset();
     loadActiveBlockMock.mockReset();
     onBlockChangeMock.mockReset();
     getTodayPlannerMock.mockReset();
+    createSchedulingWindowMock.mockReset();
+    updatePlannedSegmentMock.mockReset();
+    startWorkSegmentMock.mockReset();
+    reflowSchedulingWindowMock.mockReset();
     blockChangeHandler = null;
     getTodayPlannerMock.mockResolvedValue({
       date: '2026-03-26',
-      blocks: [],
+      windows: [],
     });
+    listTasksMock.mockResolvedValue([]);
+    checkDependenciesMetMock.mockResolvedValue({ met: true, blocking: [] });
 
     onBlockChangeMock.mockImplementation((callback: (block: ActiveBlockData | null) => void) => {
       blockChangeHandler = callback;

--- a/tests/unit/ui/now-today-tab.issue605.test.tsx
+++ b/tests/unit/ui/now-today-tab.issue605.test.tsx
@@ -10,6 +10,7 @@ const onTaskChangeMock = vi.fn(() => () => {});
 const loadTimeBlocksMock = vi.fn();
 const loadActiveBlockMock = vi.fn();
 const onBlockChangeMock = vi.fn();
+const getTodayPlannerMock = vi.fn();
 
 let blockChangeHandler: ((block: ActiveBlockData | null) => void) | null = null;
 
@@ -26,6 +27,14 @@ vi.mock('@/lib/services', () => ({
     loadTimeBlocks: loadTimeBlocksMock,
     loadActiveBlock: loadActiveBlockMock,
     onBlockChange: onBlockChangeMock,
+  }),
+  getTodayPlannerService: () => ({
+    getTodayPlanner: getTodayPlannerMock,
+    createPlannedBlock: vi.fn(),
+    updatePlannedBlock: vi.fn(),
+    reorderPlannedBlocks: vi.fn(),
+    startPlannedBlock: vi.fn(),
+    deletePlannedBlock: vi.fn(),
   }),
 }));
 
@@ -74,7 +83,12 @@ describe('NowTodayTab issue-605（活跃时间块快照闪烁修复）', () => {
     loadTimeBlocksMock.mockReset();
     loadActiveBlockMock.mockReset();
     onBlockChangeMock.mockReset();
+    getTodayPlannerMock.mockReset();
     blockChangeHandler = null;
+    getTodayPlannerMock.mockResolvedValue({
+      date: '2026-03-26',
+      blocks: [],
+    });
 
     onBlockChangeMock.mockImplementation((callback: (block: ActiveBlockData | null) => void) => {
       blockChangeHandler = callback;


### PR DESCRIPTION
﻿## Summary
- add a first-class `Scheduling Window / ?????` + `Planned Segment / ????` model, including rhythm preset data, work/break segmentation, SQLite persistence, and `sourcePlannedBlockId` provenance / ????
- add runtime HTTP API `/act/today-planner/*` for snapshot, create window, update work segment, start work segment, and window-local reflow, plus updated `curl.exe` contract docs
- replace the old form/list Today Planner UI with a 15-minute timeline planner that supports drag-select window creation, work-segment task linking, start execution, and current-window reflow while keeping today's execution history below

## Current Status
- this PR is now in `Draft` because the core flow is usable, but still suitable for team polish / ?????? PR ????????????????????
- fixed the latest feedback on task overflow: only the first 10 tasks stay visible as chips, and overflow tasks move into a dropdown / ????????????????? 10 ??????????
- fixed the default work-segment naming: new work segments inherit the scheduling-window title instead of defaulting to `Work 1` / ???????????????????????????? `Work 1`
- reviewer requested from `@ARCJ137442` / ?? `@ARCJ137442` ?? review request

## Scope
- manual single-day Today Planner only / ???????
- user creates scheduling windows on a timeline, not flat blocks / ?????????????????????
- only `work` segments can link tasks and start execution / ???????????????
- `break` segments remain soft guidance / ???????
- reflow only affects the current scheduling window / ?????????

## Out Of Scope
- MCP wiring / MCP ??
- AI auto-generate full-day plan / AI ???????
- cross-window global reschedule / ???????
- resize/drag existing windows after creation / ??????????

## Screenshot
![Today Planner draft screenshot / ????????](https://gist.githubusercontent.com/Hailaylin/44615f95759d85236bf417d4d887dfe7/raw/e3bd6a6b9b858543afa81cd80c9349ea8468b3ba/today-tab-page.svg)

## Linked Issues
- Closes #751
- Closes #752
- Closes #753
- Closes #754

## Verification
- `bunx tsc --noEmit`
- `bunx vitest run tests/unit/adapters/today-planner-rt-adapter.test.ts tests/unit/ui/now-today-planner.test.tsx tests/unit/ui/now-today-tab.issue605.test.tsx tests/unit/ui/now-today-blocks-view.issue516.test.ts tests/unit/services/timeblock.service.rt-sqlite.test.ts`
- `cargo test -p exomind-runtime today_planner_windows_create_start_and_reflow --test today_planner_routes`
- `cargo test -p exomind-runtime today_planner_work_segment_inherits_window_title_before_edit --test today_planner_routes`
- `cargo test -p exomind-runtime sqlite_store_isolates_planner_windows_by_scope`
- `bun run build`
