### PR TITLE
fix: make ChatPage event refresh incremental

### DIFF
--- a/crates/exomind-runtime/src/eventlog.rs
+++ b/crates/exomind-runtime/src/eventlog.rs
@@ -197,6 +197,11 @@ impl EventLogStore {
         })
     }
 
+    pub fn current_revision(&self, user_id: Option<&str>) -> Result<Option<i64>, String> {
+        let paths = self.resolve_paths(user_id)?;
+        Ok(read_checkpoint(&paths.checkpoint)?.map(|checkpoint| checkpoint.updated_at_ms))
+    }
+
     pub fn rebuild_markdown(&self, user_id: Option<&str>) -> Result<MirrorStatus, String> {
         let paths = self.resolve_paths(user_id)?;
         let events = self.list_events(user_id)?;

--- a/crates/exomind-runtime/src/routes/eventlog.rs
+++ b/crates/exomind-runtime/src/routes/eventlog.rs
@@ -3,7 +3,7 @@
 //! Mirrors the Tauri commands from `eventlog_commands.rs` as REST endpoints.
 
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use base64::{Engine as _, engine::general_purpose::STANDARD};
@@ -17,6 +17,8 @@ use tokio::time::{Duration, Instant};
 use crate::AppState;
 use crate::eventlog::{EventListFilter, EventRecord, MirrorStatus, sanitize_user_id};
 use crate::signal::types::SignalEvent;
+
+const EVENTLOG_REVISION_HEADER: &str = "x-exomind-eventlog-revision";
 
 // ── Request / query types ───────────────────────────────────────
 
@@ -263,7 +265,7 @@ async fn publish_eventlog_replication_append(state: &AppState, event: &EventReco
 async fn list_events(
     State(state): State<AppState>,
     Query(query): Query<EventLogQuery>,
-) -> Result<Json<Vec<EventRecord>>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(HeaderMap, Json<Vec<EventRecord>>), (StatusCode, Json<ErrorResponse>)> {
     let events = load_events_for_query(
         &state,
         query.user_id.as_deref(),
@@ -274,7 +276,18 @@ async fn list_events(
         query.tags.as_deref(),
     )
     .map_err(internal_error)?;
-    Ok(Json(events))
+    let mut headers = HeaderMap::new();
+    if let Some(revision) = state
+        .eventlog_store
+        .current_revision(query.user_id.as_deref())
+        .map_err(internal_error)?
+    {
+        let header_value = HeaderValue::from_str(&revision.to_string()).map_err(|error| {
+            internal_error(format!("invalid eventlog revision header: {error}"))
+        })?;
+        headers.insert(EVENTLOG_REVISION_HEADER, header_value);
+    }
+    Ok((headers, Json(events)))
 }
 
 /// POST /eventlog — append (or upsert) a single event.
@@ -398,6 +411,7 @@ async fn clear_events(
         .eventlog_store
         .clear_events(query.user_id.as_deref())
         .map_err(internal_error)?;
+    notify_eventlog_watchers(&state, query.user_id.as_deref());
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -623,8 +637,10 @@ fn build_eventlog_sqlite_snapshot_bytes(
         .tempdir()
         .map_err(|error| format!("failed to create temp eventlog export dir: {error}"))?;
     let sqlite_path = temp_root.path().join("eventlog-export.sqlite");
-    let scoped_store =
-        crate::eventlog::EventLogStore::with_sqlite_path(temp_root.path().to_path_buf(), &sqlite_path)?;
+    let scoped_store = crate::eventlog::EventLogStore::with_sqlite_path(
+        temp_root.path().to_path_buf(),
+        &sqlite_path,
+    )?;
     scoped_store.replace_all_events(user_id, events)?;
     let bytes = scoped_store
         .sqlite_snapshot_bytes()?
@@ -650,8 +666,10 @@ fn read_events_from_sqlite_snapshot(
     let sqlite_path = temp_root.path().join("eventlog-import.sqlite");
     std::fs::write(&sqlite_path, bytes)
         .map_err(|error| format!("failed to write temp sqlite snapshot: {error}"))?;
-    let store =
-        crate::eventlog::EventLogStore::with_sqlite_path(temp_root.path().to_path_buf(), &sqlite_path)?;
+    let store = crate::eventlog::EventLogStore::with_sqlite_path(
+        temp_root.path().to_path_buf(),
+        &sqlite_path,
+    )?;
     let events = store.list_events(user_id)?;
     drop(store);
     temp_root
@@ -775,6 +793,66 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0]["id"], appended_id);
         assert_eq!(events[0]["content"], "hello");
+    }
+
+    #[tokio::test]
+    async fn list_events_sets_revision_header_and_refreshes_it_after_mutation() {
+        let dir = tempdir().unwrap();
+        let store = Arc::new(EventLogStore::new(dir.path().to_path_buf()));
+        let app = test_router(test_state_with_eventlog(store));
+
+        let _ = append_event_via_api(
+            &app,
+            r#"{"timestamp":1700000000000,"content":"hello","tags":["note"]}"#,
+            "/eventlog",
+        )
+        .await;
+
+        let first_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/eventlog")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let first_revision = first_response
+            .headers()
+            .get(EVENTLOG_REVISION_HEADER)
+            .expect("revision header should exist after first write")
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+
+        let _ = append_event_via_api(
+            &app,
+            r#"{"timestamp":1700000001000,"content":"hello again","tags":["note"]}"#,
+            "/eventlog",
+        )
+        .await;
+
+        let second_response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/eventlog")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let second_revision = second_response
+            .headers()
+            .get(EVENTLOG_REVISION_HEADER)
+            .expect("revision header should exist after second write")
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        assert_ne!(first_revision, second_revision);
     }
 
     #[tokio::test]
@@ -1008,7 +1086,10 @@ mod tests {
         });
 
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-        assert!(!watch_handle.is_finished(), "watch should not return existing backlog without cursor");
+        assert!(
+            !watch_handle.is_finished(),
+            "watch should not return existing backlog without cursor"
+        );
 
         let appended = append_event_via_api(
             &app,

--- a/crates/exomind-runtime/src/routes/eventlog.rs
+++ b/crates/exomind-runtime/src/routes/eventlog.rs
@@ -19,6 +19,7 @@ use crate::eventlog::{EventListFilter, EventRecord, MirrorStatus, sanitize_user_
 use crate::signal::types::SignalEvent;
 
 const EVENTLOG_REVISION_HEADER: &str = "x-exomind-eventlog-revision";
+const EVENTLOG_LIST_SEMANTICS_HEADER: &str = "x-exomind-eventlog-list-semantics";
 
 // ── Request / query types ───────────────────────────────────────
 
@@ -144,18 +145,21 @@ fn apply_since_id_and_limit(
     mut events: Vec<EventRecord>,
     since_id: Option<&str>,
     limit: Option<usize>,
-) -> Vec<EventRecord> {
-    if let Some(since_id) = since_id
-        && let Some(pos) = events.iter().position(|event| event.id == since_id)
-    {
-        events.truncate(pos);
+) -> (Vec<EventRecord>, bool) {
+    let mut cursor_found = since_id.is_none();
+
+    if let Some(since_id) = since_id {
+        if let Some(pos) = events.iter().position(|event| event.id == since_id) {
+            events.truncate(pos);
+            cursor_found = true;
+        }
     }
 
     if let Some(limit) = limit {
         events.truncate(limit);
     }
 
-    events
+    (events, cursor_found)
 }
 
 fn load_events_for_query(
@@ -166,7 +170,7 @@ fn load_events_for_query(
     since_timestamp: Option<i64>,
     until_timestamp: Option<i64>,
     tags: Option<&str>,
-) -> Result<Vec<EventRecord>, String> {
+) -> Result<(Vec<EventRecord>, bool), String> {
     let filter = build_event_list_filter(since_timestamp, until_timestamp, tags);
     let events = state
         .eventlog_store
@@ -182,7 +186,7 @@ fn resolve_watch_since_id(
         return Ok(query.since_id.clone());
     }
 
-    let latest = load_events_for_query(
+    let (latest, _) = load_events_for_query(
         state,
         query.user_id.as_deref(),
         None,
@@ -266,7 +270,7 @@ async fn list_events(
     State(state): State<AppState>,
     Query(query): Query<EventLogQuery>,
 ) -> Result<(HeaderMap, Json<Vec<EventRecord>>), (StatusCode, Json<ErrorResponse>)> {
-    let events = load_events_for_query(
+    let (events, cursor_found) = load_events_for_query(
         &state,
         query.user_id.as_deref(),
         query.since_id.as_deref(),
@@ -287,6 +291,17 @@ async fn list_events(
         })?;
         headers.insert(EVENTLOG_REVISION_HEADER, header_value);
     }
+    let semantics = if query.since_id.is_some() && !cursor_found {
+        "full_snapshot"
+    } else if query.since_id.is_some() || query.since_timestamp.is_some() {
+        "incremental_batch"
+    } else {
+        "full_snapshot"
+    };
+    headers.insert(
+        EVENTLOG_LIST_SEMANTICS_HEADER,
+        HeaderValue::from_static(semantics),
+    );
     Ok((headers, Json(events)))
 }
 
@@ -331,7 +346,7 @@ async fn watch_events(
     let effective_since_id = resolve_watch_since_id(&state, &query).map_err(internal_error)?;
 
     if query.since_id.is_some() || query.since_timestamp.is_some() {
-        let initial = load_events_for_query(
+        let (initial, _) = load_events_for_query(
             &state,
             query.user_id.as_deref(),
             effective_since_id.as_deref(),
@@ -361,7 +376,7 @@ async fn watch_events(
                     continue;
                 }
 
-                let events = load_events_for_query(
+                let (events, _) = load_events_for_query(
                     &state,
                     query.user_id.as_deref(),
                     effective_since_id.as_deref(),
@@ -853,6 +868,68 @@ mod tests {
             .to_string();
 
         assert_ne!(first_revision, second_revision);
+    }
+
+    #[tokio::test]
+    async fn list_events_marks_cursor_reset_results_as_full_snapshot() {
+        let dir = tempdir().unwrap();
+        let store = Arc::new(EventLogStore::new(dir.path().to_path_buf()));
+        let app = test_router(test_state_with_eventlog(store));
+
+        let _ = append_event_via_api(
+            &app,
+            r#"{"timestamp":1700000000000,"content":"first","tags":["note"]}"#,
+            "/eventlog",
+        )
+        .await;
+
+        let _ = append_event_via_api(
+            &app,
+            r#"{"timestamp":1700000001000,"content":"second","tags":["note"]}"#,
+            "/eventlog",
+        )
+        .await;
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/eventlog")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        let _ = append_event_via_api(
+            &app,
+            r#"{"timestamp":1700000002000,"content":"after reset","tags":["note"]}"#,
+            "/eventlog",
+        )
+        .await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/eventlog?since_id=missing-cursor&since_timestamp=1700000001000")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(EVENTLOG_LIST_SEMANTICS_HEADER)
+                .expect("semantics header should exist")
+                .to_str()
+                .unwrap(),
+            "full_snapshot"
+        );
     }
 
     #[tokio::test]

--- a/src/components/Chat/ChatPage.tsx
+++ b/src/components/Chat/ChatPage.tsx
@@ -88,6 +88,8 @@ interface ChatPageProps {
   showTimerWidget?: boolean;
 }
 
+type RefreshTrigger = 'poll' | 'event' | 'external-refresh';
+
 const UNKNOWN_DEVICE_LABEL = '未知设备';
 const UNKNOWN_PLATFORM_LABEL = '未知平台';
 const CLOSED_PROFILE_EVENTLOG_NAME = '未名';
@@ -123,6 +125,14 @@ function resolveEventLogUserDisplayName(currentUser?: string | null): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isRefreshOnlyEvent(event: Event): boolean {
+  if (!isRecord(event.metadata)) {
+    return false;
+  }
+
+  return event.metadata.refreshOnly === true;
 }
 
 function readNonEmptyString(value: unknown): string | null {
@@ -214,7 +224,7 @@ export function ChatPage({
   const shouldStickToBottomRef = useRef(true);
   const refreshInFlightRef = useRef(false);
   const refreshQueuedRef = useRef(false);
-  const refreshQueuedTriggerRef = useRef<'poll' | 'event'>('poll');
+  const refreshQueuedTriggerRef = useRef<RefreshTrigger>('poll');
   const lastFullRefreshAtRef = useRef(0);
   const lastAppliedSnapshotRevisionRef = useRef<string | null | undefined>(undefined);
   const eventLogService = useRef(getEventLogService());
@@ -276,12 +286,15 @@ export function ChatPage({
 
   const refreshLatestEvents = useCallback(async (
     behavior: ScrollBehavior = 'smooth',
-    trigger: 'poll' | 'event' = 'poll',
+    trigger: RefreshTrigger = 'poll',
   ) => {
     const t0 = perfNow();
     const latestCursor = getLatestEventCursor(allEventsRef.current);
-    const shouldForceFullReconcile = latestCursor !== null
-      && (Date.now() - lastFullRefreshAtRef.current) >= RT_FULL_RECONCILE_INTERVAL_MS;
+    const shouldForceFullReconcile = trigger === 'external-refresh'
+      || (
+        latestCursor !== null
+        && (Date.now() - lastFullRefreshAtRef.current) >= RT_FULL_RECONCILE_INTERVAL_MS
+      );
     let requestedMode: 'full' | 'incremental' = latestCursor && !shouldForceFullReconcile ? 'incremental' : 'full';
     let loadedResult: EventLogLoadResult = await eventLogService.current.loadEventsDetailed(
       requestedMode === 'incremental'
@@ -299,7 +312,12 @@ export function ChatPage({
     const revisionChanged = loadedResult.snapshotRevision !== undefined
       && loadedResult.snapshotRevision !== lastAppliedSnapshotRevisionRef.current;
 
-    if (mode === 'incremental' && loadedEvents.length === 0 && (trigger === 'event' || revisionChanged)) {
+    const shouldFallbackToFull = mode === 'incremental' && (
+      (trigger === 'poll' && revisionChanged)
+      || (loadedEvents.length === 0 && (trigger === 'event' || revisionChanged))
+    );
+
+    if (shouldFallbackToFull) {
       requestedMode = 'full';
       mode = 'full';
       loadedResult = await eventLogService.current.loadEventsDetailed();
@@ -341,10 +359,12 @@ export function ChatPage({
     log.info(`[ChatPage] refreshLatestEvents ${JSON.stringify({ mode, fetched: loadedEvents.length, queryMs, totalMs: Math.round(perfNow() - t0) })}`);
   }, [applyVisibleWindow, scrollToBottom]);
 
-  const scheduleLatestRefresh = useCallback((trigger: 'poll' | 'event'): void => {
+  const scheduleLatestRefresh = useCallback((trigger: RefreshTrigger): void => {
     if (refreshInFlightRef.current) {
       refreshQueuedRef.current = true;
-      if (trigger === 'event') {
+      if (trigger === 'external-refresh') {
+        refreshQueuedTriggerRef.current = 'external-refresh';
+      } else if (trigger === 'event' && refreshQueuedTriggerRef.current === 'poll') {
         refreshQueuedTriggerRef.current = 'event';
       }
       return;
@@ -354,7 +374,7 @@ export function ChatPage({
     refreshQueuedTriggerRef.current = trigger;
     void (async () => {
       try {
-        let nextTrigger = trigger;
+        let nextTrigger: RefreshTrigger = trigger;
         do {
           refreshQueuedRef.current = false;
           await refreshLatestEvents('smooth', nextTrigger);
@@ -410,9 +430,9 @@ export function ChatPage({
     lastAppliedSnapshotRevisionRef.current = undefined;
     void loadInitialEvents();
 
-    const unsubscribe = eventLogService.current.onEvent(() => {
+    const unsubscribe = eventLogService.current.onEvent((event) => {
       shouldStickToBottomRef.current = true;
-      scheduleLatestRefresh('event');
+      scheduleLatestRefresh(isRefreshOnlyEvent(event) ? 'external-refresh' : 'event');
     });
     const intervalId = window.setInterval(() => {
       shouldStickToBottomRef.current = isNearBottom();

--- a/src/components/Chat/ChatPage.tsx
+++ b/src/components/Chat/ChatPage.tsx
@@ -28,6 +28,7 @@ import { useSyncStore } from '@/ui/stores/sync-store';
 import { log } from '@/lib/logger';
 import { registerMainWindowFocusTarget } from '@/services/main-window-focus-targets';
 import { MAIN_WINDOW_FOCUS_TARGET_EVENTLOG_RECORD_INPUT } from '@/services/main-window-shortcut.service';
+import { mergeLatestEventsAscending } from './chat-event-pagination';
 
 const PAGE_SIZE = 50;
 const TOP_LOAD_THRESHOLD = 40;
@@ -61,6 +62,18 @@ function perfNow(): number {
 
 function sortEventsAscending(events: Event[]): Event[] {
   return [...events].sort((a, b) => a.timestamp - b.timestamp);
+}
+
+function getLatestEventCursor(events: Event[]): { id: string; timestamp: number } | null {
+  const latestEvent = events[events.length - 1];
+  if (!latestEvent) {
+    return null;
+  }
+
+  return {
+    id: latestEvent.id,
+    timestamp: latestEvent.timestamp,
+  };
 }
 
 interface ChatPageProps {
@@ -251,9 +264,24 @@ export function ChatPage({
 
   const refreshLatestEvents = useCallback(async (behavior: ScrollBehavior = 'smooth') => {
     const t0 = perfNow();
-    const loadedEvents = sortEventsAscending(await eventLogService.current.loadEvents());
+    const latestCursor = getLatestEventCursor(allEventsRef.current);
+    const loadedEvents = sortEventsAscending(await eventLogService.current.loadEvents(
+      latestCursor
+        ? {
+            sinceId: latestCursor.id,
+            sinceTimestamp: latestCursor.timestamp,
+          }
+        : undefined,
+    ));
     const queryMs = Math.round(perfNow() - t0);
-    applyVisibleWindow(loadedEvents);
+
+    if (loadedEvents.length === 0) {
+      log.info(`[ChatPage] refreshLatestEvents ${JSON.stringify({ fetched: 0, queryMs, totalMs: Math.round(perfNow() - t0) })}`);
+      return;
+    }
+
+    const mergedEvents = mergeLatestEventsAscending(allEventsRef.current, loadedEvents);
+    applyVisibleWindow(mergedEvents);
 
     requestAnimationFrame(() => {
       if (shouldStickToBottomRef.current) {
@@ -261,7 +289,7 @@ export function ChatPage({
       }
     });
     log.info(`[ChatPage] refreshLatestEvents ${JSON.stringify({ fetched: loadedEvents.length, queryMs, totalMs: Math.round(perfNow() - t0) })}`);
-  }, [scrollToBottom]);
+  }, [applyVisibleWindow, scrollToBottom]);
 
   const scheduleLatestRefresh = useCallback((): void => {
     if (refreshInFlightRef.current) {
@@ -353,13 +381,12 @@ export function ChatPage({
     shouldStickToBottomRef.current = true;
     try {
       await eventLogService.current.addEvent(trimmed);
-      await refreshLatestEvents('smooth');
       log.info(`[ChatPage] handleSend done ${JSON.stringify({ totalMs: Math.round(perfNow() - t0) })}`);
     } catch (error) {
       log.error(`[ChatPage] handleSend failed: ${error instanceof Error ? error.message : String(error)}`);
       throw error;
     }
-  }, [refreshLatestEvents]);
+  }, []);
 
   // 全局快捷键：未聚焦输入框时 Enter/Shift+Enter/Ctrl+Enter 控制时间块和聚焦
   useEffect(() => {

--- a/src/components/Chat/ChatPage.tsx
+++ b/src/components/Chat/ChatPage.tsx
@@ -34,6 +34,7 @@ const PAGE_SIZE = 50;
 const TOP_LOAD_THRESHOLD = 40;
 const NEAR_BOTTOM_THRESHOLD = 120;
 const RT_REFRESH_INTERVAL_MS = 2_000;
+const RT_FULL_RECONCILE_INTERVAL_MS = 60_000;
 const TASK_CREATED_EVENT_TAGS = [
   'task_created',
 ] as const;
@@ -208,6 +209,8 @@ export function ChatPage({
   const shouldStickToBottomRef = useRef(true);
   const refreshInFlightRef = useRef(false);
   const refreshQueuedRef = useRef(false);
+  const refreshQueuedTriggerRef = useRef<'poll' | 'event'>('poll');
+  const lastFullRefreshAtRef = useRef(0);
   const eventLogService = useRef(getEventLogService());
   const { currentUser, isLoggedIn, activeProfileId } = useSyncStore();
   const syncStatus: 'connected' | 'disconnected' | 'syncing' = isLoggedIn && Boolean(currentUser)
@@ -255,6 +258,7 @@ export function ChatPage({
     const loadedEvents = sortEventsAscending(await eventLogService.current.loadEvents());
     shouldStickToBottomRef.current = true;
     applyVisibleWindow(loadedEvents, PAGE_SIZE);
+    lastFullRefreshAtRef.current = Date.now();
 
     requestAnimationFrame(() => {
       scrollToBottom('auto');
@@ -262,21 +266,45 @@ export function ChatPage({
     setIsInitialLoading(false);
   }, [applyVisibleWindow, scrollToBottom]);
 
-  const refreshLatestEvents = useCallback(async (behavior: ScrollBehavior = 'smooth') => {
+  const refreshLatestEvents = useCallback(async (
+    behavior: ScrollBehavior = 'smooth',
+    trigger: 'poll' | 'event' = 'poll',
+  ) => {
     const t0 = perfNow();
     const latestCursor = getLatestEventCursor(allEventsRef.current);
-    const loadedEvents = sortEventsAscending(await eventLogService.current.loadEvents(
-      latestCursor
+    const shouldForceFullReconcile = latestCursor !== null
+      && (Date.now() - lastFullRefreshAtRef.current) >= RT_FULL_RECONCILE_INTERVAL_MS;
+    let mode: 'full' | 'incremental' = latestCursor && !shouldForceFullReconcile ? 'incremental' : 'full';
+    let loadedEvents = sortEventsAscending(await eventLogService.current.loadEvents(
+      mode === 'incremental'
         ? {
-            sinceId: latestCursor.id,
-            sinceTimestamp: latestCursor.timestamp,
+            sinceId: latestCursor!.id,
+            sinceTimestamp: latestCursor!.timestamp,
           }
         : undefined,
     ));
+
+    if (mode === 'incremental' && loadedEvents.length === 0 && trigger === 'event') {
+      mode = 'full';
+      loadedEvents = sortEventsAscending(await eventLogService.current.loadEvents());
+    }
     const queryMs = Math.round(perfNow() - t0);
 
+    if (mode === 'full') {
+      lastFullRefreshAtRef.current = Date.now();
+      applyVisibleWindow(loadedEvents);
+
+      requestAnimationFrame(() => {
+        if (shouldStickToBottomRef.current) {
+          scrollToBottom(behavior);
+        }
+      });
+      log.info(`[ChatPage] refreshLatestEvents ${JSON.stringify({ mode, fetched: loadedEvents.length, queryMs, totalMs: Math.round(perfNow() - t0) })}`);
+      return;
+    }
+
     if (loadedEvents.length === 0) {
-      log.info(`[ChatPage] refreshLatestEvents ${JSON.stringify({ fetched: 0, queryMs, totalMs: Math.round(perfNow() - t0) })}`);
+      log.info(`[ChatPage] refreshLatestEvents ${JSON.stringify({ mode, fetched: 0, queryMs, totalMs: Math.round(perfNow() - t0) })}`);
       return;
     }
 
@@ -288,21 +316,28 @@ export function ChatPage({
         scrollToBottom(behavior);
       }
     });
-    log.info(`[ChatPage] refreshLatestEvents ${JSON.stringify({ fetched: loadedEvents.length, queryMs, totalMs: Math.round(perfNow() - t0) })}`);
+    log.info(`[ChatPage] refreshLatestEvents ${JSON.stringify({ mode, fetched: loadedEvents.length, queryMs, totalMs: Math.round(perfNow() - t0) })}`);
   }, [applyVisibleWindow, scrollToBottom]);
 
-  const scheduleLatestRefresh = useCallback((): void => {
+  const scheduleLatestRefresh = useCallback((trigger: 'poll' | 'event'): void => {
     if (refreshInFlightRef.current) {
       refreshQueuedRef.current = true;
+      if (trigger === 'event') {
+        refreshQueuedTriggerRef.current = 'event';
+      }
       return;
     }
 
     refreshInFlightRef.current = true;
+    refreshQueuedTriggerRef.current = trigger;
     void (async () => {
       try {
+        let nextTrigger = trigger;
         do {
           refreshQueuedRef.current = false;
-          await refreshLatestEvents('smooth');
+          await refreshLatestEvents('smooth', nextTrigger);
+          nextTrigger = refreshQueuedTriggerRef.current;
+          refreshQueuedTriggerRef.current = 'poll';
         } while (refreshQueuedRef.current);
       } finally {
         refreshInFlightRef.current = false;
@@ -354,11 +389,11 @@ export function ChatPage({
 
     const unsubscribe = eventLogService.current.onEvent(() => {
       shouldStickToBottomRef.current = true;
-      scheduleLatestRefresh();
+      scheduleLatestRefresh('event');
     });
     const intervalId = window.setInterval(() => {
       shouldStickToBottomRef.current = isNearBottom();
-      scheduleLatestRefresh();
+      scheduleLatestRefresh('poll');
     }, RT_REFRESH_INTERVAL_MS);
 
     return () => {

--- a/src/components/Chat/ChatPage.tsx
+++ b/src/components/Chat/ChatPage.tsx
@@ -62,7 +62,12 @@ function perfNow(): number {
 }
 
 function sortEventsAscending(events: Event[]): Event[] {
-  return [...events].sort((a, b) => a.timestamp - b.timestamp);
+  return [...events].sort((a, b) => {
+    if (a.timestamp !== b.timestamp) {
+      return a.timestamp - b.timestamp;
+    }
+    return a.id.localeCompare(b.id);
+  });
 }
 
 function getLatestEventCursor(events: Event[]): { id: string; timestamp: number } | null {

--- a/src/components/Chat/ChatPage.tsx
+++ b/src/components/Chat/ChatPage.tsx
@@ -23,7 +23,7 @@ import { MessageActions } from '@/components/Chat/MessageActions';
 import { NowInputRow } from '@/ui/app/components/NowInputRow';
 import { PageMoreMenu } from '@/ui/app/components/PageMoreMenu';
 import type { Event } from '@/lib/types/event';
-import { getEventLogService } from '@/lib/services/eventlog.service';
+import { getEventLogService, type EventLogLoadResult } from '@/lib/services/eventlog.service';
 import { useSyncStore } from '@/ui/stores/sync-store';
 import { log } from '@/lib/logger';
 import { registerMainWindowFocusTarget } from '@/services/main-window-focus-targets';
@@ -216,6 +216,7 @@ export function ChatPage({
   const refreshQueuedRef = useRef(false);
   const refreshQueuedTriggerRef = useRef<'poll' | 'event'>('poll');
   const lastFullRefreshAtRef = useRef(0);
+  const lastAppliedSnapshotRevisionRef = useRef<string | null | undefined>(undefined);
   const eventLogService = useRef(getEventLogService());
   const { currentUser, isLoggedIn, activeProfileId } = useSyncStore();
   const syncStatus: 'connected' | 'disconnected' | 'syncing' = isLoggedIn && Boolean(currentUser)
@@ -260,8 +261,10 @@ export function ChatPage({
 
   const loadInitialEvents = useCallback(async () => {
     setIsInitialLoading(true);
-    const loadedEvents = sortEventsAscending(await eventLogService.current.loadEvents());
+    const initialResult = await eventLogService.current.loadEventsDetailed();
+    const loadedEvents = sortEventsAscending(initialResult.events);
     shouldStickToBottomRef.current = true;
+    lastAppliedSnapshotRevisionRef.current = initialResult.snapshotRevision ?? null;
     applyVisibleWindow(loadedEvents, PAGE_SIZE);
     lastFullRefreshAtRef.current = Date.now();
 
@@ -279,24 +282,34 @@ export function ChatPage({
     const latestCursor = getLatestEventCursor(allEventsRef.current);
     const shouldForceFullReconcile = latestCursor !== null
       && (Date.now() - lastFullRefreshAtRef.current) >= RT_FULL_RECONCILE_INTERVAL_MS;
-    let mode: 'full' | 'incremental' = latestCursor && !shouldForceFullReconcile ? 'incremental' : 'full';
-    let loadedEvents = sortEventsAscending(await eventLogService.current.loadEvents(
-      mode === 'incremental'
+    let requestedMode: 'full' | 'incremental' = latestCursor && !shouldForceFullReconcile ? 'incremental' : 'full';
+    let loadedResult: EventLogLoadResult = await eventLogService.current.loadEventsDetailed(
+      requestedMode === 'incremental'
         ? {
             sinceId: latestCursor!.id,
             sinceTimestamp: latestCursor!.timestamp,
           }
         : undefined,
-    ));
+    );
+    let mode: 'full' | 'incremental' = requestedMode === 'incremental'
+      && loadedResult.semantics === 'incremental_batch'
+      ? 'incremental'
+      : 'full';
+    let loadedEvents = sortEventsAscending(loadedResult.events);
+    const revisionChanged = loadedResult.snapshotRevision !== undefined
+      && loadedResult.snapshotRevision !== lastAppliedSnapshotRevisionRef.current;
 
-    if (mode === 'incremental' && loadedEvents.length === 0 && trigger === 'event') {
+    if (mode === 'incremental' && loadedEvents.length === 0 && (trigger === 'event' || revisionChanged)) {
+      requestedMode = 'full';
       mode = 'full';
-      loadedEvents = sortEventsAscending(await eventLogService.current.loadEvents());
+      loadedResult = await eventLogService.current.loadEventsDetailed();
+      loadedEvents = sortEventsAscending(loadedResult.events);
     }
     const queryMs = Math.round(perfNow() - t0);
 
     if (mode === 'full') {
       lastFullRefreshAtRef.current = Date.now();
+      lastAppliedSnapshotRevisionRef.current = loadedResult.snapshotRevision ?? null;
       applyVisibleWindow(loadedEvents);
 
       requestAnimationFrame(() => {
@@ -309,11 +322,15 @@ export function ChatPage({
     }
 
     if (loadedEvents.length === 0) {
+      if (loadedResult.snapshotRevision !== undefined) {
+        lastAppliedSnapshotRevisionRef.current = loadedResult.snapshotRevision;
+      }
       log.info(`[ChatPage] refreshLatestEvents ${JSON.stringify({ mode, fetched: 0, queryMs, totalMs: Math.round(perfNow() - t0) })}`);
       return;
     }
 
     const mergedEvents = mergeLatestEventsAscending(allEventsRef.current, loadedEvents);
+    lastAppliedSnapshotRevisionRef.current = loadedResult.snapshotRevision ?? lastAppliedSnapshotRevisionRef.current ?? null;
     applyVisibleWindow(mergedEvents);
 
     requestAnimationFrame(() => {
@@ -390,6 +407,7 @@ export function ChatPage({
   // 初始化 RT EventLog 读源，并用轮询补齐跨链路写入后的 UI 刷新。
   useEffect(() => {
     visibleCountRef.current = PAGE_SIZE;
+    lastAppliedSnapshotRevisionRef.current = undefined;
     void loadInitialEvents();
 
     const unsubscribe = eventLogService.current.onEvent(() => {

--- a/src/lib/adapters/eventlog-rt-adapter.ts
+++ b/src/lib/adapters/eventlog-rt-adapter.ts
@@ -14,6 +14,7 @@ import { appendRuntimeProfileScope } from './runtime-profile-scope';
 
 type RuntimeFetch = typeof fetch;
 const EVENTLOG_REVISION_HEADER = 'x-exomind-eventlog-revision';
+const EVENTLOG_LIST_SEMANTICS_HEADER = 'x-exomind-eventlog-list-semantics';
 
 interface RuntimeEventPayload {
   id: string;
@@ -82,7 +83,7 @@ export class EventLogRtAdapter implements IEventLogPort {
     const payload = await response.json() as RuntimeEventPayload[];
     return {
       events: payload.map(toEventData),
-      semantics: this.resolveListSemantics(options),
+      semantics: this.resolveListSemantics(options, response.headers),
       snapshotRevision: response.headers?.get(EVENTLOG_REVISION_HEADER) ?? undefined,
     };
   }
@@ -155,7 +156,15 @@ export class EventLogRtAdapter implements IEventLogPort {
     return `${url.pathname}${url.search}`;
   }
 
-  private resolveListSemantics(options?: EventLogListOptions): EventLogListSemantics {
+  private resolveListSemantics(
+    options?: EventLogListOptions,
+    headers?: Headers,
+  ): EventLogListSemantics {
+    const headerValue = headers?.get(EVENTLOG_LIST_SEMANTICS_HEADER);
+    if (headerValue === 'full_snapshot' || headerValue === 'incremental_batch') {
+      return headerValue;
+    }
+
     const hasIncrementalCursor =
       (typeof options?.sinceId === 'string' && options.sinceId.length > 0)
       || typeof options?.sinceTimestamp === 'number';

--- a/src/lib/adapters/eventlog-rt-adapter.ts
+++ b/src/lib/adapters/eventlog-rt-adapter.ts
@@ -3,7 +3,7 @@ import {
   getSelectedRuntimeTarget,
   type RuntimeTarget,
 } from '@/config/runtime-target';
-import type { IEventLogPort } from '@/lib/environment/interfaces/eventlog.port';
+import type { EventLogListOptions, IEventLogPort } from '@/lib/environment/interfaces/eventlog.port';
 import type { EventData } from '@/lib/types/event';
 import { appendRuntimeProfileScope } from './runtime-profile-scope';
 
@@ -59,9 +59,9 @@ export class EventLogRtAdapter implements IEventLogPort {
     this.resolveTarget = options.resolveTarget ?? (() => getSelectedRuntimeTarget());
   }
 
-  async listEvents(): Promise<EventData[]> {
+  async listEvents(options?: EventLogListOptions): Promise<EventData[]> {
     const target = this.resolveTarget();
-    const response = await this.fetchImpl(this.url('/eventlog', target), {
+    const response = await this.fetchImpl(this.url(this.buildListPath(options), target), {
       method: 'GET',
       headers: buildRuntimeAuthHeaders(target, { Accept: 'application/json' }),
     });
@@ -122,6 +122,22 @@ export class EventLogRtAdapter implements IEventLogPort {
 
   private baseUrl(target = this.resolveTarget()): string {
     return buildBaseUrl(target);
+  }
+
+  private buildListPath(options?: EventLogListOptions): string {
+    const url = new URL('/eventlog', 'http://runtime.local');
+
+    if (typeof options?.sinceId === 'string' && options.sinceId.length > 0) {
+      url.searchParams.set('since_id', options.sinceId);
+    }
+    if (typeof options?.sinceTimestamp === 'number') {
+      url.searchParams.set('since_timestamp', String(options.sinceTimestamp));
+    }
+    if (typeof options?.limit === 'number') {
+      url.searchParams.set('limit', String(options.limit));
+    }
+
+    return `${url.pathname}${url.search}`;
   }
 
   private url(path: string, target = this.resolveTarget()): string {

--- a/src/lib/adapters/eventlog-rt-adapter.ts
+++ b/src/lib/adapters/eventlog-rt-adapter.ts
@@ -3,11 +3,17 @@ import {
   getSelectedRuntimeTarget,
   type RuntimeTarget,
 } from '@/config/runtime-target';
-import type { EventLogListOptions, IEventLogPort } from '@/lib/environment/interfaces/eventlog.port';
+import type {
+  EventLogListOptions,
+  EventLogListResult,
+  EventLogListSemantics,
+  IEventLogPort,
+} from '@/lib/environment/interfaces/eventlog.port';
 import type { EventData } from '@/lib/types/event';
 import { appendRuntimeProfileScope } from './runtime-profile-scope';
 
 type RuntimeFetch = typeof fetch;
+const EVENTLOG_REVISION_HEADER = 'x-exomind-eventlog-revision';
 
 interface RuntimeEventPayload {
   id: string;
@@ -60,6 +66,11 @@ export class EventLogRtAdapter implements IEventLogPort {
   }
 
   async listEvents(options?: EventLogListOptions): Promise<EventData[]> {
+    const result = await this.listEventsDetailed(options);
+    return result.events;
+  }
+
+  async listEventsDetailed(options?: EventLogListOptions): Promise<EventLogListResult> {
     const target = this.resolveTarget();
     const response = await this.fetchImpl(this.url(this.buildListPath(options), target), {
       method: 'GET',
@@ -69,7 +80,11 @@ export class EventLogRtAdapter implements IEventLogPort {
       throw new Error(`RT eventlog list failed: ${response.status}`);
     }
     const payload = await response.json() as RuntimeEventPayload[];
-    return payload.map(toEventData);
+    return {
+      events: payload.map(toEventData),
+      semantics: this.resolveListSemantics(options),
+      snapshotRevision: response.headers?.get(EVENTLOG_REVISION_HEADER) ?? undefined,
+    };
   }
 
   async appendEvent(event: EventData): Promise<EventData> {
@@ -138,6 +153,13 @@ export class EventLogRtAdapter implements IEventLogPort {
     }
 
     return `${url.pathname}${url.search}`;
+  }
+
+  private resolveListSemantics(options?: EventLogListOptions): EventLogListSemantics {
+    const hasIncrementalCursor =
+      (typeof options?.sinceId === 'string' && options.sinceId.length > 0)
+      || typeof options?.sinceTimestamp === 'number';
+    return hasIncrementalCursor ? 'incremental_batch' : 'full_snapshot';
   }
 
   private url(path: string, target = this.resolveTarget()): string {

--- a/src/lib/adapters/tauri-eventlog-storage.ts
+++ b/src/lib/adapters/tauri-eventlog-storage.ts
@@ -1,6 +1,14 @@
 import type { EventData } from '../types/event';
-import type { EventLogListOptions, IEventLogPort } from '../environment/interfaces/eventlog.port';
-import { applyEventLogListOptions, WebEventLogStorageAdapter } from './web-eventlog-storage';
+import type {
+  EventLogListOptions,
+  EventLogListResult,
+  IEventLogPort,
+} from '../environment/interfaces/eventlog.port';
+import {
+  applyEventLogListOptions,
+  resolveEventLogListSemantics,
+  WebEventLogStorageAdapter,
+} from './web-eventlog-storage';
 import { getCurrentUserId } from '../storage/event-storage';
 import { log } from '@/lib/logger';
 import { isTauriWindow } from '@/config/runtime-target';
@@ -35,18 +43,26 @@ export class TauriEventLogStorageAdapter implements IEventLogPort {
   }
 
   async listEvents(options?: EventLogListOptions): Promise<EventData[]> {
+    const result = await this.listEventsDetailed(options);
+    return result.events;
+  }
+
+  async listEventsDetailed(options?: EventLogListOptions): Promise<EventLogListResult> {
     const invoke = await getTauriInvoke();
     if (!invoke) {
-      return this.fallback.listEvents(options);
+      return this.fallback.listEventsDetailed(options);
     }
 
     const userId = this.resolveUserId();
     try {
       const events = await invoke<EventData[]>('eventlog_list', { userId });
-      return applyEventLogListOptions(events, options);
+      return {
+        events: applyEventLogListOptions(events, options),
+        semantics: resolveEventLogListSemantics(options),
+      };
     } catch (error) {
       log.warn(`[TauriEventLogStorageAdapter] eventlog_list failed, fallback to web storage: ${error instanceof Error ? error.message : String(error)}`);
-      return this.fallback.listEvents(options);
+      return this.fallback.listEventsDetailed(options);
     }
   }
 

--- a/src/lib/adapters/tauri-eventlog-storage.ts
+++ b/src/lib/adapters/tauri-eventlog-storage.ts
@@ -1,6 +1,6 @@
 import type { EventData } from '../types/event';
-import type { IEventLogPort } from '../environment/interfaces/eventlog.port';
-import { WebEventLogStorageAdapter } from './web-eventlog-storage';
+import type { EventLogListOptions, IEventLogPort } from '../environment/interfaces/eventlog.port';
+import { applyEventLogListOptions, WebEventLogStorageAdapter } from './web-eventlog-storage';
 import { getCurrentUserId } from '../storage/event-storage';
 import { log } from '@/lib/logger';
 import { isTauriWindow } from '@/config/runtime-target';
@@ -34,18 +34,19 @@ export class TauriEventLogStorageAdapter implements IEventLogPort {
     return this.userId ?? getCurrentUserId();
   }
 
-  async listEvents(): Promise<EventData[]> {
+  async listEvents(options?: EventLogListOptions): Promise<EventData[]> {
     const invoke = await getTauriInvoke();
     if (!invoke) {
-      return this.fallback.listEvents();
+      return this.fallback.listEvents(options);
     }
 
     const userId = this.resolveUserId();
     try {
-      return await invoke<EventData[]>('eventlog_list', { userId });
+      const events = await invoke<EventData[]>('eventlog_list', { userId });
+      return applyEventLogListOptions(events, options);
     } catch (error) {
       log.warn(`[TauriEventLogStorageAdapter] eventlog_list failed, fallback to web storage: ${error instanceof Error ? error.message : String(error)}`);
-      return this.fallback.listEvents();
+      return this.fallback.listEvents(options);
     }
   }
 
@@ -96,4 +97,3 @@ export class TauriEventLogStorageAdapter implements IEventLogPort {
     }
   }
 }
-

--- a/src/lib/adapters/web-eventlog-storage.ts
+++ b/src/lib/adapters/web-eventlog-storage.ts
@@ -1,5 +1,5 @@
 import type { EventData, EventMetadata, Tag } from '../types/event';
-import type { IEventLogPort } from '../environment/interfaces/eventlog.port';
+import type { EventLogListOptions, IEventLogPort } from '../environment/interfaces/eventlog.port';
 import { getEventStorage, type Event as StorageEvent } from '../storage/event-storage';
 import { appendEventWithEcsReplication } from '../services/ecs-eventlog-replication.service';
 
@@ -8,6 +8,34 @@ const TAGS_METADATA_KEY = 'tags';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function applyEventLogListOptions(
+  events: EventData[],
+  options?: EventLogListOptions,
+): EventData[] {
+  if (!options) {
+    return events;
+  }
+
+  let next = events;
+
+  if (typeof options.sinceTimestamp === 'number') {
+    next = next.filter((event) => event.timestamp >= options.sinceTimestamp!);
+  }
+
+  if (typeof options.sinceId === 'string' && options.sinceId.length > 0) {
+    const index = next.findIndex((event) => event.id === options.sinceId);
+    if (index >= 0) {
+      next = next.slice(0, index);
+    }
+  }
+
+  if (typeof options.limit === 'number') {
+    next = next.slice(0, Math.max(0, options.limit));
+  }
+
+  return next;
 }
 
 /**
@@ -25,9 +53,12 @@ export class WebEventLogStorageAdapter implements IEventLogPort {
     return getEventStorage(this.userId);
   }
 
-  async listEvents(): Promise<EventData[]> {
+  async listEvents(options?: EventLogListOptions): Promise<EventData[]> {
     const events = await this.storage.getEvents();
-    return events.map((event) => this.fromStorageEvent(event));
+    return applyEventLogListOptions(
+      events.map((event) => this.fromStorageEvent(event)),
+      options,
+    );
   }
 
   async appendEvent(event: EventData): Promise<EventData> {

--- a/src/lib/adapters/web-eventlog-storage.ts
+++ b/src/lib/adapters/web-eventlog-storage.ts
@@ -1,5 +1,10 @@
 import type { EventData, EventMetadata, Tag } from '../types/event';
-import type { EventLogListOptions, IEventLogPort } from '../environment/interfaces/eventlog.port';
+import type {
+  EventLogListOptions,
+  EventLogListResult,
+  EventLogListSemantics,
+  IEventLogPort,
+} from '../environment/interfaces/eventlog.port';
 import { getEventStorage, type Event as StorageEvent } from '../storage/event-storage';
 import { appendEventWithEcsReplication } from '../services/ecs-eventlog-replication.service';
 
@@ -8,6 +13,10 @@ const TAGS_METADATA_KEY = 'tags';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function resolveEventLogListSemantics(_options?: EventLogListOptions): EventLogListSemantics {
+  return 'full_snapshot';
 }
 
 export function applyEventLogListOptions(
@@ -53,11 +62,19 @@ export class WebEventLogStorageAdapter implements IEventLogPort {
   }
 
   async listEvents(options?: EventLogListOptions): Promise<EventData[]> {
+    const result = await this.listEventsDetailed(options);
+    return result.events;
+  }
+
+  async listEventsDetailed(options?: EventLogListOptions): Promise<EventLogListResult> {
     const events = await this.storage.getEvents();
-    return applyEventLogListOptions(
-      events.map((event) => this.fromStorageEvent(event)),
-      options,
-    );
+    return {
+      events: applyEventLogListOptions(
+        events.map((event) => this.fromStorageEvent(event)),
+        options,
+      ),
+      semantics: resolveEventLogListSemantics(options),
+    };
   }
 
   async appendEvent(event: EventData): Promise<EventData> {

--- a/src/lib/adapters/web-eventlog-storage.ts
+++ b/src/lib/adapters/web-eventlog-storage.ts
@@ -18,18 +18,17 @@ export function applyEventLogListOptions(
     return events;
   }
 
+  const hasIncrementalCursor =
+    (typeof options.sinceId === 'string' && options.sinceId.length > 0)
+    || typeof options.sinceTimestamp === 'number';
+
+  // Legacy PouchDB / Tauri JSON backends are ordered by event timestamp（事件时间）, not arrival order（到达顺序）.
+  // Applying local since* filters here can permanently hide late-arriving historical events（晚到旧事件）.
+  if (hasIncrementalCursor) {
+    return events;
+  }
+
   let next = events;
-
-  if (typeof options.sinceTimestamp === 'number') {
-    next = next.filter((event) => event.timestamp >= options.sinceTimestamp!);
-  }
-
-  if (typeof options.sinceId === 'string' && options.sinceId.length > 0) {
-    const index = next.findIndex((event) => event.id === options.sinceId);
-    if (index >= 0) {
-      next = next.slice(0, index);
-    }
-  }
 
   if (typeof options.limit === 'number') {
     next = next.slice(0, Math.max(0, options.limit));

--- a/src/lib/environment/interfaces/eventlog.port.ts
+++ b/src/lib/environment/interfaces/eventlog.port.ts
@@ -6,6 +6,14 @@ export interface EventLogListOptions {
   sinceTimestamp?: number;
 }
 
+export type EventLogListSemantics = 'full_snapshot' | 'incremental_batch';
+
+export interface EventLogListResult {
+  events: EventData[];
+  semantics: EventLogListSemantics;
+  snapshotRevision?: string | null;
+}
+
 /**
  * IEventLogPort - 事件日志能力接口
  *
@@ -17,6 +25,11 @@ export interface IEventLogPort {
    * 列出所有事件（建议按时间倒序）
    */
   listEvents(options?: EventLogListOptions): Promise<EventData[]>;
+
+  /**
+   * 列出事件并显式返回结果语义（快照 / 增量）
+   */
+  listEventsDetailed(options?: EventLogListOptions): Promise<EventLogListResult>;
 
   /**
    * 追加一条事件

--- a/src/lib/environment/interfaces/eventlog.port.ts
+++ b/src/lib/environment/interfaces/eventlog.port.ts
@@ -1,5 +1,11 @@
 import type { EventData } from '../../types/event';
 
+export interface EventLogListOptions {
+  limit?: number;
+  sinceId?: string;
+  sinceTimestamp?: number;
+}
+
 /**
  * IEventLogPort - 事件日志能力接口
  *
@@ -10,7 +16,7 @@ export interface IEventLogPort {
   /**
    * 列出所有事件（建议按时间倒序）
    */
-  listEvents(): Promise<EventData[]>;
+  listEvents(options?: EventLogListOptions): Promise<EventData[]>;
 
   /**
    * 追加一条事件
@@ -27,4 +33,3 @@ export interface IEventLogPort {
    */
   clearEvents(): Promise<void>;
 }
-

--- a/src/lib/services/eventlog-backup.service.ts
+++ b/src/lib/services/eventlog-backup.service.ts
@@ -5,6 +5,7 @@ import {
 } from '@/config/runtime-target';
 import { bytesToBase64 } from '@/lib/asr/volcano-config';
 import { appendRuntimeProfileScope } from '@/lib/adapters/runtime-profile-scope';
+import { notifyEventLogChanged } from '@/lib/services/eventlog.service';
 
 type RuntimeFetch = typeof fetch;
 export type EventLogImportStrategy = 'merge' | 'overwrite';
@@ -122,24 +123,28 @@ export class EventLogBackupServiceImpl {
   }
 
   async importEventsFromJson(content: string, strategy: EventLogImportStrategy): Promise<EventLogImportResult> {
-    return this.requestJson<EventLogImportResult>(`/eventlog/import/json?strategy=${strategy}`, {
+    const result = await this.requestJson<EventLogImportResult>(`/eventlog/import/json?strategy=${strategy}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
       body: content,
     });
+    notifyEventLogChanged();
+    return result;
   }
 
   async importEventsFromSqliteSnapshot(
     bytes: Uint8Array,
     strategy: EventLogImportStrategy,
   ): Promise<EventLogImportResult> {
-    return this.requestJson<EventLogImportResult>(`/eventlog/import/sqlite?strategy=${strategy}`, {
+    const result = await this.requestJson<EventLogImportResult>(`/eventlog/import/sqlite?strategy=${strategy}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
       body: JSON.stringify({
         content_base64: bytesToBase64(bytes),
       }),
     });
+    notifyEventLogChanged();
+    return result;
   }
 
   private async requestJson<T>(path: string, init?: RequestInit): Promise<T> {

--- a/src/lib/services/eventlog.service.ts
+++ b/src/lib/services/eventlog.service.ts
@@ -10,7 +10,12 @@
  */
 
 import { ExoMindEnvironment } from '../environment/environment';
-import type { EventLogListOptions, IEventLogPort } from '../environment/interfaces/eventlog.port';
+import type {
+  EventLogListOptions,
+  EventLogListResult,
+  EventLogListSemantics,
+  IEventLogPort,
+} from '../environment/interfaces/eventlog.port';
 import type { Event, NoteContent, Tag, EventData } from '../types/event';
 import { createUuidV4 } from '../utils/uuid';
 import { getEventSourceMetadata } from '../eventlog/source-metadata';
@@ -30,9 +35,18 @@ export interface ImportEventsResult {
   total: number;
 }
 
+export interface EventLogLoadResult {
+  events: Event[];
+  semantics: EventLogListSemantics;
+  snapshotRevision?: string | null;
+}
+
 export interface EventLogService {
   /** 加载所有事件 */
   loadEvents(options?: EventLogListOptions): Promise<Event[]>;
+
+  /** 加载事件并显式返回 snapshot / incremental 语义 */
+  loadEventsDetailed(options?: EventLogListOptions): Promise<EventLogLoadResult>;
 
   /** 添加普通事件 */
   addEvent(content: NoteContent, tags?: Set<Tag>): Promise<Event>;
@@ -63,8 +77,19 @@ export class EventLogServiceImpl implements EventLogService {
   }
 
   async loadEvents(options?: EventLogListOptions): Promise<Event[]> {
-    const data = await this.readEventData(options);
-    return data.map((d) => this.deserializeEvent(d)).sort((a, b) => b.timestamp - a.timestamp);
+    const result = await this.loadEventsDetailed(options);
+    return result.events;
+  }
+
+  async loadEventsDetailed(options?: EventLogListOptions): Promise<EventLogLoadResult> {
+    const result = await this.readEventDataDetailed(options);
+    return {
+      events: result.events
+        .map((data) => this.deserializeEvent(data))
+        .sort((a, b) => b.timestamp - a.timestamp),
+      semantics: result.semantics,
+      snapshotRevision: result.snapshotRevision,
+    };
   }
 
   async addEvent(content: NoteContent, tags?: Set<Tag>): Promise<Event> {
@@ -121,6 +146,7 @@ export class EventLogServiceImpl implements EventLogService {
     }
 
     await this.writeEventData(next);
+    this.notifyExternalChange();
 
     return {
       imported,
@@ -161,7 +187,19 @@ export class EventLogServiceImpl implements EventLogService {
   }
 
   private async readEventData(options?: EventLogListOptions): Promise<EventData[]> {
-    return this.port.listEvents(options);
+    const result = await this.readEventDataDetailed(options);
+    return result.events;
+  }
+
+  private async readEventDataDetailed(options?: EventLogListOptions): Promise<EventLogListResult> {
+    if (typeof this.port.listEventsDetailed === 'function') {
+      return this.port.listEventsDetailed(options);
+    }
+
+    return {
+      events: await this.port.listEvents(options),
+      semantics: 'full_snapshot',
+    };
   }
 
   private async writeEventData(events: EventData[]): Promise<void> {

--- a/src/lib/services/eventlog.service.ts
+++ b/src/lib/services/eventlog.service.ts
@@ -10,7 +10,7 @@
  */
 
 import { ExoMindEnvironment } from '../environment/environment';
-import type { IEventLogPort } from '../environment/interfaces/eventlog.port';
+import type { EventLogListOptions, IEventLogPort } from '../environment/interfaces/eventlog.port';
 import type { Event, NoteContent, Tag, EventData } from '../types/event';
 import { createUuidV4 } from '../utils/uuid';
 import { getEventSourceMetadata } from '../eventlog/source-metadata';
@@ -32,7 +32,7 @@ export interface ImportEventsResult {
 
 export interface EventLogService {
   /** 加载所有事件 */
-  loadEvents(): Promise<Event[]>;
+  loadEvents(options?: EventLogListOptions): Promise<Event[]>;
 
   /** 添加普通事件 */
   addEvent(content: NoteContent, tags?: Set<Tag>): Promise<Event>;
@@ -62,8 +62,8 @@ export class EventLogServiceImpl implements EventLogService {
     this.port = options.port ?? ExoMindEnvironment.getInstance().eventlog;
   }
 
-  async loadEvents(): Promise<Event[]> {
-    const data = await this.readEventData();
+  async loadEvents(options?: EventLogListOptions): Promise<Event[]> {
+    const data = await this.readEventData(options);
     return data.map((d) => this.deserializeEvent(d)).sort((a, b) => b.timestamp - a.timestamp);
   }
 
@@ -160,8 +160,8 @@ export class EventLogServiceImpl implements EventLogService {
     };
   }
 
-  private async readEventData(): Promise<EventData[]> {
-    return this.port.listEvents();
+  private async readEventData(options?: EventLogListOptions): Promise<EventData[]> {
+    return this.port.listEvents(options);
   }
 
   private async writeEventData(events: EventData[]): Promise<void> {

--- a/tests/components/ChatPage.test.tsx
+++ b/tests/components/ChatPage.test.tsx
@@ -199,7 +199,7 @@ describe('ChatPage 架构边界', () => {
     const source = readFileSync('src/components/Chat/ChatPage.tsx', 'utf-8');
 
     expect(source).toContain('getEventLogService');
-    expect(source).toContain('loadEvents(');
+    expect(source.includes('loadEvents(') || source.includes('loadEventsDetailed(')).toBe(true);
     expect(source).not.toContain('storageRef.current.addEvent(');
     expect(source).not.toContain('storageRef.current.getEvents(');
     expect(source).not.toContain('storage.getEvents(');

--- a/tests/unit/adapters/eventlog-rt-adapter.test.ts
+++ b/tests/unit/adapters/eventlog-rt-adapter.test.ts
@@ -131,6 +131,52 @@ describe('EventLogRtAdapter（RT 事件日志适配器）', () => {
     });
   });
 
+  it('honors backend semantics header when cursor query has been reset（后端声明 reset 快照时不再误判为增量）', async () => {
+    activateProfileScope();
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({
+        'x-exomind-eventlog-revision': 'rev-11',
+        'x-exomind-eventlog-list-semantics': 'full_snapshot',
+      }),
+      json: async () => ([
+        {
+          id: 'event-reset-1',
+          timestamp: 1700000002000,
+          content: 'after reset',
+          tags: ['note'],
+        },
+      ]),
+    }));
+
+    const adapter = new EventLogRtAdapter({
+      fetchImpl,
+      resolveTarget: () => ({ mode: 'embedded', host: '127.0.0.1', port: 9124 }),
+    }) as EventLogRtAdapter & {
+      listEventsDetailed: typeof EventLogRtAdapter.prototype.listEventsDetailed;
+    };
+
+    const result = await adapter.listEventsDetailed({
+      sinceId: 'missing-cursor',
+      sinceTimestamp: 1700000001000,
+    });
+
+    expect(result).toEqual({
+      events: [
+        {
+          id: 'event-reset-1',
+          timestamp: 1700000002000,
+          content: 'after reset',
+          tags: ['note'],
+          metadata: undefined,
+        },
+      ],
+      semantics: 'full_snapshot',
+      snapshotRevision: 'rev-11',
+    });
+  });
+
   it('serializes frontend EventData to runtime append payload', async () => {
     const profileId = activateProfileScope();
     const fetchImpl = vi.fn(async () => ({

--- a/tests/unit/adapters/eventlog-rt-adapter.test.ts
+++ b/tests/unit/adapters/eventlog-rt-adapter.test.ts
@@ -73,6 +73,34 @@ describe('EventLogRtAdapter（RT 事件日志适配器）', () => {
     expect(url.searchParams.get('user_id')).toBe(profileId);
   });
 
+  it('passes incremental query parameters to runtime eventlog list（透传增量查询参数）', async () => {
+    const profileId = activateProfileScope();
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ([]),
+    }));
+
+    const adapter = new EventLogRtAdapter({
+      fetchImpl,
+      resolveTarget: () => ({ mode: 'embedded', host: '127.0.0.1', port: 9124 }),
+    });
+
+    await adapter.listEvents({
+      sinceId: 'event-9',
+      sinceTimestamp: 1700000000500,
+      limit: 5,
+    });
+
+    const [requestUrl] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const url = new URL(requestUrl);
+    expect(`${url.origin}${url.pathname}`).toBe('http://127.0.0.1:9124/eventlog');
+    expect(url.searchParams.get('user_id')).toBe(profileId);
+    expect(url.searchParams.get('since_id')).toBe('event-9');
+    expect(url.searchParams.get('since_timestamp')).toBe('1700000000500');
+    expect(url.searchParams.get('limit')).toBe('5');
+  });
+
   it('serializes frontend EventData to runtime append payload', async () => {
     const profileId = activateProfileScope();
     const fetchImpl = vi.fn(async () => ({

--- a/tests/unit/adapters/eventlog-rt-adapter.test.ts
+++ b/tests/unit/adapters/eventlog-rt-adapter.test.ts
@@ -101,6 +101,36 @@ describe('EventLogRtAdapter（RT 事件日志适配器）', () => {
     expect(url.searchParams.get('limit')).toBe('5');
   });
 
+  it('exposes incremental semantics and runtime snapshot revision from response headers（暴露 RT 增量语义与快照修订号）', async () => {
+    activateProfileScope();
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({
+        'x-exomind-eventlog-revision': 'rev-2',
+      }),
+      json: async () => ([]),
+    }));
+
+    const adapter = new EventLogRtAdapter({
+      fetchImpl,
+      resolveTarget: () => ({ mode: 'embedded', host: '127.0.0.1', port: 9124 }),
+    }) as EventLogRtAdapter & {
+      listEventsDetailed: typeof EventLogRtAdapter.prototype.listEventsDetailed;
+    };
+
+    const result = await adapter.listEventsDetailed({
+      sinceId: 'event-9',
+      sinceTimestamp: 1700000000500,
+    });
+
+    expect(result).toEqual({
+      events: [],
+      semantics: 'incremental_batch',
+      snapshotRevision: 'rev-2',
+    });
+  });
+
   it('serializes frontend EventData to runtime append payload', async () => {
     const profileId = activateProfileScope();
     const fetchImpl = vi.fn(async () => ({

--- a/tests/unit/adapters/web-eventlog-storage.test.ts
+++ b/tests/unit/adapters/web-eventlog-storage.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import type { EventData } from '@/lib/types/event';
-import { applyEventLogListOptions } from '@/lib/adapters/web-eventlog-storage';
+import {
+  applyEventLogListOptions,
+  resolveEventLogListSemantics,
+} from '@/lib/adapters/web-eventlog-storage';
 
 const sampleEvents: EventData[] = [
   {
@@ -35,5 +38,12 @@ describe('applyEventLogListOptions', () => {
     expect(applyEventLogListOptions(sampleEvents, {
       limit: 2,
     })).toEqual(sampleEvents.slice(0, 2));
+  });
+
+  it('marks legacy cursor queries as full snapshot semantics（legacy cursor 查询应显式标记为全量快照）', () => {
+    expect(resolveEventLogListSemantics({
+      sinceId: 'evt-cursor',
+      sinceTimestamp: 1_500,
+    })).toBe('full_snapshot');
   });
 });

--- a/tests/unit/adapters/web-eventlog-storage.test.ts
+++ b/tests/unit/adapters/web-eventlog-storage.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { EventData } from '@/lib/types/event';
+import { applyEventLogListOptions } from '@/lib/adapters/web-eventlog-storage';
+
+const sampleEvents: EventData[] = [
+  {
+    id: 'evt-newest',
+    timestamp: 2_000,
+    content: 'newest',
+    tags: ['note'],
+  },
+  {
+    id: 'evt-cursor',
+    timestamp: 1_500,
+    content: 'cursor',
+    tags: ['note'],
+  },
+  {
+    id: 'evt-late-old',
+    timestamp: 500,
+    content: 'late-old',
+    tags: ['note'],
+  },
+];
+
+describe('applyEventLogListOptions', () => {
+  it('keeps full results when legacy adapters receive incremental cursor options（legacy 增量参数回退为全量结果）', () => {
+    expect(applyEventLogListOptions(sampleEvents, {
+      sinceId: 'evt-cursor',
+      sinceTimestamp: 1_500,
+    })).toEqual(sampleEvents);
+  });
+
+  it('still applies limit when only limit is provided（仅 limit 时仍保留截断能力）', () => {
+    expect(applyEventLogListOptions(sampleEvents, {
+      limit: 2,
+    })).toEqual(sampleEvents.slice(0, 2));
+  });
+});

--- a/tests/unit/components/chat-page.incremental-refresh.issue769.test.tsx
+++ b/tests/unit/components/chat-page.incremental-refresh.issue769.test.tsx
@@ -102,6 +102,22 @@ const sameTimestampHigherIdEvent: Event = {
   tags: new Set<string>(),
 };
 
+const refreshOnlySignalEvent: Event = {
+  id: 'evt-refresh-signal',
+  timestamp: new Date('2026-03-30T10:10:01.000Z').getTime(),
+  content: '',
+  tags: new Set<string>(['note']),
+  metadata: {
+    refreshOnly: true,
+    source: {
+      deviceId: 'device-refresh',
+      deviceName: 'Refresh Only',
+      platform: 'windows',
+      app: 'ExoMind',
+    },
+  },
+};
+
 describe('ChatPage incremental refresh issue 769', () => {
   const unsubscribe = vi.fn();
   const loadEventsDetailed = vi.fn<() => Promise<MockLoadEventsDetailedResult>>();
@@ -227,17 +243,12 @@ describe('ChatPage incremental refresh issue 769', () => {
     });
   });
 
-  it('reconciles full state when signaled refresh sees an empty delta（外部刷新信号遇到空增量时应回退全量对账）', async () => {
+  it('reconciles full state immediately for refresh-only signals（仅刷新信号应立即走全量对账）', async () => {
     loadEventsDetailed.mockReset();
     loadEventsDetailed
       .mockResolvedValueOnce({
         events: [initialEvent],
         semantics: 'full_snapshot',
-        snapshotRevision: 'rev-1',
-      })
-      .mockResolvedValueOnce({
-        events: [],
-        semantics: 'incremental_batch',
         snapshotRevision: 'rev-1',
       })
       .mockResolvedValueOnce({
@@ -255,20 +266,55 @@ describe('ChatPage incremental refresh issue 769', () => {
     expect(onEventCallback).not.toBeNull();
 
     await act(async () => {
-      onEventCallback?.(lateHistoricalEvent);
+      onEventCallback?.(refreshOnlySignalEvent);
       await Promise.resolve();
       await Promise.resolve();
     });
 
-    expect(loadEventsDetailed).toHaveBeenCalledTimes(3);
-    expect(loadEventsDetailed).toHaveBeenNthCalledWith(2, {
-      sinceId: 'evt-initial',
-      sinceTimestamp: initialEvent.timestamp,
-    });
-    expect(loadEventsDetailed).toHaveBeenNthCalledWith(3);
+    expect(loadEventsDetailed).toHaveBeenCalledTimes(2);
+    expect(loadEventsDetailed).toHaveBeenNthCalledWith(2, undefined);
     expect(screen.queryByText('初始事件')).not.toBeInTheDocument();
     expect(screen.getByText('补导入的历史事件')).toBeInTheDocument();
     expect(mockedLog.info).toHaveBeenCalledWith(expect.stringContaining('"mode":"full"'));
+  });
+
+  it('refresh-only signals keep late historical events and new tail events together（外部刷新含历史补录和新尾事件时必须整页对账）', async () => {
+    const appendedNewestEvent: Event = {
+      id: 'evt-new-tail',
+      timestamp: new Date('2026-03-30T10:12:00.000Z').getTime(),
+      content: '外部同步带来的新尾事件',
+      tags: new Set<string>(),
+    };
+
+    loadEventsDetailed.mockReset();
+    loadEventsDetailed
+      .mockResolvedValueOnce({
+        events: [initialEvent],
+        semantics: 'full_snapshot',
+        snapshotRevision: 'rev-mixed-1',
+      })
+      .mockResolvedValueOnce({
+        events: [lateHistoricalEvent, initialEvent, appendedNewestEvent],
+        semantics: 'full_snapshot',
+        snapshotRevision: 'rev-mixed-2',
+      });
+
+    await act(async () => {
+      render(<ChatPage variant="new-mobile" showTimerWidget={false} />);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      onEventCallback?.(refreshOnlySignalEvent);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(loadEventsDetailed).toHaveBeenCalledTimes(2);
+    expect(loadEventsDetailed).toHaveBeenNthCalledWith(2, undefined);
+    expect(screen.getByText('补导入的历史事件')).toBeInTheDocument();
+    expect(screen.getByText('初始事件')).toBeInTheDocument();
+    expect(screen.getByText('外部同步带来的新尾事件')).toBeInTheDocument();
   });
 
   it('replaces visible events when legacy cursor queries resolve as full snapshot（legacy 快照结果不应继续按增量 merge）', async () => {
@@ -344,5 +390,104 @@ describe('ChatPage incremental refresh issue 769', () => {
     expect(loadEventsDetailed).toHaveBeenNthCalledWith(3);
     expect(screen.queryByText('初始事件')).not.toBeInTheDocument();
     expect(screen.getByText('补导入的历史事件')).toBeInTheDocument();
+  });
+
+  it('forces full reconcile when poll sees revision drift with non-empty delta（轮询发现 revision 漂移且增量非空时也必须全量对账）', async () => {
+    const appendedNewestEvent: Event = {
+      id: 'evt-poll-new-tail',
+      timestamp: new Date('2026-03-30T10:12:30.000Z').getTime(),
+      content: '轮询先看到的新尾事件',
+      tags: new Set<string>(),
+    };
+
+    loadEventsDetailed.mockReset();
+    loadEventsDetailed
+      .mockResolvedValueOnce({
+        events: [initialEvent],
+        semantics: 'full_snapshot',
+        snapshotRevision: 'rt-rev-mixed-1',
+      })
+      .mockResolvedValueOnce({
+        events: [appendedNewestEvent],
+        semantics: 'incremental_batch',
+        snapshotRevision: 'rt-rev-mixed-2',
+      })
+      .mockResolvedValueOnce({
+        events: [lateHistoricalEvent, initialEvent, appendedNewestEvent],
+        semantics: 'full_snapshot',
+        snapshotRevision: 'rt-rev-mixed-2',
+      });
+
+    await act(async () => {
+      render(<ChatPage variant="new-mobile" showTimerWidget={false} />);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(loadEventsDetailed).toHaveBeenCalledTimes(3);
+    expect(loadEventsDetailed).toHaveBeenNthCalledWith(2, {
+      sinceId: 'evt-initial',
+      sinceTimestamp: initialEvent.timestamp,
+    });
+    expect(loadEventsDetailed).toHaveBeenNthCalledWith(3);
+    expect(screen.getByText('补导入的历史事件')).toBeInTheDocument();
+    expect(screen.getByText('初始事件')).toBeInTheDocument();
+    expect(screen.getByText('轮询先看到的新尾事件')).toBeInTheDocument();
+    expect(mockedLog.info).toHaveBeenCalledWith(expect.stringContaining('"mode":"full"'));
+  });
+
+  it('replaces stale rows when RT cursor query is downgraded to full snapshot（RT cursor reset 后应直接按快照替换）', async () => {
+    const staleEvent: Event = {
+      id: 'evt-stale',
+      timestamp: new Date('2026-03-30T10:06:00.000Z').getTime(),
+      content: '应被移除的旧事件',
+      tags: new Set<string>(),
+    };
+    const rewrittenLatestEvent: Event = {
+      id: 'evt-rewritten-latest',
+      timestamp: new Date('2026-03-30T10:08:00.000Z').getTime(),
+      content: '重写后的新尾事件',
+      tags: new Set<string>(),
+    };
+
+    loadEventsDetailed.mockReset();
+    loadEventsDetailed
+      .mockResolvedValueOnce({
+        events: [initialEvent, staleEvent],
+        semantics: 'full_snapshot',
+        snapshotRevision: 'rt-rev-10',
+      })
+      .mockResolvedValueOnce({
+        events: [rewrittenLatestEvent],
+        semantics: 'full_snapshot',
+        snapshotRevision: 'rt-rev-11',
+      });
+
+    await act(async () => {
+      render(<ChatPage variant="new-mobile" showTimerWidget={false} />);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('应被移除的旧事件')).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(loadEventsDetailed).toHaveBeenCalledTimes(2);
+    expect(loadEventsDetailed).toHaveBeenNthCalledWith(2, {
+      sinceId: 'evt-stale',
+      sinceTimestamp: staleEvent.timestamp,
+    });
+    expect(screen.queryByText('应被移除的旧事件')).not.toBeInTheDocument();
+    expect(screen.queryByText('初始事件')).not.toBeInTheDocument();
+    expect(screen.getByText('重写后的新尾事件')).toBeInTheDocument();
   });
 });

--- a/tests/unit/components/chat-page.incremental-refresh.issue769.test.tsx
+++ b/tests/unit/components/chat-page.incremental-refresh.issue769.test.tsx
@@ -80,6 +80,12 @@ const initialEvent: Event = {
   },
 };
 
+type MockLoadEventsDetailedResult = {
+  events: Event[];
+  semantics: 'full_snapshot' | 'incremental_batch';
+  snapshotRevision?: string | null;
+};
+
 const sameTimestampBase = new Date('2026-03-30T10:05:00.000Z').getTime();
 
 const sameTimestampLowerIdEvent: Event = {
@@ -98,7 +104,7 @@ const sameTimestampHigherIdEvent: Event = {
 
 describe('ChatPage incremental refresh issue 769', () => {
   const unsubscribe = vi.fn();
-  const loadEvents = vi.fn();
+  const loadEventsDetailed = vi.fn<() => Promise<MockLoadEventsDetailedResult>>();
   let onEventCallback: ((event: Event) => void) | null = null;
 
   const lateHistoricalEvent: Event = {
@@ -135,12 +141,21 @@ describe('ChatPage incremental refresh issue 769', () => {
       activeProfileId: 'profile-alice',
     } as never);
 
-    loadEvents
-      .mockResolvedValueOnce([initialEvent])
-      .mockResolvedValueOnce([]);
+    loadEventsDetailed
+      .mockResolvedValueOnce({
+        events: [initialEvent],
+        semantics: 'full_snapshot',
+        snapshotRevision: 'rev-1',
+      })
+      .mockResolvedValueOnce({
+        events: [],
+        semantics: 'incremental_batch',
+        snapshotRevision: 'rev-1',
+      });
 
     mockGetEventLogService.mockReturnValue({
-      loadEvents,
+      loadEventsDetailed,
+      loadEvents: vi.fn(),
       addEvent: vi.fn(),
       appendEventData: vi.fn(),
       exportEventsAsJson: vi.fn(),
@@ -164,16 +179,16 @@ describe('ChatPage incremental refresh issue 769', () => {
       await Promise.resolve();
     });
 
-    expect(loadEvents).toHaveBeenCalledTimes(1);
+    expect(loadEventsDetailed).toHaveBeenCalledTimes(1);
     expect(screen.getByText('初始事件')).toBeInTheDocument();
-    expect(loadEvents.mock.calls[0]).toEqual([]);
+    expect(loadEventsDetailed.mock.calls[0]).toEqual([]);
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2_000);
     });
 
-    expect(loadEvents).toHaveBeenCalledTimes(2);
-    expect(loadEvents).toHaveBeenNthCalledWith(2, {
+    expect(loadEventsDetailed).toHaveBeenCalledTimes(2);
+    expect(loadEventsDetailed).toHaveBeenNthCalledWith(2, {
       sinceId: 'evt-initial',
       sinceTimestamp: initialEvent.timestamp,
     });
@@ -181,13 +196,21 @@ describe('ChatPage incremental refresh issue 769', () => {
   });
 
   it('uses the timestamp+id tail event as incremental cursor（同时间戳时应使用 timestamp+id 尾事件做游标）', async () => {
-    loadEvents.mockReset();
-    loadEvents
-      .mockResolvedValueOnce([
-        sameTimestampHigherIdEvent,
-        sameTimestampLowerIdEvent,
-      ])
-      .mockResolvedValueOnce([]);
+    loadEventsDetailed.mockReset();
+    loadEventsDetailed
+      .mockResolvedValueOnce({
+        events: [
+          sameTimestampHigherIdEvent,
+          sameTimestampLowerIdEvent,
+        ],
+        semantics: 'full_snapshot',
+        snapshotRevision: 'rev-same-1',
+      })
+      .mockResolvedValueOnce({
+        events: [],
+        semantics: 'incremental_batch',
+        snapshotRevision: 'rev-same-1',
+      });
 
     await act(async () => {
       render(<ChatPage variant="new-mobile" showTimerWidget={false} />);
@@ -198,18 +221,30 @@ describe('ChatPage incremental refresh issue 769', () => {
       await vi.advanceTimersByTimeAsync(2_000);
     });
 
-    expect(loadEvents).toHaveBeenNthCalledWith(2, {
+    expect(loadEventsDetailed).toHaveBeenNthCalledWith(2, {
       sinceId: 'evt-same-b',
       sinceTimestamp: sameTimestampBase,
     });
   });
 
   it('reconciles full state when signaled refresh sees an empty delta（外部刷新信号遇到空增量时应回退全量对账）', async () => {
-    loadEvents.mockReset();
-    loadEvents
-      .mockResolvedValueOnce([initialEvent])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([lateHistoricalEvent]);
+    loadEventsDetailed.mockReset();
+    loadEventsDetailed
+      .mockResolvedValueOnce({
+        events: [initialEvent],
+        semantics: 'full_snapshot',
+        snapshotRevision: 'rev-1',
+      })
+      .mockResolvedValueOnce({
+        events: [],
+        semantics: 'incremental_batch',
+        snapshotRevision: 'rev-1',
+      })
+      .mockResolvedValueOnce({
+        events: [lateHistoricalEvent],
+        semantics: 'full_snapshot',
+        snapshotRevision: 'rev-2',
+      });
 
     await act(async () => {
       render(<ChatPage variant="new-mobile" showTimerWidget={false} />);
@@ -225,14 +260,89 @@ describe('ChatPage incremental refresh issue 769', () => {
       await Promise.resolve();
     });
 
-    expect(loadEvents).toHaveBeenCalledTimes(3);
-    expect(loadEvents).toHaveBeenNthCalledWith(2, {
+    expect(loadEventsDetailed).toHaveBeenCalledTimes(3);
+    expect(loadEventsDetailed).toHaveBeenNthCalledWith(2, {
       sinceId: 'evt-initial',
       sinceTimestamp: initialEvent.timestamp,
     });
-    expect(loadEvents).toHaveBeenNthCalledWith(3);
+    expect(loadEventsDetailed).toHaveBeenNthCalledWith(3);
     expect(screen.queryByText('初始事件')).not.toBeInTheDocument();
     expect(screen.getByText('补导入的历史事件')).toBeInTheDocument();
     expect(mockedLog.info).toHaveBeenCalledWith(expect.stringContaining('"mode":"full"'));
+  });
+
+  it('replaces visible events when legacy cursor queries resolve as full snapshot（legacy 快照结果不应继续按增量 merge）', async () => {
+    loadEventsDetailed.mockReset();
+    loadEventsDetailed
+      .mockResolvedValueOnce({
+        events: [initialEvent],
+        semantics: 'full_snapshot',
+        snapshotRevision: 'legacy-rev-1',
+      })
+      .mockResolvedValueOnce({
+        events: [lateHistoricalEvent],
+        semantics: 'full_snapshot',
+        snapshotRevision: 'legacy-rev-2',
+      });
+
+    await act(async () => {
+      render(<ChatPage variant="new-mobile" showTimerWidget={false} />);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('初始事件')).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    expect(loadEventsDetailed).toHaveBeenNthCalledWith(2, {
+      sinceId: 'evt-initial',
+      sinceTimestamp: initialEvent.timestamp,
+    });
+    expect(screen.queryByText('初始事件')).not.toBeInTheDocument();
+    expect(screen.getByText('补导入的历史事件')).toBeInTheDocument();
+  });
+
+  it('forces full reconcile when incremental poll sees a newer snapshot revision with empty delta（空增量但 revision 变化时应立即全量对账）', async () => {
+    loadEventsDetailed.mockReset();
+    loadEventsDetailed
+      .mockResolvedValueOnce({
+        events: [initialEvent],
+        semantics: 'full_snapshot',
+        snapshotRevision: 'rt-rev-1',
+      })
+      .mockResolvedValueOnce({
+        events: [],
+        semantics: 'incremental_batch',
+        snapshotRevision: 'rt-rev-2',
+      })
+      .mockResolvedValueOnce({
+        events: [lateHistoricalEvent],
+        semantics: 'full_snapshot',
+        snapshotRevision: 'rt-rev-2',
+      });
+
+    await act(async () => {
+      render(<ChatPage variant="new-mobile" showTimerWidget={false} />);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('初始事件')).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(loadEventsDetailed).toHaveBeenCalledTimes(3);
+    expect(loadEventsDetailed).toHaveBeenNthCalledWith(2, {
+      sinceId: 'evt-initial',
+      sinceTimestamp: initialEvent.timestamp,
+    });
+    expect(loadEventsDetailed).toHaveBeenNthCalledWith(3);
+    expect(screen.queryByText('初始事件')).not.toBeInTheDocument();
+    expect(screen.getByText('补导入的历史事件')).toBeInTheDocument();
   });
 });

--- a/tests/unit/components/chat-page.incremental-refresh.issue769.test.tsx
+++ b/tests/unit/components/chat-page.incremental-refresh.issue769.test.tsx
@@ -83,10 +83,28 @@ const initialEvent: Event = {
 describe('ChatPage incremental refresh issue 769', () => {
   const unsubscribe = vi.fn();
   const loadEvents = vi.fn();
+  let onEventCallback: ((event: Event) => void) | null = null;
+
+  const lateHistoricalEvent: Event = {
+    id: 'evt-late-history',
+    timestamp: new Date('2026-03-29T08:00:00.000Z').getTime(),
+    content: '补导入的历史事件',
+    tags: new Set<string>(),
+    metadata: {
+      source: {
+        deviceId: 'device-2',
+        deviceName: 'Imported',
+        platform: 'windows',
+        app: 'ExoMind',
+      },
+    },
+  };
 
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-30T10:10:00.000Z'));
     vi.clearAllMocks();
+    onEventCallback = null;
 
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
       callback(0);
@@ -111,7 +129,10 @@ describe('ChatPage incremental refresh issue 769', () => {
       appendEventData: vi.fn(),
       exportEventsAsJson: vi.fn(),
       importEventsFromJson: vi.fn(),
-      onEvent: vi.fn(() => unsubscribe),
+      onEvent: vi.fn((callback: (event: Event) => void) => {
+        onEventCallback = callback;
+        return unsubscribe;
+      }),
     });
   });
 
@@ -141,5 +162,37 @@ describe('ChatPage incremental refresh issue 769', () => {
       sinceTimestamp: initialEvent.timestamp,
     });
     expect(mockedLog.info).toHaveBeenCalledWith(expect.stringContaining('"fetched":0'));
+  });
+
+  it('reconciles full state when signaled refresh sees an empty delta（外部刷新信号遇到空增量时应回退全量对账）', async () => {
+    loadEvents.mockReset();
+    loadEvents
+      .mockResolvedValueOnce([initialEvent])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([lateHistoricalEvent]);
+
+    await act(async () => {
+      render(<ChatPage variant="new-mobile" showTimerWidget={false} />);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('初始事件')).toBeInTheDocument();
+    expect(onEventCallback).not.toBeNull();
+
+    await act(async () => {
+      onEventCallback?.(lateHistoricalEvent);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(loadEvents).toHaveBeenCalledTimes(3);
+    expect(loadEvents).toHaveBeenNthCalledWith(2, {
+      sinceId: 'evt-initial',
+      sinceTimestamp: initialEvent.timestamp,
+    });
+    expect(loadEvents).toHaveBeenNthCalledWith(3);
+    expect(screen.queryByText('初始事件')).not.toBeInTheDocument();
+    expect(screen.getByText('补导入的历史事件')).toBeInTheDocument();
+    expect(mockedLog.info).toHaveBeenCalledWith(expect.stringContaining('"mode":"full"'));
   });
 });

--- a/tests/unit/components/chat-page.incremental-refresh.issue769.test.tsx
+++ b/tests/unit/components/chat-page.incremental-refresh.issue769.test.tsx
@@ -1,0 +1,145 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Event } from '@/lib/types/event';
+import { ChatPage } from '@/components/Chat/ChatPage';
+import { useSyncStore } from '@/ui/stores/sync-store';
+import { getEventLogService } from '@/lib/services/eventlog.service';
+import { log } from '@/lib/logger';
+
+vi.mock('@/ui/stores/sync-store', () => ({
+  useSyncStore: vi.fn(),
+}));
+
+vi.mock('@/lib/services/eventlog.service', () => ({
+  getEventLogService: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/components/Chat/EventMarkdown', () => ({
+  EventMarkdown: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+vi.mock('@/components/Chat/MessageActions', () => ({
+  MessageActions: () => null,
+}));
+
+vi.mock('@/ui/app/components/NowInputRow', async () => {
+  const React = await import('react');
+  return {
+    NowInputRow: React.forwardRef<HTMLDivElement>((_, ref) => (
+      <div ref={ref} data-testid="now-input-row" />
+    )),
+  };
+});
+
+vi.mock('@/ui/app/components/PageMoreMenu', () => ({
+  PageMoreMenu: () => <div data-testid="page-more-menu" />,
+}));
+
+vi.mock('@/ui/app/components/FocusTimerWidget', async () => {
+  const React = await import('react');
+  return {
+    FocusTimerWidget: React.forwardRef<HTMLDivElement>((_, ref) => (
+      <div ref={ref} data-testid="focus-timer-widget" />
+    )),
+  };
+});
+
+vi.mock('@/components/TimeBlockWidget', () => ({
+  TimeBlockWidget: () => <div data-testid="time-block-widget" />,
+}));
+
+vi.mock('@/components/VoiceMessageInput', () => ({
+  VoiceMessageInput: () => <div data-testid="voice-message-input" />,
+}));
+
+const mockUseSyncStore = vi.mocked(useSyncStore);
+const mockGetEventLogService = vi.mocked(getEventLogService);
+const mockedLog = vi.mocked(log, true);
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+
+const initialEvent: Event = {
+  id: 'evt-initial',
+  timestamp: new Date('2026-03-30T10:00:00.000Z').getTime(),
+  content: '初始事件',
+  tags: new Set<string>(),
+  metadata: {
+    source: {
+      deviceId: 'device-1',
+      deviceName: 'Desktop',
+      platform: 'windows',
+      app: 'ExoMind',
+    },
+  },
+};
+
+describe('ChatPage incremental refresh issue 769', () => {
+  const unsubscribe = vi.fn();
+  const loadEvents = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+
+    mockUseSyncStore.mockReturnValue({
+      currentUser: 'Alice',
+      isLoggedIn: true,
+      activeProfileId: 'profile-alice',
+    } as never);
+
+    loadEvents
+      .mockResolvedValueOnce([initialEvent])
+      .mockResolvedValueOnce([]);
+
+    mockGetEventLogService.mockReturnValue({
+      loadEvents,
+      addEvent: vi.fn(),
+      appendEventData: vi.fn(),
+      exportEventsAsJson: vi.fn(),
+      importEventsFromJson: vi.fn(),
+      onEvent: vi.fn(() => unsubscribe),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+  });
+
+  it('poll refreshes with latest event cursor instead of reloading all events（轮询刷新应带最新事件游标）', async () => {
+    await act(async () => {
+      render(<ChatPage variant="new-mobile" showTimerWidget={false} />);
+      await Promise.resolve();
+    });
+
+    expect(loadEvents).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('初始事件')).toBeInTheDocument();
+    expect(loadEvents.mock.calls[0]).toEqual([]);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    expect(loadEvents).toHaveBeenCalledTimes(2);
+    expect(loadEvents).toHaveBeenNthCalledWith(2, {
+      sinceId: 'evt-initial',
+      sinceTimestamp: initialEvent.timestamp,
+    });
+    expect(mockedLog.info).toHaveBeenCalledWith(expect.stringContaining('"fetched":0'));
+  });
+});

--- a/tests/unit/components/chat-page.incremental-refresh.issue769.test.tsx
+++ b/tests/unit/components/chat-page.incremental-refresh.issue769.test.tsx
@@ -80,6 +80,22 @@ const initialEvent: Event = {
   },
 };
 
+const sameTimestampBase = new Date('2026-03-30T10:05:00.000Z').getTime();
+
+const sameTimestampLowerIdEvent: Event = {
+  id: 'evt-same-a',
+  timestamp: sameTimestampBase,
+  content: '同时间戳 A',
+  tags: new Set<string>(),
+};
+
+const sameTimestampHigherIdEvent: Event = {
+  id: 'evt-same-b',
+  timestamp: sameTimestampBase,
+  content: '同时间戳 B',
+  tags: new Set<string>(),
+};
+
 describe('ChatPage incremental refresh issue 769', () => {
   const unsubscribe = vi.fn();
   const loadEvents = vi.fn();
@@ -162,6 +178,30 @@ describe('ChatPage incremental refresh issue 769', () => {
       sinceTimestamp: initialEvent.timestamp,
     });
     expect(mockedLog.info).toHaveBeenCalledWith(expect.stringContaining('"fetched":0'));
+  });
+
+  it('uses the timestamp+id tail event as incremental cursor（同时间戳时应使用 timestamp+id 尾事件做游标）', async () => {
+    loadEvents.mockReset();
+    loadEvents
+      .mockResolvedValueOnce([
+        sameTimestampHigherIdEvent,
+        sameTimestampLowerIdEvent,
+      ])
+      .mockResolvedValueOnce([]);
+
+    await act(async () => {
+      render(<ChatPage variant="new-mobile" showTimerWidget={false} />);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    expect(loadEvents).toHaveBeenNthCalledWith(2, {
+      sinceId: 'evt-same-b',
+      sinceTimestamp: sameTimestampBase,
+    });
   });
 
   it('reconciles full state when signaled refresh sees an empty delta（外部刷新信号遇到空增量时应回退全量对账）', async () => {

--- a/tests/unit/eventlog/eventlog-port-contract.test.ts
+++ b/tests/unit/eventlog/eventlog-port-contract.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { EventLogListOptions } from '@/lib/environment/interfaces/eventlog.port';
+import type { EventLogListOptions, EventLogListResult } from '@/lib/environment/interfaces/eventlog.port';
 import type { EventData } from '@/lib/types/event';
 import { EventLogServiceImpl } from '@/lib/services/eventlog.service';
 
@@ -20,6 +20,10 @@ describe('EventLogService port contract', () => {
 
   it('uses injected eventlog port for read/write instead of direct storage dependency', async () => {
     const port = {
+      listEventsDetailed: vi.fn(async (_options?: EventLogListOptions) => ({
+        events: [] as EventData[],
+        semantics: 'full_snapshot' as const,
+      })),
       listEvents: vi.fn(async (_options?: EventLogListOptions) => [] as EventData[]),
       appendEvent: vi.fn(async (event: EventData) => event),
       getEvent: vi.fn<(_: string) => Promise<EventData | null>>().mockResolvedValue(null),
@@ -31,7 +35,7 @@ describe('EventLogService port contract', () => {
     await service.loadEvents();
     await service.addEvent('hello from port');
 
-    expect(port.listEvents).toHaveBeenCalled();
+    expect(port.listEventsDetailed).toHaveBeenCalled();
     expect(port.appendEvent).toHaveBeenCalledTimes(1);
     const [event] = port.appendEvent.mock.calls[0] as [EventData];
     expect(event.metadata?.source).toEqual(expect.objectContaining({
@@ -44,6 +48,10 @@ describe('EventLogService port contract', () => {
 
   it('keeps addEvent working when crypto.randomUUID is unavailable', async () => {
     const port = {
+      listEventsDetailed: vi.fn(async (_options?: EventLogListOptions) => ({
+        events: [] as EventData[],
+        semantics: 'full_snapshot' as const,
+      })),
       listEvents: vi.fn(async (_options?: EventLogListOptions) => [] as EventData[]),
       appendEvent: vi.fn(async (event: EventData) => event),
       getEvent: vi.fn<(_: string) => Promise<EventData | null>>().mockResolvedValue(null),
@@ -97,6 +105,10 @@ describe('EventLogService port contract', () => {
     };
 
     const port = {
+      listEventsDetailed: vi.fn(async (_options?: EventLogListOptions) => ({
+        events: [sample],
+        semantics: 'full_snapshot' as const,
+      })),
       listEvents: vi.fn(async (_options?: EventLogListOptions) => [sample]),
       appendEvent: vi.fn(async (event: EventData) => event),
       getEvent: vi.fn<(_: string) => Promise<EventData | null>>().mockResolvedValue(sample),
@@ -118,6 +130,10 @@ describe('EventLogService port contract', () => {
   it('passes optional loadEvents query parameters to the injected port（透传增量读取参数）', async () => {
     const port = {
       listEvents: vi.fn(async (_options?: EventLogListOptions) => [] as EventData[]),
+      listEventsDetailed: vi.fn(async (_options?: EventLogListOptions) => ({
+        events: [] as EventData[],
+        semantics: 'full_snapshot' as const,
+      })),
       appendEvent: vi.fn(async (event: EventData) => event),
       getEvent: vi.fn<(_: string) => Promise<EventData | null>>().mockResolvedValue(null),
       clearEvents: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
@@ -131,10 +147,59 @@ describe('EventLogService port contract', () => {
       limit: 20,
     });
 
-    expect(port.listEvents).toHaveBeenCalledWith({
+    expect(port.listEventsDetailed).toHaveBeenCalledWith({
       sinceId: 'evt-2',
       sinceTimestamp: 1700000000000,
       limit: 20,
+    });
+  });
+
+  it('exposes detailed load semantics for incremental consumers（向增量消费者暴露快照/增量语义）', async () => {
+    const sample: EventData = {
+      id: 'evt-detailed-1',
+      timestamp: 1700000001111,
+      content: 'detailed result',
+      tags: ['note'],
+    };
+
+    const port = {
+      listEvents: vi.fn(async (_options?: EventLogListOptions) => [] as EventData[]),
+      listEventsDetailed: vi.fn(async (_options?: EventLogListOptions) => ({
+        events: [sample],
+        semantics: 'incremental_batch' as const,
+        snapshotRevision: '42',
+      })),
+      appendEvent: vi.fn(async (event: EventData) => event),
+      getEvent: vi.fn<(_: string) => Promise<EventData | null>>().mockResolvedValue(null),
+      clearEvents: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    };
+
+    const service = new EventLogServiceImpl({ port }) as EventLogServiceImpl & {
+      loadEventsDetailed: (options?: EventLogListOptions) => Promise<{
+        events: Array<{ id: string; content: string }>;
+        semantics: 'full_snapshot' | 'incremental_batch';
+        snapshotRevision?: string;
+      }>;
+    };
+
+    const result = await service.loadEventsDetailed({
+      sinceId: 'evt-detailed-0',
+      sinceTimestamp: 1700000000000,
+    });
+
+    expect(port.listEventsDetailed).toHaveBeenCalledWith({
+      sinceId: 'evt-detailed-0',
+      sinceTimestamp: 1700000000000,
+    });
+    expect(result).toEqual({
+      events: [
+        expect.objectContaining({
+          id: 'evt-detailed-1',
+          content: 'detailed result',
+        }),
+      ],
+      semantics: 'incremental_batch',
+      snapshotRevision: '42',
     });
   });
 });

--- a/tests/unit/eventlog/eventlog-port-contract.test.ts
+++ b/tests/unit/eventlog/eventlog-port-contract.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { EventLogListOptions } from '@/lib/environment/interfaces/eventlog.port';
 import type { EventData } from '@/lib/types/event';
 import { EventLogServiceImpl } from '@/lib/services/eventlog.service';
 
@@ -19,8 +20,8 @@ describe('EventLogService port contract', () => {
 
   it('uses injected eventlog port for read/write instead of direct storage dependency', async () => {
     const port = {
-      listEvents: vi.fn<() => Promise<EventData[]>>().mockResolvedValue([]),
-      appendEvent: vi.fn<(_: EventData) => Promise<void>>().mockResolvedValue(undefined),
+      listEvents: vi.fn(async (_options?: EventLogListOptions) => [] as EventData[]),
+      appendEvent: vi.fn(async (event: EventData) => event),
       getEvent: vi.fn<(_: string) => Promise<EventData | null>>().mockResolvedValue(null),
       clearEvents: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     };
@@ -43,8 +44,8 @@ describe('EventLogService port contract', () => {
 
   it('keeps addEvent working when crypto.randomUUID is unavailable', async () => {
     const port = {
-      listEvents: vi.fn<() => Promise<EventData[]>>().mockResolvedValue([]),
-      appendEvent: vi.fn<(_: EventData) => Promise<void>>().mockResolvedValue(undefined),
+      listEvents: vi.fn(async (_options?: EventLogListOptions) => [] as EventData[]),
+      appendEvent: vi.fn(async (event: EventData) => event),
       getEvent: vi.fn<(_: string) => Promise<EventData | null>>().mockResolvedValue(null),
       clearEvents: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     };
@@ -96,8 +97,8 @@ describe('EventLogService port contract', () => {
     };
 
     const port = {
-      listEvents: vi.fn<() => Promise<EventData[]>>().mockResolvedValue([sample]),
-      appendEvent: vi.fn<(_: EventData) => Promise<void>>().mockResolvedValue(undefined),
+      listEvents: vi.fn(async (_options?: EventLogListOptions) => [sample]),
+      appendEvent: vi.fn(async (event: EventData) => event),
       getEvent: vi.fn<(_: string) => Promise<EventData | null>>().mockResolvedValue(sample),
       clearEvents: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     };
@@ -112,5 +113,28 @@ describe('EventLogService port contract', () => {
       agentId: 'codex',
       sessionId: 'session-002',
     }));
+  });
+
+  it('passes optional loadEvents query parameters to the injected port（透传增量读取参数）', async () => {
+    const port = {
+      listEvents: vi.fn(async (_options?: EventLogListOptions) => [] as EventData[]),
+      appendEvent: vi.fn(async (event: EventData) => event),
+      getEvent: vi.fn<(_: string) => Promise<EventData | null>>().mockResolvedValue(null),
+      clearEvents: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    };
+
+    const service = new EventLogServiceImpl({ port });
+
+    await service.loadEvents({
+      sinceId: 'evt-2',
+      sinceTimestamp: 1700000000000,
+      limit: 20,
+    });
+
+    expect(port.listEvents).toHaveBeenCalledWith({
+      sinceId: 'evt-2',
+      sinceTimestamp: 1700000000000,
+      limit: 20,
+    });
   });
 });

--- a/tests/unit/eventlog/service-import-export.test.ts
+++ b/tests/unit/eventlog/service-import-export.test.ts
@@ -4,7 +4,12 @@ import { EventLogServiceImpl } from '@/lib/services/eventlog.service';
 
 type EventLogPortShape = {
   listEvents: () => Promise<EventData[]>;
-  appendEvent: (event: EventData) => Promise<void>;
+  listEventsDetailed: () => Promise<{
+    events: EventData[];
+    semantics: 'full_snapshot' | 'incremental_batch';
+    snapshotRevision?: string;
+  }>;
+  appendEvent: (event: EventData) => Promise<EventData>;
   getEvent: (id: string) => Promise<EventData | null>;
   clearEvents: () => Promise<void>;
 };
@@ -13,8 +18,13 @@ function createMockPort(initialEvents: EventData[] = []): EventLogPortShape {
   let current = initialEvents;
   return {
     listEvents: vi.fn(async () => [...current]),
+    listEventsDetailed: vi.fn(async () => ({
+      events: [...current],
+      semantics: 'full_snapshot',
+    })),
     appendEvent: vi.fn(async (event: EventData) => {
       current = [event, ...current];
+      return event;
     }),
     getEvent: vi.fn(async (id: string) => current.find((event) => event.id === id) ?? null),
     clearEvents: vi.fn(async () => {
@@ -43,6 +53,8 @@ describe('EventLogService import/export', () => {
 
   it('imports backup with merge strategy', async () => {
     const service = new EventLogServiceImpl({ port });
+    const onEvent = vi.fn();
+    service.onEvent(onEvent);
     const backup = JSON.stringify({
       version: 1,
       exportedAt: new Date().toISOString(),
@@ -56,6 +68,7 @@ describe('EventLogService import/export', () => {
     expect(result.imported).toBe(1);
     expect(result.skipped).toBe(1);
     expect(result.total).toBe(3);
+    expect(onEvent).toHaveBeenCalledTimes(1);
   });
 
   it('appends raw event data without regenerating timestamp or tags', async () => {

--- a/tests/unit/eventlog/service-pouchdb-backend.test.ts
+++ b/tests/unit/eventlog/service-pouchdb-backend.test.ts
@@ -25,8 +25,11 @@ vi.mock('@/lib/services/ecs-eventlog-replication.service', () => ({
 }));
 
 import { EventLogServiceImpl } from '@/lib/services/eventlog.service';
+import { WebEventLogStorageAdapter } from '@/lib/adapters/web-eventlog-storage';
 
 describe('EventLogService PouchDB backend', () => {
+  const createPouchPort = () => new WebEventLogStorageAdapter();
+
   beforeEach(() => {
     replicationMocks.appendEventWithEcsReplication.mockReset().mockImplementation(async (event) => {
       await mocks.addEvent(event);
@@ -49,7 +52,7 @@ describe('EventLogService PouchDB backend', () => {
       },
     ]);
 
-    const service = new EventLogServiceImpl();
+    const service = new EventLogServiceImpl({ port: createPouchPort() });
     const raw = await service.exportEventsAsJson();
     const payload = JSON.parse(raw) as { events: Array<{ content: string }> };
 
@@ -68,7 +71,7 @@ describe('EventLogService PouchDB backend', () => {
       replicationSeq: 1,
     });
 
-    const service = new EventLogServiceImpl();
+    const service = new EventLogServiceImpl({ port: createPouchPort() });
     const backup = JSON.stringify({
       version: 1,
       exportedAt: new Date().toISOString(),
@@ -84,4 +87,3 @@ describe('EventLogService PouchDB backend', () => {
     expect(result).toEqual({ imported: 1, skipped: 0, total: 1 });
   });
 });
-

--- a/tests/unit/services/eventlog-backup.service.test.ts
+++ b/tests/unit/services/eventlog-backup.service.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EventLogBackupServiceImpl } from '@/lib/services/eventlog-backup.service';
 import { createLocalProfile, setProfileSession } from '@/lib/profile/profile-storage';
+import { notifyEventLogChanged } from '@/lib/services/eventlog.service';
+
+vi.mock('@/lib/services/eventlog.service', () => ({
+  notifyEventLogChanged: vi.fn(),
+}));
 
 function activateProfileScope(): string {
   const profile = createLocalProfile({
@@ -18,6 +23,7 @@ function activateProfileScope(): string {
 describe('EventLogBackupService（事件日志备份服务）', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    vi.clearAllMocks();
   });
 
   it('exports eventlog JSON backup under active profile scope（导出带当前档案作用域）', async () => {
@@ -81,5 +87,53 @@ describe('EventLogBackupService（事件日志备份服务）', () => {
     expect(JSON.parse(String(requestInit.body))).toEqual({
       content_base64: 'AQID',
     });
+  });
+
+  it('notifies EventLog listeners after JSON import succeeds（JSON 导入成功后应通知事件流刷新）', async () => {
+    activateProfileScope();
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        imported: 2,
+        skipped: 1,
+        total: 5,
+      }),
+    }));
+
+    const service = new EventLogBackupServiceImpl({
+      fetchImpl,
+      resolveTarget: () => ({ mode: 'embedded', host: '127.0.0.1', port: 9124 }),
+    });
+
+    await service.importEventsFromJson(JSON.stringify({
+      version: 1,
+      exportedAt: '2026-03-30T00:00:00.000Z',
+      events: [],
+    }), 'merge');
+
+    expect(notifyEventLogChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies EventLog listeners after SQLite import succeeds（SQLite 导入成功后应通知事件流刷新）', async () => {
+    activateProfileScope();
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        imported: 3,
+        skipped: 0,
+        total: 3,
+      }),
+    }));
+
+    const service = new EventLogBackupServiceImpl({
+      fetchImpl,
+      resolveTarget: () => ({ mode: 'embedded', host: '127.0.0.1', port: 9124 }),
+    });
+
+    await service.importEventsFromSqliteSnapshot(new Uint8Array([1, 2, 3]), 'merge');
+
+    expect(notifyEventLogChanged).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
﻿## Summary
- make `ChatPage.refreshLatestEvents` use the latest loaded event as a cursor and merge only incremental events
- add optional `sinceId / sinceTimestamp / limit` query support to `EventLogService` and `IEventLogPort`
- map incremental query params through `EventLogRtAdapter`, while keeping Web/Tauri legacy adapters contract-compatible via local filtering
- add regression tests for service passthrough, RT adapter query mapping, and ChatPage polling refresh behavior

## Testing
- `bunx vitest run tests/unit/eventlog/eventlog-port-contract.test.ts tests/unit/adapters/eventlog-rt-adapter.test.ts tests/unit/eventlog/tauri-eventlog-invoke.test.ts tests/components/ChatPage.test.tsx tests/unit/chat/chat-event-pagination.test.ts tests/unit/components/chat-page.incremental-refresh.issue769.test.tsx`

## Issue
- Refs #769
