### PR TITLE
fix: isolate Windows Tauri dev instance state

### DIFF
--- a/docs/plans/2026-03-30-issue-776-windows-dev-instance-isolation-plan.md
+++ b/docs/plans/2026-03-30-issue-776-windows-dev-instance-isolation-plan.md
@@ -1,0 +1,268 @@
+# Issue #776 Windows Dev Instance Isolation Implementation Plan
+
+> **For Claude / Codex:** REQUIRED SUB-SKILL: Use superpowers:executing-plans or equivalent disciplined execution workflow to implement this plan task-by-task.
+
+**Goal:** 修复 Windows 下多个 worktree / manager 启动的 Tauri dev 实例共享 `WebView2 data dir（WebView2 数据目录）`、`app data dir（应用数据目录）`、`runtime dir（运行时目录）` 导致的白屏、窗口串状态、实例互相污染问题。
+
+**Architecture:** 本次只做 `dev-only instance isolation（仅开发态实例隔离）`，不改发布版 `identifier`，也不提前重构 `config / sqlite（配置 / SQLite）` 模块。由 `tauri-wrapper.ps1` 计算实例专属目录并注入环境变量；Tauri 主窗口和 overlay 显式落到实例级目录；Rust 侧统一从实例级 `app data / runtime` 读写；首次启动新实例目录时，从旧共享 runtime 目录做一次性 `seed / bootstrap copy（播种 / 首次复制）`。播种只复制用户数据快照，不复制 `device_id` 这类逻辑实例身份。
+
+**Tech Stack:** PowerShell, Bun, TypeScript, Tauri v2, Rust, WebView2
+
+---
+
+## Scope Guardrails（范围护栏）
+
+1. 只解决 `#776` 根因：Windows 多实例共享目录。
+2. 不在本次 PR 中合入或预实现 `PR758 / issue-756` 的大规模 `config.sqlite` 迁移。
+3. 允许为后续 `config.sqlite` 接入预留扩展点，但当前不依赖它。
+4. 不修复与 `#776` 无关的仓库基线 `tsc` 红灯；验证以目标测试与真实实例复现为准。
+
+---
+
+### Task 1: 固化实例路径契约（instance path contract，实例路径约定）
+
+**Files:**
+- Create: `scripts/dev/tauri-dev-instance-paths.ts`
+- Test: `tests/unit/scripts/tauri-dev-instance-paths.test.ts`
+- Modify: `scripts/dev/tauri-wrapper.ps1`
+
+**Step 1: 写失败测试**
+
+覆盖这些行为：
+
+1. 同一项目根目录下，不同 `EXOMIND_TAURI_INSTANCE_NAME` 得到不同目录。
+2. 返回结构至少包含：
+   - `instanceName`
+   - `stateRootDir`
+   - `webviewMainDataDir`
+   - `webviewOverlayDataRoot`
+   - `appDataDir`
+   - `runtimeDataDir`
+   - `legacySharedAppDataDir`
+   - `legacySharedRuntimeDir`
+   - `mcpBridgeBasePort`
+3. `desktop` 与 `issue-773-node-first` 不会映射到相同路径。
+
+**Step 2: 跑测试确认先失败**
+
+Run: `npx vitest run tests/unit/scripts/tauri-dev-instance-paths.test.ts`
+
+Expected: `FAIL`
+
+**Step 3: 最小实现**
+
+让 helper 输出稳定 JSON，目录形态建议为：
+
+```json
+{
+  "instanceName": "desktop",
+  "stateRootDir": "<project>/.tmp/tauri-dev-state/desktop",
+  "webviewMainDataDir": "<project>/.tmp/tauri-dev-state/desktop/webview/main",
+  "webviewOverlayDataRoot": "<project>/.tmp/tauri-dev-state/desktop/webview/overlay",
+  "appDataDir": "<project>/.tmp/tauri-dev-state/desktop/app-data",
+  "runtimeDataDir": "<project>/.tmp/tauri-dev-state/desktop/app-data/runtime",
+  "legacySharedAppDataDir": "%APPDATA%/com.exomind.app",
+  "legacySharedRuntimeDir": "%APPDATA%/com.exomind.app/runtime",
+  "mcpBridgeBasePort": 9223
+}
+```
+
+**Step 4: 测试转绿**
+
+Run: `npx vitest run tests/unit/scripts/tauri-dev-instance-paths.test.ts`
+
+Expected: `PASS`
+
+**Step 5: wrapper 接线**
+
+让 `scripts/dev/tauri-wrapper.ps1` 调用 helper 并设置：
+
+1. `EXOMIND_DEV_INSTANCE_NAME`
+2. `EXOMIND_DEV_APP_DATA_DIR`
+3. `EXOMIND_DEV_RUNTIME_DATA_DIR`
+4. `EXOMIND_DEV_WEBVIEW_MAIN_DATA_DIR`
+5. `EXOMIND_DEV_WEBVIEW_OVERLAY_DATA_ROOT`
+6. `EXOMIND_DEV_LEGACY_SHARED_APP_DATA_DIR`
+7. `EXOMIND_DEV_LEGACY_SHARED_RUNTIME_DIR`
+8. `EXOMIND_MCP_BRIDGE_BASE_PORT`
+
+---
+
+### Task 2: 先补首次播种（seed old runtime once，旧 runtime 首次播种）
+
+**Files:**
+- Create: `src-tauri/src/dev_instance_paths.rs`
+- Modify: `src-tauri/src/lib.rs`
+- Test: `src-tauri/src/dev_instance_paths.rs` 内联测试
+
+**Step 1: 写失败测试**
+
+至少覆盖：
+
+1. 当实例 `runtime` 目录为空、旧共享 `runtime` 存在时，会把允许复制的文件复制过去。
+2. 当实例 `runtime` 已有文件时，不会被旧共享目录覆盖。
+3. 当前允许复制的文件白名单至少包括：
+   - `signal-pool.sqlite`
+   - `eventlog.sqlite`
+   - `tasks.sqlite`
+   - `timeblocks.sqlite`
+   - `sessions.sqlite`
+   - `runtime-network-mode.json`
+   - `runtime-target-mode.json`
+4. 未命中白名单的文件不会被盲目整目录拷贝。
+
+**Step 2: 跑 Rust 单测确认先失败**
+
+Run: `cargo test dev_instance_paths --manifest-path src-tauri/Cargo.toml`
+
+Expected: `FAIL`
+
+**Step 3: 最小实现**
+
+新增统一 helper，例如：
+
+```rust
+pub fn resolve_instance_app_data_dir(app: &AppHandle) -> Result<PathBuf, String>
+pub fn resolve_instance_runtime_dir(app: &AppHandle) -> Result<PathBuf, String>
+pub fn seed_instance_runtime_dir_if_needed(runtime_dir: &Path, legacy_runtime_dir: &Path) -> Result<(), String>
+```
+
+其中 `seed_instance_runtime_dir_if_needed` 规则：
+
+1. 只在目标 runtime 目录不存在或为空时执行。
+2. 只复制白名单文件。
+3. 不覆盖目标已有文件。
+4. 打日志说明是否 `seeded / skipped（已播种 / 跳过）`。
+
+**Step 4: 单测转绿**
+
+Run: `cargo test dev_instance_paths --manifest-path src-tauri/Cargo.toml`
+
+Expected: `PASS`
+
+**Step 5: Tauri setup 接线**
+
+在 `src-tauri/src/lib.rs` setup 早期：
+
+1. 优先解析实例级 `appDataDir / runtimeDir`
+2. 先执行一次播种
+3. 再设置 `EXOMIND_RT_DATA_DIR` 与各个 SQLite env path
+
+---
+
+### Task 3: Rust 命令层统一切到实例目录
+
+**Files:**
+- Modify: `src-tauri/src/commands/runtime_commands.rs`
+- Modify: `src-tauri/src/commands/device_commands.rs`
+- Modify: `src-tauri/src/commands/eventlog_commands.rs`
+- Modify: `src-tauri/src/commands/file_commands.rs`
+
+**Step 1: 写失败测试或补现有测试**
+
+至少证明这些命令不再直接依赖 `app.path().app_data_dir()` 的共享默认路径，而是走实例级 helper。
+
+**Step 2: 最小实现**
+
+把现有直接调用：
+
+```rust
+app.path().app_data_dir()
+```
+
+的地方替换为统一 helper。
+
+**Step 3: 跑定向测试**
+
+Run: `cargo test runtime_commands --manifest-path src-tauri/Cargo.toml`
+
+Run: `cargo test eventlog_commands --manifest-path src-tauri/Cargo.toml`
+
+Expected: `PASS` 或无回归
+
+---
+
+### Task 4: 隔离主窗口 / overlay / MCP Bridge
+
+**Files:**
+- Modify: `scripts/dev/tauri-wrapper.ps1`
+- Modify: `src-tauri/src/commands/shortcut_commands.rs`
+- Modify: `src-tauri/src/commands/now_workbench_overlay_commands.rs`
+- Modify: `src-tauri/src/lib.rs`
+
+**Step 1: 写失败测试或脚本级验证**
+
+至少覆盖：
+
+1. 主窗口 `main` 有实例级 `dataDirectory`
+2. `voice-overlay`
+3. `now-workbench-overlay`
+
+都显式绑定到实例级 data dir
+
+**Step 2: 最小实现**
+
+1. 在 wrapper 生成的临时 Tauri config 中给 `main` 注入 `dataDirectory`
+2. 在 overlay builder 上显式加 `.data_directory(...)`
+3. MCP Bridge 读取 `EXOMIND_MCP_BRIDGE_BASE_PORT`
+
+**Step 3: 手动真实验证**
+
+启动两个 worktree：
+
+```powershell
+bun run tauri:manager -- start --name desktop --web-port 1420 --hmr-port 1421
+bun run tauri:manager -- start --name issue-773-node-first --web-port 1430 --hmr-port 1431
+```
+
+验证：
+
+1. 两边都能起
+2. `msedgewebview2.exe` 的 `--user-data-dir` 不再共用
+3. 当前 `dev` 不会因另一边启动而白屏
+4. overlay 不再因为共享状态飞到别的实例布局里
+
+---
+
+### Task 5: 计划内评审与验证收口
+
+**Files:**
+- Modify: `docs/plans/2026-03-30-issue-776-windows-dev-instance-isolation-plan.md`
+- Optional: `docs/issues` / PR 描述草稿
+
+**Step 1: 自查 diff**
+
+重点检查：
+
+1. 没有把 `PR758 / issue-756` 的大范围 config 改造带进来
+2. 没有修改发布版 `identifier`
+3. 没有引入对其他 worktree 进程的清理逻辑
+
+**Step 2: 运行 fresh verification**
+
+至少记录：
+
+1. `npx vitest run tests/unit/scripts/tauri-dev-instance-paths.test.ts`
+2. `cargo test dev_instance_paths --manifest-path src-tauri/Cargo.toml`
+3. 与 `#776` 直接相关的新增 / 修改测试
+4. 真实双实例复现实验的命令与结果
+
+**Step 3: 整理提交**
+
+提交信息建议：
+
+```bash
+git commit -m "fix(dev): isolate windows tauri instance state"
+```
+
+**Step 4: 人工评审交接**
+
+给用户的交接信息必须包含：
+
+1. worktree 路径
+2. 分支名
+3. 核心改动范围
+4. 已验证命令与结果
+5. 当前仍未处理的 follow-up：
+   - `PR758 / issue-756` 合并后的 `config.sqlite` 接入
+   - 剩余前端 settings 快照迁移

--- a/scripts/dev/tauri-dev-instance-paths.ts
+++ b/scripts/dev/tauri-dev-instance-paths.ts
@@ -1,0 +1,89 @@
+#!/usr/bin/env bun
+
+import path from 'node:path';
+
+type EnvLike = Record<string, string | undefined>;
+
+export type TauriDevInstancePaths = {
+  instanceName: string;
+  stateRootDir: string;
+  webviewMainDataDir: string;
+  webviewOverlayDataRoot: string;
+  appDataDir: string;
+  runtimeDataDir: string;
+  legacySharedAppDataDir: string;
+  legacySharedRuntimeDir: string;
+  mcpBridgeBasePort: number;
+};
+
+function sanitizeInstanceSegment(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return normalized || 'default';
+}
+
+export function resolveTauriDevInstanceName(env: EnvLike): string {
+  const explicitName = env.EXOMIND_TAURI_INSTANCE_NAME?.trim();
+  if (explicitName) {
+    return sanitizeInstanceSegment(explicitName);
+  }
+
+  const webPort = env.EXOMIND_WEB_PORT?.trim();
+  if (webPort && /^\d+$/.test(webPort)) {
+    return `web-${webPort}`;
+  }
+
+  return 'default';
+}
+
+function resolveMcpBridgeBasePort(env: EnvLike): number {
+  const webPort = env.EXOMIND_WEB_PORT?.trim();
+  if (webPort && /^\d+$/.test(webPort)) {
+    const parsed = Number.parseInt(webPort, 10);
+    return 9223 + Math.max(0, parsed - 1420);
+  }
+
+  return 9223;
+}
+
+export function resolveTauriDevInstancePaths(
+  projectRoot: string,
+  env: EnvLike,
+): TauriDevInstancePaths {
+  const instanceName = resolveTauriDevInstanceName(env);
+  const resolvedProjectRoot = path.resolve(projectRoot);
+  const stateRootDir = path.join(
+    resolvedProjectRoot,
+    '.tmp',
+    'tauri-dev-state',
+    instanceName,
+  );
+  const appDataDir = path.join(stateRootDir, 'app-data');
+  const runtimeDataDir = path.join(appDataDir, 'runtime');
+  const legacySharedAppDataDir = path.join(
+    env.APPDATA?.trim() || env.LOCALAPPDATA?.trim() || '',
+    'com.exomind.app',
+  );
+
+  return {
+    instanceName,
+    stateRootDir,
+    webviewMainDataDir: path.join(stateRootDir, 'webview', 'main'),
+    webviewOverlayDataRoot: path.join(stateRootDir, 'webview', 'overlay'),
+    appDataDir,
+    runtimeDataDir,
+    legacySharedAppDataDir,
+    legacySharedRuntimeDir: path.join(legacySharedAppDataDir, 'runtime'),
+    mcpBridgeBasePort: resolveMcpBridgeBasePort(env),
+  };
+}
+
+if (import.meta.main) {
+  const projectRoot = process.argv[2]?.trim() || process.cwd();
+  const payload = resolveTauriDevInstancePaths(projectRoot, process.env);
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+}

--- a/scripts/dev/tauri-wrapper.ps1
+++ b/scripts/dev/tauri-wrapper.ps1
@@ -430,6 +430,30 @@ function Resolve-TauriDevTargetDir {
   Write-Host "[tauri-wrapper] Cargo target dir resolved: $resolved"
 }
 
+function Resolve-TauriDevInstancePaths {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ProjectRoot
+  )
+
+  $scriptPath = Join-Path $PSScriptRoot "tauri-dev-instance-paths.ts"
+  if (-not (Test-Path -LiteralPath $scriptPath)) {
+    throw "tauri dev instance path resolver script not found: $scriptPath"
+  }
+
+  $raw = (& bun $scriptPath $ProjectRoot 2>$null | Select-Object -First 1)
+  if (-not $raw) {
+    throw "failed to resolve tauri dev instance paths"
+  }
+
+  $payload = $raw.Trim() | ConvertFrom-Json
+  if (-not $payload) {
+    throw "resolved tauri dev instance path payload is empty"
+  }
+
+  return $payload
+}
+
 function Test-TruthyEnvValue {
   param(
     [string]$Value
@@ -720,6 +744,27 @@ if ($isTauriDev) {
   Resolve-FreeDevPort
   Resolve-EmbeddedRuntimePort
   Resolve-TauriDevTargetDir -ProjectRoot $projectRoot
+
+  $instancePaths = Resolve-TauriDevInstancePaths -ProjectRoot $projectRoot
+  $env:EXOMIND_DEV_INSTANCE_NAME = "$($instancePaths.instanceName)"
+  $env:EXOMIND_DEV_APP_DATA_DIR = "$($instancePaths.appDataDir)"
+  $env:EXOMIND_DEV_RUNTIME_DATA_DIR = "$($instancePaths.runtimeDataDir)"
+  $env:EXOMIND_DEV_WEBVIEW_MAIN_DATA_DIR = "$($instancePaths.webviewMainDataDir)"
+  $env:EXOMIND_DEV_WEBVIEW_OVERLAY_DATA_ROOT = "$($instancePaths.webviewOverlayDataRoot)"
+  $env:EXOMIND_DEV_LEGACY_SHARED_APP_DATA_DIR = "$($instancePaths.legacySharedAppDataDir)"
+  $env:EXOMIND_DEV_LEGACY_SHARED_RUNTIME_DIR = "$($instancePaths.legacySharedRuntimeDir)"
+  $env:EXOMIND_MCP_BRIDGE_BASE_PORT = "$($instancePaths.mcpBridgeBasePort)"
+
+  foreach ($dir in @(
+    $env:EXOMIND_DEV_APP_DATA_DIR,
+    $env:EXOMIND_DEV_RUNTIME_DATA_DIR,
+    $env:EXOMIND_DEV_WEBVIEW_MAIN_DATA_DIR,
+    $env:EXOMIND_DEV_WEBVIEW_OVERLAY_DATA_ROOT
+  )) {
+    if (-not [string]::IsNullOrWhiteSpace($dir)) {
+      New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+  }
 }
 
 # Sync launcher icons before android build/dev/run/init (构建前同步 Android 图标)
@@ -738,12 +783,20 @@ try {
   if ($TauriArgs -and $TauriArgs.Count -gt 0) {
     $tauriCommandArgs = Add-TauriDevDefaultFlags -CommandArgs $TauriArgs
 
-    # Inject --config to override devUrl when port differs from default
-    # (端口非默认值时，通过 --config 覆盖 devUrl)
-    if ($isTauriDev -and $env:EXOMIND_WEB_PORT -and $env:EXOMIND_WEB_PORT -ne "1420") {
+    # Inject --config for devUrl override only
+    #（仅通过 --config 覆盖 devUrl；主窗口 data directory 走 Rust builder 绝对路径注入）
+    if ($isTauriDev) {
       $tempConfigPath = Join-Path $env:TEMP ("exomind-tauri-dev-config-{0}.json" -f [Guid]::NewGuid().ToString("N"))
-      $devUrlOverride = '{"build":{"devUrl":"http://localhost:' + $env:EXOMIND_WEB_PORT + '"}}'
-      Write-TextUtf8NoBom -Path $tempConfigPath -Content $devUrlOverride
+      $tempConfig = @{}
+
+      if ($env:EXOMIND_WEB_PORT) {
+        $tempConfig.build = @{
+          devUrl = "http://localhost:$($env:EXOMIND_WEB_PORT)"
+        }
+      }
+
+      $devConfigOverride = $tempConfig | ConvertTo-Json -Compress -Depth 10
+      Write-TextUtf8NoBom -Path $tempConfigPath -Content $devConfigOverride
       $tauriCommandArgs += @("--config", $tempConfigPath)
     }
   }

--- a/src-tauri/src/commands/device_commands.rs
+++ b/src-tauri/src/commands/device_commands.rs
@@ -1,16 +1,14 @@
 //! 设备标识命令
 //! 提供稳定 device id（持久化到 app data）
 
+use crate::dev_instance_paths::resolve_instance_app_data_dir;
 use std::fs;
 use std::path::PathBuf;
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 use uuid::Uuid;
 
 fn resolve_device_id_path(app: &AppHandle) -> Result<PathBuf, String> {
-    let data_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|err| format!("failed to resolve app data dir: {err}"))?;
+    let data_dir = resolve_instance_app_data_dir(app)?;
 
     if !data_dir.exists() {
         fs::create_dir_all(&data_dir)

--- a/src-tauri/src/commands/eventlog_commands.rs
+++ b/src-tauri/src/commands/eventlog_commands.rs
@@ -1,11 +1,12 @@
 //! EventLog 命令
 //! 提供 Tauri 端最小闭环：append/list/get/clear + markdown mirror
 
+use crate::dev_instance_paths::resolve_instance_app_data_dir;
 use chrono::{TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 const EVENTLOG_DIR_NAME: &str = "eventlog";
 const MIRROR_HEADER: &str = "# EventLog Mirror\n\n";
@@ -62,11 +63,7 @@ fn sanitize_user_id(user_id: Option<&str>) -> String {
 }
 
 fn resolve_eventlog_dir(app: &AppHandle) -> Result<PathBuf, String> {
-    let data_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|err| format!("failed to resolve app data dir: {err}"))?;
-
+    let data_dir = resolve_instance_app_data_dir(app)?;
     let eventlog_dir = data_dir.join(EVENTLOG_DIR_NAME);
     if !eventlog_dir.exists() {
         fs::create_dir_all(&eventlog_dir)

--- a/src-tauri/src/commands/file_commands.rs
+++ b/src-tauri/src/commands/file_commands.rs
@@ -1,10 +1,11 @@
 //! 文件操作命令
 //! 用于消息持久化存储 - 重构版（同步版本）
 
+use crate::dev_instance_paths::resolve_instance_app_data_dir;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
-use tauri::{ipc::InvokeError, AppHandle, Manager};
+use tauri::{ipc::InvokeError, AppHandle};
 use tauri_plugin_dialog::{DialogExt, FilePath};
 use tauri_plugin_fs::{FsExt, OpenOptions};
 use thiserror::Error;
@@ -45,9 +46,9 @@ impl std::convert::From<FileError> for InvokeError {
 
 /// 获取应用数据目录
 fn get_data_dir(app: &AppHandle) -> Result<PathBuf, FileError> {
-    let path = app.path().app_data_dir().map_err(|e| FileError::IoError {
+    let path = resolve_instance_app_data_dir(app).map_err(|e| FileError::IoError {
         message: format!("获取应用数据目录失败: {}", e),
-        source: std::io::Error::new(std::io::ErrorKind::Other, e.to_string()),
+        source: std::io::Error::other(e),
     })?;
 
     // 确保目录存在
@@ -538,10 +539,7 @@ pub fn save_binary_file(
     default_name: String,
     filters: Option<Vec<String>>,
 ) -> FileResult<Option<String>> {
-    let mut dialog = app
-        .dialog()
-        .file()
-        .set_file_name(&default_name);
+    let mut dialog = app.dialog().file().set_file_name(&default_name);
 
     if let Some(filters) = filters.as_ref() {
         if !filters.is_empty() {

--- a/src-tauri/src/commands/now_workbench_overlay_commands.rs
+++ b/src-tauri/src/commands/now_workbench_overlay_commands.rs
@@ -1,6 +1,8 @@
 use tauri::AppHandle;
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
+use crate::dev_instance_paths::resolve_overlay_webview_data_dir;
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 use tauri::{Manager, PhysicalPosition, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -42,6 +44,14 @@ pub fn ensure_now_workbench_overlay_window(app: &AppHandle) -> Result<(), String
 
     #[cfg(not(target_os = "macos"))]
     let builder = builder.transparent(true);
+
+    let builder = if let Some(data_dir) =
+        resolve_overlay_webview_data_dir(NOW_WORKBENCH_OVERLAY_WINDOW_LABEL)
+    {
+        builder.data_directory(data_dir)
+    } else {
+        builder
+    };
 
     let window = builder.build().map_err(|error| error.to_string())?;
     position_now_workbench_overlay_default(app, &window)

--- a/src-tauri/src/commands/runtime_commands.rs
+++ b/src-tauri/src/commands/runtime_commands.rs
@@ -1,6 +1,7 @@
 //! Runtime 服务命令（embedded mode，内嵌模式）
 //! 提供桌面端 Runtime 的启动、停止与状态查询。
 
+use crate::dev_instance_paths::resolve_instance_app_data_dir;
 use chrono::Utc;
 use exomind_android_keepalive::AndroidRuntimeKeepaliveExt;
 use exomind_runtime::{
@@ -11,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, ToSocketAddrs, UdpSocket};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use tauri::{AppHandle, Manager, State};
+use tauri::{AppHandle, State};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::time::{sleep, timeout, Duration};
 
@@ -219,18 +220,12 @@ fn save_runtime_target_mode_to_path(path: &Path, mode: RuntimeTargetMode) -> Res
 }
 
 pub fn load_persisted_runtime_network_mode(app: &AppHandle) -> Result<RuntimeNetworkMode, String> {
-    let app_data_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|error| format!("failed to resolve app data dir: {error}"))?;
+    let app_data_dir = resolve_instance_app_data_dir(app)?;
     load_runtime_network_mode_from_path(&runtime_network_mode_path(&app_data_dir))
 }
 
 pub fn load_persisted_runtime_target_mode(app: &AppHandle) -> Result<RuntimeTargetMode, String> {
-    let app_data_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|error| format!("failed to resolve app data dir: {error}"))?;
+    let app_data_dir = resolve_instance_app_data_dir(app)?;
     load_runtime_target_mode_from_path(&runtime_target_mode_path(&app_data_dir))
 }
 
@@ -238,10 +233,7 @@ fn save_persisted_runtime_network_mode(
     app: &AppHandle,
     mode: RuntimeNetworkMode,
 ) -> Result<RuntimeNetworkMode, String> {
-    let app_data_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|error| format!("failed to resolve app data dir: {error}"))?;
+    let app_data_dir = resolve_instance_app_data_dir(app)?;
     save_runtime_network_mode_to_path(&runtime_network_mode_path(&app_data_dir), mode)?;
     Ok(mode)
 }
@@ -250,10 +242,7 @@ fn save_persisted_runtime_target_mode(
     app: &AppHandle,
     mode: RuntimeTargetMode,
 ) -> Result<RuntimeTargetMode, String> {
-    let app_data_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|error| format!("failed to resolve app data dir: {error}"))?;
+    let app_data_dir = resolve_instance_app_data_dir(app)?;
     save_runtime_target_mode_to_path(&runtime_target_mode_path(&app_data_dir), mode)?;
     Ok(mode)
 }

--- a/src-tauri/src/commands/shortcut_commands.rs
+++ b/src-tauri/src/commands/shortcut_commands.rs
@@ -1,10 +1,11 @@
-use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use std::sync::atomic::AtomicI32;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
-use tauri::{AppHandle, State};
+use crate::dev_instance_paths::resolve_overlay_webview_data_dir;
 use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, State};
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 use tauri::{Emitter, Manager, PhysicalPosition, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
@@ -298,6 +299,13 @@ pub fn ensure_voice_overlay_window(app: &AppHandle) -> Result<(), String> {
 
     #[cfg(not(target_os = "macos"))]
     let builder = builder.transparent(true);
+
+    let builder =
+        if let Some(data_dir) = resolve_overlay_webview_data_dir(VOICE_OVERLAY_WINDOW_LABEL) {
+            builder.data_directory(data_dir)
+        } else {
+            builder
+        };
 
     let window = builder.build().map_err(|error| error.to_string())?;
 

--- a/src-tauri/src/dev_instance_paths.rs
+++ b/src-tauri/src/dev_instance_paths.rs
@@ -1,0 +1,504 @@
+use std::path::{Path, PathBuf};
+use tauri::{AppHandle, Manager};
+
+pub const DEV_APP_DATA_DIR_ENV: &str = "EXOMIND_DEV_APP_DATA_DIR";
+pub const DEV_RUNTIME_DATA_DIR_ENV: &str = "EXOMIND_DEV_RUNTIME_DATA_DIR";
+pub const DEV_WEBVIEW_MAIN_DATA_DIR_ENV: &str = "EXOMIND_DEV_WEBVIEW_MAIN_DATA_DIR";
+pub const DEV_WEBVIEW_OVERLAY_DATA_ROOT_ENV: &str = "EXOMIND_DEV_WEBVIEW_OVERLAY_DATA_ROOT";
+pub const DEV_LEGACY_SHARED_APP_DATA_DIR_ENV: &str = "EXOMIND_DEV_LEGACY_SHARED_APP_DATA_DIR";
+pub const DEV_LEGACY_SHARED_RUNTIME_DIR_ENV: &str = "EXOMIND_DEV_LEGACY_SHARED_RUNTIME_DIR";
+
+const RUNTIME_DIR_NAME: &str = "runtime";
+const APP_DATA_LEGACY_SEED_MARKER_NAME: &str = ".legacy-app-data-seeded";
+const RUNTIME_LEGACY_SEED_MARKER_NAME: &str = ".legacy-runtime-seeded";
+const APP_DATA_SEED_ENTRY_NAMES: &[&str] = &[".exomind", "eventlog", "settings"];
+const RUNTIME_SQLITE_BASENAMES: &[&str] = &[
+    "signal-pool.sqlite",
+    "eventlog.sqlite",
+    "tasks.sqlite",
+    "timeblocks.sqlite",
+    "sessions.sqlite",
+    "config.sqlite",
+];
+const RUNTIME_JSON_FILE_NAMES: &[&str] = &["runtime-network-mode.json", "runtime-target-mode.json"];
+const RUNTIME_DIR_ENTRY_NAMES: &[&str] = &["agents", "eventlog"];
+
+fn resolve_env_path(key: &str) -> Option<PathBuf> {
+    std::env::var_os(key)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn ensure_dir(path: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(path)
+        .map_err(|error| format!("failed to create dir {:?}: {error}", path))
+}
+
+pub fn resolve_instance_app_data_dir_with_fallback(fallback: &Path) -> PathBuf {
+    resolve_env_path(DEV_APP_DATA_DIR_ENV).unwrap_or_else(|| fallback.to_path_buf())
+}
+
+pub fn resolve_instance_runtime_dir_from_app_data_dir(app_data_dir: &Path) -> PathBuf {
+    if let Some(runtime_dir) = resolve_env_path(DEV_RUNTIME_DATA_DIR_ENV) {
+        return runtime_dir;
+    }
+
+    app_data_dir.join(RUNTIME_DIR_NAME)
+}
+
+pub fn resolve_instance_app_data_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let fallback = app
+        .path()
+        .app_data_dir()
+        .map_err(|error| format!("failed to resolve app data dir: {error}"))?;
+    let resolved = resolve_instance_app_data_dir_with_fallback(&fallback);
+    ensure_dir(&resolved)?;
+    Ok(resolved)
+}
+
+pub fn resolve_overlay_webview_data_dir(label: &str) -> Option<PathBuf> {
+    let root = resolve_env_path(DEV_WEBVIEW_OVERLAY_DATA_ROOT_ENV)?;
+    let resolved = root.join(label);
+    ensure_dir(&resolved).ok()?;
+    Some(resolved)
+}
+
+pub fn resolve_main_webview_data_dir() -> Option<PathBuf> {
+    let resolved = resolve_env_path(DEV_WEBVIEW_MAIN_DATA_DIR_ENV)?;
+    ensure_dir(&resolved).ok()?;
+    Some(resolved)
+}
+
+pub fn resolve_legacy_shared_app_data_dir() -> Option<PathBuf> {
+    resolve_env_path(DEV_LEGACY_SHARED_APP_DATA_DIR_ENV)
+}
+
+pub fn resolve_legacy_shared_runtime_dir() -> Option<PathBuf> {
+    resolve_env_path(DEV_LEGACY_SHARED_RUNTIME_DIR_ENV)
+}
+
+pub fn resolve_mcp_bridge_base_port() -> Option<u16> {
+    std::env::var("EXOMIND_MCP_BRIDGE_BASE_PORT")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u16>().ok())
+        .filter(|port| *port > 0)
+}
+
+fn runtime_seed_whitelist() -> Vec<String> {
+    let mut names = Vec::new();
+    for base in RUNTIME_SQLITE_BASENAMES {
+        names.push((*base).to_string());
+        names.push(format!("{base}-wal"));
+        names.push(format!("{base}-shm"));
+    }
+    for file_name in RUNTIME_JSON_FILE_NAMES {
+        names.push((*file_name).to_string());
+    }
+    names
+}
+
+fn app_data_seed_whitelist() -> Vec<String> {
+    APP_DATA_SEED_ENTRY_NAMES
+        .iter()
+        .map(|name| (*name).to_string())
+        .collect()
+}
+
+fn runtime_seed_entry_names() -> Vec<String> {
+    let mut names = runtime_seed_whitelist();
+    for entry_name in RUNTIME_DIR_ENTRY_NAMES {
+        names.push((*entry_name).to_string());
+    }
+    names
+}
+
+fn copy_missing_path_recursive(source_path: &Path, target_path: &Path) -> Result<(), String> {
+    if source_path.is_dir() {
+        ensure_dir(target_path)?;
+        let entries = std::fs::read_dir(source_path)
+            .map_err(|error| format!("failed to read legacy dir {:?}: {error}", source_path))?;
+
+        for entry in entries {
+            let entry = entry.map_err(|error| {
+                format!("failed to iterate legacy dir {:?}: {error}", source_path)
+            })?;
+            let child_source = entry.path();
+            let child_target = target_path.join(entry.file_name());
+            copy_missing_path_recursive(&child_source, &child_target)?;
+        }
+        return Ok(());
+    }
+
+    if source_path.is_file() {
+        if target_path.exists() {
+            return Ok(());
+        }
+        if let Some(parent) = target_path.parent() {
+            ensure_dir(parent)?;
+        }
+        std::fs::copy(source_path, target_path).map_err(|error| {
+            format!(
+                "failed to seed path {:?} -> {:?}: {error}",
+                source_path, target_path
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+fn seed_named_entries_if_missing(
+    target_root: &Path,
+    legacy_root: &Path,
+    entry_names: &[String],
+) -> Result<(), String> {
+    let mut errors = Vec::new();
+
+    for entry_name in entry_names {
+        let source_path = legacy_root.join(entry_name);
+        if !source_path.exists() {
+            continue;
+        }
+
+        let target_path = target_root.join(entry_name);
+        if let Err(error) = copy_missing_path_recursive(&source_path, &target_path) {
+            errors.push(error);
+        }
+    }
+
+    if !errors.is_empty() {
+        return Err(errors.join("; "));
+    }
+
+    Ok(())
+}
+
+fn write_seed_marker(target_dir: &Path, marker_name: &str) -> Result<(), String> {
+    std::fs::write(target_dir.join(marker_name), b"seeded\n").map_err(|error| {
+        format!(
+            "failed to write legacy seed marker {:?}: {error}",
+            target_dir.join(marker_name)
+        )
+    })
+}
+
+pub fn seed_instance_app_data_dir_if_needed(
+    app_data_dir: &Path,
+    legacy_app_data_dir: &Path,
+) -> Result<(), String> {
+    ensure_dir(app_data_dir)?;
+
+    let marker_path = app_data_dir.join(APP_DATA_LEGACY_SEED_MARKER_NAME);
+    if marker_path.exists() {
+        return Ok(());
+    }
+    if legacy_app_data_dir.exists() {
+        let entry_names = app_data_seed_whitelist();
+        seed_named_entries_if_missing(app_data_dir, legacy_app_data_dir, &entry_names)?;
+    }
+
+    write_seed_marker(app_data_dir, APP_DATA_LEGACY_SEED_MARKER_NAME)
+}
+
+pub fn seed_instance_runtime_dir_if_needed(
+    runtime_dir: &Path,
+    legacy_runtime_dir: &Path,
+) -> Result<(), String> {
+    ensure_dir(runtime_dir)?;
+
+    let marker_path = runtime_dir.join(RUNTIME_LEGACY_SEED_MARKER_NAME);
+    if marker_path.exists() {
+        return Ok(());
+    }
+    if legacy_runtime_dir.exists() {
+        let entry_names = runtime_seed_entry_names();
+        seed_named_entries_if_missing(runtime_dir, legacy_runtime_dir, &entry_names)?;
+    }
+
+    write_seed_marker(runtime_dir, RUNTIME_LEGACY_SEED_MARKER_NAME)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+    use std::fs;
+    use std::sync::Mutex;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard {
+        key: &'static str,
+        original: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: Option<&str>) -> Self {
+            let original = std::env::var_os(key);
+            match value {
+                Some(next) => unsafe { std::env::set_var(key, next) },
+                None => unsafe { std::env::remove_var(key) },
+            }
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    fn temp_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("exomind-{name}-{nanos}"))
+    }
+
+    #[test]
+    fn dev_instance_paths_env_override_wins_over_fallback() {
+        let _lock = ENV_MUTEX.lock().expect("env test lock should succeed");
+        let _guard = EnvGuard::set(
+            DEV_APP_DATA_DIR_ENV,
+            Some("D:/tmp/exomind-instance/app-data"),
+        );
+        let fallback = PathBuf::from("C:/Users/test/AppData/Local/com.exomind.app");
+
+        let resolved = resolve_instance_app_data_dir_with_fallback(&fallback);
+
+        assert_eq!(resolved, PathBuf::from("D:/tmp/exomind-instance/app-data"));
+    }
+
+    #[test]
+    fn dev_instance_paths_fallback_is_used_when_override_missing() {
+        let _lock = ENV_MUTEX.lock().expect("env test lock should succeed");
+        let _guard = EnvGuard::set(DEV_APP_DATA_DIR_ENV, None);
+        let fallback = PathBuf::from("C:/Users/test/AppData/Local/com.exomind.app");
+
+        let resolved = resolve_instance_app_data_dir_with_fallback(&fallback);
+
+        assert_eq!(resolved, fallback);
+    }
+
+    #[test]
+    fn dev_instance_paths_runtime_dir_defaults_to_app_data_runtime() {
+        let _lock = ENV_MUTEX.lock().expect("env test lock should succeed");
+        let _guard = EnvGuard::set(DEV_RUNTIME_DATA_DIR_ENV, None);
+        let app_data_dir = PathBuf::from("D:/tmp/exomind-instance/app-data");
+
+        let resolved = resolve_instance_runtime_dir_from_app_data_dir(&app_data_dir);
+
+        assert_eq!(resolved, app_data_dir.join("runtime"));
+    }
+
+    #[test]
+    fn dev_instance_paths_app_data_seed_copies_selected_entries_once() {
+        let app_data_dir = temp_path("app-data-seed-target");
+        let legacy_dir = temp_path("app-data-seed-legacy");
+        fs::create_dir_all(legacy_dir.join(".exomind")).expect("legacy .exomind dir should exist");
+        fs::create_dir_all(legacy_dir.join("settings")).expect("legacy settings dir should exist");
+        fs::create_dir_all(legacy_dir.join("eventlog")).expect("legacy eventlog dir should exist");
+        fs::create_dir_all(legacy_dir.join("runtime")).expect("legacy runtime dir should exist");
+
+        fs::write(
+            legacy_dir.join(".exomind").join("messages.jsonl"),
+            "legacy-messages",
+        )
+        .expect("legacy messages should be written");
+        fs::write(
+            legacy_dir.join("settings").join("runtime-target-mode.json"),
+            "{\"targetMode\":\"embedded\"}",
+        )
+        .expect("legacy settings should be written");
+        fs::write(
+            legacy_dir.join("eventlog").join("anonymous.md"),
+            "legacy-eventlog-md",
+        )
+        .expect("legacy eventlog markdown should be written");
+        fs::write(
+            legacy_dir.join("runtime").join("config.sqlite"),
+            "ignore-runtime",
+        )
+        .expect("legacy runtime file should be written");
+        fs::write(legacy_dir.join("cache.tmp"), "ignore-cache")
+            .expect("legacy cache file should be written");
+
+        seed_instance_app_data_dir_if_needed(&app_data_dir, &legacy_dir)
+            .expect("first app data seed should succeed");
+
+        assert_eq!(
+            fs::read_to_string(app_data_dir.join(".exomind").join("messages.jsonl"))
+                .expect("messages snapshot should exist"),
+            "legacy-messages"
+        );
+        assert_eq!(
+            fs::read_to_string(
+                app_data_dir
+                    .join("settings")
+                    .join("runtime-target-mode.json")
+            )
+            .expect("settings snapshot should exist"),
+            "{\"targetMode\":\"embedded\"}"
+        );
+        assert_eq!(
+            fs::read_to_string(app_data_dir.join("eventlog").join("anonymous.md"))
+                .expect("eventlog snapshot should exist"),
+            "legacy-eventlog-md"
+        );
+        assert!(
+            !app_data_dir.join("device_id.txt").exists(),
+            "device identity should stay instance-specific"
+        );
+        assert!(
+            !app_data_dir.join("runtime").exists(),
+            "runtime should be handled by dedicated runtime seeding"
+        );
+        assert!(
+            !app_data_dir.join("cache.tmp").exists(),
+            "non-whitelist root files must not be copied"
+        );
+
+        seed_instance_app_data_dir_if_needed(&app_data_dir, &legacy_dir)
+            .expect("second app data seed should be a no-op");
+
+        fs::remove_dir_all(&app_data_dir).ok();
+        fs::remove_dir_all(&legacy_dir).ok();
+    }
+
+    #[test]
+    fn dev_instance_paths_runtime_seed_copies_whitelist_once_without_overwriting() {
+        let runtime_dir = temp_path("runtime-seed-target");
+        let legacy_dir = temp_path("runtime-seed-legacy");
+        fs::create_dir_all(&legacy_dir).expect("legacy runtime dir should be created");
+        fs::create_dir_all(legacy_dir.join("agents").join("life-alpha"))
+            .expect("legacy agent dir should be created");
+        fs::create_dir_all(legacy_dir.join("eventlog"))
+            .expect("legacy runtime eventlog dir should exist");
+
+        fs::write(legacy_dir.join("eventlog.sqlite"), "legacy-eventlog")
+            .expect("legacy eventlog should be written");
+        fs::write(legacy_dir.join("tasks.sqlite"), "legacy-tasks")
+            .expect("legacy tasks should be written");
+        fs::write(
+            legacy_dir
+                .join("agents")
+                .join("life-alpha")
+                .join("agent.state.json"),
+            "{\"name\":\"life-alpha\"}",
+        )
+        .expect("legacy agent state should be written");
+        fs::write(
+            legacy_dir.join("eventlog").join("profile-v2.md"),
+            "legacy-eventlog-markdown",
+        )
+        .expect("legacy runtime eventlog markdown should be written");
+        fs::write(legacy_dir.join("note.txt"), "ignore-me")
+            .expect("non-whitelist file should be written");
+
+        seed_instance_runtime_dir_if_needed(&runtime_dir, &legacy_dir)
+            .expect("first seed should succeed");
+
+        let seeded_eventlog = fs::read_to_string(runtime_dir.join("eventlog.sqlite"))
+            .expect("eventlog sqlite should be copied on first seed");
+        assert_eq!(seeded_eventlog, "legacy-eventlog");
+        assert_eq!(
+            fs::read_to_string(
+                runtime_dir
+                    .join("agents")
+                    .join("life-alpha")
+                    .join("agent.state.json")
+            )
+            .expect("agent state snapshot should exist"),
+            "{\"name\":\"life-alpha\"}"
+        );
+        assert_eq!(
+            fs::read_to_string(runtime_dir.join("eventlog").join("profile-v2.md"))
+                .expect("runtime eventlog markdown snapshot should exist"),
+            "legacy-eventlog-markdown"
+        );
+        assert!(
+            !runtime_dir.join("note.txt").exists(),
+            "non-whitelist file must not be copied"
+        );
+
+        fs::write(runtime_dir.join("tasks.sqlite"), "instance-owned")
+            .expect("instance-owned file should be written");
+        fs::write(legacy_dir.join("tasks.sqlite"), "legacy-updated")
+            .expect("legacy tasks should be updated");
+
+        seed_instance_runtime_dir_if_needed(&runtime_dir, &legacy_dir)
+            .expect("second seed should succeed");
+
+        let preserved_tasks = fs::read_to_string(runtime_dir.join("tasks.sqlite"))
+            .expect("existing instance file should remain");
+        assert_eq!(preserved_tasks, "instance-owned");
+
+        fs::remove_dir_all(&runtime_dir).ok();
+        fs::remove_dir_all(&legacy_dir).ok();
+    }
+
+    #[test]
+    fn dev_instance_paths_runtime_seed_retries_when_some_entries_fail() {
+        let runtime_dir = temp_path("runtime-seed-retry-target");
+        let legacy_dir = temp_path("runtime-seed-retry-legacy");
+        fs::create_dir_all(&legacy_dir).expect("legacy runtime dir should be created");
+        fs::create_dir_all(legacy_dir.join("agents").join("life-alpha"))
+            .expect("legacy agent dir should be created");
+        fs::write(legacy_dir.join("eventlog.sqlite"), "legacy-eventlog")
+            .expect("legacy eventlog should be written");
+        fs::write(
+            legacy_dir
+                .join("agents")
+                .join("life-alpha")
+                .join("agent.state.json"),
+            "{\"name\":\"life-alpha\"}",
+        )
+        .expect("legacy agent state should be written");
+
+        fs::create_dir_all(&runtime_dir).expect("runtime target should be created");
+        fs::write(runtime_dir.join("agents"), "blocking-file")
+            .expect("blocking file should be created");
+
+        let first_seed = seed_instance_runtime_dir_if_needed(&runtime_dir, &legacy_dir);
+        assert!(
+            first_seed.is_err(),
+            "a conflicting target path should fail this seed attempt"
+        );
+        assert_eq!(
+            fs::read_to_string(runtime_dir.join("eventlog.sqlite"))
+                .expect("successful entries should still be copied"),
+            "legacy-eventlog"
+        );
+        assert!(
+            !runtime_dir.join(RUNTIME_LEGACY_SEED_MARKER_NAME).exists(),
+            "marker must stay absent so the next launch retries the missing entries"
+        );
+
+        fs::remove_file(runtime_dir.join("agents")).expect("blocking file should be removable");
+        seed_instance_runtime_dir_if_needed(&runtime_dir, &legacy_dir)
+            .expect("seed should succeed after the blocking file is removed");
+        assert_eq!(
+            fs::read_to_string(
+                runtime_dir
+                    .join("agents")
+                    .join("life-alpha")
+                    .join("agent.state.json")
+            )
+            .expect("retry should populate previously failed entries"),
+            "{\"name\":\"life-alpha\"}"
+        );
+        assert!(
+            runtime_dir.join(RUNTIME_LEGACY_SEED_MARKER_NAME).exists(),
+            "marker should be written after a fully successful retry"
+        );
+
+        fs::remove_dir_all(&runtime_dir).ok();
+        fs::remove_dir_all(&legacy_dir).ok();
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 
 mod commands;
+mod dev_instance_paths;
 
 use commands::asr_commands::{
     volcano_asr_check_config, volcano_asr_recognize, volcano_asr_stream_cancel,
@@ -43,6 +44,12 @@ use commands::workspace_commands::{
     get_agent_workspace_soul, get_agent_workspace_status,
 };
 use commands::ws_commands::{ws_connect, ws_disconnect, ws_get_state, ws_send, WsClientState};
+use dev_instance_paths::{
+    resolve_instance_app_data_dir, resolve_instance_runtime_dir_from_app_data_dir,
+    resolve_legacy_shared_app_data_dir, resolve_legacy_shared_runtime_dir,
+    resolve_main_webview_data_dir, resolve_mcp_bridge_base_port,
+    seed_instance_app_data_dir_if_needed, seed_instance_runtime_dir_if_needed,
+};
 use tauri::Manager;
 use tauri_plugin_log::{RotationStrategy, Target, TargetKind, TimezoneStrategy};
 
@@ -100,6 +107,33 @@ pub fn run() {
     let voice_shortcut_state = VoiceShortcutState::new();
     let main_window_shortcut_state = MainWindowShortcutState::new();
     let volcano_asr_stream_state = std::sync::Arc::new(VolcanoAsrStreamState::default());
+    let mut context = tauri::generate_context!();
+
+    #[cfg(all(debug_assertions, not(any(target_os = "android", target_os = "ios"))))]
+    let main_window_override = resolve_main_webview_data_dir().and_then(|main_data_dir| {
+        // Tauri config only honors relative dataDirectory values, so debug-only
+        // instance isolation must recreate the main window from Rust with an
+        // absolute per-instance WebView2 data dir.
+        let main_window_config = context
+            .config()
+            .app
+            .windows
+            .iter()
+            .find(|window| window.label == "main")
+            .cloned()?;
+
+        if let Some(window_config) = context
+            .config_mut()
+            .app
+            .windows
+            .iter_mut()
+            .find(|window| window.label == "main")
+        {
+            window_config.create = false;
+        }
+
+        Some((main_window_config, main_data_dir))
+    });
 
     let mut builder = tauri::Builder::default()
         .plugin(
@@ -130,6 +164,15 @@ pub fn run() {
         .manage(main_window_shortcut_state)
         .manage(volcano_asr_stream_state)
         .setup(move |app| {
+            #[cfg(all(debug_assertions, not(any(target_os = "android", target_os = "ios"))))]
+            if let Some((main_window_config, main_data_dir)) = main_window_override.as_ref() {
+                if app.get_webview_window("main").is_none() {
+                    tauri::WebviewWindowBuilder::from_config(app.handle(), main_window_config)?
+                        .data_directory(main_data_dir.clone())
+                        .build()?;
+                }
+            }
+
             // Register global voice shortcut (toggle, 按一次开始再按一次结束) and prewarm overlay window（预热悬浮窗）.
             let voice_shortcut_state = app.state::<VoiceShortcutState>();
             let main_window_shortcut_state = app.state::<MainWindowShortcutState>();
@@ -152,14 +195,35 @@ pub fn run() {
                 || std::env::var_os("EXOMIND_RT_TIMEBLOCK_SQLITE_PATH").is_none()
                 || std::env::var_os("EXOMIND_RT_SESSION_SQLITE_PATH").is_none()
             {
-                match app.path().app_data_dir() {
+                match resolve_instance_app_data_dir(&app.handle()) {
                     Ok(app_data_dir) => {
-                        let runtime_dir = app_data_dir.join("runtime");
+                        if let Some(legacy_app_data_dir) = resolve_legacy_shared_app_data_dir() {
+                            if let Err(error) = seed_instance_app_data_dir_if_needed(
+                                &app_data_dir,
+                                &legacy_app_data_dir,
+                            ) {
+                                log::warn!(
+                                    "instance app data seed incomplete, will retry on next launch: {error}"
+                                );
+                            }
+                        }
+
+                        let runtime_dir = resolve_instance_runtime_dir_from_app_data_dir(&app_data_dir);
                         if let Err(error) = std::fs::create_dir_all(&runtime_dir) {
                             log::error!(
-                                "failed to create runtime data dir for signal sqlite: {error}"
+                                "failed to create instance runtime data dir for runtime sqlite files: {error}"
                             );
                         } else {
+                            if let Some(legacy_runtime_dir) = resolve_legacy_shared_runtime_dir() {
+                                if let Err(error) =
+                                    seed_instance_runtime_dir_if_needed(&runtime_dir, &legacy_runtime_dir)
+                                {
+                                    log::warn!(
+                                        "instance runtime seed incomplete, will retry on next launch: {error}"
+                                    );
+                                }
+                            }
+
                             // Set EXOMIND_RT_DATA_DIR so the EventLog JSON-files backend
                             // and other file-based stores write inside the app sandbox
                             // instead of the read-only CWD (critical on Android).
@@ -173,7 +237,7 @@ pub fn run() {
                     }
                     Err(error) => {
                         log::error!(
-                            "failed to resolve app data dir for runtime sqlite files: {error}"
+                            "failed to resolve instance app data dir for runtime sqlite files: {error}"
                         );
                     }
                 }
@@ -315,7 +379,11 @@ pub fn run() {
 
     #[cfg(debug_assertions)]
     {
-        builder = builder.plugin(tauri_plugin_mcp_bridge::init());
+        let mut mcp_bridge_builder = tauri_plugin_mcp_bridge::Builder::new();
+        if let Some(base_port) = resolve_mcp_bridge_base_port() {
+            mcp_bridge_builder = mcp_bridge_builder.base_port(base_port);
+        }
+        builder = builder.plugin(mcp_bridge_builder.build());
     }
 
     builder
@@ -328,7 +396,7 @@ pub fn run() {
                 }
             }
         })
-        .run(tauri::generate_context!())
+        .run(context)
         .expect("error while running tauri application");
 }
 

--- a/tests/unit/scripts/tauri-dev-instance-paths.test.ts
+++ b/tests/unit/scripts/tauri-dev-instance-paths.test.ts
@@ -1,0 +1,42 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  resolveTauriDevInstancePaths,
+  resolveTauriDevInstanceName,
+} from '../../../scripts/dev/tauri-dev-instance-paths';
+
+describe('tauri-dev-instance-paths', () => {
+  it('derives a stable sanitized instance name（实例名应稳定且可净化）', () => {
+    expect(resolveTauriDevInstanceName({
+      EXOMIND_TAURI_INSTANCE_NAME: 'Issue 773 / Node First',
+    })).toBe('issue-773-node-first');
+  });
+
+  it('resolves isolated paths per instance（不同实例应映射到不同隔离目录）', () => {
+    const projectRoot = path.resolve('D:/project/exomind');
+    const desktop = resolveTauriDevInstancePaths(projectRoot, {
+      EXOMIND_TAURI_INSTANCE_NAME: 'desktop',
+      EXOMIND_WEB_PORT: '1420',
+      APPDATA: 'C:\\Users\\starlin\\AppData\\Roaming',
+      LOCALAPPDATA: 'C:\\Users\\starlin\\AppData\\Local',
+    });
+    const issue773 = resolveTauriDevInstancePaths(projectRoot, {
+      EXOMIND_TAURI_INSTANCE_NAME: 'issue-773-node-first',
+      EXOMIND_WEB_PORT: '1430',
+      APPDATA: 'C:\\Users\\starlin\\AppData\\Roaming',
+      LOCALAPPDATA: 'C:\\Users\\starlin\\AppData\\Local',
+    });
+
+    expect(desktop.instanceName).toBe('desktop');
+    expect(issue773.instanceName).toBe('issue-773-node-first');
+    expect(desktop.stateRootDir).not.toBe(issue773.stateRootDir);
+    expect(desktop.webviewMainDataDir).toBe(path.join(projectRoot, '.tmp', 'tauri-dev-state', 'desktop', 'webview', 'main'));
+    expect(desktop.webviewOverlayDataRoot).toBe(path.join(projectRoot, '.tmp', 'tauri-dev-state', 'desktop', 'webview', 'overlay'));
+    expect(desktop.appDataDir).toBe(path.join(projectRoot, '.tmp', 'tauri-dev-state', 'desktop', 'app-data'));
+    expect(desktop.runtimeDataDir).toBe(path.join(projectRoot, '.tmp', 'tauri-dev-state', 'desktop', 'app-data', 'runtime'));
+    expect(desktop.legacySharedAppDataDir).toBe(path.join('C:\\Users\\starlin\\AppData\\Roaming', 'com.exomind.app'));
+    expect(desktop.legacySharedRuntimeDir).toBe(path.join('C:\\Users\\starlin\\AppData\\Roaming', 'com.exomind.app', 'runtime'));
+    expect(desktop.mcpBridgeBasePort).toBe(9223);
+    expect(issue773.mcpBridgeBasePort).toBe(9233);
+  });
+});

--- a/tests/unit/scripts/tauri-wrapper.test.ts
+++ b/tests/unit/scripts/tauri-wrapper.test.ts
@@ -120,6 +120,63 @@ describeWindowsOnly('tauri-wrapper', () => {
     }
   }, 20000);
 
+  it('injects isolated instance dirs for tauri dev（tauri dev 应注入实例级数据目录）', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'tauri-wrapper-instance-paths-'));
+    const fakeBinDir = join(tempDir, 'bin');
+    const fakeTauriCmd = join(fakeBinDir, 'tauri.cmd');
+    const wrapperPath = join(process.cwd(), 'Scripts', 'dev', 'tauri-wrapper.ps1');
+
+    try {
+      spawnSync('cmd.exe', ['/c', 'mkdir', fakeBinDir], { stdio: 'ignore' });
+
+      writeFileSync(
+        fakeTauriCmd,
+        [
+          '@echo off',
+          'echo EXOMIND_DEV_INSTANCE_NAME=%EXOMIND_DEV_INSTANCE_NAME%',
+          'echo EXOMIND_DEV_APP_DATA_DIR=%EXOMIND_DEV_APP_DATA_DIR%',
+          'echo EXOMIND_DEV_RUNTIME_DATA_DIR=%EXOMIND_DEV_RUNTIME_DATA_DIR%',
+          'echo EXOMIND_DEV_WEBVIEW_MAIN_DATA_DIR=%EXOMIND_DEV_WEBVIEW_MAIN_DATA_DIR%',
+          'echo EXOMIND_DEV_WEBVIEW_OVERLAY_DATA_ROOT=%EXOMIND_DEV_WEBVIEW_OVERLAY_DATA_ROOT%',
+          'echo EXOMIND_DEV_LEGACY_SHARED_RUNTIME_DIR=%EXOMIND_DEV_LEGACY_SHARED_RUNTIME_DIR%',
+          'echo EXOMIND_MCP_BRIDGE_BASE_PORT=%EXOMIND_MCP_BRIDGE_BASE_PORT%',
+          'if /I "%3"=="--config" type "%4"',
+          'exit /b 0',
+          '',
+        ].join('\r\n'),
+        'utf8',
+      );
+
+      const result = spawnSync(
+        POWERSHELL_PATH,
+        ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', wrapperPath, 'dev'],
+        {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PATH: `${fakeBinDir};${process.env.PATH ?? ''}`,
+            APPDATA: 'C:\\Users\\starlin\\AppData\\Roaming',
+            LOCALAPPDATA: 'C:\\Users\\starlin\\AppData\\Local',
+            EXOMIND_TAURI_INSTANCE_NAME: 'desktop',
+            EXOMIND_WEB_PORT: '1520',
+            EXOMIND_HMR_PORT: '1521',
+            EXOMIND_RT_PORT: '1949',
+          },
+        },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('EXOMIND_DEV_INSTANCE_NAME=desktop');
+      expect(result.stdout).toContain('.tmp\\tauri-dev-state\\desktop\\app-data');
+      expect(result.stdout).toContain('.tmp\\tauri-dev-state\\desktop\\webview\\main');
+      expect(result.stdout).toContain('EXOMIND_DEV_LEGACY_SHARED_RUNTIME_DIR=C:\\Users\\starlin\\AppData\\Roaming\\com.exomind.app\\runtime');
+      expect(result.stdout).toContain('EXOMIND_MCP_BRIDGE_BASE_PORT=9323');
+      expect(result.stdout).toContain('"devUrl":"http://localhost:1520"');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }, 20000);
+
   it('disables tauri watcher by default for dev（默认关闭 tauri watcher 避免无关改动触发黑屏重启）', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'tauri-wrapper-no-watch-'));
     const fakeBinDir = join(tempDir, 'bin');


### PR DESCRIPTION
﻿## Summary
- isolate Windows Tauri dev instances across WebView2 user data dir（WebView2 用户数据目录）, app data dir（应用数据目录）, runtime dir（运行时目录）, and MCP bridge base port（MCP bridge 基础端口）
- route desktop commands, main window, and overlay windows through instance-aware paths with first-launch seed / bootstrap copy（首次播种 / 启动复制） from legacy shared directories
- keep device identity instance-specific and make partial legacy seed failures retry safely on next launch instead of pinning a broken snapshot

## Test Plan
- [x] `npx vitest run tests/unit/scripts/tauri-dev-instance-paths.test.ts tests/unit/scripts/tauri-wrapper.test.ts`
- [x] `cargo test dev_instance_paths --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test runtime_ --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test now_workbench_overlay_commands --manifest-path src-tauri/Cargo.toml`
- [x] Manual manager verification on Windows: started `issue-776-verify-final` at `16020/16021`, got `HTTP 200`, and confirmed `msedgewebview2.exe --user-data-dir` resolves under `.tmp/tauri-dev-state/issue-776-verify-final` for `main`, `voice-overlay`, and `now-workbench-overlay`

Closes #776
