### PR TITLE
fix(issue-756): migrate runtime-backed settings to sqlite config

### DIFF
--- a/crates/exomind-runtime/src/config/mod.rs
+++ b/crates/exomind-runtime/src/config/mod.rs
@@ -1,0 +1,6 @@
+pub mod sqlite_store;
+pub mod store;
+pub mod types;
+
+pub use store::{ConfigStore, ConfigStoreBackendKind, ConfigStoreError};
+pub use types::{ConfigEntry, PutConfigEntryInput};

--- a/crates/exomind-runtime/src/config/sqlite_store.rs
+++ b/crates/exomind-runtime/src/config/sqlite_store.rs
@@ -1,0 +1,155 @@
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use rusqlite::{Connection, OptionalExtension, params};
+
+use super::store::ConfigStoreError;
+use super::types::{ConfigEntry, PutConfigEntryInput};
+
+pub struct SqliteConfigStore {
+    path: PathBuf,
+    connection: Mutex<Connection>,
+}
+
+impl SqliteConfigStore {
+    pub fn open(path: &Path) -> Result<Self, ConfigStoreError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let connection = Connection::open(path)?;
+        let store = Self {
+            path: path.to_path_buf(),
+            connection: Mutex::new(connection),
+        };
+        store.init()?;
+        Ok(store)
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn connection(&self) -> std::sync::MutexGuard<'_, Connection> {
+        self.connection
+            .lock()
+            .expect("config store connection lock poisoned")
+    }
+
+    fn init(&self) -> Result<(), ConfigStoreError> {
+        let conn = self.connection();
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS runtime_config_entries (
+                scope         TEXT NOT NULL,
+                entry_key     TEXT NOT NULL,
+                value         TEXT NOT NULL,
+                sensitive     INTEGER NOT NULL DEFAULT 0,
+                updated_at    TEXT NOT NULL,
+                source        TEXT,
+                source_origin TEXT,
+                PRIMARY KEY (scope, entry_key)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_runtime_config_scope
+                ON runtime_config_entries(scope);
+            CREATE INDEX IF NOT EXISTS idx_runtime_config_scope_key
+                ON runtime_config_entries(scope, entry_key);",
+        )?;
+        Ok(())
+    }
+
+    pub fn put(&self, input: PutConfigEntryInput) -> Result<ConfigEntry, ConfigStoreError> {
+        let updated_at = chrono::Utc::now().to_rfc3339();
+        let entry = ConfigEntry {
+            scope: input.scope,
+            key: input.key,
+            value: input.value,
+            sensitive: input.sensitive,
+            updated_at,
+            source: input.source,
+            source_origin: input.source_origin,
+        };
+
+        let conn = self.connection();
+        conn.execute(
+            "INSERT INTO runtime_config_entries (
+                scope, entry_key, value, sensitive, updated_at, source, source_origin
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT(scope, entry_key) DO UPDATE SET
+                value = excluded.value,
+                sensitive = excluded.sensitive,
+                updated_at = excluded.updated_at,
+                source = excluded.source,
+                source_origin = excluded.source_origin",
+            params![
+                entry.scope,
+                entry.key,
+                entry.value,
+                i64::from(entry.sensitive),
+                entry.updated_at,
+                entry.source,
+                entry.source_origin,
+            ],
+        )?;
+
+        Ok(entry)
+    }
+
+    pub fn get(&self, scope: &str, key: &str) -> Result<Option<ConfigEntry>, ConfigStoreError> {
+        let conn = self.connection();
+        let mut stmt = conn.prepare(
+            "SELECT scope, entry_key, value, sensitive, updated_at, source, source_origin
+             FROM runtime_config_entries
+             WHERE scope = ?1 AND entry_key = ?2",
+        )?;
+
+        stmt.query_row(params![scope, key], map_config_row)
+            .optional()
+            .map_err(ConfigStoreError::from)
+    }
+
+    pub fn list(
+        &self,
+        scope: Option<&str>,
+        prefix: Option<&str>,
+    ) -> Result<Vec<ConfigEntry>, ConfigStoreError> {
+        let conn = self.connection();
+        let prefix_like = prefix.map(|value| format!("{value}%"));
+        let mut stmt = conn.prepare(
+            "SELECT scope, entry_key, value, sensitive, updated_at, source, source_origin
+             FROM runtime_config_entries
+             WHERE (?1 IS NULL OR scope = ?1)
+               AND (?2 IS NULL OR entry_key LIKE ?2)
+             ORDER BY scope ASC, entry_key ASC",
+        )?;
+        let rows = stmt.query_map(params![scope, prefix_like], map_config_row)?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(ConfigStoreError::from)
+    }
+
+    pub fn delete(&self, scope: &str, key: &str) -> Result<Option<ConfigEntry>, ConfigStoreError> {
+        let existing = self.get(scope, key)?;
+        if existing.is_none() {
+            return Ok(None);
+        }
+
+        let conn = self.connection();
+        conn.execute(
+            "DELETE FROM runtime_config_entries WHERE scope = ?1 AND entry_key = ?2",
+            params![scope, key],
+        )?;
+        Ok(existing)
+    }
+}
+
+fn map_config_row(row: &rusqlite::Row<'_>) -> Result<ConfigEntry, rusqlite::Error> {
+    Ok(ConfigEntry {
+        scope: row.get(0)?,
+        key: row.get(1)?,
+        value: row.get(2)?,
+        sensitive: row.get::<_, i64>(3)? != 0,
+        updated_at: row.get(4)?,
+        source: row.get(5)?,
+        source_origin: row.get(6)?,
+    })
+}

--- a/crates/exomind-runtime/src/config/store.rs
+++ b/crates/exomind-runtime/src/config/store.rs
@@ -1,0 +1,241 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::RwLock;
+
+use thiserror::Error;
+
+use super::sqlite_store::SqliteConfigStore;
+use super::types::{ConfigEntry, PutConfigEntryInput};
+
+#[derive(Debug, Error)]
+pub enum ConfigStoreError {
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+enum ConfigStoreBackend {
+    Memory(RwLock<HashMap<(String, String), ConfigEntry>>),
+    Sqlite(SqliteConfigStore),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigStoreBackendKind {
+    Memory,
+    Sqlite,
+}
+
+pub struct ConfigStore {
+    backend: ConfigStoreBackend,
+}
+
+impl ConfigStore {
+    pub fn new() -> Self {
+        Self {
+            backend: ConfigStoreBackend::Memory(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub fn with_sqlite_path(path: &Path) -> Result<Self, ConfigStoreError> {
+        Ok(Self {
+            backend: ConfigStoreBackend::Sqlite(SqliteConfigStore::open(path)?),
+        })
+    }
+
+    pub fn put(&self, input: PutConfigEntryInput) -> Result<ConfigEntry, ConfigStoreError> {
+        match &self.backend {
+            ConfigStoreBackend::Sqlite(store) => store.put(input),
+            ConfigStoreBackend::Memory(_) => {
+                let entry = ConfigEntry {
+                    scope: input.scope,
+                    key: input.key,
+                    value: input.value,
+                    sensitive: input.sensitive,
+                    updated_at: chrono::Utc::now().to_rfc3339(),
+                    source: input.source,
+                    source_origin: input.source_origin,
+                };
+                self.with_memory_mut(|entries| {
+                    entries.insert((entry.scope.clone(), entry.key.clone()), entry.clone());
+                    Ok(entry)
+                })
+            }
+        }
+    }
+
+    pub fn get(&self, scope: &str, key: &str) -> Result<Option<ConfigEntry>, ConfigStoreError> {
+        match &self.backend {
+            ConfigStoreBackend::Sqlite(store) => store.get(scope, key),
+            ConfigStoreBackend::Memory(_) => {
+                Ok(self.memory_entries().get(&(scope.to_string(), key.to_string())).cloned())
+            }
+        }
+    }
+
+    pub fn list(&self, scope: Option<&str>) -> Result<Vec<ConfigEntry>, ConfigStoreError> {
+        self.list_by_prefix(scope, None)
+    }
+
+    pub fn list_by_prefix(
+        &self,
+        scope: Option<&str>,
+        prefix: Option<&str>,
+    ) -> Result<Vec<ConfigEntry>, ConfigStoreError> {
+        match &self.backend {
+            ConfigStoreBackend::Sqlite(store) => store.list(scope, prefix),
+            ConfigStoreBackend::Memory(_) => {
+                let mut entries: Vec<ConfigEntry> = self
+                    .memory_entries()
+                    .into_values()
+                    .filter(|entry| scope.is_none_or(|value| entry.scope == value))
+                    .filter(|entry| prefix.is_none_or(|value| entry.key.starts_with(value)))
+                    .collect();
+                entries.sort_by(|left, right| {
+                    left.scope
+                        .cmp(&right.scope)
+                        .then_with(|| left.key.cmp(&right.key))
+                });
+                Ok(entries)
+            }
+        }
+    }
+
+    pub fn delete(&self, scope: &str, key: &str) -> Result<Option<ConfigEntry>, ConfigStoreError> {
+        match &self.backend {
+            ConfigStoreBackend::Sqlite(store) => store.delete(scope, key),
+            ConfigStoreBackend::Memory(_) => Ok(
+                self.with_memory_mut(|entries| entries.remove(&(scope.to_string(), key.to_string())))
+            ),
+        }
+    }
+
+    pub fn backend_kind(&self) -> ConfigStoreBackendKind {
+        match &self.backend {
+            ConfigStoreBackend::Memory(_) => ConfigStoreBackendKind::Memory,
+            ConfigStoreBackend::Sqlite(_) => ConfigStoreBackendKind::Sqlite,
+        }
+    }
+
+    fn memory_entries(&self) -> HashMap<(String, String), ConfigEntry> {
+        match &self.backend {
+            ConfigStoreBackend::Memory(entries) => entries.read().unwrap().clone(),
+            ConfigStoreBackend::Sqlite(_) => unreachable!("memory_entries called on sqlite backend"),
+        }
+    }
+
+    fn with_memory_mut<R>(
+        &self,
+        f: impl FnOnce(&mut HashMap<(String, String), ConfigEntry>) -> R,
+    ) -> R {
+        match &self.backend {
+            ConfigStoreBackend::Memory(entries) => {
+                let mut guard = entries.write().unwrap();
+                f(&mut guard)
+            }
+            ConfigStoreBackend::Sqlite(_) => {
+                unreachable!("with_memory_mut called on sqlite backend")
+            }
+        }
+    }
+}
+
+impl Default for ConfigStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::config::types::{DEVICE_CONFIG_SCOPE, USER_CONFIG_SCOPE};
+
+    fn put_input(scope: &str, key: &str, value: &str) -> PutConfigEntryInput {
+        PutConfigEntryInput {
+            scope: scope.to_string(),
+            key: key.to_string(),
+            value: value.to_string(),
+            sensitive: false,
+            source: Some("test".to_string()),
+            source_origin: Some("http://localhost:1420".to_string()),
+        }
+    }
+
+    #[test]
+    fn starts_empty_in_memory() {
+        let store = ConfigStore::new();
+
+        let entries = store.list(Some(USER_CONFIG_SCOPE)).unwrap();
+
+        assert!(entries.is_empty());
+        assert_eq!(store.backend_kind(), ConfigStoreBackendKind::Memory);
+    }
+
+    #[test]
+    fn upserts_and_filters_entries_in_memory() {
+        let store = ConfigStore::new();
+        store
+            .put(put_input(USER_CONFIG_SCOPE, "exomind:themePreference", "dark"))
+            .unwrap();
+        store
+            .put(put_input(USER_CONFIG_SCOPE, "exomind:voiceShortcutHotkey", "Alt+Q"))
+            .unwrap();
+        store
+            .put(put_input(DEVICE_CONFIG_SCOPE, "exomind:themePreference", "light"))
+            .unwrap();
+        store
+            .put(put_input(USER_CONFIG_SCOPE, "exomind:themePreference", "light"))
+            .unwrap();
+
+        let entries = store
+            .list_by_prefix(Some(USER_CONFIG_SCOPE), Some("exomind:"))
+            .unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].key, "exomind:themePreference");
+        assert_eq!(entries[0].value, "light");
+        assert_eq!(entries[1].key, "exomind:voiceShortcutHotkey");
+        assert_eq!(store.get(USER_CONFIG_SCOPE, "exomind:themePreference").unwrap().unwrap().value, "light");
+    }
+
+    #[test]
+    fn sqlite_backend_persists_between_reopens() {
+        let temp_dir = tempdir().unwrap();
+        let sqlite_path = temp_dir.path().join("config.sqlite");
+
+        {
+            let store = ConfigStore::with_sqlite_path(&sqlite_path).unwrap();
+            store
+                .put(put_input(USER_CONFIG_SCOPE, "moss_api_key", "sk-test-123"))
+                .unwrap();
+            assert_eq!(store.backend_kind(), ConfigStoreBackendKind::Sqlite);
+        }
+
+        let reopened = ConfigStore::with_sqlite_path(&sqlite_path).unwrap();
+        let entry = reopened
+            .get(USER_CONFIG_SCOPE, "moss_api_key")
+            .unwrap()
+            .expect("config entry should persist");
+
+        assert_eq!(entry.value, "sk-test-123");
+        assert_eq!(reopened.list(Some(USER_CONFIG_SCOPE)).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn delete_removes_existing_entry() {
+        let store = ConfigStore::new();
+        store
+            .put(put_input(USER_CONFIG_SCOPE, "exomind:inputSendMode", "enter-send"))
+            .unwrap();
+
+        let deleted = store
+            .delete(USER_CONFIG_SCOPE, "exomind:inputSendMode")
+            .unwrap();
+
+        assert!(deleted.is_some());
+        assert!(store.get(USER_CONFIG_SCOPE, "exomind:inputSendMode").unwrap().is_none());
+    }
+}

--- a/crates/exomind-runtime/src/config/types.rs
+++ b/crates/exomind-runtime/src/config/types.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+
+pub const USER_CONFIG_SCOPE: &str = "user";
+pub const DEVICE_CONFIG_SCOPE: &str = "device";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigEntry {
+    pub scope: String,
+    pub key: String,
+    pub value: String,
+    #[serde(default)]
+    pub sensitive: bool,
+    pub updated_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_origin: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PutConfigEntryInput {
+    pub scope: String,
+    pub key: String,
+    pub value: String,
+    #[serde(default)]
+    pub sensitive: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_origin: Option<String>,
+}

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -18,6 +18,7 @@ use signal::SignalPool;
 
 pub mod agent;
 pub mod auth;
+pub mod config;
 pub mod discovery;
 pub mod energy;
 pub mod eventlog;
@@ -771,6 +772,7 @@ pub struct AppState {
     pub auth_secret: Option<String>,
     pub mdns: Option<Arc<discovery::MdnsDiscovery>>,
     pub pairing: Arc<pairing::PairingManager>,
+    pub config_store: Arc<config::ConfigStore>,
     pub task_store: Arc<task::TaskStore>,
     pub session_store: Arc<session::SessionStore>,
     pub session_event_tx: Option<tokio::sync::broadcast::Sender<routes::sessions::SessionEvent>>,
@@ -800,6 +802,7 @@ struct RuntimeStoragePaths {
     task_sqlite_path: Option<PathBuf>,
     timeblock_sqlite_path: Option<PathBuf>,
     session_sqlite_path: Option<PathBuf>,
+    config_sqlite_path: Option<PathBuf>,
 }
 
 fn runtime_storage_paths_from_env() -> RuntimeStoragePaths {
@@ -815,6 +818,9 @@ fn runtime_storage_paths_from_env() -> RuntimeStoragePaths {
             .ok()
             .map(PathBuf::from),
         session_sqlite_path: env::var("EXOMIND_RT_SESSION_SQLITE_PATH")
+            .ok()
+            .map(PathBuf::from),
+        config_sqlite_path: env::var("EXOMIND_RT_CONFIG_SQLITE_PATH")
             .ok()
             .map(PathBuf::from),
     }
@@ -839,6 +845,10 @@ fn runtime_storage_paths_for_persistent_start(data_dir: Option<PathBuf>) -> Runt
             .ok()
             .map(PathBuf::from)
             .or_else(|| Some(data_dir.join("sessions.sqlite"))),
+        config_sqlite_path: env::var("EXOMIND_RT_CONFIG_SQLITE_PATH")
+            .ok()
+            .map(PathBuf::from)
+            .or_else(|| Some(data_dir.join("config.sqlite"))),
         data_dir,
     }
 }
@@ -931,6 +941,19 @@ impl AppState {
                 })
             })
             .unwrap_or_else(|| EventLogStore::new(data_dir));
+        let config_store = storage_paths
+            .config_sqlite_path
+            .map(|path| {
+                config::ConfigStore::with_sqlite_path(&path).unwrap_or_else(|error| {
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %error,
+                        "config sqlite init failed, falling back to in-memory store (Config SQLite 初始化失败，降级到内存存储)"
+                    );
+                    config::ConfigStore::new()
+                })
+            })
+            .unwrap_or_else(config::ConfigStore::new);
         let task_store = storage_paths
             .task_sqlite_path
             .map(|path| {
@@ -991,6 +1014,7 @@ impl AppState {
             auth_secret,
             mdns: None,
             pairing: Arc::new(pairing::PairingManager::new()),
+            config_store: Arc::new(config_store),
             task_store: Arc::new(task_store),
             session_store: Arc::new(session_store),
             session_event_tx: {
@@ -1110,6 +1134,7 @@ mod tests {
             auth_secret: None,
             mdns: None,
             pairing: Arc::new(pairing::PairingManager::new()),
+            config_store: Arc::new(config::ConfigStore::new()),
             task_store: Arc::new(task::TaskStore::new()),
             session_store: Arc::new(session::SessionStore::new()),
             session_event_tx: None,

--- a/crates/exomind-runtime/src/routes/config.rs
+++ b/crates/exomind-runtime/src/routes/config.rs
@@ -1,0 +1,395 @@
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::routing::{get, post, put};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+use crate::config::{PutConfigEntryInput, types::USER_CONFIG_SCOPE};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ListQuery {
+    #[serde(default = "default_scope")]
+    scope: String,
+    #[serde(default)]
+    prefix: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DeleteQuery {
+    #[serde(default = "default_scope")]
+    scope: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PutConfigRequest {
+    #[serde(default = "default_scope")]
+    scope: String,
+    value: String,
+    #[serde(default)]
+    sensitive: bool,
+    #[serde(default)]
+    source: Option<String>,
+    #[serde(default)]
+    source_origin: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FrontendImportRequest {
+    #[serde(default = "default_scope")]
+    scope: String,
+    #[serde(default)]
+    strategy: Option<String>,
+    entries: Vec<FrontendImportEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FrontendImportEntry {
+    key: String,
+    value: String,
+    #[serde(default)]
+    sensitive: bool,
+    #[serde(default)]
+    source: Option<String>,
+    #[serde(default)]
+    source_origin: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ImportResponse {
+    imported: usize,
+    skipped: usize,
+    total: usize,
+}
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/config", get(list_config))
+        .route("/config/import/frontend", post(import_frontend_config))
+        .route("/config/:key", put(put_config).delete(delete_config))
+}
+
+async fn list_config(
+    State(state): State<AppState>,
+    Query(query): Query<ListQuery>,
+) -> Result<Json<Vec<crate::config::ConfigEntry>>, (StatusCode, String)> {
+    let entries = state
+        .config_store
+        .list_by_prefix(Some(&query.scope), query.prefix.as_deref())
+        .map_err(internal_error)?;
+    Ok(Json(entries))
+}
+
+async fn put_config(
+    Path(key): Path<String>,
+    State(state): State<AppState>,
+    Json(payload): Json<PutConfigRequest>,
+) -> Result<Json<crate::config::ConfigEntry>, (StatusCode, String)> {
+    let entry = state
+        .config_store
+        .put(PutConfigEntryInput {
+            scope: payload.scope,
+            key,
+            value: payload.value,
+            sensitive: payload.sensitive,
+            source: payload.source,
+            source_origin: payload.source_origin,
+        })
+        .map_err(internal_error)?;
+    Ok(Json(entry))
+}
+
+async fn delete_config(
+    Path(key): Path<String>,
+    State(state): State<AppState>,
+    Query(query): Query<DeleteQuery>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    state
+        .config_store
+        .delete(&query.scope, &key)
+        .map_err(internal_error)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn import_frontend_config(
+    State(state): State<AppState>,
+    Json(payload): Json<FrontendImportRequest>,
+) -> Result<Json<ImportResponse>, (StatusCode, String)> {
+    let strategy = payload.strategy.as_deref().unwrap_or("if-empty");
+    if strategy != "if-empty" {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("unsupported import strategy: {strategy}"),
+        ));
+    }
+
+    let mut imported = 0usize;
+    let mut skipped = 0usize;
+    let total = payload.entries.len();
+
+    for entry in payload.entries {
+        if state
+            .config_store
+            .get(&payload.scope, &entry.key)
+            .map_err(internal_error)?
+            .is_some()
+        {
+            skipped += 1;
+            continue;
+        }
+
+        state
+            .config_store
+            .put(PutConfigEntryInput {
+                scope: payload.scope.clone(),
+                key: entry.key,
+                value: entry.value,
+                sensitive: entry.sensitive,
+                source: entry.source,
+                source_origin: entry.source_origin,
+            })
+            .map_err(internal_error)?;
+        imported += 1;
+    }
+
+    Ok(Json(ImportResponse {
+        imported,
+        skipped,
+        total,
+    }))
+}
+
+fn internal_error(error: impl std::fmt::Display) -> (StatusCode, String) {
+    (StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
+}
+
+fn default_scope() -> String {
+    USER_CONFIG_SCOPE.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use http_body_util::BodyExt;
+    use serde_json::{Value, json};
+    use tower::util::ServiceExt;
+
+    use super::*;
+    use crate::mesh::MeshState;
+    use crate::signal::SignalPool;
+
+    fn test_state() -> AppState {
+        let signal_pool = Arc::new(SignalPool::new(None));
+        let host_id = "config-route-test".to_string();
+        let registry = crate::agent::AgentRegistry::new();
+        let energy_registry = crate::energy::EnergyRegistry::new();
+        AppState {
+            port: 0,
+            host_id: host_id.clone(),
+            registry: registry.clone(),
+            signal_pool: Arc::clone(&signal_pool),
+            mesh: Arc::new(MeshState::new(
+                host_id.clone(),
+                Arc::clone(&signal_pool),
+                None,
+            )),
+            mesh_relay: None,
+            auth_secret: None,
+            mdns: None,
+            pairing: Arc::new(crate::pairing::PairingManager::new()),
+            config_store: Arc::new(crate::config::ConfigStore::new()),
+            task_store: Arc::new(crate::task::TaskStore::new()),
+            session_store: Arc::new(crate::session::SessionStore::new()),
+            session_event_tx: None,
+            eventlog_watch_tx: {
+                let (tx, _rx) = crate::routes::eventlog::eventlog_watch_channel();
+                tx
+            },
+            timeblock_store: Arc::new(crate::timeblock::TimeBlockStore::new()),
+            energy_registry: energy_registry.clone(),
+            tick_manager: Arc::new(crate::tick::TickManager::new(
+                host_id.clone(),
+                registry,
+                energy_registry,
+                Arc::clone(&signal_pool),
+            )),
+            life_agents: std::collections::HashMap::new(),
+            eventlog_store: Arc::new(crate::eventlog::EventLogStore::new(
+                std::env::temp_dir().join("exomind-test-config-routes"),
+            )),
+            #[cfg(not(target_os = "android"))]
+            pty_manager: Arc::new(crate::pty::PtyManager::new(
+                Arc::clone(&signal_pool),
+                host_id,
+            )),
+        }
+    }
+
+    fn test_router(state: AppState) -> Router {
+        router().with_state(state)
+    }
+
+    #[tokio::test]
+    async fn put_and_list_config_entries() {
+        let app = test_router(test_state());
+
+        let put_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/config/exomind:themePreference")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "scope": "user",
+                            "value": "dark",
+                            "source": "settings-page",
+                            "sourceOrigin": "http://localhost:1420"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(put_response.status(), StatusCode::OK);
+
+        let list_response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/config?scope=user&prefix=exomind:")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(list_response.status(), StatusCode::OK);
+        let body = list_response.into_body().collect().await.unwrap().to_bytes();
+        let payload: Vec<Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(payload.len(), 1);
+        assert_eq!(payload[0]["key"], "exomind:themePreference");
+        assert_eq!(payload[0]["value"], "dark");
+    }
+
+    #[tokio::test]
+    async fn delete_config_entry_returns_no_content() {
+        let state = test_state();
+        state
+            .config_store
+            .put(PutConfigEntryInput {
+                scope: "user".to_string(),
+                key: "moss_api_key".to_string(),
+                value: "sk-123".to_string(),
+                sensitive: true,
+                source: None,
+                source_origin: None,
+            })
+            .unwrap();
+        let app = test_router(state);
+
+        let delete_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/config/moss_api_key?scope=user")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(delete_response.status(), StatusCode::NO_CONTENT);
+
+        let list_response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/config?scope=user")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let body = list_response.into_body().collect().await.unwrap().to_bytes();
+        let payload: Vec<Value> = serde_json::from_slice(&body).unwrap();
+        assert!(payload.is_empty());
+    }
+
+    #[tokio::test]
+    async fn import_frontend_config_skips_existing_entries_when_if_empty() {
+        let state = test_state();
+        state
+            .config_store
+            .put(PutConfigEntryInput {
+                scope: "user".to_string(),
+                key: "exomind:themePreference".to_string(),
+                value: "dark".to_string(),
+                sensitive: false,
+                source: Some("existing".to_string()),
+                source_origin: None,
+            })
+            .unwrap();
+        let app = test_router(state);
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/config/import/frontend")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "scope": "user",
+                            "strategy": "if-empty",
+                            "entries": [
+                                { "key": "exomind:themePreference", "value": "light" },
+                                { "key": "moss_api_key", "value": "sk-imported", "sensitive": true }
+                            ]
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let payload: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(payload["imported"], 1);
+        assert_eq!(payload["skipped"], 1);
+
+        let list_response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/config?scope=user")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let body = list_response.into_body().collect().await.unwrap().to_bytes();
+        let payload: Vec<Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(payload.len(), 2);
+        let theme = payload.iter().find(|entry| entry["key"] == "exomind:themePreference").unwrap();
+        let moss = payload.iter().find(|entry| entry["key"] == "moss_api_key").unwrap();
+        assert_eq!(theme["value"], "dark");
+        assert_eq!(moss["value"], "sk-imported");
+        assert_eq!(moss["sensitive"], true);
+    }
+}

--- a/crates/exomind-runtime/src/routes/eventlog.rs
+++ b/crates/exomind-runtime/src/routes/eventlog.rs
@@ -715,6 +715,7 @@ mod tests {
             auth_secret: None,
             mdns: None,
             pairing: Arc::new(crate::pairing::PairingManager::new()),
+            config_store: Arc::new(crate::config::ConfigStore::new()),
             task_store: Arc::new(crate::task::TaskStore::new()),
             session_store: Arc::new(crate::session::SessionStore::new()),
             session_event_tx: None,

--- a/crates/exomind-runtime/src/routes/mod.rs
+++ b/crates/exomind-runtime/src/routes/mod.rs
@@ -3,6 +3,7 @@ use axum::{Router, routing::get};
 use crate::AppState;
 
 pub mod agents;
+pub mod config;
 pub mod energy;
 pub mod eventlog;
 pub mod mesh;
@@ -22,6 +23,7 @@ pub fn router() -> Router<AppState> {
     let r = Router::new()
         .route("/topology", get(topology::get_topology))
         .merge(agents::router())
+        .merge(config::router())
         .merge(energy::router())
         .merge(eventlog::router())
         .merge(mesh::router())

--- a/crates/exomind-runtime/src/routes/profiles.rs
+++ b/crates/exomind-runtime/src/routes/profiles.rs
@@ -110,6 +110,7 @@ mod tests {
             auth_secret: None,
             mdns: None,
             pairing: Arc::new(crate::pairing::PairingManager::new()),
+            config_store: Arc::new(crate::config::ConfigStore::new()),
             task_store: Arc::new(crate::task::TaskStore::new()),
             session_store: Arc::new(crate::session::SessionStore::new()),
             session_event_tx: None,

--- a/crates/exomind-runtime/src/routes/signals.rs
+++ b/crates/exomind-runtime/src/routes/signals.rs
@@ -398,6 +398,7 @@ mod tests {
             auth_secret: None,
             mdns: None,
             pairing: Arc::new(crate::pairing::PairingManager::new()),
+            config_store: Arc::new(crate::config::ConfigStore::new()),
             task_store: Arc::new(crate::task::TaskStore::new()),
             session_store: Arc::new(crate::session::SessionStore::new()),
             session_event_tx: None,

--- a/crates/exomind-runtime/src/routes/tasks.rs
+++ b/crates/exomind-runtime/src/routes/tasks.rs
@@ -703,6 +703,7 @@ mod tests {
             auth_secret: None,
             mdns: None,
             pairing: Arc::new(crate::pairing::PairingManager::new()),
+            config_store: Arc::new(crate::config::ConfigStore::new()),
             task_store,
             session_store: Arc::new(crate::session::SessionStore::new()),
             session_event_tx: None,

--- a/crates/exomind-runtime/src/routes/timeblocks.rs
+++ b/crates/exomind-runtime/src/routes/timeblocks.rs
@@ -1083,6 +1083,7 @@ mod tests {
             auth_secret: None,
             mdns: None,
             pairing: Arc::new(crate::pairing::PairingManager::new()),
+            config_store: Arc::new(crate::config::ConfigStore::new()),
             task_store: Arc::new(crate::task::TaskStore::new()),
             session_store: Arc::new(crate::session::SessionStore::new()),
             session_event_tx: None,

--- a/crates/exomind-runtime/tests/agent_lifecycle_routes.rs
+++ b/crates/exomind-runtime/tests/agent_lifecycle_routes.rs
@@ -31,6 +31,7 @@ fn test_app_state(port: u16, host_id: &str, signal_pool: Arc<SignalPool>) -> App
         auth_secret: None,
         mdns: None,
         pairing: Arc::new(exomind_runtime::pairing::PairingManager::new()),
+        config_store: Arc::new(exomind_runtime::config::ConfigStore::new()),
         task_store: Arc::new(exomind_runtime::task::TaskStore::new()),
         session_store: Arc::new(exomind_runtime::session::SessionStore::new()),
         session_event_tx: None,

--- a/crates/exomind-runtime/tests/timeblock_routes.rs
+++ b/crates/exomind-runtime/tests/timeblock_routes.rs
@@ -33,6 +33,7 @@ fn test_state_with_timeblock_store(timeblock_store: Arc<TimeBlockStore>) -> AppS
         auth_secret: None,
         mdns: None,
         pairing: Arc::new(exomind_runtime::pairing::PairingManager::new()),
+        config_store: Arc::new(exomind_runtime::config::ConfigStore::new()),
         task_store: Arc::new(exomind_runtime::task::TaskStore::new()),
         session_store: Arc::new(exomind_runtime::session::SessionStore::new()),
         session_event_tx: None,

--- a/crates/exomind-runtime/tests/today_planner_routes.rs
+++ b/crates/exomind-runtime/tests/today_planner_routes.rs
@@ -51,6 +51,7 @@ fn test_state_with_timeblock_store(timeblock_store: Arc<TimeBlockStore>) -> AppS
         eventlog_store: Arc::new(exomind_runtime::eventlog::EventLogStore::new(
             std::env::temp_dir().join("exomind-test-today-planner"),
         )),
+        config_store: Arc::new(exomind_runtime::config::ConfigStore::new()),
         #[cfg(not(target_os = "android"))]
         pty_manager: Arc::new(exomind_runtime::pty::PtyManager::new(
             Arc::clone(&signal_pool),

--- a/docs/plans/2026-03-27-issue-756-runtime-settings-migration-design.md
+++ b/docs/plans/2026-03-27-issue-756-runtime-settings-migration-design.md
@@ -1,0 +1,569 @@
+# Issue #756 Runtime Settings Migration Design
+
+**Date:** 2026-03-27  
+**Status:** Draft  
+**Scope:** 把仍滞留在前端 `localStorage / IndexedDB` 的关键设置、快捷键、密钥迁到 Runtime SQLite，打通 `tauri dev` 与安装版的数据连续性
+
+---
+
+## 1. 背景 / Background（背景）
+
+当前 ExoMind 的核心业务数据已经基本进入 Runtime SQLite：
+
+1. `eventlog.sqlite`
+2. `tasks.sqlite`
+3. `timeblocks.sqlite`
+4. `sessions.sqlite`
+
+这意味着：
+
+1. 事件日志、任务、时间块、Agent session 元数据本身，已经不再主要卡在前端 origin（来源域）里。
+2. 用户从 `dev` 切到安装版时，真正导致“连续性断裂”的，主要不是核心业务数据，而是**设置真相源（settings source of truth，设置真相源）仍在前端**。
+
+当前前端仍直接持久化大量关键配置：
+
+1. `src/config/config-factory.ts`
+2. `src/ui/app/config/settings/settings-registry.ts`
+3. `src/lib/ai-registry/storage.ts`
+4. `src/lib/ai-registry/secrets.ts`
+
+已经确认本机同时存在两个 WebView origin（来源域）数据空间：
+
+1. `http://localhost:1420`（当前 `tauri dev`）
+2. `tauri.localhost / tauri://localhost`（安装版）
+
+这两个 origin 的 `localStorage / IndexedDB` 是隔离的，因此：
+
+1. 安装版不能天然读到 `dev` 的前端设置。
+2. `dev` 也不能天然复用安装版的前端设置。
+3. 只要设置继续以前端存储为真相源，用户就会持续遇到“核心数据在，偏好和密钥没了”的问题。
+
+---
+
+## 2. 目标 / Goals（目标）
+
+`#756` 的目标不是“把所有浏览器缓存全搬走”，而是先解决用户真正会痛的连续性问题：
+
+1. 把**关键用户设置（critical user settings，关键用户设置）**迁到 Runtime SQLite。
+2. 把**敏感凭据（secrets，密钥/令牌）**迁到 Runtime SQLite。
+3. 让 `tauri dev` 与安装版共享同一份 Runtime 设置数据。
+4. 保持现有前端大量同步 `get / set / subscribe` 调用方式基本不崩。
+5. 保持 Web-first（先保证 Web 端不坏），Runtime 不可用时仍可回退到浏览器本地存储。
+6. 提供一次性 migration（迁移）路径，把旧前端存储导入 Runtime。
+
+---
+
+## 3. 非目标 / Non-goals（本次不做）
+
+本轮明确不做以下事情，避免 `#756` 失控：
+
+1. 不一次性迁走全部 `localStorage` key。
+2. 不迁 `sessionStorage`、页面草稿、路由记忆、临时 UI 状态。
+3. 不做 Windows/WebView2 磁盘级跨 origin 扫描和解析。
+4. 不在本轮解决 PTY 进程级恢复、Codex 进程续跑问题。
+5. 不重做设置页 UI 结构。
+6. 不在本轮引入操作系统级密钥链（OS keychain，系统密钥链）。
+
+说明：
+
+1. Agent session 元数据已经进入 `sessions.sqlite`，这和“设置连续性”是两条线。
+2. PTY/Codex 进程在关闭桌面应用后的恢复控制，应继续走 Agent/PTY 专题，不应塞进 `#756`。
+
+---
+
+## 4. 为什么不能继续用前端存储 / Why Frontend Storage Must Stop Being Source of Truth
+
+### 4.1 前端 origin 天然分叉
+
+`localStorage / IndexedDB` 是按 origin 隔离的。  
+因此 `http://localhost:1420` 与安装版 WebView 不是同一个设置空间。
+
+### 4.2 当前关键配置仍直接写前端
+
+已确认以下内容仍直接写前端：
+
+1. 主题、快捷键、输入偏好、Overlay 偏好
+2. `moss_api_key`
+3. 火山 `AppKey / AccessKey / Resource ID / endpoint / language`
+4. `AI Registry snapshot`
+5. `AI Registry energy secrets`
+
+### 4.3 快捷键当前是“前端配置 + Runtime apply”
+
+当前全局快捷键链路并不是 Runtime 持久化：
+
+1. 前端从 `localStorage` 读快捷键
+2. 设置页或服务启动时再调用 Runtime command 去 apply（应用）
+3. 切换壳层后，前端配置丢了，Runtime 也无法自动恢复用户原值
+
+### 4.4 继续 patch localStorage 没有终局价值
+
+如果只是继续补 localStorage 逻辑：
+
+1. `dev` / 安装版 依然两套数据
+2. 多窗口 / 多 origin 一致性依然脆弱
+3. 密钥仍然散落在浏览器存储层
+
+结论：**前端存储可以继续做缓存层（cache，缓存），但不能再做真相源。**
+
+---
+
+## 5. 设置分类 / Settings Classification（设置分类）
+
+本轮采用“先分类，再迁移”的策略。
+
+### 5.1 Batch A：优先迁移的关键用户设置
+
+这批直接影响“安装版接上就能用”：
+
+1. `exomind:themePreference`
+2. `exomind:voiceShortcutHotkey`
+3. `exomind:mainWindowShortcutSelection`
+4. `exomind:mainWindowShortcutSelectionCustomized`
+5. `exomind:mainWindowShortcutQuickFocusEnabled`
+6. `exomind:voiceShortcutAsrProvider`
+7. `exomind:voiceShortcutSendMode`
+8. `exomind:voiceShortcutMicPrewarmEnabled`
+9. `exomind:voiceTranscriptSendMode`
+10. `exomind:inputSendMode`
+11. `moss_api_key`
+12. 火山 ASR 相关 key 与识别参数
+13. `exomind:ai-registry:snapshot`
+14. `exomind:ai-registry:energy-secret:*`
+
+### 5.2 Batch B：高频偏好，但不阻塞连续性
+
+这批适合在 Runtime 配置基础设施稳定后继续收口：
+
+1. `feedbackPreferences`
+2. `timerPreferences`
+3. `focusBgmPreferences`
+4. `voiceOverlay*`
+5. `nowWorkbenchOverlay*`
+6. `task-dag-*`
+7. `tasks-default-tab`
+8. `task-page-fuzzy-search`
+9. `task-create-success-action`
+10. 页面开关与部分 feature toggles（功能开关）
+
+### 5.3 Batch C：暂时保留前端或单独处理
+
+这批更像设备/调试/联调状态，不应和用户设置混在第一批：
+
+1. `exomind:syncServerUrl`
+2. `exomind:runtimeTargetMode`
+3. `exomind:runtimeExternalAddress`
+4. `exomind:embeddedRuntimeNetworkMode`
+5. `exomind:embeddedRuntimeStatus`
+6. `exomind:developerMode`
+7. `exomind:devtoolsEnabled`
+8. `exomind:useMockData`
+9. `eventlog/task/timeblock backend mode`
+10. 各类 `sessionStorage` 路由记忆、草稿、临时 UI 状态
+
+---
+
+## 6. 选定方案 / Chosen Architecture（选定架构）
+
+### 6.1 核心决策：新增 `RuntimeConfigStore (SQLite)`
+
+在 Runtime 内新增一个通用配置存储模块，结构风格对齐现有：
+
+1. `task::TaskStore`
+2. `timeblock::TimeBlockStore`
+3. `session::SessionStore`
+
+建议新增：
+
+1. `crates/exomind-runtime/src/config/store.rs`
+2. `crates/exomind-runtime/src/config/sqlite_store.rs`
+3. `crates/exomind-runtime/src/config/types.rs`
+4. `crates/exomind-runtime/src/routes/config.rs`
+
+### 6.2 不重造值结构，先存“原始字符串（raw string，原始串）”
+
+本轮**不把所有设置都翻译成 Rust 强类型结构体**。  
+Runtime 配置表优先存储“前端原本写进 localStorage 的 canonical raw value（规范化后的原始值）”。
+
+这样做的原因：
+
+1. 现有前端每个设置模块已经有自己的 normalize（归一化）逻辑。
+2. 像 `timerPreferences`、`feedbackPreferences` 本来就是 JSON 字符串。
+3. 像 `themePreference`、`voiceShortcutHotkey` 本来就是简单字符串。
+4. 这样可以最大限度减少前端模块改造量。
+5. 不需要在 Rust 再复制一套完整设置 schema（模式）。
+
+换句话说，第一阶段的 RuntimeConfigStore 更像：
+
+1. `selected localStorage mirror（受控的 localStorage 镜像）`
+2. 但真相源在 Runtime SQLite，而不在浏览器 origin
+
+### 6.3 表结构建议
+
+建议使用单表：
+
+`runtime_config_entries`
+
+字段：
+
+1. `scope TEXT NOT NULL`  
+   值：`user` | `device`
+2. `key TEXT NOT NULL`
+3. `value TEXT NOT NULL`
+4. `sensitive INTEGER NOT NULL DEFAULT 0`
+5. `updated_at TEXT NOT NULL`
+6. `source TEXT`
+7. `source_origin TEXT`
+
+主键：
+
+1. `(scope, key)`
+
+当前 `#756` 只落 `scope = user` 的 Batch A。  
+`device` 列先保留，为后续 Batch C 或诊断配置做准备。
+
+### 6.4 Runtime HTTP API
+
+建议新增以下最小路由：
+
+1. `GET /config?scope=user&prefix=exomind:`
+2. `PUT /config/{key}`
+3. `DELETE /config/{key}`
+4. `POST /config/import/frontend`
+5. `POST /config/reset`
+6. `GET /config/stream`
+
+说明：
+
+1. `GET /config` 用于前端 bootstrap snapshot（启动快照）拉取。
+2. `PUT / DELETE` 用于日常设置读写。
+3. `POST /config/import/frontend` 用于一次性导入旧前端设置。
+4. `POST /config/reset` 用于“重置全部设置”。
+5. `GET /config/stream` 用于跨窗口/跨客户端订阅配置变化。
+
+### 6.5 Runtime 启动默认路径
+
+Tauri 启动时应新增：
+
+1. `EXOMIND_RT_CONFIG_SQLITE_PATH`
+
+默认落在现有 Runtime 数据目录中：
+
+1. `config.sqlite`
+
+对应位置与现有：
+
+1. `eventlog.sqlite`
+2. `tasks.sqlite`
+3. `timeblocks.sqlite`
+4. `sessions.sqlite`
+
+保持一致。
+
+---
+
+## 7. 前端过渡层 / Frontend Transition Layer（前端过渡层）
+
+### 7.1 不能把现有配置模块直接改成纯异步
+
+当前很多地方默认配置 API 是同步的：
+
+1. `ThemeController`
+2. `App.tsx` 里的服务初始化
+3. `SettingsPage`
+4. 各种 `getXxx() / subscribeXxxChanges()`
+
+如果直接把这些配置模块改成“每次都 fetch Runtime”，会造成：
+
+1. 首屏闪烁
+2. 服务初始化顺序混乱
+3. 大量 UI/测试改造
+
+### 7.2 选定方案：`RuntimeConfigCache + Bootstrap`
+
+前端新增一个运行时配置桥接层：
+
+1. 启动时先从 Runtime 拉取 Batch A 快照
+2. 把这些 key 放进内存 Map（内存缓存）
+3. 现有 `get / set / subscribe` 仍然同步读取这个内存缓存
+4. 设置变更时，先更新内存缓存并发本地事件，再异步写 Runtime
+
+建议新增：
+
+1. `src/config/runtime-config-cache.ts`
+2. `src/config/runtime-config-adapter.ts`
+
+### 7.3 启动顺序
+
+建议在 `src/main.tsx` 里把顺序改为：
+
+1. `ensureCryptoRandomUUID()`
+2. `await bootstrapRuntimeConfig()`
+3. `syncDevtoolsWithSettings()`
+4. `render(<App />)`
+
+这样可以保证：
+
+1. 主题首帧读取的是 Runtime 值
+2. 快捷键服务初始化时拿到的是 Runtime 值
+3. 设置页首开不会先显示默认值再跳变
+
+### 7.4 前端模块改造策略
+
+不建议一次性重写全部 `src/config/*`。  
+更稳的做法是：
+
+1. 保留现有模块导出接口不变
+2. 先让 Batch A 这些模块从 `RuntimeConfigCache` 读写
+3. 非 Batch A 模块继续走原 `localStorage`
+
+这样 `#756` 是**受控收口（controlled convergence，受控收口）**，而不是大爆炸迁移。
+
+---
+
+## 8. Migration 设计 / Migration Design（迁移设计）
+
+### 8.1 关键现实：浏览器不能跨 origin 读旧设置
+
+安装版第一次启动时，无法直接从 `http://localhost:1420` 读取旧 dev 的 `localStorage`。  
+这不是实现细节，而是浏览器安全边界。
+
+所以本轮**不做**以下脆弱方案：
+
+1. 直接扫描 WebView2 磁盘文件
+2. 解析不同 origin 的浏览器内部数据库
+
+### 8.2 选定迁移策略：`same-origin export -> Runtime import`
+
+哪一个 origin 被升级了，它就负责把**自己当前 origin 下的旧设置**导入 Runtime。
+
+流程：
+
+1. 升级后的 `dev` 启动
+2. 读取自己当前 origin 下的旧前端设置
+3. 通过 `POST /config/import/frontend` 导入 Runtime SQLite
+4. 导入成功后，Runtime 成为真相源
+5. 之后安装版启动时直接读 Runtime，就能接上
+
+安装版旧用户同理：
+
+1. 升级后的安装版启动
+2. 读取安装版自己旧 origin 下的前端设置
+3. 导入 Runtime
+
+### 8.3 自动迁移规则
+
+自动迁移必须满足两个要求：
+
+1. **幂等（idempotent，重复执行结果稳定）**
+2. **不互相覆盖**
+
+建议规则：
+
+1. Runtime 里若不存在 `settings-migration-v1` 标记，则允许自动导入
+2. 自动导入采用 `if-empty（仅填充空目标）`
+3. 一旦 Runtime 已有目标 key，不再自动覆盖
+4. 在 Runtime 里记录：
+   - `migration_version`
+   - `source_origin`
+   - `completed_at`
+
+这意味着：
+
+1. **第一个升级并完成导入的 origin，成为自动迁移的基准来源**
+2. 后续 origin 不会默默把已有 Runtime 配置冲掉
+
+### 8.4 手动重导入
+
+由于自动迁移采取“first writer wins（首个写入者生效）”，建议在设置页开发者/数据区补一个手动动作：
+
+1. `Import current app settings into Runtime（把当前壳层的旧设置重新导入 Runtime）`
+
+这个动作允许：
+
+1. 用户明确以当前壳层为准
+2. `mode = overwrite`
+3. 解决双 origin 都有旧配置、但用户想指定以哪边为准的问题
+
+### 8.5 AI Registry 迁移
+
+AI Registry 目前不只是一个 key，而是：
+
+1. `snapshot`
+2. `energy-secret:*`
+
+建议第一阶段仍按现有 key 体系迁移，不重建新的 AI provider store：
+
+1. `exomind:ai-registry:snapshot`
+2. `exomind:ai-registry:energy-secret:*`
+
+原因：
+
+1. 用户当前最关心的是“密钥别丢、模型别重配”
+2. 不是“立刻把 AI Registry 变成新领域模型”
+
+---
+
+## 9. 快捷键与设置副作用 / Side Effects（副作用处理）
+
+不是所有设置都只是“存个值”。
+
+### 9.1 需要 Runtime apply 的设置
+
+以下配置修改后，除了持久化，还要立即 apply 到系统/运行时：
+
+1. `voiceShortcutHotkey`
+2. `mainWindowShortcutSelection`
+
+建议新链路：
+
+1. 前端更新 `RuntimeConfigCache`
+2. 持久化写入 `RuntimeConfigStore`
+3. 成功后调用对应 Tauri command 做快捷键 apply
+4. 失败时回滚内存值，并给设置页错误提示
+
+### 9.2 只影响 UI 的设置
+
+例如：
+
+1. `themePreference`
+2. `inputSendMode`
+3. `voiceOverlay*`
+
+这类可以：
+
+1. 先更新内存值与 UI
+2. 异步写 Runtime
+3. 写失败时提示，但不必阻断当前 UI 更新
+
+---
+
+## 10. 清理与重置语义 / Reset Semantics（清理与重置语义）
+
+当前设置页里有两个危险动作：
+
+1. `清空本地缓存`
+2. `重置所有设置`
+
+迁移到 Runtime 后，这两个动作必须重新定义。
+
+### 10.1 清空本地缓存
+
+新的语义应为：
+
+1. 只清理浏览器本地缓存、`sessionStorage`、临时 UI 状态
+2. 不删除 Runtime-backed（Runtime 托管）的关键设置
+
+### 10.2 重置所有设置
+
+新的语义应为：
+
+1. 删除 Runtime 里的 Batch A / Batch B 用户设置
+2. 同时清理残留 localStorage 的本地 UI 键
+3. 重新回到默认值
+
+否则用户会看到：
+
+1. 表面点了“重置”
+2. 实际一重启又从 Runtime 恢复回来
+
+这会非常迷惑。
+
+---
+
+## 11. 推荐拆分 / Recommended Delivery Split（推荐拆分）
+
+不建议把 `#756` 一次性做成一个超大 PR。  
+建议在同一个 issue 下拆成 3 个连续批次：
+
+### PR 1：Runtime Config 基础设施 + Batch A 核心设置
+
+范围：
+
+1. `RuntimeConfigStore`
+2. `/config` 路由
+3. `config.sqlite` 默认路径
+4. 前端 `RuntimeConfigCache`
+5. 主题、快捷键、语音 provider、MOSS、火山 key
+6. 自动 migration v1
+
+这是最有用户价值的一步，优先落地。
+
+### PR 2：AI Registry 与 Secrets 收口
+
+范围：
+
+1. `ai-registry snapshot`
+2. `ai-registry energy-secret:*`
+3. LLM 默认草稿兼容迁移
+4. 手动重导入动作
+
+这是“密钥别丢、模型别重配”的关键补全。
+
+### PR 3：高频偏好 + reset/cleanup 完整语义
+
+范围：
+
+1. `timer / feedback / focus bgm / overlay / DAG / default tab`
+2. `clear local cache / reset all settings`
+3. 开发者诊断与 backend status
+
+---
+
+## 12. 验收标准 / Acceptance Criteria（验收标准）
+
+`#756` 至少需要满足以下验收：
+
+1. 在 `tauri dev` 中修改 Batch A 设置后，关闭应用再开，设置仍在。
+2. 在升级后的 `tauri dev` 中完成一次导入后，安装版启动能直接读到相同 Batch A 设置。
+3. 安装版修改 Batch A 设置后，重新打开 `dev`，设置保持一致。
+4. `MOSS / 火山 / AI Registry` 不需要重复手填。
+5. `ThemeController`、语音快捷键、主窗口快捷键在首帧/首启时读取的是 Runtime 值，而不是默认值。
+6. `清空本地缓存` 不会误删 Runtime 托管设置。
+7. `重置所有设置` 会真正把 Runtime 托管设置也清掉。
+
+---
+
+## 13. 测试建议 / Test Strategy（测试建议）
+
+### 13.1 Rust
+
+1. `ConfigStore` SQLite reopen persistence（重开持久化）
+2. `/config` routes
+3. `/config/import/frontend` 幂等性
+4. `first writer wins` 自动迁移规则
+5. `/config/reset`
+
+### 13.2 Frontend
+
+1. `bootstrapRuntimeConfig()` 在 render 前注入快照
+2. Batch A 配置模块改走 RuntimeCache 后，`get / set / subscribe` 语义不变
+3. `settings-registry` 中的 MOSS/火山/主题/快捷键行为保持正确
+4. `AI Registry` 改走 Runtime 后，默认草稿和现有兼容逻辑仍成立
+
+### 13.3 Manual（手测）
+
+1. `dev -> 安装版`
+2. `安装版 -> dev`
+3. 手动“重新导入当前壳层旧设置”
+4. `reset all settings`
+
+---
+
+## 14. 最终建议 / Recommendation（建议结论）
+
+围绕 `#756`，我建议采用下面这条主线：
+
+1. **先新增 RuntimeConfigStore，而不是继续补 localStorage。**
+2. **第一阶段直接复用现有 localStorage key 名，不做大规模 key 重命名。**
+3. **前端通过 bootstrap + 内存缓存维持同步配置 API，避免全项目异步化。**
+4. **迁移采用 same-origin export -> Runtime import，不做磁盘级跨 origin 读取。**
+5. **先做 Batch A，先解决主题、快捷键、密钥、AI Registry。**
+
+这条路径的优点是：
+
+1. 真正解决 `dev / 安装版` 连续性
+2. 改造量受控
+3. 与现有 Runtime SQLite 架构一致
+4. 能在不破坏当前 Web-first 开发链路的前提下落地
+

--- a/docs/plans/2026-03-27-issue-756-runtime-settings-migration-plan.md
+++ b/docs/plans/2026-03-27-issue-756-runtime-settings-migration-plan.md
@@ -1,0 +1,315 @@
+# Issue #756 Runtime Settings Migration Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 在不影响当前 `dev` 使用链路的前提下，把第一批关键设置从前端 `localStorage` 迁到 Runtime SQLite，并让 `tauri dev` 与安装版共享同一份设置数据。
+
+**Architecture:** 新增 `RuntimeConfigStore` 作为 SQLite 持久化真相源，前端通过 `bootstrap + in-memory cache（启动快照 + 内存缓存）` 保持现有同步 `get / set / subscribe` 调用方式。被迁移模块仍兼容镜像写 `localStorage`，但优先从 Runtime cache 读，避免 origin 分叉继续成为真相源。
+
+**Tech Stack:** Rust + Axum + Rusqlite + Tauri v2 + React 18 + TypeScript + Vitest
+
+---
+
+### Task 1: Runtime config store（运行时配置存储）
+
+**Files:**
+- Create: `crates/exomind-runtime/src/config/mod.rs`
+- Create: `crates/exomind-runtime/src/config/store.rs`
+- Create: `crates/exomind-runtime/src/config/sqlite_store.rs`
+- Create: `crates/exomind-runtime/src/config/types.rs`
+- Modify: `crates/exomind-runtime/src/lib.rs`
+
+**Step 1: Write the failing test**
+
+在 `store.rs` 的测试里覆盖：
+- 空库读配置返回空数组
+- `put` 后 `get/list` 可读回
+- 相同 `(scope, key)` 再写会覆盖旧值
+- 重新打开 SQLite 后数据仍存在
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p exomind-runtime config::store`
+Expected: FAIL，因为 `config` 模块尚不存在
+
+**Step 3: Write minimal implementation**
+
+实现最小能力：
+- `ConfigEntry { scope, key, value, sensitive, updated_at, source, source_origin }`
+- `ConfigStore::new()` 内存版
+- `ConfigStore::with_sqlite_path(path)`
+- `put/get/list/delete/list_by_prefix`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p exomind-runtime config::store`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/exomind-runtime/src/config crates/exomind-runtime/src/lib.rs
+git commit -m "feat(runtime): add config store for issue 756"
+```
+
+### Task 2: Runtime config routes（运行时配置路由）
+
+**Files:**
+- Create: `crates/exomind-runtime/src/routes/config.rs`
+- Modify: `crates/exomind-runtime/src/routes/mod.rs`
+- Modify: `crates/exomind-runtime/src/lib.rs`
+
+**Step 1: Write the failing test**
+
+在 `routes/config.rs` 的测试里覆盖：
+- `GET /config?scope=user&prefix=exomind:` 返回前缀过滤结果
+- `PUT /config/{key}` 可写入 value
+- `DELETE /config/{key}` 删除成功
+- `POST /config/import/frontend` 只在目标 key 为空时导入（`if-empty`）
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p exomind-runtime routes::config`
+Expected: FAIL，因为路由尚未注册
+
+**Step 3: Write minimal implementation**
+
+实现最小 HTTP API：
+- `GET /config`
+- `PUT /config/:key`
+- `DELETE /config/:key`
+- `POST /config/import/frontend`
+
+本 PR 不做：
+- `GET /config/stream`
+- `POST /config/reset`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p exomind-runtime routes::config`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/exomind-runtime/src/routes/config.rs crates/exomind-runtime/src/routes/mod.rs crates/exomind-runtime/src/lib.rs
+git commit -m "feat(runtime): expose config routes for issue 756"
+```
+
+### Task 3: Tauri runtime path wiring（桌面端路径注入）
+
+**Files:**
+- Modify: `src-tauri/src/lib.rs`
+
+**Step 1: Write the failing test**
+
+如果当前测试基础不足，则补一个针对 `seed_runtime_sqlite_env_paths` 的单测，验证会写入：
+- `EXOMIND_RT_CONFIG_SQLITE_PATH -> config.sqlite`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo test -p exomind --lib config_sqlite`
+Expected: FAIL，或没有对应变量注入
+
+**Step 3: Write minimal implementation**
+
+在 Tauri setup 阶段补上 `config.sqlite` 默认路径注入，并让 Runtime 启动时读取该 env。
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo test -p exomind --lib config_sqlite`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src-tauri/src/lib.rs
+git commit -m "feat(tauri): seed runtime config sqlite path"
+```
+
+### Task 4: Frontend runtime config bootstrap（前端运行时配置启动快照）
+
+**Files:**
+- Create: `src/config/runtime-config-types.ts`
+- Create: `src/config/runtime-config-cache.ts`
+- Create: `src/config/runtime-config-adapter.ts`
+- Modify: `src/main.tsx`
+- Test: `tests/unit/config/runtime-config-cache.test.ts`
+
+**Step 1: Write the failing test**
+
+覆盖：
+- bootstrap 成功后缓存命中
+- Runtime 不可用时回退 localStorage
+- `set/remove/importIfEmpty` 会更新内存缓存并发出事件
+
+**Step 2: Run test to verify it fails**
+
+Run: `bunx vitest run tests/unit/config/runtime-config-cache.test.ts`
+Expected: FAIL，因为模块不存在
+
+**Step 3: Write minimal implementation**
+
+实现：
+- 启动前空缓存 + local fallback
+- `bootstrapRuntimeConfig()`
+- `getRuntimeConfigValueSync(key)`
+- `setRuntimeConfigValue(key, value, options?)`
+- `removeRuntimeConfigValue(key)`
+- `importFrontendConfigIfEmpty(entries)`
+- 事件分发与本地镜像写
+
+**Step 4: Run test to verify it passes**
+
+Run: `bunx vitest run tests/unit/config/runtime-config-cache.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/config/runtime-config-* src/main.tsx tests/unit/config/runtime-config-cache.test.ts
+git commit -m "feat(web): bootstrap runtime-backed config cache"
+```
+
+### Task 5: Migrate Batch A config modules（迁移首批关键配置模块）
+
+**Files:**
+- Modify: `src/config/config-factory.ts`
+- Modify: `src/config/theme.ts`
+- Modify: `src/config/voice-shortcut-hotkey.ts`
+- Modify: `src/config/main-window-shortcut.ts`
+- Modify: `src/config/main-window-shortcut-focus.ts`
+- Modify: `src/config/voice-shortcut-asr-provider.ts`
+- Modify: `src/config/voice-shortcut-mic-prewarm.ts`
+- Modify: `src/config/voice-shortcut-send-mode.ts`
+- Modify: `src/config/voice-transcript-send-mode.ts`
+- Modify: `src/config/input-send-mode.ts`
+- Modify: `src/config/volcano-asr-settings.ts`
+- Modify: `src/ui/app/config/settings/settings-registry.ts`
+- Modify: `src/lib/adapters/asr/moss-asr.ts`
+- Test: `tests/unit/ui/theme-preference.test.ts`
+- Test: `tests/unit/config/voice-shortcut-hotkey.test.ts`
+- Test: `tests/unit/config/main-window-shortcut.test.ts`
+- Test: `tests/unit/adapters/moss-asr-auth.test.ts`
+
+**Step 1: Write the failing test**
+
+逐个补充或扩展测试，验证：
+- 被迁移 key 优先从 runtime cache 读取
+- 写入后仍镜像到 localStorage
+- Runtime 不可用时行为与当前一致
+- `moss_api_key` 不再只依赖 localStorage
+
+**Step 2: Run test to verify it fails**
+
+Run:
+- `bunx vitest run tests/unit/ui/theme-preference.test.ts`
+- `bunx vitest run tests/unit/config/voice-shortcut-hotkey.test.ts`
+- `bunx vitest run tests/unit/config/main-window-shortcut.test.ts`
+- `bunx vitest run tests/unit/adapters/moss-asr-auth.test.ts`
+
+Expected: FAIL，因为模块尚未接入 runtime cache
+
+**Step 3: Write minimal implementation**
+
+做法：
+- 为 `createConfigModule` 增加“可选 runtime-backed mode（运行时后端模式）”
+- 维持外部同步 API 不变
+- `settings-registry` 的 `moss_api_key` 改走统一 config adapter
+- 火山配置统一接入 runtime config
+
+**Step 4: Run test to verify it passes**
+
+Run 同上
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/config src/ui/app/config/settings/settings-registry.ts src/lib/adapters/asr/moss-asr.ts tests/unit/ui/theme-preference.test.ts tests/unit/config/voice-shortcut-hotkey.test.ts tests/unit/config/main-window-shortcut.test.ts tests/unit/adapters/moss-asr-auth.test.ts
+git commit -m "feat(settings): migrate batch-a settings to runtime config"
+```
+
+### Task 6: Migrate AI registry storage（迁移 AI Registry 快照与密钥）
+
+**Files:**
+- Modify: `src/lib/ai-registry/storage.ts`
+- Modify: `src/lib/ai-registry/secrets.ts`
+- Test: `tests/unit/storage/ai-registry-storage.test.ts`
+
+**Step 1: Write the failing test**
+
+验证：
+- snapshot 与 energy secret 仍分离存储
+- 优先读 runtime cache
+- Runtime 不可用时仍回退 localStorage
+
+**Step 2: Run test to verify it fails**
+
+Run: `bunx vitest run tests/unit/storage/ai-registry-storage.test.ts`
+Expected: FAIL，因为当前只读写 localStorage
+
+**Step 3: Write minimal implementation**
+
+把 `AI_REGISTRY_SNAPSHOT_KEY` 与 `AI_ENERGY_SECRET_KEY_PREFIX` 接到 runtime config adapter，并保留事件通知。
+
+**Step 4: Run test to verify it passes**
+
+Run: `bunx vitest run tests/unit/storage/ai-registry-storage.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/lib/ai-registry/storage.ts src/lib/ai-registry/secrets.ts tests/unit/storage/ai-registry-storage.test.ts
+git commit -m "feat(ai-registry): persist snapshot and secrets via runtime config"
+```
+
+### Task 7: Full verification and PR prep（全量验证与 PR 准备）
+
+**Files:**
+- Modify: `docs/plans/2026-03-27-issue-756-runtime-settings-migration-design.md`
+- Modify: `docs/plans/2026-03-27-issue-756-runtime-settings-migration-plan.md`
+
+**Step 1: Run focused verification**
+
+Run:
+- `bunx tsc --noEmit`
+- `bunx vitest run tests/unit/config/runtime-config-cache.test.ts`
+- `bunx vitest run tests/unit/ui/theme-preference.test.ts`
+- `bunx vitest run tests/unit/config/voice-shortcut-hotkey.test.ts`
+- `bunx vitest run tests/unit/config/main-window-shortcut.test.ts`
+- `bunx vitest run tests/unit/adapters/moss-asr-auth.test.ts`
+- `bunx vitest run tests/unit/storage/ai-registry-storage.test.ts`
+- `cargo test -p exomind-runtime config::store`
+- `cargo test -p exomind-runtime routes::config`
+
+**Step 2: Fix anything still red**
+
+只修与 `#756` 第一阶段直接相关的问题，不顺手扩散。
+
+**Step 3: Push branch**
+
+```bash
+git push -u origin feature/issue-756-runtime-settings-migration
+```
+
+**Step 4: Create PR**
+
+PR 标题建议：
+
+```text
+fix(issue-756): migrate runtime settings from localStorage to SQLite
+```
+
+PR 描述必须包含：
+- 问题背景
+- 第一阶段范围
+- 测试命令与结果
+- 未纳入本 PR 的后续项
+
+**Step 5: Link issue**
+
+在 PR 描述与评论中写明：
+- `Closes #756` 或 `Refs #756`（若本 PR 只是第一阶段则用 `Refs #756`）
+- 附设计文档与实施计划链接

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -82,6 +82,13 @@ fn seed_runtime_sqlite_env_paths(runtime_dir: &std::path::Path) {
             std::env::set_var("EXOMIND_RT_SESSION_SQLITE_PATH", session_sqlite_path);
         }
     }
+    if std::env::var_os("EXOMIND_RT_CONFIG_SQLITE_PATH").is_none() {
+        let config_sqlite_path = runtime_dir.join("config.sqlite");
+        // SAFETY: setup runs before the embedded runtime starts and before worker threads read this env var.
+        unsafe {
+            std::env::set_var("EXOMIND_RT_CONFIG_SQLITE_PATH", config_sqlite_path);
+        }
+    }
 }
 
 fn resolve_embedded_runtime_port() -> u16 {
@@ -151,6 +158,7 @@ pub fn run() {
                 || std::env::var_os("EXOMIND_RT_TASK_SQLITE_PATH").is_none()
                 || std::env::var_os("EXOMIND_RT_TIMEBLOCK_SQLITE_PATH").is_none()
                 || std::env::var_os("EXOMIND_RT_SESSION_SQLITE_PATH").is_none()
+                || std::env::var_os("EXOMIND_RT_CONFIG_SQLITE_PATH").is_none()
             {
                 match app.path().app_data_dir() {
                     Ok(app_data_dir) => {
@@ -343,6 +351,7 @@ mod tests {
             "EXOMIND_RT_TASK_SQLITE_PATH",
             "EXOMIND_RT_TIMEBLOCK_SQLITE_PATH",
             "EXOMIND_RT_SESSION_SQLITE_PATH",
+            "EXOMIND_RT_CONFIG_SQLITE_PATH",
         ] {
             // SAFETY: tests mutate process env in a controlled single-threaded scope.
             unsafe {
@@ -377,6 +386,10 @@ mod tests {
         assert_eq!(
             std::env::var_os("EXOMIND_RT_SESSION_SQLITE_PATH"),
             Some(runtime_dir.join("sessions.sqlite").into_os_string())
+        );
+        assert_eq!(
+            std::env::var_os("EXOMIND_RT_CONFIG_SQLITE_PATH"),
+            Some(runtime_dir.join("config.sqlite").into_os_string())
         );
 
         clear_runtime_sqlite_envs();

--- a/src/bootstrap-before-render.ts
+++ b/src/bootstrap-before-render.ts
@@ -1,0 +1,15 @@
+export async function bootstrapBeforeRender(
+  bootstrap: () => Promise<void>,
+  render: () => void,
+  reportError: (error: unknown) => void = (error) => {
+    console.warn('[bootstrap-before-render] bootstrap failed, fallback to render', error);
+  },
+): Promise<void> {
+  try {
+    await bootstrap();
+  } catch (error) {
+    reportError(error);
+  }
+
+  render();
+}

--- a/src/config/config-factory.ts
+++ b/src/config/config-factory.ts
@@ -19,6 +19,11 @@
  *   export const subscribeMyConfigChanges = myConfig.subscribe;
  */
 
+import {
+  getRuntimeConfigValueSync,
+  setRuntimeConfigValue,
+} from './runtime-config-cache';
+
 export interface ConfigModuleOptions<T> {
   /** localStorage key */
   storageKey: string;
@@ -36,6 +41,8 @@ export interface ConfigModuleOptions<T> {
    * Defaults to String(value).
    */
   serialize?: (value: T) => string;
+  /** Persist to Runtime first while still mirroring localStorage（优先写 Runtime，同时镜像到 localStorage） */
+  persistMode?: 'localStorage' | 'runtime-preferred';
 }
 
 export interface ConfigModule<T> {
@@ -56,8 +63,17 @@ function getStorage(): Pick<Storage, 'getItem' | 'setItem'> | null {
 export function createConfigModule<T>(options: ConfigModuleOptions<T>): ConfigModule<T> {
   const { storageKey, eventName, defaultValue, normalize } = options;
   const serialize: (value: T) => string = options.serialize ?? String;
+  const persistMode = options.persistMode ?? 'localStorage';
 
   function get(): T {
+    if (persistMode === 'runtime-preferred') {
+      try {
+        return normalize(getRuntimeConfigValueSync(storageKey));
+      } catch {
+        return defaultValue;
+      }
+    }
+
     const storage = getStorage();
     if (!storage) return defaultValue;
     try {
@@ -72,13 +88,20 @@ export function createConfigModule<T>(options: ConfigModuleOptions<T>): ConfigMo
     // pass a value of type T still get the canonical form back, matching the
     // behaviour of hand-written setters that call normalizeXxx(input) first.
     const normalized = normalize(serialize(value));
-    const storage = getStorage();
-    if (!storage) return normalized;
     try {
-      storage.setItem(storageKey, serialize(normalized));
+      if (persistMode === 'runtime-preferred') {
+        setRuntimeConfigValue(storageKey, serialize(normalized), {
+          source: eventName,
+          sourceOrigin: typeof window !== 'undefined' ? window.location?.origin : undefined,
+        });
+      } else {
+        const storage = getStorage();
+        if (!storage) return normalized;
+        storage.setItem(storageKey, serialize(normalized));
+      }
       window.dispatchEvent(new CustomEvent<T>(eventName, { detail: normalized }));
     } catch {
-      // ignore localStorage write errors
+      // ignore localStorage/runtime write errors
     }
     return normalized;
   }

--- a/src/config/input-send-mode.ts
+++ b/src/config/input-send-mode.ts
@@ -20,6 +20,7 @@ const _module = createConfigModule<InputSendMode>({
   eventName: 'exomind:input-send-mode-changed',
   defaultValue: 'ctrl-enter-send',
   normalize: normalizeMode,
+  persistMode: 'runtime-preferred',
 });
 
 export function getInputSendMode(): InputSendMode {

--- a/src/config/main-window-shortcut-focus.ts
+++ b/src/config/main-window-shortcut-focus.ts
@@ -1,3 +1,8 @@
+import {
+  getRuntimeConfigValueSync,
+  setRuntimeConfigValue,
+} from './runtime-config-cache';
+
 const MAIN_WINDOW_SHORTCUT_FOCUS_STORAGE_KEY = 'exomind:mainWindowShortcutQuickFocusEnabled';
 const MAIN_WINDOW_SHORTCUT_FOCUS_CHANGED_EVENT = 'exomind:main-window-shortcut-quick-focus-changed';
 
@@ -7,37 +12,26 @@ type SetMainWindowShortcutQuickFocusOptions = {
   emitEvent?: boolean;
 };
 
-function getStorage(): Pick<Storage, 'getItem' | 'setItem'> | null {
-  if (typeof window === 'undefined') return null;
-  const localStorageLike = window.localStorage as Partial<Storage> | undefined;
-  if (!localStorageLike) return null;
-  if (typeof localStorageLike.getItem !== 'function') return null;
-  if (typeof localStorageLike.setItem !== 'function') return null;
-  return localStorageLike as Pick<Storage, 'getItem' | 'setItem'>;
-}
-
 function normalizeEnabled(rawValue: string | null | undefined): boolean {
   return rawValue === 'true';
 }
 
 export function getMainWindowShortcutQuickFocusEnabled(): MainWindowShortcutQuickFocusEnabled {
-  const storage = getStorage();
-  if (!storage) {
-    return false;
-  }
-  return normalizeEnabled(storage.getItem(MAIN_WINDOW_SHORTCUT_FOCUS_STORAGE_KEY));
+  return normalizeEnabled(getRuntimeConfigValueSync(MAIN_WINDOW_SHORTCUT_FOCUS_STORAGE_KEY));
 }
 
 export function setMainWindowShortcutQuickFocusEnabled(
   enabled: boolean,
   options: SetMainWindowShortcutQuickFocusOptions = {},
 ): MainWindowShortcutQuickFocusEnabled {
-  const storage = getStorage();
-  if (!storage) {
+  if (typeof window === 'undefined') {
     return enabled;
   }
 
-  storage.setItem(MAIN_WINDOW_SHORTCUT_FOCUS_STORAGE_KEY, enabled ? 'true' : 'false');
+  setRuntimeConfigValue(MAIN_WINDOW_SHORTCUT_FOCUS_STORAGE_KEY, enabled ? 'true' : 'false', {
+    source: MAIN_WINDOW_SHORTCUT_FOCUS_CHANGED_EVENT,
+    sourceOrigin: window.location?.origin,
+  });
   if (options.emitEvent !== false) {
     window.dispatchEvent(new CustomEvent<boolean>(MAIN_WINDOW_SHORTCUT_FOCUS_CHANGED_EVENT, { detail: enabled }));
   }

--- a/src/config/main-window-shortcut.ts
+++ b/src/config/main-window-shortcut.ts
@@ -1,3 +1,8 @@
+import {
+  getRuntimeConfigValueSync,
+  setRuntimeConfigValue,
+} from './runtime-config-cache';
+
 const MAIN_WINDOW_SHORTCUT_SELECTION_STORAGE_KEY = 'exomind:mainWindowShortcutSelection';
 const MAIN_WINDOW_SHORTCUT_CUSTOMIZED_STORAGE_KEY = 'exomind:mainWindowShortcutSelectionCustomized';
 const MAIN_WINDOW_SHORTCUT_SELECTION_CHANGED_EVENT = 'exomind:main-window-shortcut-selection-changed';
@@ -32,15 +37,6 @@ type SetMainWindowShortcutSelectionOptions = {
   emitEvent?: boolean;
   customized?: boolean;
 };
-
-function getStorage(): Pick<Storage, 'getItem' | 'setItem'> | null {
-  if (typeof window === 'undefined') return null;
-  const localStorageLike = window.localStorage as Partial<Storage> | undefined;
-  if (!localStorageLike) return null;
-  if (typeof localStorageLike.getItem !== 'function') return null;
-  if (typeof localStorageLike.setItem !== 'function') return null;
-  return localStorageLike as Pick<Storage, 'getItem' | 'setItem'>;
-}
 
 function isMainWindowShortcutOption(value: unknown): value is MainWindowShortcutOption {
   return typeof value === 'string'
@@ -86,24 +82,26 @@ function isSameSelection(
   return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
-function isCustomizedSelection(storage: Pick<Storage, 'getItem' | 'setItem'>): boolean {
-  return storage.getItem(MAIN_WINDOW_SHORTCUT_CUSTOMIZED_STORAGE_KEY) === 'true';
+function isCustomizedSelection(): boolean {
+  return getRuntimeConfigValueSync(MAIN_WINDOW_SHORTCUT_CUSTOMIZED_STORAGE_KEY) === 'true';
 }
 
-function readStoredMainWindowShortcutSelection(
-  storage: Pick<Storage, 'getItem' | 'setItem'>,
-): MainWindowShortcutSelection {
+function readStoredMainWindowShortcutSelection(): MainWindowShortcutSelection {
   const normalized = normalizeMainWindowShortcutSelection(
-    storage.getItem(MAIN_WINDOW_SHORTCUT_SELECTION_STORAGE_KEY),
+    getRuntimeConfigValueSync(MAIN_WINDOW_SHORTCUT_SELECTION_STORAGE_KEY),
   );
 
   if (
-    !isCustomizedSelection(storage)
+    !isCustomizedSelection()
     && isSameSelection(normalized, LEGACY_DEFAULT_MAIN_WINDOW_SHORTCUT_SELECTION)
   ) {
-    storage.setItem(
+    setRuntimeConfigValue(
       MAIN_WINDOW_SHORTCUT_SELECTION_STORAGE_KEY,
       stringifySelection(DEFAULT_MAIN_WINDOW_SHORTCUT_SELECTION),
+      {
+        source: 'main-window-shortcut-legacy-default-migration',
+        sourceOrigin: typeof window !== 'undefined' ? window.location?.origin : undefined,
+      },
     );
     return [...DEFAULT_MAIN_WINDOW_SHORTCUT_SELECTION];
   }
@@ -126,12 +124,11 @@ function buildHotkey(selection: MainWindowShortcutSelection): string | null {
 }
 
 export function getMainWindowShortcutSelection(): MainWindowShortcutSelection {
-  const storage = getStorage();
-  if (!storage) {
+  if (typeof window === 'undefined') {
     return [...DEFAULT_MAIN_WINDOW_SHORTCUT_SELECTION];
   }
 
-  return readStoredMainWindowShortcutSelection(storage);
+  return readStoredMainWindowShortcutSelection();
 }
 
 export function setMainWindowShortcutSelection(
@@ -139,18 +136,25 @@ export function setMainWindowShortcutSelection(
   options: SetMainWindowShortcutSelectionOptions = {},
 ): MainWindowShortcutSelection {
   const normalized = normalizeMainWindowShortcutSelection(selection);
-  const storage = getStorage();
-  if (!storage) {
+  if (typeof window === 'undefined') {
     return normalized;
   }
 
-  storage.setItem(
+  setRuntimeConfigValue(
     MAIN_WINDOW_SHORTCUT_SELECTION_STORAGE_KEY,
     stringifySelection(normalized),
+    {
+      source: MAIN_WINDOW_SHORTCUT_SELECTION_CHANGED_EVENT,
+      sourceOrigin: window.location?.origin,
+    },
   );
-  storage.setItem(
+  setRuntimeConfigValue(
     MAIN_WINDOW_SHORTCUT_CUSTOMIZED_STORAGE_KEY,
     options.customized === false ? 'false' : 'true',
+    {
+      source: MAIN_WINDOW_SHORTCUT_SELECTION_CHANGED_EVENT,
+      sourceOrigin: window.location?.origin,
+    },
   );
 
   if (options.emitEvent !== false) {

--- a/src/config/moss-api-key.ts
+++ b/src/config/moss-api-key.ts
@@ -1,0 +1,37 @@
+import {
+  getRuntimeConfigValueSync,
+  removeRuntimeConfigValue,
+  setRuntimeConfigValue,
+} from './runtime-config-cache';
+
+export const MOSS_API_KEY_STORAGE_KEY = 'moss_api_key';
+
+function normalizeMossApiKey(value: string): string {
+  if (!value) {
+    return '';
+  }
+
+  let normalized = value.trim();
+  normalized = normalized.replace(/^['"]|['"]$/g, '');
+  normalized = normalized.replace(/^Bearer\s+/i, '');
+  return normalized.trim();
+}
+
+export function getMossApiKey(): string {
+  return normalizeMossApiKey(getRuntimeConfigValueSync(MOSS_API_KEY_STORAGE_KEY) || '');
+}
+
+export function setMossApiKey(value: string): string {
+  const normalized = normalizeMossApiKey(value);
+  if (!normalized) {
+    removeRuntimeConfigValue(MOSS_API_KEY_STORAGE_KEY);
+    return '';
+  }
+
+  setRuntimeConfigValue(MOSS_API_KEY_STORAGE_KEY, normalized, {
+    sensitive: true,
+    source: 'settings-registry',
+    sourceOrigin: typeof window !== 'undefined' ? window.location?.origin : undefined,
+  });
+  return normalized;
+}

--- a/src/config/runtime-config-adapter.ts
+++ b/src/config/runtime-config-adapter.ts
@@ -133,11 +133,10 @@ async function resolveRuntimeTransport(): Promise<RuntimeConfigTransport | null>
         host: status.host,
         port: status.port,
         hostId: status.hostId,
-        authSecret: status.authSecret,
       });
       return {
         baseUrl: toRuntimeBaseUrl({ host: status.host, port: status.port }),
-        authToken: status.authSecret?.trim() || undefined,
+        authToken: undefined,
       };
     }
 

--- a/src/config/runtime-config-adapter.ts
+++ b/src/config/runtime-config-adapter.ts
@@ -1,0 +1,247 @@
+import { invoke, isTauri } from '@tauri-apps/api/core';
+import {
+  persistEmbeddedRuntimeStatus,
+  toRuntimeBaseUrl,
+} from '@/config/runtime-target';
+import type { RuntimeServiceStatus } from '@/lib/types/agent-hub-runtime';
+import type {
+  RuntimeConfigBootstrapPayload,
+  RuntimeConfigEntryRecord,
+  RuntimeConfigTransport,
+  RuntimeConfigWriteOptions,
+} from './runtime-config-types';
+
+const USER_SCOPE = 'user';
+const BOOTSTRAP_IMPORT_SOURCE = 'frontend-bootstrap-import';
+const FRONTEND_IMPORT_KEYS = [
+  'exomind:themePreference',
+  'exomind:voiceShortcutHotkey',
+  'exomind:mainWindowShortcutSelection',
+  'exomind:mainWindowShortcutSelectionCustomized',
+  'exomind:mainWindowShortcutQuickFocusEnabled',
+  'exomind:voiceShortcutAsrProvider',
+  'exomind:voiceShortcutSendMode',
+  'exomind:voiceShortcutMicPrewarmEnabled',
+  'exomind:voiceTranscriptSendMode',
+  'exomind:inputSendMode',
+  'moss_api_key',
+  'volcano_asr_app_key',
+  'volcano_asr_access_key',
+  'volcano_asr_resource_id',
+  'volcano_asr_endpoint',
+  'volcano_asr_language',
+  'volcano_asr_enable_nonstream',
+  'volcano_asr_show_utterances',
+  'volcano_asr_end_window_size',
+  'volcano_asr_force_to_speech_time',
+  'exomind:ai-registry:snapshot',
+] as const;
+const FRONTEND_IMPORT_PREFIXES = [
+  'exomind:ai-registry:energy-secret:',
+] as const;
+const SENSITIVE_EXACT_KEYS = new Set<string>([
+  'moss_api_key',
+  'volcano_asr_app_key',
+  'volcano_asr_access_key',
+]);
+const SENSITIVE_PREFIXES = [
+  'exomind:ai-registry:energy-secret:',
+] as const;
+
+let activeTransport: RuntimeConfigTransport | null = null;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+function buildHeaders(transport: RuntimeConfigTransport, headers?: HeadersInit): Headers {
+  const nextHeaders = new Headers(headers);
+  const token = transport.authToken?.trim();
+  if (token) {
+    nextHeaders.set('Authorization', `Bearer ${token}`);
+  }
+  return nextHeaders;
+}
+
+function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_EXACT_KEYS.has(key)
+    || SENSITIVE_PREFIXES.some((prefix) => key.startsWith(prefix));
+}
+
+function readLocalStorageEntry(key: string): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function collectFrontendImportEntries(): RuntimeConfigEntryRecord[] {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  const keys = new Set<string>(FRONTEND_IMPORT_KEYS);
+  try {
+    for (let index = 0; index < window.localStorage.length; index += 1) {
+      const key = window.localStorage.key(index);
+      if (!key) {
+        continue;
+      }
+      if (FRONTEND_IMPORT_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+        keys.add(key);
+      }
+    }
+  } catch {
+    return [];
+  }
+
+  const sourceOrigin = window.location?.origin || undefined;
+  const entries: RuntimeConfigEntryRecord[] = [];
+  for (const key of keys) {
+    const value = readLocalStorageEntry(key);
+    if (value == null) {
+      continue;
+    }
+    entries.push({
+      key,
+      value,
+      sensitive: isSensitiveKey(key),
+      source: BOOTSTRAP_IMPORT_SOURCE,
+      sourceOrigin,
+    });
+  }
+
+  return entries;
+}
+
+async function resolveRuntimeTransport(): Promise<RuntimeConfigTransport | null> {
+  if (!await isTauri()) {
+    return null;
+  }
+
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const status = await invoke<RuntimeServiceStatus>('runtime_service_status');
+    if (status.running) {
+      persistEmbeddedRuntimeStatus({
+        host: status.host,
+        port: status.port,
+        hostId: status.hostId,
+        authSecret: status.authSecret,
+      });
+      return {
+        baseUrl: toRuntimeBaseUrl({ host: status.host, port: status.port }),
+        authToken: status.authSecret?.trim() || undefined,
+      };
+    }
+
+    await sleep(150);
+  }
+
+  return null;
+}
+
+async function fetchRuntimeSnapshot(
+  transport: RuntimeConfigTransport,
+): Promise<RuntimeConfigEntryRecord[]> {
+  const response = await fetch(`${transport.baseUrl}/config?scope=${USER_SCOPE}`, {
+    headers: buildHeaders(transport),
+  });
+  if (!response.ok) {
+    throw new Error(`runtime config snapshot failed: ${response.status}`);
+  }
+  return response.json() as Promise<RuntimeConfigEntryRecord[]>;
+}
+
+async function importFrontendEntriesIfEmpty(
+  transport: RuntimeConfigTransport,
+): Promise<void> {
+  const entries = collectFrontendImportEntries();
+  if (entries.length === 0) {
+    return;
+  }
+
+  const response = await fetch(`${transport.baseUrl}/config/import/frontend`, {
+    method: 'POST',
+    headers: buildHeaders(transport, {
+      'Content-Type': 'application/json',
+    }),
+    body: JSON.stringify({
+      scope: USER_SCOPE,
+      strategy: 'if-empty',
+      entries,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`runtime config import failed: ${response.status}`);
+  }
+}
+
+export async function bootstrapRuntimeConfigTransport(): Promise<RuntimeConfigBootstrapPayload | null> {
+  const transport = await resolveRuntimeTransport();
+  activeTransport = transport;
+  if (!transport) {
+    return null;
+  }
+
+  await importFrontendEntriesIfEmpty(transport);
+  const entries = await fetchRuntimeSnapshot(transport);
+  return { transport, entries };
+}
+
+export async function writeRuntimeConfigValue(
+  key: string,
+  value: string,
+  options: RuntimeConfigWriteOptions = {},
+): Promise<void> {
+  if (!activeTransport) {
+    return;
+  }
+
+  const response = await fetch(`${activeTransport.baseUrl}/config/${encodeURIComponent(key)}`, {
+    method: 'PUT',
+    headers: buildHeaders(activeTransport, {
+      'Content-Type': 'application/json',
+    }),
+    body: JSON.stringify({
+      scope: USER_SCOPE,
+      value,
+      sensitive: options.sensitive ?? false,
+      source: options.source,
+      sourceOrigin: options.sourceOrigin,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`runtime config put failed: ${response.status}`);
+  }
+}
+
+export async function deleteRuntimeConfigValue(key: string): Promise<void> {
+  if (!activeTransport) {
+    return;
+  }
+
+  const response = await fetch(
+    `${activeTransport.baseUrl}/config/${encodeURIComponent(key)}?scope=${USER_SCOPE}`,
+    {
+      method: 'DELETE',
+      headers: buildHeaders(activeTransport),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`runtime config delete failed: ${response.status}`);
+  }
+}
+
+export function __resetRuntimeConfigAdapterForTests(): void {
+  activeTransport = null;
+}

--- a/src/config/runtime-config-cache.ts
+++ b/src/config/runtime-config-cache.ts
@@ -14,13 +14,17 @@ type RuntimeConfigCacheState = {
   runtimeEnabled: boolean;
   entries: Map<string, string>;
   bootstrapPromise: Promise<void> | null;
+  bootstrapRetryTimer: number | null;
 };
+
+const BOOTSTRAP_RETRY_DELAY_MS = 1000;
 
 const state: RuntimeConfigCacheState = {
   bootstrapped: false,
   runtimeEnabled: false,
   entries: new Map(),
   bootstrapPromise: null,
+  bootstrapRetryTimer: null,
 };
 
 function readLocalStorageValue(key: string): string | null {
@@ -63,6 +67,29 @@ function replaceRuntimeEntries(entries: RuntimeConfigEntryRecord[]): void {
   state.entries = new Map(entries.map((entry) => [entry.key, entry.value]));
 }
 
+function clearBootstrapRetryTimer(): void {
+  if (state.bootstrapRetryTimer == null) {
+    return;
+  }
+
+  window.clearTimeout(state.bootstrapRetryTimer);
+  state.bootstrapRetryTimer = null;
+}
+
+function scheduleBootstrapRetry(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  if (state.bootstrapRetryTimer != null || state.bootstrapped) {
+    return;
+  }
+
+  state.bootstrapRetryTimer = window.setTimeout(() => {
+    state.bootstrapRetryTimer = null;
+    void bootstrapRuntimeConfig().catch(() => {});
+  }, BOOTSTRAP_RETRY_DELAY_MS);
+}
+
 export async function bootstrapRuntimeConfig(): Promise<void> {
   if (state.bootstrapped) {
     return;
@@ -72,16 +99,25 @@ export async function bootstrapRuntimeConfig(): Promise<void> {
   }
 
   state.bootstrapPromise = (async () => {
-    const payload = await bootstrapRuntimeConfigTransport();
-    state.bootstrapped = true;
-    if (!payload) {
+    try {
+      const payload = await bootstrapRuntimeConfigTransport();
+      if (!payload) {
+        state.runtimeEnabled = false;
+        state.entries.clear();
+        scheduleBootstrapRetry();
+        return;
+      }
+
+      clearBootstrapRetryTimer();
+      state.bootstrapped = true;
+      state.runtimeEnabled = true;
+      replaceRuntimeEntries(payload.entries);
+    } catch (error) {
       state.runtimeEnabled = false;
       state.entries.clear();
-      return;
+      scheduleBootstrapRetry();
+      throw error;
     }
-
-    state.runtimeEnabled = true;
-    replaceRuntimeEntries(payload.entries);
   })().finally(() => {
     state.bootstrapPromise = null;
   });
@@ -132,9 +168,11 @@ export function __primeRuntimeConfigForTests(entries: Record<string, string>): v
 }
 
 export function __resetRuntimeConfigCacheForTests(): void {
+  clearBootstrapRetryTimer();
   state.bootstrapped = false;
   state.runtimeEnabled = false;
   state.entries.clear();
   state.bootstrapPromise = null;
+  state.bootstrapRetryTimer = null;
   __resetRuntimeConfigAdapterForTests();
 }

--- a/src/config/runtime-config-cache.ts
+++ b/src/config/runtime-config-cache.ts
@@ -1,0 +1,140 @@
+import {
+  bootstrapRuntimeConfigTransport,
+  deleteRuntimeConfigValue as deleteRuntimeConfigValueRemote,
+  writeRuntimeConfigValue as writeRuntimeConfigValueRemote,
+  __resetRuntimeConfigAdapterForTests,
+} from './runtime-config-adapter';
+import type {
+  RuntimeConfigEntryRecord,
+  RuntimeConfigWriteOptions,
+} from './runtime-config-types';
+
+type RuntimeConfigCacheState = {
+  bootstrapped: boolean;
+  runtimeEnabled: boolean;
+  entries: Map<string, string>;
+  bootstrapPromise: Promise<void> | null;
+};
+
+const state: RuntimeConfigCacheState = {
+  bootstrapped: false,
+  runtimeEnabled: false,
+  entries: new Map(),
+  bootstrapPromise: null,
+};
+
+function readLocalStorageValue(key: string): string | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeLocalStorageValue(key: string, value: string): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Ignore local mirror failures（忽略本地镜像写入失败）
+  }
+}
+
+function removeLocalStorageValue(key: string): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // Ignore local mirror removal failures（忽略本地镜像删除失败）
+  }
+}
+
+function replaceRuntimeEntries(entries: RuntimeConfigEntryRecord[]): void {
+  state.entries = new Map(entries.map((entry) => [entry.key, entry.value]));
+}
+
+export async function bootstrapRuntimeConfig(): Promise<void> {
+  if (state.bootstrapped) {
+    return;
+  }
+  if (state.bootstrapPromise) {
+    return state.bootstrapPromise;
+  }
+
+  state.bootstrapPromise = (async () => {
+    const payload = await bootstrapRuntimeConfigTransport();
+    state.bootstrapped = true;
+    if (!payload) {
+      state.runtimeEnabled = false;
+      state.entries.clear();
+      return;
+    }
+
+    state.runtimeEnabled = true;
+    replaceRuntimeEntries(payload.entries);
+  })().finally(() => {
+    state.bootstrapPromise = null;
+  });
+
+  return state.bootstrapPromise;
+}
+
+export function isRuntimeConfigEnabled(): boolean {
+  return state.runtimeEnabled;
+}
+
+export function getRuntimeConfigValueSync(key: string): string | null {
+  if (state.runtimeEnabled && state.entries.has(key)) {
+    return state.entries.get(key) ?? null;
+  }
+
+  return readLocalStorageValue(key);
+}
+
+export function setRuntimeConfigValue(
+  key: string,
+  value: string,
+  options: RuntimeConfigWriteOptions = {},
+): void {
+  writeLocalStorageValue(key, value);
+  if (!state.runtimeEnabled) {
+    return;
+  }
+
+  state.entries.set(key, value);
+  void writeRuntimeConfigValueRemote(key, value, options).catch(() => {});
+}
+
+export function removeRuntimeConfigValue(key: string): void {
+  removeLocalStorageValue(key);
+  if (!state.runtimeEnabled) {
+    return;
+  }
+
+  state.entries.delete(key);
+  void deleteRuntimeConfigValueRemote(key).catch(() => {});
+}
+
+export function __primeRuntimeConfigForTests(entries: Record<string, string>): void {
+  state.bootstrapped = true;
+  state.runtimeEnabled = true;
+  state.entries = new Map(Object.entries(entries));
+}
+
+export function __resetRuntimeConfigCacheForTests(): void {
+  state.bootstrapped = false;
+  state.runtimeEnabled = false;
+  state.entries.clear();
+  state.bootstrapPromise = null;
+  __resetRuntimeConfigAdapterForTests();
+}

--- a/src/config/runtime-config-types.ts
+++ b/src/config/runtime-config-types.ts
@@ -1,0 +1,24 @@
+export interface RuntimeConfigEntryRecord {
+  key: string;
+  value: string;
+  sensitive?: boolean;
+  updatedAt?: string;
+  source?: string;
+  sourceOrigin?: string;
+}
+
+export interface RuntimeConfigTransport {
+  baseUrl: string;
+  authToken?: string;
+}
+
+export interface RuntimeConfigBootstrapPayload {
+  transport: RuntimeConfigTransport;
+  entries: RuntimeConfigEntryRecord[];
+}
+
+export interface RuntimeConfigWriteOptions {
+  sensitive?: boolean;
+  source?: string;
+  sourceOrigin?: string;
+}

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -1,3 +1,8 @@
+import {
+  getRuntimeConfigValueSync,
+  setRuntimeConfigValue,
+} from './runtime-config-cache';
+
 export const THEME_PREFERENCE_STORAGE_KEY = 'exomind:themePreference';
 export const THEME_PREFERENCE_CHANGED_EVENT = 'exomind:theme-preference-changed';
 
@@ -17,7 +22,7 @@ export function getThemePreference(): ThemePreference {
   }
 
   try {
-    const stored = window.localStorage.getItem(THEME_PREFERENCE_STORAGE_KEY);
+    const stored = getRuntimeConfigValueSync(THEME_PREFERENCE_STORAGE_KEY);
     if (!stored) {
       return 'system';
     }
@@ -34,7 +39,10 @@ export function setThemePreference(preference: ThemePreference): void {
   }
 
   try {
-    window.localStorage.setItem(THEME_PREFERENCE_STORAGE_KEY, preference);
+    setRuntimeConfigValue(THEME_PREFERENCE_STORAGE_KEY, preference, {
+      source: THEME_PREFERENCE_CHANGED_EVENT,
+      sourceOrigin: window.location?.origin,
+    });
     window.dispatchEvent(
       new CustomEvent(THEME_PREFERENCE_CHANGED_EVENT, {
         detail: { value: preference },
@@ -129,4 +137,3 @@ export function subscribeSystemThemeChanges(listener: (theme: ResolvedTheme) => 
   mql.addListener(handler);
   return () => mql.removeListener(handler);
 }
-

--- a/src/config/voice-shortcut-asr-provider.ts
+++ b/src/config/voice-shortcut-asr-provider.ts
@@ -12,6 +12,7 @@ const _module = createConfigModule<VoiceShortcutAsrProvider>({
   eventName: 'exomind:voice-shortcut-asr-provider-changed',
   defaultValue: 'moss',
   normalize: normalizeProvider,
+  persistMode: 'runtime-preferred',
 });
 
 export function getVoiceShortcutAsrProvider(): VoiceShortcutAsrProvider {

--- a/src/config/voice-shortcut-hotkey.ts
+++ b/src/config/voice-shortcut-hotkey.ts
@@ -1,3 +1,8 @@
+import {
+  getRuntimeConfigValueSync,
+  setRuntimeConfigValue,
+} from './runtime-config-cache';
+
 const VOICE_SHORTCUT_HOTKEY_STORAGE_KEY = 'exomind:voiceShortcutHotkey';
 const VOICE_SHORTCUT_HOTKEY_CHANGED_EVENT = 'exomind:voice-shortcut-hotkey-changed';
 
@@ -15,19 +20,8 @@ type SetVoiceShortcutOptions = {
   emitEvent?: boolean;
 };
 
-function getStorage(): Pick<Storage, 'getItem' | 'setItem'> | null {
-  if (typeof window === 'undefined') return null;
-  const localStorageLike = window.localStorage as Partial<Storage> | undefined;
-  if (!localStorageLike) return null;
-  if (typeof localStorageLike.getItem !== 'function') return null;
-  if (typeof localStorageLike.setItem !== 'function') return null;
-  return localStorageLike as Pick<Storage, 'getItem' | 'setItem'>;
-}
-
 export function getVoiceShortcutHotkey(): VoiceShortcutHotkey {
-  const storage = getStorage();
-  if (!storage) return 'Alt+Q';
-  return normalizeHotkey(storage.getItem(VOICE_SHORTCUT_HOTKEY_STORAGE_KEY));
+  return normalizeHotkey(getRuntimeConfigValueSync(VOICE_SHORTCUT_HOTKEY_STORAGE_KEY));
 }
 
 export function setVoiceShortcutHotkey(
@@ -35,9 +29,11 @@ export function setVoiceShortcutHotkey(
   options: SetVoiceShortcutOptions = {},
 ): VoiceShortcutHotkey {
   const normalized = normalizeHotkey(hotkey);
-  const storage = getStorage();
-  if (!storage) return normalized;
-  storage.setItem(VOICE_SHORTCUT_HOTKEY_STORAGE_KEY, normalized);
+  if (typeof window === 'undefined') return normalized;
+  setRuntimeConfigValue(VOICE_SHORTCUT_HOTKEY_STORAGE_KEY, normalized, {
+    source: VOICE_SHORTCUT_HOTKEY_CHANGED_EVENT,
+    sourceOrigin: window.location?.origin,
+  });
   if (options.emitEvent !== false) {
     window.dispatchEvent(new CustomEvent<VoiceShortcutHotkey>(VOICE_SHORTCUT_HOTKEY_CHANGED_EVENT, { detail: normalized }));
   }

--- a/src/config/voice-shortcut-mic-prewarm.ts
+++ b/src/config/voice-shortcut-mic-prewarm.ts
@@ -1,3 +1,8 @@
+import {
+  getRuntimeConfigValueSync,
+  setRuntimeConfigValue,
+} from './runtime-config-cache';
+
 const VOICE_SHORTCUT_MIC_PREWARM_STORAGE_KEY = 'exomind:voiceShortcutMicPrewarmEnabled';
 const VOICE_SHORTCUT_MIC_PREWARM_CHANGED_EVENT = 'exomind:voice-shortcut-mic-prewarm-changed';
 
@@ -8,27 +13,16 @@ function normalizeBoolean(rawValue: string | null | undefined): boolean {
   return rawValue === 'true';
 }
 
-function getStorage():
-  | Pick<Storage, 'getItem' | 'setItem'>
-  | null {
-  if (typeof window === 'undefined') return null;
-  const localStorageLike = window.localStorage as Partial<Storage> | undefined;
-  if (!localStorageLike) return null;
-  if (typeof localStorageLike.getItem !== 'function') return null;
-  if (typeof localStorageLike.setItem !== 'function') return null;
-  return localStorageLike as Pick<Storage, 'getItem' | 'setItem'>;
-}
-
 export function getVoiceShortcutMicPrewarmEnabled(): boolean {
-  const storage = getStorage();
-  if (!storage) return true;
-  return normalizeBoolean(storage.getItem(VOICE_SHORTCUT_MIC_PREWARM_STORAGE_KEY));
+  return normalizeBoolean(getRuntimeConfigValueSync(VOICE_SHORTCUT_MIC_PREWARM_STORAGE_KEY));
 }
 
 export function setVoiceShortcutMicPrewarmEnabled(enabled: boolean): void {
-  const storage = getStorage();
-  if (!storage) return;
-  storage.setItem(VOICE_SHORTCUT_MIC_PREWARM_STORAGE_KEY, String(enabled));
+  if (typeof window === 'undefined') return;
+  setRuntimeConfigValue(VOICE_SHORTCUT_MIC_PREWARM_STORAGE_KEY, String(enabled), {
+    source: VOICE_SHORTCUT_MIC_PREWARM_CHANGED_EVENT,
+    sourceOrigin: window.location?.origin,
+  });
   window.dispatchEvent(new CustomEvent<boolean>(VOICE_SHORTCUT_MIC_PREWARM_CHANGED_EVENT, { detail: enabled }));
 }
 

--- a/src/config/voice-shortcut-send-mode.ts
+++ b/src/config/voice-shortcut-send-mode.ts
@@ -13,6 +13,7 @@ const _module = createConfigModule<VoiceShortcutSendMode>({
   eventName: 'exomind:voice-shortcut-send-mode-changed',
   defaultValue: 'insert-only',
   normalize: normalizeMode,
+  persistMode: 'runtime-preferred',
 });
 
 export function getVoiceShortcutSendMode(): VoiceShortcutSendMode {

--- a/src/config/voice-transcript-send-mode.ts
+++ b/src/config/voice-transcript-send-mode.ts
@@ -13,6 +13,7 @@ const _module = createConfigModule<VoiceTranscriptSendMode>({
   eventName: 'exomind:voice-transcript-send-mode-changed',
   defaultValue: 'insert',
   normalize: normalizeMode,
+  persistMode: 'runtime-preferred',
 });
 
 export function getVoiceTranscriptSendMode(): VoiceTranscriptSendMode {

--- a/src/config/volcano-asr-settings.ts
+++ b/src/config/volcano-asr-settings.ts
@@ -41,6 +41,7 @@ const volcanoAppKeyModule = createConfigModule<string>({
   eventName: 'exomind:volcano-asr-app-key-changed',
   defaultValue: envMap.VITE_VOLCANO_APP_KEY || '',
   normalize: (rawValue) => normalizeTrimmedString(rawValue, envMap.VITE_VOLCANO_APP_KEY || ''),
+  persistMode: 'runtime-preferred',
 });
 
 const volcanoAccessKeyModule = createConfigModule<string>({
@@ -48,6 +49,7 @@ const volcanoAccessKeyModule = createConfigModule<string>({
   eventName: 'exomind:volcano-asr-access-key-changed',
   defaultValue: envMap.VITE_VOLCANO_ACCESS_KEY || '',
   normalize: (rawValue) => normalizeTrimmedString(rawValue, envMap.VITE_VOLCANO_ACCESS_KEY || ''),
+  persistMode: 'runtime-preferred',
 });
 
 const volcanoResourceIdModule = createConfigModule<string>({
@@ -55,6 +57,7 @@ const volcanoResourceIdModule = createConfigModule<string>({
   eventName: 'exomind:volcano-asr-resource-id-changed',
   defaultValue: envMap.VITE_VOLCANO_RESOURCE_ID || DEFAULT_VOLCANO_RESOURCE_ID,
   normalize: (rawValue) => normalizeVolcanoResourceId(rawValue ?? envMap.VITE_VOLCANO_RESOURCE_ID),
+  persistMode: 'runtime-preferred',
 });
 
 const volcanoEndpointModule = createConfigModule<VolcanoEndpoint>({
@@ -62,6 +65,7 @@ const volcanoEndpointModule = createConfigModule<VolcanoEndpoint>({
   eventName: 'exomind:volcano-asr-endpoint-changed',
   defaultValue: DEFAULT_VOLCANO_ASR_OPTIONS.endpoint,
   normalize: normalizeVolcanoEndpoint,
+  persistMode: 'runtime-preferred',
 });
 
 const volcanoLanguageModule = createConfigModule<string>({
@@ -69,6 +73,7 @@ const volcanoLanguageModule = createConfigModule<string>({
   eventName: 'exomind:volcano-asr-language-changed',
   defaultValue: 'zh-CN',
   normalize: normalizeVolcanoLanguage,
+  persistMode: 'runtime-preferred',
 });
 
 export function getVolcanoAppKey(): string {

--- a/src/lib/adapters/asr/moss-asr.ts
+++ b/src/lib/adapters/asr/moss-asr.ts
@@ -16,6 +16,7 @@
  */
 
 import type { IASRPort, IASRConfig, ASRInput, ASRResult, ASRPartialResult } from '../../ports/asr-port';
+import { getMossApiKey } from '@/config/moss-api-key';
 import { log } from '@/lib/logger';
 
 // ========== 配置 ==========
@@ -50,8 +51,6 @@ const DEFAULT_CONFIG: Partial<MOSSASRConfig> = {
   timeout: 60000, // 60秒超时（音频处理可能较慢）
 };
 
-const MOSS_API_KEY_STORAGE_KEY = 'moss_api_key';
-
 function normalizeApiKey(value?: string): string {
   if (!value) return '';
 
@@ -62,28 +61,7 @@ function normalizeApiKey(value?: string): string {
 }
 
 function readStoredApiKey(): string {
-  const storage = (() => {
-    if (typeof window !== 'undefined' && typeof window.localStorage !== 'undefined') {
-      return window.localStorage;
-    }
-
-    const globalStorage = (globalThis as { localStorage?: Storage }).localStorage;
-    if (typeof globalStorage !== 'undefined') {
-      return globalStorage;
-    }
-
-    return null;
-  })();
-
-  if (!storage) {
-    return '';
-  }
-
-  try {
-    return normalizeApiKey(storage.getItem(MOSS_API_KEY_STORAGE_KEY) || '');
-  } catch {
-    return '';
-  }
+  return normalizeApiKey(getMossApiKey());
 }
 
 // ========== 适配器实现 ==========

--- a/src/lib/ai-registry/secrets.ts
+++ b/src/lib/ai-registry/secrets.ts
@@ -3,21 +3,13 @@ export interface AIEnergySecretRecord {
   updatedAt: string;
 }
 
+import {
+  getRuntimeConfigValueSync,
+  setRuntimeConfigValue,
+} from '@/config/runtime-config-cache';
+
 const AI_REGISTRY_CHANGED_EVENT = 'exomind:ai-registry:changed';
 const AI_ENERGY_SECRET_KEY_PREFIX = 'exomind:ai-registry:energy-secret:';
-
-function getStorage(): Pick<Storage, 'getItem' | 'setItem'> | null {
-  if (typeof globalThis.localStorage === 'undefined') {
-    return null;
-  }
-
-  const localStorageLike = globalThis.localStorage as Partial<Storage>;
-  if (typeof localStorageLike.getItem !== 'function' || typeof localStorageLike.setItem !== 'function') {
-    return null;
-  }
-
-  return localStorageLike as Pick<Storage, 'getItem' | 'setItem'>;
-}
 
 function getEnergySecretStorageKey(energySourceId: string): string {
   return `${AI_ENERGY_SECRET_KEY_PREFIX}${energySourceId}`;
@@ -32,13 +24,8 @@ function emitRegistryChanged(): void {
 }
 
 export function getAIEnergySecret(energySourceId: string): AIEnergySecretRecord | null {
-  const storage = getStorage();
-  if (!storage) {
-    return null;
-  }
-
   try {
-    const raw = storage.getItem(getEnergySecretStorageKey(energySourceId));
+    const raw = getRuntimeConfigValueSync(getEnergySecretStorageKey(energySourceId));
     return raw ? (JSON.parse(raw) as AIEnergySecretRecord) : null;
   } catch {
     return null;
@@ -49,11 +36,10 @@ export function saveAIEnergySecret(
   energySourceId: string,
   secret: AIEnergySecretRecord,
 ): void {
-  const storage = getStorage();
-  if (!storage) {
-    return;
-  }
-
-  storage.setItem(getEnergySecretStorageKey(energySourceId), JSON.stringify(secret));
+  setRuntimeConfigValue(getEnergySecretStorageKey(energySourceId), JSON.stringify(secret), {
+    sensitive: true,
+    source: AI_REGISTRY_CHANGED_EVENT,
+    sourceOrigin: typeof window !== 'undefined' ? window.location?.origin : undefined,
+  });
   emitRegistryChanged();
 }

--- a/src/lib/ai-registry/storage.ts
+++ b/src/lib/ai-registry/storage.ts
@@ -1,4 +1,8 @@
 import type { AIRegistrySnapshot } from './types';
+import {
+  getRuntimeConfigValueSync,
+  setRuntimeConfigValue,
+} from '@/config/runtime-config-cache';
 
 const AI_REGISTRY_SNAPSHOT_KEY = 'exomind:ai-registry:snapshot';
 export const AI_REGISTRY_CHANGED_EVENT = 'exomind:ai-registry:changed';
@@ -13,19 +17,6 @@ const EMPTY_AI_REGISTRY_SNAPSHOT: AIRegistrySnapshot = {
   resolutionRules: [],
   updatedAt: '',
 };
-
-function getStorage(): Pick<Storage, 'getItem' | 'setItem'> | null {
-  if (typeof globalThis.localStorage === 'undefined') {
-    return null;
-  }
-
-  const localStorageLike = globalThis.localStorage as Partial<Storage>;
-  if (typeof localStorageLike.getItem !== 'function' || typeof localStorageLike.setItem !== 'function') {
-    return null;
-  }
-
-  return localStorageLike as Pick<Storage, 'getItem' | 'setItem'>;
-}
 
 function emitRegistryChanged(): void {
   if (typeof window === 'undefined') {
@@ -48,13 +39,8 @@ export function getDefaultAIRegistrySnapshot(): AIRegistrySnapshot {
 }
 
 export function getAIRegistrySnapshot(): AIRegistrySnapshot {
-  const storage = getStorage();
-  if (!storage) {
-    return getDefaultAIRegistrySnapshot();
-  }
-
   try {
-    const raw = storage.getItem(AI_REGISTRY_SNAPSHOT_KEY);
+    const raw = getRuntimeConfigValueSync(AI_REGISTRY_SNAPSHOT_KEY);
     if (!raw) {
       return getDefaultAIRegistrySnapshot();
     }
@@ -76,12 +62,10 @@ export function getAIRegistrySnapshot(): AIRegistrySnapshot {
 }
 
 export function saveAIRegistrySnapshot(snapshot: AIRegistrySnapshot): void {
-  const storage = getStorage();
-  if (!storage) {
-    return;
-  }
-
-  storage.setItem(AI_REGISTRY_SNAPSHOT_KEY, JSON.stringify(snapshot));
+  setRuntimeConfigValue(AI_REGISTRY_SNAPSHOT_KEY, JSON.stringify(snapshot), {
+    source: AI_REGISTRY_CHANGED_EVENT,
+    sourceOrigin: typeof window !== 'undefined' ? window.location?.origin : undefined,
+  });
   emitRegistryChanged();
 }
 

--- a/src/lib/asr/volcano-config.ts
+++ b/src/lib/asr/volcano-config.ts
@@ -1,3 +1,8 @@
+import {
+  getRuntimeConfigValueSync,
+  setRuntimeConfigValue,
+} from '@/config/runtime-config-cache';
+
 /**
  * Volcano ASR config helpers（火山 ASR 配置辅助）
  *
@@ -55,18 +60,9 @@ export const VOLCANO_STORAGE_KEYS = {
   forceToSpeechTime: 'volcano_asr_force_to_speech_time',
 } as const;
 
-function getStorage(): Pick<Storage, 'getItem' | 'setItem'> | null {
-  if (typeof window === 'undefined') return null;
-  const localStorageLike = window.localStorage as Partial<Storage> | undefined;
-  if (!localStorageLike) return null;
-  if (typeof localStorageLike.getItem !== 'function') return null;
-  if (typeof localStorageLike.setItem !== 'function') return null;
-  return localStorageLike as Pick<Storage, 'getItem' | 'setItem'>;
-}
-
 function readStoredString(key: string): string {
   try {
-    return getStorage()?.getItem(key)?.trim() || '';
+    return getRuntimeConfigValueSync(key)?.trim() || '';
   } catch {
     return '';
   }
@@ -74,7 +70,7 @@ function readStoredString(key: string): string {
 
 function readStoredBoolean(key: string, fallback: boolean): boolean {
   try {
-    const raw = getStorage()?.getItem(key);
+    const raw = getRuntimeConfigValueSync(key);
     return raw == null ? fallback : raw === 'true';
   } catch {
     return fallback;
@@ -83,7 +79,7 @@ function readStoredBoolean(key: string, fallback: boolean): boolean {
 
 function readStoredNumber(key: string, fallback: number): number {
   try {
-    const raw = getStorage()?.getItem(key);
+    const raw = getRuntimeConfigValueSync(key);
     const parsed = Number.parseInt(raw ?? '', 10);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
   } catch {
@@ -154,9 +150,10 @@ export function getVolcanoResourceId(
 
 export function setVolcanoResourceId(resourceId: string): string {
   const normalized = findVolcanoResourcePreset(resourceId.trim()) || DEFAULT_VOLCANO_RESOURCE_ID;
-  const storage = getStorage();
-  if (!storage) return normalized;
-  storage.setItem(VOLCANO_STORAGE_KEYS.resourceId, normalized);
+  setRuntimeConfigValue(VOLCANO_STORAGE_KEYS.resourceId, normalized, {
+    source: 'volcano-resource-id',
+    sourceOrigin: typeof window !== 'undefined' ? window.location?.origin : undefined,
+  });
   return normalized;
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { bootstrapBeforeRender } from "./bootstrap-before-render";
 import { bootstrapRuntimeConfig } from "./config/runtime-config-cache";
 import "./index.css";
 import { syncDevtoolsWithSettings } from "./lib/debug/devtools-runtime";
@@ -9,9 +10,7 @@ import { ensureCryptoRandomUUID } from "./lib/utils/uuid";
 ensureCryptoRandomUUID();
 void syncDevtoolsWithSettings();
 
-async function bootstrapAndRenderApp(): Promise<void> {
-  await bootstrapRuntimeConfig();
-
+function renderApp(): void {
   ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>
       <App />
@@ -19,4 +18,4 @@ async function bootstrapAndRenderApp(): Promise<void> {
   );
 }
 
-void bootstrapAndRenderApp();
+void bootstrapBeforeRender(bootstrapRuntimeConfig, renderApp);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { bootstrapRuntimeConfig } from "./config/runtime-config-cache";
 import "./index.css";
 import { syncDevtoolsWithSettings } from "./lib/debug/devtools-runtime";
 import { ensureCryptoRandomUUID } from "./lib/utils/uuid";
@@ -8,8 +9,14 @@ import { ensureCryptoRandomUUID } from "./lib/utils/uuid";
 ensureCryptoRandomUUID();
 void syncDevtoolsWithSettings();
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+async function bootstrapAndRenderApp(): Promise<void> {
+  await bootstrapRuntimeConfig();
+
+  ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+}
+
+void bootstrapAndRenderApp();

--- a/src/pages/VolcanoASRTestPage.tsx
+++ b/src/pages/VolcanoASRTestPage.tsx
@@ -37,6 +37,10 @@ import {
   subscribeVolcanoLanguageChanges,
   subscribeVolcanoResourceIdChanges,
 } from '@/config/volcano-asr-settings';
+import {
+  getRuntimeConfigValueSync,
+  setRuntimeConfigValue,
+} from '@/config/runtime-config-cache';
 import { isTauriWindow } from '@/config/runtime-target';
 import { recordVolcanoUsageDuration } from '@/config/volcano-usage-stats';
 
@@ -57,7 +61,7 @@ interface LogEntry {
 
 function loadSavedBoolean(key: string, fallback: boolean): boolean {
   try {
-    const raw = localStorage.getItem(key);
+    const raw = getRuntimeConfigValueSync(key);
     return raw == null ? fallback : raw === 'true';
   } catch {
     return fallback;
@@ -66,7 +70,7 @@ function loadSavedBoolean(key: string, fallback: boolean): boolean {
 
 function loadSavedNumber(key: string, fallback: number): number {
   try {
-    const raw = localStorage.getItem(key);
+    const raw = getRuntimeConfigValueSync(key);
     const parsed = Number.parseInt(raw ?? '', 10);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
   } catch {
@@ -150,10 +154,22 @@ export function VolcanoASRTestPage() {
 
   const handleSaveTestOptions = () => {
     try {
-      localStorage.setItem(VOLCANO_STORAGE_KEYS.enableNonstream, String(enableNonstream));
-      localStorage.setItem(VOLCANO_STORAGE_KEYS.showUtterances, String(showUtterances));
-      localStorage.setItem(VOLCANO_STORAGE_KEYS.endWindowSize, String(endWindowSize));
-      localStorage.setItem(VOLCANO_STORAGE_KEYS.forceToSpeechTime, String(forceToSpeechTime));
+      setRuntimeConfigValue(VOLCANO_STORAGE_KEYS.enableNonstream, String(enableNonstream), {
+        source: 'volcano-test-options',
+        sourceOrigin: window.location?.origin,
+      });
+      setRuntimeConfigValue(VOLCANO_STORAGE_KEYS.showUtterances, String(showUtterances), {
+        source: 'volcano-test-options',
+        sourceOrigin: window.location?.origin,
+      });
+      setRuntimeConfigValue(VOLCANO_STORAGE_KEYS.endWindowSize, String(endWindowSize), {
+        source: 'volcano-test-options',
+        sourceOrigin: window.location?.origin,
+      });
+      setRuntimeConfigValue(VOLCANO_STORAGE_KEYS.forceToSpeechTime, String(forceToSpeechTime), {
+        source: 'volcano-test-options',
+        sourceOrigin: window.location?.origin,
+      });
       setTestOptionsSaved(true);
       addLog(`测试参数已保存，模式=${endpoint}，资源=${resourceId}`);
       setTimeout(() => setTestOptionsSaved(false), 2000);

--- a/src/ui/app/config/settings/settings-registry.ts
+++ b/src/ui/app/config/settings/settings-registry.ts
@@ -182,6 +182,10 @@ import {
   subscribeVoiceShortcutAsrProviderChanges,
 } from '@/config/voice-shortcut-asr-provider';
 import {
+  getMossApiKey,
+  setMossApiKey,
+} from '@/config/moss-api-key';
+import {
   DEFAULT_VOLCANO_RESOURCE_ID,
   VOLCANO_ENDPOINT_OPTIONS,
   VOLCANO_LANGUAGE_OPTIONS,
@@ -257,8 +261,6 @@ import { syncMainWindowShortcutSelectionWithRuntime } from '@/services/main-wind
  * Product/runtime code should import the owning config/service module directly.
  */
 
-const MOSS_API_KEY_STORAGE_KEY = 'moss_api_key';
-
 function normalizeMossApiKey(value: string): string {
   if (!value) {
     return '';
@@ -270,29 +272,12 @@ function normalizeMossApiKey(value: string): string {
 }
 
 function readStoredMossApiKey(): string {
-  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
-    return '';
-  }
-
-  try {
-    return normalizeMossApiKey(window.localStorage.getItem(MOSS_API_KEY_STORAGE_KEY) || '');
-  } catch {
-    return '';
-  }
+  return normalizeMossApiKey(getMossApiKey());
 }
 
 function writeStoredMossApiKey(value: string): void {
-  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
-    return;
-  }
-
   const normalized = normalizeMossApiKey(value);
-  if (!normalized) {
-    window.localStorage.removeItem(MOSS_API_KEY_STORAGE_KEY);
-    return;
-  }
-
-  window.localStorage.setItem(MOSS_API_KEY_STORAGE_KEY, normalized);
+  setMossApiKey(normalized);
 }
 
 function maskStoredSecret(value: string): string {

--- a/tests/unit/adapters/moss-asr-auth.test.ts
+++ b/tests/unit/adapters/moss-asr-auth.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MOSSASRAdapter } from '@/lib/adapters/asr/moss-asr';
+import {
+  __primeRuntimeConfigForTests,
+  __resetRuntimeConfigCacheForTests,
+} from '@/config/runtime-config-cache';
 
 const successResponse = new Response(
   JSON.stringify({
@@ -24,6 +28,7 @@ describe('MOSSASRAdapter auth header', () => {
     if (typeof localStorage !== 'undefined') {
       localStorage.removeItem('moss_api_key');
     }
+    __resetRuntimeConfigCacheForTests();
   });
 
   afterEach(() => {
@@ -33,6 +38,7 @@ describe('MOSSASRAdapter auth header', () => {
     if (typeof localStorage !== 'undefined') {
       localStorage.removeItem('moss_api_key');
     }
+    __resetRuntimeConfigCacheForTests();
   });
 
   it('normalizes Bearer-prefixed apiKey before request', async () => {
@@ -70,5 +76,24 @@ describe('MOSSASRAdapter auth header', () => {
     const headers = init.headers as Record<string, string>;
 
     expect(headers.Authorization).toBe('Bearer sk-local-key-456');
+  });
+
+  it('prefers runtime-backed moss_api_key over localStorage（优先使用 Runtime 中的 MOSS Key）', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successResponse.clone());
+    (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+    localStorage.setItem('moss_api_key', 'sk-local-key-456');
+    __primeRuntimeConfigForTests({ moss_api_key: 'sk-runtime-key-789' });
+
+    const adapter = new MOSSASRAdapter();
+
+    await adapter.transcribe({
+      lang: 'zh-CN',
+      preRecordedAudio: new Uint8Array([9, 8, 7, 6]),
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+
+    expect(headers.Authorization).toBe('Bearer sk-runtime-key-789');
   });
 });

--- a/tests/unit/app/bootstrap-before-render.test.ts
+++ b/tests/unit/app/bootstrap-before-render.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import { bootstrapBeforeRender } from '@/bootstrap-before-render';
+
+describe('bootstrapBeforeRender（启动引导后渲染）', () => {
+  it('still renders when bootstrap fails（bootstrap 失败时仍继续渲染）', async () => {
+    const bootstrap = vi.fn().mockRejectedValue(new Error('runtime bootstrap failed'));
+    const render = vi.fn();
+    const reportError = vi.fn();
+
+    await bootstrapBeforeRender(bootstrap, render, reportError);
+
+    expect(bootstrap).toHaveBeenCalledTimes(1);
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders without reporting when bootstrap succeeds（bootstrap 成功时直接渲染）', async () => {
+    const bootstrap = vi.fn().mockResolvedValue(undefined);
+    const render = vi.fn();
+    const reportError = vi.fn();
+
+    await bootstrapBeforeRender(bootstrap, render, reportError);
+
+    expect(reportError).not.toHaveBeenCalled();
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/config/main-window-shortcut.test.ts
+++ b/tests/unit/config/main-window-shortcut.test.ts
@@ -7,10 +7,15 @@ import {
   subscribeMainWindowShortcutSelectionChanges,
   validateMainWindowShortcutSelection,
 } from '@/config/main-window-shortcut';
+import {
+  __primeRuntimeConfigForTests,
+  __resetRuntimeConfigCacheForTests,
+} from '@/config/runtime-config-cache';
 
 describe('main window shortcut config（主窗口快捷键配置）', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    __resetRuntimeConfigCacheForTests();
   });
 
   it('uses Ctrl+E as default selection and hotkey', () => {
@@ -38,6 +43,17 @@ describe('main window shortcut config（主窗口快捷键配置）', () => {
 
     expect(getMainWindowShortcutSelection()).toEqual(['Alt', 'E']);
     expect(getResolvedMainWindowShortcutHotkey()).toBe('Alt+E');
+  });
+
+  it('reads selection from runtime snapshot first（优先读取 Runtime 快照组合）', () => {
+    window.localStorage.setItem('exomind:mainWindowShortcutSelection', JSON.stringify(['Ctrl', 'E']));
+    __primeRuntimeConfigForTests({
+      'exomind:mainWindowShortcutSelection': JSON.stringify(['Alt', 'Space']),
+      'exomind:mainWindowShortcutSelectionCustomized': 'true',
+    });
+
+    expect(getMainWindowShortcutSelection()).toEqual(['Alt', 'Space']);
+    expect(getResolvedMainWindowShortcutHotkey()).toBe('Alt+Space');
   });
 
   it('flags multiple primary keys as invalid', () => {

--- a/tests/unit/config/runtime-config-cache.test.ts
+++ b/tests/unit/config/runtime-config-cache.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const invokeMock = vi.fn();
+const isTauriMock = vi.fn();
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock,
+  isTauri: isTauriMock,
+}));
+
+describe('runtime config cache（Runtime 配置缓存）', () => {
+  let originalFetch: typeof globalThis.fetch | undefined;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    originalFetch = globalThis.fetch;
+    isTauriMock.mockResolvedValue(false);
+    invokeMock.mockResolvedValue({
+      running: true,
+      host: '127.0.0.1',
+      port: 9124,
+      authSecret: 'secret-123',
+    });
+  });
+
+  afterEach(async () => {
+    const cacheModule = await import('@/config/runtime-config-cache');
+    cacheModule.__resetRuntimeConfigCacheForTests();
+    if (originalFetch) {
+      (globalThis as { fetch: typeof fetch }).fetch = originalFetch;
+    }
+  });
+
+  it('bootstraps from embedded runtime and imports same-origin local entries（启动时导入同源旧设置）', async () => {
+    window.localStorage.setItem('exomind:themePreference', 'dark');
+    isTauriMock.mockResolvedValue(true);
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ imported: 1, skipped: 0, total: 1 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify([
+        { key: 'exomind:themePreference', value: 'dark' },
+      ]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+
+    const cacheModule = await import('@/config/runtime-config-cache');
+    await cacheModule.bootstrapRuntimeConfig();
+
+    expect(cacheModule.isRuntimeConfigEnabled()).toBe(true);
+    expect(cacheModule.getRuntimeConfigValueSync('exomind:themePreference')).toBe('dark');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[0]).toContain('/config/import/frontend');
+    expect(fetchMock.mock.calls[1]?.[0]).toContain('/config?scope=user');
+  });
+
+  it('falls back to localStorage when runtime transport is unavailable（Runtime 不可用时回退本地存储）', async () => {
+    window.localStorage.setItem('exomind:inputSendMode', 'enter-send');
+    isTauriMock.mockResolvedValue(false);
+
+    const cacheModule = await import('@/config/runtime-config-cache');
+    await cacheModule.bootstrapRuntimeConfig();
+
+    expect(cacheModule.isRuntimeConfigEnabled()).toBe(false);
+    expect(cacheModule.getRuntimeConfigValueSync('exomind:inputSendMode')).toBe('enter-send');
+  });
+
+  it('set writes runtime and keeps local mirror（写入 Runtime 并保留本地镜像）', async () => {
+    isTauriMock.mockResolvedValue(true);
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        key: 'exomind:voiceShortcutHotkey',
+        value: 'Ctrl+Space',
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+
+    const cacheModule = await import('@/config/runtime-config-cache');
+    await cacheModule.bootstrapRuntimeConfig();
+    cacheModule.setRuntimeConfigValue('exomind:voiceShortcutHotkey', 'Ctrl+Space', {
+      source: 'test',
+    });
+    await Promise.resolve();
+
+    expect(window.localStorage.getItem('exomind:voiceShortcutHotkey')).toBe('Ctrl+Space');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toContain('/config/exomind%3AvoiceShortcutHotkey');
+    expect((fetchMock.mock.calls[1]?.[1] as RequestInit).method).toBe('PUT');
+  });
+
+  it('remove deletes runtime and local mirror（删除 Runtime 与本地镜像）', async () => {
+    window.localStorage.setItem('moss_api_key', 'sk-old');
+    isTauriMock.mockResolvedValue(true);
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ imported: 1, skipped: 0, total: 1 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify([
+        { key: 'moss_api_key', value: 'sk-old' },
+      ]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+
+    const cacheModule = await import('@/config/runtime-config-cache');
+    await cacheModule.bootstrapRuntimeConfig();
+    cacheModule.removeRuntimeConfigValue('moss_api_key');
+    await Promise.resolve();
+
+    expect(window.localStorage.getItem('moss_api_key')).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[2]?.[0]).toContain('/config/moss_api_key?scope=user');
+    expect((fetchMock.mock.calls[2]?.[1] as RequestInit).method).toBe('DELETE');
+  });
+});

--- a/tests/unit/config/runtime-config-cache.test.ts
+++ b/tests/unit/config/runtime-config-cache.test.ts
@@ -71,6 +71,63 @@ describe('runtime config cache（Runtime 配置缓存）', () => {
     expect(cacheModule.getRuntimeConfigValueSync('exomind:inputSendMode')).toBe('enter-send');
   });
 
+  it('retries bootstrap after startup lag and enables runtime later（启动稍慢时会后台重试）', async () => {
+    vi.useFakeTimers();
+    window.localStorage.setItem('exomind:themePreference', 'dark');
+    isTauriMock.mockResolvedValue(true);
+
+    let runtimeReady = false;
+    invokeMock.mockImplementation(async () => {
+      if (!runtimeReady) {
+        return {
+          running: false,
+          host: '127.0.0.1',
+          port: 9124,
+          authSecret: 'secret-123',
+        };
+      }
+
+      return {
+        running: true,
+        host: '127.0.0.1',
+        port: 9124,
+        authSecret: 'secret-123',
+      };
+    });
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ imported: 1, skipped: 0, total: 1 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify([
+        { key: 'exomind:themePreference', value: 'dark' },
+      ]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+
+    const cacheModule = await import('@/config/runtime-config-cache');
+    const bootstrapPromise = cacheModule.bootstrapRuntimeConfig();
+    await vi.advanceTimersByTimeAsync(8 * 150);
+    await bootstrapPromise;
+
+    expect(cacheModule.isRuntimeConfigEnabled()).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    runtimeReady = true;
+    await vi.advanceTimersByTimeAsync(1000);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(cacheModule.isRuntimeConfigEnabled()).toBe(true);
+    expect(cacheModule.getRuntimeConfigValueSync('exomind:themePreference')).toBe('dark');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
   it('set writes runtime and keeps local mirror（写入 Runtime 并保留本地镜像）', async () => {
     isTauriMock.mockResolvedValue(true);
     const fetchMock = vi.fn()

--- a/tests/unit/config/voice-shortcut-hotkey.test.ts
+++ b/tests/unit/config/voice-shortcut-hotkey.test.ts
@@ -4,10 +4,15 @@ import {
   setVoiceShortcutHotkey,
   subscribeVoiceShortcutHotkeyChanges,
 } from '@/config/voice-shortcut-hotkey';
+import {
+  __primeRuntimeConfigForTests,
+  __resetRuntimeConfigCacheForTests,
+} from '@/config/runtime-config-cache';
 
 describe('voice shortcut hotkey config（语音全局快捷键配置）', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    __resetRuntimeConfigCacheForTests();
   });
 
   it('uses Alt+Q as default hotkey（默认快捷键）', () => {
@@ -25,6 +30,13 @@ describe('voice shortcut hotkey config（语音全局快捷键配置）', () => 
     setVoiceShortcutHotkey('Alt+1');
 
     expect(getVoiceShortcutHotkey()).toBe('Alt+Q');
+  });
+
+  it('reads runtime-backed value before localStorage（优先读取 Runtime 值）', () => {
+    window.localStorage.setItem('exomind:voiceShortcutHotkey', 'Alt+W');
+    __primeRuntimeConfigForTests({ 'exomind:voiceShortcutHotkey': 'Ctrl+Space' });
+
+    expect(getVoiceShortcutHotkey()).toBe('Ctrl+Space');
   });
 
   it('can store hotkey without notifying subscribers（可静默同步快捷键存储）', () => {

--- a/tests/unit/services/voice-shortcut.service.test.ts
+++ b/tests/unit/services/voice-shortcut.service.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { VOICE_AUTO_RECORD_KEY } from '@/config/voice-auto-record';
 import { setVoiceShortcutAsrProvider } from '@/config/voice-shortcut-asr-provider';
 import { setVoiceShortcutMicPrewarmEnabled } from '@/config/voice-shortcut-mic-prewarm';
+import { __resetRuntimeConfigCacheForTests } from '@/config/runtime-config-cache';
 import { VOLCANO_STORAGE_KEYS } from '@/lib/asr/volcano-config';
 import {
   getActiveInteractionContextService,
@@ -20,6 +21,7 @@ const convertWebmBlobToWavMock = vi.fn();
 const writeClipboardMock = vi.fn();
 const addEventMock = vi.fn();
 const publishVoiceTranscriptSignalMock = vi.fn();
+const buildVoiceShortcutStorageEventMock = vi.fn();
 const getUserMediaWithConstraintFallbackMock = vi.fn();
 const subscribeHotkeyMock = vi.fn(() => () => {});
 const livePreviewIsAvailableMock = vi.fn(() => true);
@@ -132,6 +134,10 @@ vi.mock('@/lib/services/ecs-eventlog-replication.service', () => ({
   appendEventWithEcsReplication: (...args: unknown[]) => addEventMock(...args),
 }));
 
+vi.mock('@/services/voice-shortcut-eventlog', () => ({
+  buildVoiceShortcutStorageEvent: (...args: unknown[]) => buildVoiceShortcutStorageEventMock(...args),
+}));
+
 vi.mock('@/lib/asr/live-preview', () => ({
   createDefaultVoiceLivePreviewSource: () => ({
     isAvailable: (...args: unknown[]) => livePreviewIsAvailableMock(...args),
@@ -242,6 +248,7 @@ describe('VoiceShortcutService（全局语音快捷键服务）', () => {
     writeClipboardMock.mockReset();
     addEventMock.mockReset();
     publishVoiceTranscriptSignalMock.mockReset();
+    buildVoiceShortcutStorageEventMock.mockReset();
     publishVoiceTranscriptSignalMock.mockResolvedValue(undefined);
     getUserMediaWithConstraintFallbackMock.mockReset();
     subscribeHotkeyMock.mockClear();
@@ -262,6 +269,7 @@ describe('VoiceShortcutService（全局语音快捷键服务）', () => {
     runtimeFlags.developerModeEnabled = false;
     runtimeFlags.voiceShortcutSendMode = 'insert-only';
     resetActiveInteractionContextServiceForTests();
+    __resetRuntimeConfigCacheForTests();
 
     Object.defineProperty(window.navigator, 'permissions', {
       configurable: true,
@@ -298,6 +306,36 @@ describe('VoiceShortcutService（全局语音快捷键服务）', () => {
 
     writeClipboardMock.mockResolvedValue({ ok: true, title: 'ok' });
     addEventMock.mockResolvedValue(undefined);
+    buildVoiceShortcutStorageEventMock.mockImplementation(async (input: {
+      text: string;
+      startedAtMs?: number;
+      targetScope: string;
+      window?: {
+        title?: string;
+        processName?: string;
+      };
+      agentContext?: {
+        agentId?: string;
+        agentName?: string;
+        sessionId?: string;
+      };
+    }) => ({
+      id: `voice-event-${input.startedAtMs ?? 0}`,
+      content: input.text,
+      type: 'voice',
+      createdAt: new Date(input.startedAtMs ?? 0).toISOString(),
+      metadata: {
+        inputSource: 'voice',
+        inputMethod: 'recognition',
+        voiceShortcut: {
+          text: input.text,
+          captureSource: 'global-shortcut',
+          targetScope: input.targetScope,
+          ...(input.window ? { window: input.window } : {}),
+          ...(input.agentContext ? { agentContext: input.agentContext } : {}),
+        },
+      },
+    }));
     setVoiceShortcutMicPrewarmEnabled(true);
 
     invokeMock.mockImplementation(async (command: string, payload?: { shortcut?: string }) => {

--- a/tests/unit/settings/settings-registry-coverage.test.ts
+++ b/tests/unit/settings/settings-registry-coverage.test.ts
@@ -143,6 +143,7 @@ const BUTTON_ACTION_IDS = [
 ] as const;
 
 const CUSTOM_ITEM_IDS = [
+  'sound-preset',
   'focus-bgm',
   'volcano-engine-key',
   'moss-voice-test',
@@ -245,8 +246,8 @@ describe('settings registry coverage audit', () => {
     const countdownEndMode = getItem('countdown-end-mode', 'enum');
     expect(countdownEndMode.options.every((option) => Boolean(option.description))).toBe(true);
 
-    const soundPreset = getItem('sound-preset', 'enum');
-    expect(soundPreset.dialogTitle).toBe('选择提示音');
+    const soundPreset = getItem('sound-preset', 'custom');
+    expect(soundPreset.label).toBe('提示音');
 
     const volcanoResourceModel = getItem('volcano-resource-model', 'enum');
     expect(volcanoResourceModel.options.map((option) => option.label)).toEqual([
@@ -290,6 +291,7 @@ describe('settings registry coverage audit', () => {
     expect(featureToggles.children.map((child) => child.id)).toEqual([
       'me-page-enabled',
       'agent-page-enabled',
+      'goals-page-enabled',
       'desktop-adaptive',
       'command-palette-enabled',
     ]);
@@ -397,6 +399,7 @@ describe('settings registry coverage audit', () => {
     expect(FEATURE_TOGGLE_SETTING_IDS).toEqual([
       'me-page-enabled',
       'agent-page-enabled',
+      'goals-page-enabled',
       'desktop-adaptive',
       'command-palette-enabled',
     ]);

--- a/tests/unit/settings/settings-registry-coverage.test.ts
+++ b/tests/unit/settings/settings-registry-coverage.test.ts
@@ -40,6 +40,7 @@ const AUDITED_SETTINGS_IDS = [
   'voice-overlay-bottom-offset',
   'now-workbench-overlay-enabled',
   'volcano-engine-key',
+  'volcano-usage-summary',
   'volcano-endpoint',
   'volcano-resource-model',
   'volcano-resource-id',
@@ -48,6 +49,7 @@ const AUDITED_SETTINGS_IDS = [
   'moss-voice-test',
   'volcano-asr-test',
   'ai-registry',
+  'runtime-target-mode',
   'embedded-runtime-open-mode',
   'sync-server-url',
   'eventlog-backend-mode',
@@ -89,7 +91,7 @@ const INLINE_SINGLE_ENUM_IDS = [
 
 const DIALOG_ENUM_IDS = [
   'countdown-end-mode',
-  'sound-preset',
+  'runtime-target-mode',
   'embedded-runtime-open-mode',
   'volcano-endpoint',
   'volcano-language',
@@ -146,6 +148,7 @@ const CUSTOM_ITEM_IDS = [
   'sound-preset',
   'focus-bgm',
   'volcano-engine-key',
+  'volcano-usage-summary',
   'moss-voice-test',
   'volcano-asr-test',
   'ai-registry',
@@ -155,14 +158,17 @@ const CUSTOM_ITEM_IDS = [
 ] as const;
 
 const DEV_ONLY_IDS = [
-  'eventlog-backend-mode',
-  'task-backend-mode',
-  'timeblock-backend-mode',
   'use-mock-data',
   'devtools',
   'feature-toggles',
   'instance-diagnostics',
   'device-pairing',
+] as const;
+
+const TAURI_DEV_ONLY_IDS = [
+  'eventlog-backend-mode',
+  'task-backend-mode',
+  'timeblock-backend-mode',
 ] as const;
 
 function getItem<T extends typeof SETTINGS_REGISTRY[number]['type']>(
@@ -273,7 +279,7 @@ describe('settings registry coverage audit', () => {
     const syncServerUrl = getItem('sync-server-url', 'string');
     expect(syncServerUrl.stringStyle).toBe('dialog');
     expect(syncServerUrl.dialogFieldKind).toBe('plain');
-    expect(syncServerUrl.dialogInputType).toBe('url');
+    expect(syncServerUrl.dialogInputType).toBe('text');
 
     const embeddedRuntimeOpenMode = getItem('embedded-runtime-open-mode', 'enum');
     expect(embeddedRuntimeOpenMode.options.map((option) => option.value)).toEqual(['local', 'lan']);
@@ -334,6 +340,17 @@ describe('settings registry coverage audit', () => {
     DEV_ONLY_IDS.forEach((id) => {
       expect(baseIds).not.toContain(id);
       expect(developerIds).toContain(id);
+    });
+
+    const tauriDevIds = getVisibleSettings({
+      ...getBaseCtx(),
+      isTauriWindow: true,
+      developerMode: true,
+    }).map((item) => item.id);
+    TAURI_DEV_ONLY_IDS.forEach((id) => {
+      expect(baseIds).not.toContain(id);
+      expect(developerIds).not.toContain(id);
+      expect(tauriDevIds).toContain(id);
     });
 
     expect(baseIds).toContain('moss-api-token');

--- a/tests/unit/storage/ai-registry-storage.test.ts
+++ b/tests/unit/storage/ai-registry-storage.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
 const mockLocalStorageData: Record<string, string> = {};
 
 const mockLocalStorage = {
@@ -26,12 +25,16 @@ Object.defineProperty(globalThis, 'localStorage', {
 });
 
 describe('ai-registry storage（AI 注册中心存储）', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     Object.keys(mockLocalStorageData).forEach((key) => delete mockLocalStorageData[key]);
     vi.clearAllMocks();
+    const runtimeConfigCache = await import('@/config/runtime-config-cache');
+    runtimeConfigCache.__resetRuntimeConfigCacheForTests();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    const runtimeConfigCache = await import('@/config/runtime-config-cache');
+    runtimeConfigCache.__resetRuntimeConfigCacheForTests();
     vi.resetModules();
   });
 
@@ -75,5 +78,45 @@ describe('ai-registry storage（AI 注册中心存储）', () => {
     expect(Object.keys(mockLocalStorageData)).toHaveLength(2);
     expect(Object.values(mockLocalStorageData).some((value) => value.includes('"channels"'))).toBe(true);
     expect(Object.values(mockLocalStorageData).some((value) => value.includes('"apiKey":"sk-test"'))).toBe(true);
+  });
+
+  it('reads runtime snapshot before mirrored localStorage（优先读取 Runtime 快照）', async () => {
+    const runtimeConfigCache = await import('@/config/runtime-config-cache');
+    runtimeConfigCache.__primeRuntimeConfigForTests({
+      'exomind:ai-registry:snapshot': JSON.stringify({
+        version: 1,
+        channels: [{
+          channelId: 'openai-runtime',
+          name: 'OpenAI Runtime',
+          vendor: 'openai',
+          channelType: 'official',
+          apiHost: 'https://api.openai.com/v1',
+          authKind: 'api_key',
+          enabled: true,
+          createdAt: '2026-03-18T00:00:00.000Z',
+          updatedAt: '2026-03-18T00:00:00.000Z',
+        }],
+        models: [],
+        capabilities: [],
+        offerings: [],
+        energySources: [],
+        resolutionRules: [],
+        updatedAt: '2026-03-18T00:00:00.000Z',
+      }),
+    });
+    mockLocalStorageData['exomind:ai-registry:snapshot'] = JSON.stringify({
+      version: 1,
+      channels: [],
+      models: [],
+      capabilities: [],
+      offerings: [],
+      energySources: [],
+      resolutionRules: [],
+      updatedAt: '',
+    });
+
+    const storageModule = await import('@/lib/ai-registry/storage');
+
+    expect(storageModule.getAIRegistrySnapshot().channels[0]?.channelId).toBe('openai-runtime');
   });
 });

--- a/tests/unit/ui/theme-preference.test.ts
+++ b/tests/unit/ui/theme-preference.test.ts
@@ -6,12 +6,17 @@ import {
   setThemePreference,
   subscribeThemePreferenceChanges,
 } from '@/config/theme';
+import {
+  __primeRuntimeConfigForTests,
+  __resetRuntimeConfigCacheForTests,
+} from '@/config/runtime-config-cache';
 
 describe('theme preference', () => {
   beforeEach(() => {
     window.localStorage.clear();
     document.documentElement.classList.remove('dark');
     document.documentElement.style.colorScheme = '';
+    __resetRuntimeConfigCacheForTests();
   });
 
   it('defaults to system when not set', () => {
@@ -21,6 +26,13 @@ describe('theme preference', () => {
   it('falls back to system for invalid stored values', () => {
     window.localStorage.setItem('exomind:themePreference', 'nope');
     expect(getThemePreference()).toBe('system');
+  });
+
+  it('prefers runtime snapshot over localStorage when available（优先读取 Runtime 快照）', () => {
+    window.localStorage.setItem('exomind:themePreference', 'light');
+    __primeRuntimeConfigForTests({ 'exomind:themePreference': 'dark' });
+
+    expect(getThemePreference()).toBe('dark');
   });
 
   it('persists preference and notifies subscribers', () => {
@@ -82,4 +94,3 @@ describe('theme preference', () => {
     window.matchMedia = originalMatchMedia;
   });
 });
-


### PR DESCRIPTION
## Summary
- add a Runtime config store backed by in-memory storage and optional SQLite persistence（新增 Runtime 配置存储，支持内存态与 SQLite 持久化）
- expose `/config` CRUD plus frontend import API for first-run migration（新增 `/config` 读写与前端导入迁移接口）
- bootstrap desktop runtime config on app start and migrate selected settings from same-origin localStorage（桌面端启动时导入同源 localStorage 并切到 Runtime 配置快照）
- move high-value settings and secrets to runtime-backed config modules, including voice shortcuts, theme, send modes, volcano config, AI registry, and MOSS key（把高价值设置与密钥迁到 Runtime 配置层）
- add design/plan docs and coverage tests for migration flow（补充设计/计划文档与迁移覆盖测试）

## Migration Strategy
- Runtime SQLite is the source of truth（Runtime SQLite 作为真源）
- frontend cache plus localStorage mirror remains as compatibility layer（前端缓存与 localStorage 镜像保留兼容层）
- desktop startup imports existing same-origin localStorage entries with `if-empty` semantics, so existing users keep shortcuts, API keys, and preferences after switching to installed builds（桌面端启动时按 `if-empty` 规则导入已有同源 localStorage，保证安装版切换后继续复用快捷键、密钥和偏好）

## Verification
- `cargo test -p exomind-runtime config::store -- --nocapture`
- `cargo test -p exomind-runtime routes::config -- --nocapture`
- `bunx tsc --noEmit`
- `bunx vitest run tests/unit/config/runtime-config-cache.test.ts tests/unit/ui/theme-preference.test.ts tests/unit/config/voice-shortcut-hotkey.test.ts tests/unit/config/main-window-shortcut.test.ts tests/unit/adapters/moss-asr-auth.test.ts tests/unit/storage/ai-registry-storage.test.ts tests/unit/services/voice-shortcut.service.test.ts tests/unit/settings/settings-registry-coverage.test.ts`
- `bun run build:web`

Closes #756