### PR TITLE
fix(security): stop exposing embedded runtime auth secret

### DIFF
--- a/crates/exomind-runtime/src/auth.rs
+++ b/crates/exomind-runtime/src/auth.rs
@@ -1,7 +1,8 @@
-use axum::extract::{Request, State};
+use axum::extract::{ConnectInfo, Request, State};
 use axum::http::StatusCode;
 use axum::middleware::Next;
 use axum::response::Response;
+use std::net::SocketAddr;
 
 use crate::AppState;
 
@@ -32,6 +33,76 @@ fn is_peer_allowed_path(path: &str) -> bool {
         .any(|prefix| path.starts_with(prefix))
 }
 
+fn is_loopback_request(request: &Request) -> bool {
+    request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ConnectInfo(addr)| addr.ip().is_loopback())
+        .unwrap_or(false)
+}
+
+fn parse_origin_scheme_and_host(origin: &str) -> Option<(&str, &str)> {
+    let origin = origin.trim();
+    let (scheme, remainder) = origin.split_once("://")?;
+    let authority = remainder
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or_default()
+        .trim();
+
+    if scheme.is_empty() || authority.is_empty() || authority.contains('@') {
+        return None;
+    }
+
+    if let Some(rest) = authority.strip_prefix('[') {
+        let end = rest.find(']')?;
+        let host = &rest[..end];
+        let trailing = &rest[end + 1..];
+        if !trailing.is_empty()
+            && !(trailing.starts_with(':')
+                && trailing[1..].chars().all(|char| char.is_ascii_digit())
+                && !trailing[1..].is_empty())
+        {
+            return None;
+        }
+        return Some((scheme, host));
+    }
+
+    let (host, trailing) = authority.split_once(':').unwrap_or((authority, ""));
+    if host.is_empty()
+        || trailing.contains(':')
+        || (!trailing.is_empty() && !trailing.chars().all(|char| char.is_ascii_digit()))
+    {
+        return None;
+    }
+
+    Some((scheme, host))
+}
+
+pub(crate) fn is_trusted_loopback_origin_value(origin: &str) -> bool {
+    let Some((scheme, host)) = parse_origin_scheme_and_host(origin) else {
+        return false;
+    };
+
+    if !matches!(scheme.to_ascii_lowercase().as_str(), "http" | "https" | "tauri") {
+        return false;
+    }
+
+    matches!(
+        host.to_ascii_lowercase().as_str(),
+        "localhost" | "127.0.0.1" | "::1" | "tauri.localhost"
+    )
+}
+
+fn has_trusted_loopback_origin(request: &Request) -> bool {
+    request
+        .headers()
+        .get("origin")
+        .and_then(|value| value.to_str().ok())
+        .map(is_trusted_loopback_origin_value)
+        .unwrap_or(false)
+}
+
 /// Bearer token auth middleware (Bearer Token 鉴权中间件).
 ///
 /// If `AppState.auth_secret` is `None`, all requests are allowed (local dev mode).
@@ -47,6 +118,10 @@ pub async fn require_auth(
     request: Request,
     next: Next,
 ) -> Result<Response, StatusCode> {
+    if is_loopback_request(&request) && has_trusted_loopback_origin(&request) {
+        return Ok(next.run(request).await);
+    }
+
     let Some(expected_secret) = &state.auth_secret else {
         // No secret configured: allow all requests (local dev mode).
         return Ok(next.run(request).await);

--- a/crates/exomind-runtime/src/lib.rs
+++ b/crates/exomind-runtime/src/lib.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 use tokio::process::{Child, Command};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 
 use eventlog::EventLogStore;
 use mesh::{MeshRelayManager, MeshState};
@@ -70,6 +70,30 @@ pub fn configured_host_id_from_env() -> String {
 
 fn default_runtime_host_id(port: u16) -> String {
     format!("rt-local-{port}")
+}
+
+fn bind_host_is_loopback_or_local(host: &str) -> bool {
+    let normalized = host.trim().trim_matches(['[', ']']);
+    if normalized.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+
+    normalized
+        .parse::<std::net::IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
+}
+
+fn ensure_auth_secret_for_bind_host(options: &mut RuntimeStartOptions) {
+    if options.auth_secret.is_some() || bind_host_is_loopback_or_local(&options.bind_host) {
+        return;
+    }
+
+    tracing::warn!(
+        "EXOMIND_RT_SECRET not configured for non-loopback bind host {}; generating ephemeral admin secret for this runtime session",
+        options.bind_host
+    );
+    options.auth_secret = Some(format!("rt-admin-{}", uuid::Uuid::new_v4()));
 }
 
 /// Runtime startup options（运行时启动选项）.
@@ -404,6 +428,9 @@ pub async fn start() -> Result<RuntimeHandle, RuntimeStartError> {
 pub async fn start_with_options(
     options: RuntimeStartOptions,
 ) -> Result<RuntimeHandle, RuntimeStartError> {
+    let mut options = options;
+    ensure_auth_secret_for_bind_host(&mut options);
+
     let bind_addr_raw = format!("{}:{}", options.bind_host, options.port);
     let bind_addr: SocketAddr =
         bind_addr_raw
@@ -552,7 +579,7 @@ pub async fn start_with_options(
     let app = app_with_state(state);
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
     let server_task = tokio::spawn(async move {
-        axum::serve(listener, app)
+        axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())
             .with_graceful_shutdown(async move {
                 let _ = shutdown_rx.await;
             })
@@ -700,7 +727,13 @@ pub fn app_with_state(state: AppState) -> Router {
     // Enable CORS for browser-side host aggregation (允许浏览器跨端口访问 runtime).
     // CORS must be outermost so that preflight OPTIONS requests (which carry no token) are handled.
     let cors = CorsLayer::new()
-        .allow_origin(Any)
+        .allow_origin(AllowOrigin::predicate(|origin, _parts| {
+            origin
+                .to_str()
+                .ok()
+                .map(auth::is_trusted_loopback_origin_value)
+                .unwrap_or(false)
+        }))
         .allow_methods([
             Method::GET,
             Method::POST,
@@ -1295,7 +1328,57 @@ mod tests {
                 .headers()
                 .get("access-control-allow-origin")
                 .and_then(|value| value.to_str().ok()),
-            Some("*")
+            Some("http://127.0.0.1:1420")
+        );
+    }
+
+    #[tokio::test]
+    async fn agents_endpoint_omits_cors_header_for_untrusted_origin() {
+        const TEST_PORT: u16 = 3004;
+        let response = app(TEST_PORT)
+            .oneshot(
+                Request::builder()
+                    .uri("/agents")
+                    .header("origin", "https://evil.example")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(StatusCode::OK, response.status());
+        assert!(
+            response.headers().get("access-control-allow-origin").is_none(),
+            "untrusted origin must not receive a CORS allow header"
+        );
+    }
+
+    #[tokio::test]
+    async fn pairing_initiate_preflight_allows_trusted_local_origin() {
+        const TEST_PORT: u16 = 3004;
+        let response = app(TEST_PORT)
+            .oneshot(
+                Request::builder()
+                    .method(Method::OPTIONS)
+                    .uri("/mesh/pairing/initiate")
+                    .header("origin", "http://127.0.0.1:1420")
+                    .header("access-control-request-method", "POST")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            response.status(),
+            StatusCode::OK | StatusCode::NO_CONTENT
+        ));
+        assert_eq!(
+            response
+                .headers()
+                .get("access-control-allow-origin")
+                .and_then(|value| value.to_str().ok()),
+            Some("http://127.0.0.1:1420")
         );
     }
 
@@ -1773,6 +1856,38 @@ mod tests {
                 .is_file(),
             "resolved project root must contain classifier agent entry: {}",
             resolved.display()
+        );
+    }
+
+    #[test]
+    fn ensure_auth_secret_for_lan_bind_generates_ephemeral_secret() {
+        let mut options = RuntimeStartOptions {
+            bind_host: "0.0.0.0".to_string(),
+            auth_secret: None,
+            ..RuntimeStartOptions::default()
+        };
+
+        ensure_auth_secret_for_bind_host(&mut options);
+
+        assert!(
+            options.auth_secret.is_some(),
+            "non-loopback bind host must not run without an admin secret"
+        );
+    }
+
+    #[test]
+    fn ensure_auth_secret_for_loopback_bind_keeps_secret_optional() {
+        let mut options = RuntimeStartOptions {
+            bind_host: "127.0.0.1".to_string(),
+            auth_secret: None,
+            ..RuntimeStartOptions::default()
+        };
+
+        ensure_auth_secret_for_bind_host(&mut options);
+
+        assert!(
+            options.auth_secret.is_none(),
+            "loopback bind host may keep secret optional for local-only dev mode"
         );
     }
 }

--- a/crates/exomind-runtime/tests/auth_middleware.rs
+++ b/crates/exomind-runtime/tests/auth_middleware.rs
@@ -16,7 +16,7 @@ async fn auth_with_secret_no_token_returns_401() {
     assert_eq!(
         response.status(),
         401,
-        "should reject request without token"
+        "should reject request without token when origin is missing"
     );
 
     stop_runtime(&mut rt, "auth-test-1").await;
@@ -58,7 +58,7 @@ async fn auth_with_secret_wrong_token_returns_401() {
     assert_eq!(
         response.status(),
         401,
-        "should reject request with wrong token"
+        "should reject request with wrong token when origin is missing"
     );
 
     stop_runtime(&mut rt, "auth-test-3").await;
@@ -132,4 +132,46 @@ async fn auth_via_query_param_token() {
     );
 
     stop_runtime(&mut rt, "auth-test-6").await;
+}
+
+#[tokio::test]
+async fn auth_with_secret_trusted_loopback_origin_returns_200_without_token() {
+    let mut rt = start_test_runtime_with_secret("auth-test-7", Some("s3cret".to_string())).await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!("{}/topology", runtime_base_url(&rt)))
+        .header("Origin", "http://tauri.localhost")
+        .send()
+        .await
+        .expect("request should send");
+
+    assert_eq!(
+        response.status(),
+        200,
+        "trusted local UI origin should be allowed without token"
+    );
+
+    stop_runtime(&mut rt, "auth-test-7").await;
+}
+
+#[tokio::test]
+async fn auth_with_secret_untrusted_origin_still_returns_401() {
+    let mut rt = start_test_runtime_with_secret("auth-test-8", Some("s3cret".to_string())).await;
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!("{}/topology", runtime_base_url(&rt)))
+        .header("Origin", "https://evil.example")
+        .send()
+        .await
+        .expect("request should send");
+
+    assert_eq!(
+        response.status(),
+        401,
+        "untrusted browser origin must still provide a valid token"
+    );
+
+    stop_runtime(&mut rt, "auth-test-8").await;
 }

--- a/src-tauri/src/commands/runtime_commands.rs
+++ b/src-tauri/src/commands/runtime_commands.rs
@@ -63,7 +63,6 @@ pub struct RuntimeServiceStatus {
     pub host: String,
     pub port: u16,
     pub host_id: Option<String>,
-    pub auth_secret: Option<String>,
     pub pid: Option<u32>,
     pub started_at: Option<String>,
     pub error: Option<String>,
@@ -278,7 +277,6 @@ fn compose_status(
         host: inner.host.clone(),
         port: inner.port,
         host_id: inner.host_id.clone(),
-        auth_secret: inner.auth_secret.clone(),
         pid: (running && inner.handle.is_some()).then_some(std::process::id()),
         started_at: inner.started_at.clone(),
         error: error.or_else(|| inner.last_error.clone()),
@@ -882,11 +880,15 @@ mod tests {
         assert!(status.running);
         assert_eq!(status.pid, None);
         assert_eq!(status.host_id.as_deref(), Some("host-local"));
-        assert_eq!(status.auth_secret.as_deref(), Some("embedded-secret"));
+        let serialized = serde_json::to_value(&status).expect("status should serialize");
+        assert!(
+            serialized.get("authSecret").is_none(),
+            "runtime status must not expose authSecret"
+        );
     }
 
     #[test]
-    fn compose_status_includes_auth_secret_for_embedded_runtime() {
+    fn compose_status_hides_auth_secret_for_embedded_runtime() {
         let inner = super::RuntimeInner {
             handle: None,
             host: "127.0.0.1".to_string(),
@@ -900,6 +902,10 @@ mod tests {
         let status = super::compose_status(&inner, true, None);
 
         assert!(status.running);
-        assert_eq!(status.auth_secret.as_deref(), Some("embedded-secret"));
+        let serialized = serde_json::to_value(&status).expect("status should serialize");
+        assert!(
+            serialized.get("authSecret").is_none(),
+            "embedded runtime status must not expose authSecret"
+        );
     }
 }

--- a/src/config/runtime-target.ts
+++ b/src/config/runtime-target.ts
@@ -21,8 +21,6 @@ export interface EmbeddedRuntimeStatusSnapshot {
   host: string;
   port: number;
   hostId?: string;
-  /** Admin auth secret for the embedded runtime (when EXOMIND_RT_SECRET is set). */
-  authSecret?: string;
 }
 
 function resolveEmbeddedRuntimePort(rawValue: string | undefined): number {
@@ -67,7 +65,7 @@ export function formatHostForUrl(host: string): string {
   return host;
 }
 
-function readEmbeddedRuntimeStatus(): EmbeddedRuntimeStatusSnapshot | null {
+export function readEmbeddedRuntimeStatus(): EmbeddedRuntimeStatusSnapshot | null {
   if (typeof window === 'undefined') {
     return null;
   }
@@ -83,16 +81,24 @@ function readEmbeddedRuntimeStatus(): EmbeddedRuntimeStatusSnapshot | null {
   }
 
   try {
-    const parsed = JSON.parse(raw) as Partial<EmbeddedRuntimeStatusSnapshot>;
+    const parsed = JSON.parse(raw) as Partial<EmbeddedRuntimeStatusSnapshot> & {
+      authSecret?: unknown;
+    };
     if (typeof parsed.host !== 'string' || typeof parsed.port !== 'number') {
       return null;
     }
-    return {
+    const snapshot = {
       host: resolveLocalServiceHost(parsed.host),
       port: parsed.port,
       hostId: typeof parsed.hostId === 'string' ? parsed.hostId : undefined,
-      authSecret: typeof parsed.authSecret === 'string' ? parsed.authSecret : undefined,
     };
+    if (Object.prototype.hasOwnProperty.call(parsed, 'authSecret')) {
+      window.localStorage.setItem(
+        EMBEDDED_RUNTIME_STATUS_STORAGE_KEY,
+        JSON.stringify(snapshot),
+      );
+    }
+    return snapshot;
   } catch {
     return null;
   }
@@ -156,11 +162,6 @@ function resolveEmbeddedPort(): number {
   }
 
   return DEFAULT_EMBEDDED_RUNTIME_PORT;
-}
-
-function resolveEmbeddedAuthToken(): string | undefined {
-  const authSecret = readEmbeddedRuntimeStatus()?.authSecret?.trim();
-  return authSecret ? authSecret : undefined;
 }
 
 export function getPreferredEmbeddedRuntimePort(): number {
@@ -350,7 +351,6 @@ export function getSelectedRuntimeTarget(): RuntimeTarget {
     mode,
     host: resolveEmbeddedHost(),
     port: resolveEmbeddedPort(),
-    authToken: resolveEmbeddedAuthToken(),
   };
 }
 
@@ -383,7 +383,6 @@ export function persistEmbeddedRuntimeStatus(status: EmbeddedRuntimeStatusSnapsh
       host: resolveLocalServiceHost(status.host),
       port: status.port,
       hostId: status.hostId,
-      authSecret: status.authSecret,
     }),
   );
   emitRuntimeTargetChanged();

--- a/src/lib/adapters/tauri-runtime-adapter.ts
+++ b/src/lib/adapters/tauri-runtime-adapter.ts
@@ -23,7 +23,6 @@ function rememberEmbeddedRuntimeStatus(status: RuntimeServiceStatus): RuntimeSer
       host: status.host,
       port: status.port,
       hostId: status.hostId,
-      authSecret: status.authSecret,
     });
   }
   return status;

--- a/src/lib/types/agent-hub-runtime.ts
+++ b/src/lib/types/agent-hub-runtime.ts
@@ -26,7 +26,6 @@ export interface RuntimeServiceStatus {
   host: string;
   port: number;
   hostId?: string; // host_id（逻辑主机 ID）
-  authSecret?: string; // auth_secret（本地 Runtime 管理鉴权密钥）
   pid?: number;
   startedAt?: string;
   error?: string;

--- a/src/ui/app/components/settings/settings-custom-items.tsx
+++ b/src/ui/app/components/settings/settings-custom-items.tsx
@@ -63,6 +63,7 @@ import {
   EMBEDDED_RUNTIME_STATUS_STORAGE_KEY,
   getSelectedRuntimeTarget,
   isTauriWindow,
+  readEmbeddedRuntimeStatus,
   toRuntimeBaseUrl,
 } from '@/config/runtime-target';
 import {
@@ -665,28 +666,12 @@ export function AiApiKeySetting(_props: { ctx: SettingsContext }) {
 
 function readRuntimeInfo() {
   const runtimeBaseUrl = toRuntimeBaseUrl(getSelectedRuntimeTarget());
-  let localHostId = 'local';
-  let localAuthToken: string | undefined;
-
-  try {
-    const raw = window.localStorage.getItem(EMBEDDED_RUNTIME_STATUS_STORAGE_KEY);
-    if (raw) {
-      const parsed = JSON.parse(raw) as { hostId?: string; authSecret?: string };
-      if (typeof parsed.hostId === 'string') {
-        localHostId = parsed.hostId;
-      }
-      if (typeof parsed.authSecret === 'string') {
-        localAuthToken = parsed.authSecret;
-      }
-    }
-  } catch {
-    // Ignore malformed runtime status cache.
-  }
+  const localHostId = readEmbeddedRuntimeStatus()?.hostId ?? 'local';
 
   return {
     runtimeBaseUrl,
     localHostId,
-    localAuthToken,
+    localAuthToken: undefined,
   };
 }
 

--- a/src/ui/app/pages/AgentsPage.tsx
+++ b/src/ui/app/pages/AgentsPage.tsx
@@ -923,7 +923,7 @@ export function AgentsPage() {
   const resolveRtAuthToken = (): string | undefined => {
     const activeHost = activeSignalRouteHost ?? sortRouteHostsByPriority(runtimeHostSnapshots).find((s) => s.host)?.host;
     if (activeHost?.authToken) return activeHost.authToken;
-    return runtimeServiceStatus?.authSecret ?? undefined;
+    return undefined;
   };
 
   const resolveActiveRuntimeHost = (): RuntimeHostRecord => {

--- a/src/ui/hooks/useSignalStream.ts
+++ b/src/ui/hooks/useSignalStream.ts
@@ -123,7 +123,6 @@ export function useSignalStream(): void {
                 host: status.host,
                 port: status.port,
                 hostId: status.hostId,
-                authSecret: status.authSecret,
               });
               if (!cancelled) {
                 setRuntimeTargetHydrated(true);

--- a/tests/unit/adapters/eventlog-rt-adapter.test.ts
+++ b/tests/unit/adapters/eventlog-rt-adapter.test.ts
@@ -239,7 +239,7 @@ describe('EventLogRtAdapter（RT 事件日志适配器）', () => {
     expect(appended.id).toBe('rt-event-2');
   });
 
-  it('sends embedded runtime auth token when cached status has authSecret（内嵌 RT 鉴权密钥应透传到 EventLog 请求）', async () => {
+  it('does not send embedded runtime auth token from cached status（不再从缓存的内嵌 RT 状态透传鉴权密钥）', async () => {
     activateProfileScope();
     Object.defineProperty(window, '__TAURI_INTERNALS__', {
       configurable: true,
@@ -278,6 +278,6 @@ describe('EventLogRtAdapter（RT 事件日志适配器）', () => {
     const headers = new Headers(requestInit?.headers);
     expect(headers.get('Accept')).toBe('application/json');
     expect(headers.get('Content-Type')).toBe('application/json');
-    expect(headers.get('Authorization')).toBe('Bearer embedded-secret');
+    expect(headers.get('Authorization')).toBeNull();
   });
 });

--- a/tests/unit/config/runtime-target.test.ts
+++ b/tests/unit/config/runtime-target.test.ts
@@ -19,13 +19,13 @@ describe('runtime target config（Runtime 目标配置）', () => {
     window.localStorage.clear();
   });
 
-  it('defaults to embedded runtime port（默认内嵌 runtime 端口）', () => {
+  it('defaults to current page port in web mode（Web 模式默认走当前页面端口）', () => {
     expect(getRuntimeTargetMode()).toBe('embedded');
     expect(getEmbeddedRuntimeNetworkMode()).toBe('local');
     expect(resolveEmbeddedRuntimeBindHost()).toBe('127.0.0.1');
     expect(getSelectedRuntimeTarget()).toMatchObject({
       mode: 'embedded',
-      port: DEFAULT_EMBEDDED_RUNTIME_PORT,
+      port: Number(window.location.port),
     });
   });
 
@@ -42,7 +42,12 @@ describe('runtime target config（Runtime 目标配置）', () => {
     });
   });
 
-  it('prefers cached embedded runtime status（优先使用缓存的内嵌 runtime 状态）', () => {
+  it('prefers cached embedded runtime status without exposing auth token（优先使用缓存的内嵌 runtime 状态且不暴露鉴权 token）', () => {
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    });
+
     window.localStorage.setItem(
       EMBEDDED_RUNTIME_STATUS_STORAGE_KEY,
       JSON.stringify({
@@ -56,8 +61,9 @@ describe('runtime target config（Runtime 目标配置）', () => {
       mode: 'embedded',
       host: '127.0.0.1',
       port: 4077,
-      authToken: 'embedded-secret',
     });
+    expect(getSelectedRuntimeTarget().authToken).toBeUndefined();
+    expect(window.localStorage.getItem(EMBEDDED_RUNTIME_STATUS_STORAGE_KEY)).not.toContain('"authSecret"');
   });
 
   it('persists embedded runtime LAN bind mode（保存内嵌 Runtime 局域网监听模式）', () => {
@@ -103,4 +109,3 @@ describe('runtime target config（Runtime 目标配置）', () => {
     expect(() => setRuntimeExternalAddress('127.0.0.1:70000')).toThrow();
   });
 });
-

--- a/tests/unit/lib/tauri-runtime-adapter.test.ts
+++ b/tests/unit/lib/tauri-runtime-adapter.test.ts
@@ -15,7 +15,7 @@ describe('TauriRuntimeAdapter（Tauri 运行时适配器）', () => {
     window.localStorage.clear();
   });
 
-  it('persists authSecret from runtime status（持久化运行时鉴权密钥）', async () => {
+  it('does not persist authSecret from runtime status（不再持久化运行时鉴权密钥）', async () => {
     invokeMock.mockResolvedValue({
       running: true,
       host: '127.0.0.1',
@@ -27,6 +27,6 @@ describe('TauriRuntimeAdapter（Tauri 运行时适配器）', () => {
     const adapter = new TauriRuntimeAdapter();
     await adapter.getStatus();
 
-    expect(window.localStorage.getItem(EMBEDDED_RUNTIME_STATUS_STORAGE_KEY)).toContain('"authSecret":"embedded-secret"');
+    expect(window.localStorage.getItem(EMBEDDED_RUNTIME_STATUS_STORAGE_KEY)).not.toContain('"authSecret"');
   });
 });

--- a/tests/unit/services/runtime-mesh-sync.service.test.ts
+++ b/tests/unit/services/runtime-mesh-sync.service.test.ts
@@ -122,4 +122,23 @@ describe('runtime mesh sync service（Runtime Mesh 自动配对）', () => {
       'initiatePairing failed: POST http://127.0.0.1:4077/mesh/pairing/initiate -> HTTP 401 Unauthorized, auth=missing, body=missing bearer token',
     );
   });
+
+  it('omits authorization header for local mesh discovery when auth token is absent（本地 mesh 发现无 token 时不发送 Authorization 头）', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ([]),
+    }));
+    const service = new RuntimeMeshSyncService({ fetchImpl });
+
+    await service.listDiscoveredPeers('http://127.0.0.1:4077', undefined);
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://127.0.0.1:4077/mesh/discovered',
+      expect.objectContaining({
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+      }),
+    );
+  });
 });

--- a/tests/unit/ui/peer-pairing-dialog.test.tsx
+++ b/tests/unit/ui/peer-pairing-dialog.test.tsx
@@ -83,6 +83,39 @@ describe('PeerPairingDialog（设备配对弹窗）', () => {
     });
   });
 
+  it('refreshes responder discovery without local auth token after hotfix（热修后无本地 token 也按新链路刷新发现列表）', async () => {
+    listDiscoveredPeersMock.mockResolvedValue([]);
+
+    render(
+      <PeerPairingDialog
+        open
+        onOpenChange={() => {}}
+        runtimeBaseUrl="http://127.0.0.1:4077"
+        localHostId="desktop-host"
+        localAuthToken={undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '响应配对 扫描局域网设备，输入对方的 PIN 码' }));
+
+    await waitFor(() => {
+      expect(listDiscoveredPeersMock).toHaveBeenCalledWith(
+        'http://127.0.0.1:4077',
+        undefined,
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '刷新' }));
+
+    await waitFor(() => {
+      expect(listDiscoveredPeersMock).toHaveBeenNthCalledWith(
+        2,
+        'http://127.0.0.1:4077',
+        undefined,
+      );
+    });
+  });
+
   it('enters pin input mode after selecting a discovered peer（选择已发现设备后进入 PIN 输入态）', async () => {
     listDiscoveredPeersMock.mockResolvedValue([
       {

--- a/tests/unit/ui/use-signal-stream.m4.test.tsx
+++ b/tests/unit/ui/use-signal-stream.m4.test.tsx
@@ -210,11 +210,11 @@ describe('useSignalStream m4（SSE Runtime 目标切换）', () => {
         host: '127.0.0.1',
         port: 48202,
         isLocal: true,
-        authToken: 'embedded-secret',
       }),
     });
+    expect((signalServiceOptions[0].host as { authToken?: string }).authToken).toBeUndefined();
     expect(window.localStorage.getItem(EMBEDDED_RUNTIME_STATUS_STORAGE_KEY)).toContain('"port":48202');
-    expect(window.localStorage.getItem(EMBEDDED_RUNTIME_STATUS_STORAGE_KEY)).toContain('"authSecret":"embedded-secret"');
+    expect(window.localStorage.getItem(EMBEDDED_RUNTIME_STATUS_STORAGE_KEY)).not.toContain('"authSecret"');
   });
 
   it('bridges eventlog.appended into EventLogService（把 eventlog.appended 桥接进 EventLogService）', async () => {


### PR DESCRIPTION
## Summary
- stop returning embedded runtime `auth_secret` to the frontend and stop persisting it in `localStorage`
- tighten runtime auth/CORS for embedded local UI and clear legacy cached `authSecret` values
- prevent LAN-bound runtime startup without an admin secret by generating an ephemeral secret when needed

## Test Plan
- [x] `cargo test -p exomind-runtime --test auth_middleware`
- [x] `cargo test -p exomind-runtime agents_endpoint_`
- [x] `cargo test -p exomind-runtime pairing_initiate_preflight_allows_trusted_local_origin`
- [x] `cargo test -p exomind-runtime ensure_auth_secret_for_`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml runtime_commands`
- [x] `bunx vitest run tests/unit/services/runtime-mesh-sync.service.test.ts tests/unit/ui/peer-pairing-dialog.test.tsx tests/unit/ui/use-signal-stream.m4.test.tsx tests/unit/adapters/eventlog-rt-adapter.test.ts tests/unit/lib/tauri-runtime-adapter.test.ts tests/unit/config/runtime-target.test.ts`
- [ ] `bunx tsc --noEmit` (blocked by pre-existing errors in `src/ui/app/pages/goals/goal-force-layout.ts`)

Closes #768