### PR TITLE
feat(workbench): wire runtime-fed pane handoff for issue 777

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 ## 架构与设计
 
 - [架构总览](architecture/overview.md) -- 分层模型、Port/Service、Phase 路线（唯一权威）
+- [Agent Workbench 共享工作图谱](architecture/agent-workbench-shared-graph-spec.md) -- Agent Workbench 长期架构规格与实施阶段
 - [信号池架构](architecture/ARCH-signal-pool-agent-process.md) -- SignalPool 进程模型与信号流
 - [同步架构](architecture/ARCH-SYNC.md) -- 多设备同步模块架构分析
 - [ECS 通信栈](architecture/ECS-communication-stack.md) -- ExoMind Communication Stack 协议栈架构
@@ -93,6 +94,7 @@
 > 以下文件均为进行中的计划，已完成的计划已移至 [ARCHIVE-INDEX.md](ARCHIVE-INDEX.md)。
 
 - [产品规划](plans/product-plan.md) -- 外心产品规划与实施计划
+- [Agent Workbench Phase 1 平铺工作台](plans/2026-03-30-agent-workbench-phase1-flat-workbench-design.md) -- Agent Workbench 第一阶段设计
 - [任务 MCP 集成](plans/task-mcp-integration.md) -- 任务系统通过 MCP 接入 Agent
 - [同步服务器统一数据架构](plans/2026-03-01-sync-server-unified-data-architecture.md) -- 讨论稿
 - [Agent Hub Claude/Codex 调研](plans/2026-03-06-agent-hub-claude-codex-runtime-research.md) -- Agent Runtime 对接调研

--- a/docs/architecture/agent-workbench-shared-graph-spec.md
+++ b/docs/architecture/agent-workbench-shared-graph-spec.md
@@ -8,6 +8,7 @@
 > **关联**:
 > - Epic: `#728`
 > - 讨论笔记: `docs/plans/2026-03-30-agent-workbench-canvas-brainstorm.md`
+> - Phase 1 设计: `docs/plans/2026-03-30-agent-workbench-phase1-flat-workbench-design.md`
 > - 参考: `docs/architecture/agent-hub-ui-spec.md`
 > - 参考: `docs/specs/SPEC-goal-system-v0.3-logic.md`
 > - 现有运行时: `crates/exomind-runtime/src/session/types.rs`
@@ -188,7 +189,34 @@ Derived Layer
   └─ replay read models
 ```
 
-### 3.2 四层分工
+### 3.2 Obsidian 速览图
+
+```mermaid
+flowchart TD
+  WS["WorkbenchSpace<br/>工作空间"]
+  SL["SurfaceSlot / SurfaceNavigationState<br/>承载槽 / 导航态"]
+  VI["ViewInstance<br/>视图实例"]
+  SO["SessionObject<br/>会话对象"]
+  RB["RuntimeBinding<br/>运行时绑定"]
+  ET["EventTape<br/>事件带"]
+  DA["DerivedArtifact<br/>派生产物"]
+
+  WS --> SL
+  WS --> VI
+  VI --> SO
+  SO --> RB
+  SO --> ET
+  ET --> DA
+```
+
+```mermaid
+flowchart LR
+  P1["Phase 1<br/>Flat Workbench<br/>平铺工作台"] --> P2["Phase 2<br/>Cross-Window Federation<br/>跨窗口联邦"]
+  P2 --> P3["Phase 3<br/>EventTape + Structured Projection<br/>事实层与结构化投影"]
+  P3 --> P4["Phase 4<br/>Work-Area Projections<br/>Canvas / Network / Replay"]
+```
+
+### 3.3 四层分工
 
 #### A. `space layer（空间层）`
 
@@ -295,6 +323,7 @@ type ViewType =
   | 'session'
   | 'conversation'
   | 'terminal'
+  | 'browser'
   | 'work-area'
   | 'note'
   | 'inspector'
@@ -567,7 +596,7 @@ type ResultObject = WorkbenchObjectBase & {
 ```ts
 type RuntimeBinding = {
   id: string;
-  bindingType: 'pty' | 'ssh' | 'agent-session' | 'external-process';
+  bindingType: 'pty' | 'ssh' | 'agent-session' | 'browser-runtime' | 'external-process';
   runtimeRef: string;
   status: 'running' | 'idle' | 'waiting' | 'stopped' | 'error';
   metadata?: Record<string, unknown>;
@@ -1242,156 +1271,197 @@ MVP 兼容规则：
 
 ---
 
-## 12. MVP 边界
+## 12. 分阶段实施策略
 
-## 12.1 MVP 必须具备
+## 12.1 长期愿景与当前落点
+
+长期愿景保持不变：
+
+1. `WorkbenchSpace` 仍是产品主对象
+2. `container graph + shared work graph + EventTape` 仍是底层骨架
+3. `Signal Network / Canvas / Replay` 最终仍要回到同一底层模型
+
+但当前开工落点必须收紧为：
+
+> **先做 `Flat Workbench（平铺工作台）`，再做 `Cross-Window Federation（跨窗口联邦）`，最后再把 `canvas / network / replay` 做成统一投影。**
+
+这意味着：
+
+1. Phase 1 不把自由画布当成阻塞项
+2. Phase 1 先交付“一个稳定的多会话工作台”
+3. `agent / PTY / SSH / browser runtime` 先通过统一 `SessionObject + RuntimeBinding` 纳管
+4. 跨窗口先做“共享同一空间语义”的联邦骨架，而不是完整窗口管理器
+
+## 12.2 Phase 1：`Flat Workbench（平铺工作台）`
+
+Phase 1 必须具备：
+
+1. `WorkbenchPage`
+   - 提供固定或半固定的平铺工作面
+   - 不先要求自由画布
+2. `WorkbenchSpace`
+   - 至少有一个稳定 `default space（默认空间）`
+   - 能恢复最近使用的会话集合
+3. `SessionObject`
+   - MVP 先稳定兼容现有 `agent-backed session`
+   - 同时给 `PTY / SSH / browser runtime` 预留一致纳管入口
+4. `RuntimeBinding + RuntimeAttachment + SessionAnchor`
+   - 统一表示运行时句柄、宿主语义与附着关系
+5. `SurfaceSlot + SurfaceNavigationState`
+   - 先支撑“主窗口 + 次窗口/次承载面”的基本联邦
+6. `EventTape`
+   - 至少记录会话输入、会话输出、系统控制事件
+7. `/agents/*` shim
+   - 旧路由可以逐步映射到新的 `WorkbenchPage`
+
+## 12.3 Phase 1 明确不做
+
+1. 自由画布编排
+2. 完整 `network` 投影编辑器
+3. 完整多窗口管理器
+4. 完整插件系统
+5. 一次性替换所有旧页面
+6. 全量智能解析与自动洞察
+
+## 12.4 Phase 1 首批对象集合
 
 1. `WorkbenchSpace`
-   - 支持三端 layout profile
-2. `ViewInstance + LayoutNode + SurfaceNavigationState`
-   - 至少能表达 desktop / mobile 的差异
-3. `SessionObject`
-   - MVP 先稳定兼容现有 agent-backed session
-4. `AgentNodeObject` 与 `TerminalNodeObject`
-   - 作为空间中的长期节点
-5. `RuntimeBinding + RuntimeAttachment + SessionAnchor`
-6. `FocusRun + EventTape`
-   - 先桥接现有 `TimeBlock`
-7. `work-area`
-   - 支持 `canvas` 与 `network` 两种投影模式
+2. `ViewInstance`
+3. `SurfaceSlot + SurfaceNavigationState`
+4. `SessionObject`
+5. `AgentNodeObject`
+6. `TerminalNodeObject`
+7. `ResultObject`（轻量）
+8. `TaskObject / NoteObject`（轻量接入）
 
-## 12.2 MVP 明确不做
+注意：
 
-1. 完整插件系统
-2. 完整多窗口管理器
-3. 全对象类型一次性统一
-4. 全量智能解析与自动洞察
-5. 一次性替换所有旧页面
-6. 原生 `terminal / conversation` 新运行时协议
+1. `browser runtime` 在 Phase 1 先作为 `RuntimeBinding.bindingType = 'browser-runtime'`
+2. 是否升级为独立 `BrowserNodeObject` 留到下一轮评审
 
-## 12.3 MVP 首批对象集合
+## 12.5 Phase 1 关键用户旅程
 
-1. `AgentNodeObject`
-2. `TerminalNodeObject`
-3. `SessionObject`
-4. `ResultObject`
-5. `TaskObject`（轻量接入）
-6. `NoteObject`（轻量接入）
+1. 打开 `/workbench`
+   - 系统解析或创建 `default space`
+   - 恢复最近活跃的 `SessionObject`
+   - 用平铺工作面显示多个会话 pane（面板）
+2. 在同一工作台中新增会话
+   - 用户新建 `agent / PTY / SSH / browser runtime`
+   - 系统创建 `SessionObject`
+   - 系统通过 `RuntimeBinding` 附着到底层运行时
+3. 从主窗口派生次窗口
+   - 用户把某个 pane 或 view 弹到新窗口
+   - 新窗口仍然属于同一 `WorkbenchSpace`
+   - 共享同一底层对象、关系与事实流
 
 ---
 
-## 13. 开工切片建议
+## 13. Phase 1 开工切片建议
 
-## 13.1 Slice A: 核心模型与关系存储
-
-目标：
-
-1. 新增 `WorkbenchSpace / LayoutProfile / SurfaceNavigationState`
-2. 新增 `WorkbenchRelation / SessionAnchor / RuntimeAttachment`
-3. 明确 `FocusRun / EventTape` 不变量
-
-交付标准：
-
-1. 能存空间
-2. 能存布局 profile
-3. 能存对象边与成员关系
-
-## 13.2 Slice B: 抽取 adapter / read model
-
-目标：
-
-1. 抽 `SessionInteropAdapter`
-2. 抽 `TimeBlockFocusRunAdapter`
-3. 抽 `TopologyProjectionAdapter`
-4. 抽 `TaskDagViewStateAdapter`
-
-交付标准：
-
-1. 不改旧页面主行为
-2. 新模型已经能读旧数据
-
-## 13.3 Slice C: Workbench 壳层与兼容路由
+## 13.1 Slice A：平铺壳层与兼容路由
 
 目标：
 
 1. 新增 `WorkbenchPage.tsx`
 2. 接入 `/workbench`
 3. 建立 `/agents/*` shim
+4. 提供固定或半固定的多 pane 布局
 
 交付标准：
 
 1. 壳层能打开
 2. 不打断当前移动端全屏与二级页面
+3. 平铺工作面能稳定显示多个 pane
 
-## 13.4 Slice D: 会话与终端纳管
+## 13.2 Slice B：统一会话与运行时注册表
 
 目标：
 
-1. 把现有 `AgentSession`、PTY、SSH 纳入 `SessionObject + RuntimeBinding`
-2. 让一个空间里能稳定展示多个会话与终端工作面
+1. 抽 `SessionInteropAdapter`
+2. 把现有 `AgentSession` 映射到 `SessionObject`
+3. 把 `PTY / SSH / browser runtime` 收到统一 `RuntimeBinding` 语义
+4. 消除“PTY 伪装成 agent”这类语义污染
 
 交付标准：
 
-1. 一个空间里能恢复多个 agent-backed session
-2. PTY 不再以 `agent` 语义进入投影
+1. 一个空间里能恢复多个 `agent-backed session`
+2. 新旧语义映射可追溯
+3. 新增运行时不再要求复制一套页面模型
 
-## 13.5 Slice E: `FocusRun + EventTape`
+## 13.3 Slice C：跨窗口联邦前置抽象
+
+目标：
+
+1. 让多个 `SurfaceSlot` 能映射到“主窗口 + 次窗口/次承载面”
+2. 接入 `#646` 的窗口研究结论
+3. 确立“同一 `WorkbenchSpace`，多个窗口共享对象与导航语义”的骨架
+
+交付标准：
+
+1. 可以从主窗口打开第二个工作面
+2. 新窗口能加载同一空间中的子集视图
+3. 不要求完整窗口拖放与任意停靠
+
+## 13.4 Slice D：`FocusRun + EventTape` 基础接入
 
 目标：
 
 1. 桥接现有 `TimeBlock`
-2. 开始记录 append-only 事件
+2. 把会话输入/输出与系统控制事件写入 append-only 事实流
+3. 为后续 `structured projection（结构化投影）` 预留稳定来源链路
 
 交付标准：
 
 1. 能开始/结束 `FocusRun`
-2. 会话输出和用户输入进入 `EventTape`
-3. 能产出基础 replay timeline
+2. 同一空间内多个会话的事件进入同一 `EventTape`
+3. 可生成最基础的 replay 时间线
 
-## 13.6 Slice F: `work-area` 投影模式
+## 13.5 Slice E：恢复、只读视图与评审支撑
 
 目标：
 
-1. `canvas`
-2. `network`
+1. 形成 `session list + active panes + outcome / inspector` 的稳定读模型
+2. 把当前状态持久化到空间级模型，而不是散落在临时 `localStorage`
+3. 给后续 `canvas / network` 投影提供只读恢复底座
 
 交付标准：
 
-1. 同一批对象在两种投影里切换
-2. 共享同一底层对象与关系，不造两套假数据
+1. 重启后可恢复最近工作台
+2. 同一空间中的 pane 排布与会话集合可恢复
+3. 评审文档与真实对象模型一致
 
 ---
 
 ## 14. 团队评审重点
 
-- [ ] `WorkbenchSpace` 是长期工作场景，而不是任务或会话
-- [ ] 三端布局根节点按 `surface profile` 分离
-- [ ] `ViewInstance` 是呈现机制，不是产品主对象
-- [ ] `SessionObject` 与 `AgentNodeObject` 分开，但产品入口仍然收敛
-- [ ] `workbench_relations` 是正式对象边存储
-- [ ] `EventTape` 是事实源，`TapeEvent` 有稳定顺序键
-- [ ] `FocusRun` 在 MVP 中桥接现有 `TimeBlock`
+- [ ] 长期愿景仍是 `WorkbenchSpace + shared work graph + EventTape`
+- [ ] 当前第一阶段明确收敛为 `Flat Workbench`，不是自由画布
+- [ ] `SessionObject + RuntimeBinding` 能统一承载 `agent / PTY / SSH / browser runtime`
+- [ ] `SurfaceSlot + SurfaceNavigationState` 足以支撑跨窗口联邦前置抽象
+- [ ] `EventTape` 仍是事实源，结构化层只能派生
 - [ ] `/agents/*` 必须通过兼容路由逐步迁移
+- [ ] Epic 与阶段 issue 的治理方式保持最小扩散
 
 ---
 
 ## 15. 仍保留的开放问题
 
-1. `TaskObject / NoteObject` 在 MVP 是只读投影还是半托管对象
-2. 手机端默认首页更偏 `current focus（当前专注）` 还是 `current task flow（当前任务流）`
-3. `workbench_relations` 的端点类型约束是写在 schema 还是 service 层
-4. `terminal / conversation` 何时从未来类型升级为首批原生运行时对象
+1. `default space` 的创建、归档、删除生命周期仍需补充
+2. `browser runtime` 是长期保持在 `RuntimeBinding` 层，还是升级为 `BrowserNodeObject`
+3. `EventTape` 与现有 `eventlog / signals` 的最终归属仍需补明确迁移关系
+4. `tape_events` 的 retention / compression / backpressure 策略仍需补充
+5. `workbench_relations` 的端点类型约束是写在 schema 还是 service 层
 
 ---
 
 ## 16. 结论
 
-这次规格的关键不是“再做一个更自由的 UI”，而是把下面五件事写成可执行模型：
+这次规格现在的执行重点，不再是“先做一个完美自由的 UI”，而是先把下面五件事落地：
 
-1. 外层是按端分离的 `container graph`
-2. 内层是有正式对象边存储的 `shared work graph`
-3. 事实层由 `FocusRun + EventTape` 承担，并桥接现有 `TimeBlock`
-4. `SessionObject`、节点对象、运行时资源通过 typed relation（类型化关系）连接
-5. `Signal Network / Canvas / Replay` 不再是平行产品，而是 `work-area` 的不同投影模式
+1. `WorkbenchSpace` 作为长期工作场景先站住
+2. `Flat Workbench` 先把多个会话工作面稳定纳管起来
+3. `RuntimeBinding` 统一承载 `agent / PTY / SSH / browser runtime`
+4. 跨窗口先实现联邦骨架，而不是完整窗口管理器
+5. `EventTape` 为后续 `structured projection / canvas / network / replay` 提供稳定事实层
 
-只要团队确认这五条，就已经可以按新的切片顺序开始第一批 PR。
+只要团队接受这个阶段收口，第一批 PR 就不必再被“先做自由画布”卡住。

--- a/docs/architecture/agent-workbench-shared-graph-spec.md
+++ b/docs/architecture/agent-workbench-shared-graph-spec.md
@@ -211,7 +211,7 @@ flowchart TD
 
 ```mermaid
 flowchart LR
-  P1["Phase 1<br/>Flat Workbench<br/>平铺工作台"] --> P2["Phase 2<br/>Cross-Window Federation<br/>跨窗口联邦"]
+  P1["Phase 1<br/>Flat Workbench + Federation Skeleton<br/>平铺工作台 + 联邦骨架"] --> P2["Phase 2<br/>Expanded Cross-Window Federation<br/>增强跨窗口联邦"]
   P2 --> P3["Phase 3<br/>EventTape + Structured Projection<br/>事实层与结构化投影"]
   P3 --> P4["Phase 4<br/>Work-Area Projections<br/>Canvas / Network / Replay"]
 ```
@@ -1093,6 +1093,31 @@ type StoredTapeEvent = {
 2. append-only（追加写入）
 3. 派生层单独存，不回写原始事件
 
+## 9.6 Phase 1 存储位置与迁移边界
+
+当前必须明确：Phase 1 不是一次性把所有存储都搬完，而是分层落位。
+
+### Phase 1 推荐落位
+
+| 层 | Phase 1 推荐落位 | 说明 |
+|---|---|---|
+| `Flat Workbench` 壳层、最近 pane 恢复 | 前端本地持久层（`localStorage / PouchDB`） | 允许先做可见恢复，不阻塞 `/workbench` 起步 |
+| `AgentSession -> SessionObject` 读模型桥接 | 前端 adapter + 现有 runtime API | 先桥接现有模型，不要求先反向改写 runtime 真相源 |
+| `FocusRun / EventTape` 正式事实层 | runtime 侧持久层（优先复用现有 SQLite 能力） | 不能长期只留在前端本地缓存 |
+| `signal / session / terminal` 原始输入 | 继续来自现有 runtime / signal 通道 | Workbench 先接入，不重复造第二份事实源 |
+
+### Phase 1 迁移原则
+
+1. `Slice A / B / E`
+   - 允许先用前端本地恢复模型完成可见工作台
+   - 但字段命名、对象边界、adapter 接口要向长期模型靠拢
+2. `Slice D`
+   - `EventTape` 进入正式事实层时，必须优先挂到 runtime 持久化能力
+   - 不能让前端 `localStorage / PouchDB` 成为长期事实源
+3. `Cross-Window Federation`
+   - 如果需要跨窗口共享当前空间与当前 pane 集合，优先通过共享 service / runtime 通道实现
+   - 不能依赖每个窗口各自维护一份互不相认的本地状态
+
 ---
 
 ## 10. 模块、服务与桥接层
@@ -1221,7 +1246,41 @@ MVP 规则：
 | `loadActiveBlock()` | `resolveRunningFocusRun()` | 先走 adapter |
 | `endBlock()` | `endFocusRun()` | 仍由旧服务执行，结果映射回新语义 |
 
-## 11.3 `AgentsPage`
+## 11.3 `EventTape` 与现有 `eventlog / signals` 的阶段关系
+
+这一条必须说清楚，否则后面会重复造“第二套事件系统”。
+
+### 当前阶段结论
+
+1. `eventlog`
+   - 当前仍是已有事实日志基础设施
+   - Phase 1 不能直接把它当成废弃系统
+2. `signals`
+   - 当前仍是实时分发与路由基础设施
+   - Phase 1 不能要求它先完全改写成 Workbench 对象模型
+3. `EventTape`
+   - 当前是 Workbench 规格下的事实层目标形态
+   - 需要通过 adapter 逐步和现有 `eventlog / signals` 对齐，而不是平地起第二套孤立存储
+
+### 分阶段要求
+
+1. `Slice A / B / C / E`
+   - `EventTape` 可以只停留在接口与对象语义层
+   - 旧系统继续承担现有运行时事实输入
+2. `Slice D`
+   - 必须明确 `EventTape` 的正式写入位置、序列化格式、以及和现有 `eventlog` 的关系
+   - 若暂时复用现有 SQLite 事件日志实现，也必须保证 `Workbench` 读写接口稳定
+3. 长期目标
+   - `EventTape` 成为 Workbench 对象可追溯事实层
+   - `signals / session stdout / terminal stream` 通过统一 ingress（事件入口）进入它
+
+### 强约束
+
+1. 不允许 Workbench 自己再造一套脱离 `eventlog / signals` 的孤立“事实流”
+2. 不允许派生摘要回写覆盖原始事件
+3. `Slice D` 关闭前，必须给出 `raw` 序列化与 retention（保留）策略
+
+## 11.4 `AgentsPage`
 
 当前现状：
 
@@ -1241,7 +1300,7 @@ MVP 规则：
 1. 只能复用它的 read model 和交互经验
 2. 不能直接把它的对象语义搬进共享工作图谱
 
-## 11.4 `TaskDagPage`
+## 11.5 `TaskDagPage`
 
 当前现状：
 
@@ -1255,7 +1314,7 @@ MVP 规则：
 2. 不能直接复用状态持久化方式
 3. 必须先做 `TaskDagViewStateAdapter`
 
-## 11.5 路由兼容策略
+## 11.6 路由兼容策略
 
 当前现状：
 
@@ -1273,9 +1332,10 @@ MVP 兼容规则：
 3. `/agents/agent/*`
 4. `/agents/actor/*`
 5. `/agents/signal/*`
-6. `/agents/pty/*`
-   - 全部保留 shim（兼容壳）
-   - 内部映射到 `WorkbenchPage + SurfaceNavigationState`
+6. `legacy /agents/pty/*`
+   - 当前仍属于 `AgentsPage` 内部裸 `pushState` 次级路径
+   - 不作为 `Slice A` 第一批 shim 完成标准
+   - 归入后续路由正规化工作
 
 强约束：
 
@@ -1296,14 +1356,14 @@ MVP 兼容规则：
 
 但当前开工落点必须收紧为：
 
-> **先做 `Flat Workbench（平铺工作台）`，再做 `Cross-Window Federation（跨窗口联邦）`，最后再把 `canvas / network / replay` 做成统一投影。**
+> **先做 `Flat Workbench（平铺工作台）` 并立起最小 `federation skeleton（联邦骨架）`，再增强 `Cross-Window Federation（跨窗口联邦）`，最后再把 `canvas / network / replay` 做成统一投影。**
 
 这意味着：
 
 1. Phase 1 不把自由画布当成阻塞项
 2. Phase 1 先交付“一个稳定的多会话工作台”
 3. `agent / PTY / SSH / browser runtime` 先通过统一 `SessionObject + RuntimeBinding` 纳管
-4. 跨窗口先做“共享同一空间语义”的联邦骨架，而不是完整窗口管理器
+4. Phase 1 只做“共享同一空间语义”的联邦骨架，增强型跨窗口能力留到后续阶段
 
 ## 12.2 Phase 1：`Flat Workbench（平铺工作台）`
 
@@ -1324,19 +1384,73 @@ Phase 1 必须具备：
    - 先支撑“主窗口 + 次窗口/次承载面”的基本联邦
 6. `EventTape`
    - 至少记录会话输入、会话输出、系统控制事件
+   - 这是 Phase 1 终局要求，不是 `Slice A` 首刀阻塞项
 7. `/agents/*` shim
    - 旧路由可以逐步映射到新的 `WorkbenchPage`
+   - 允许先从代表性旧入口开始收口，再逐步覆盖完整兼容面
+
+### 12.2.1 Phase 1 `default space` 生命周期
+
+为了避免 `WorkbenchSpace` 继续停留在抽象名词，Phase 1 先把默认空间规则写死：
+
+1. 首次打开 `/workbench`
+   - 若本地还没有任何空间记录，则自动创建一个 `default space`
+2. 再次打开 `/workbench`
+   - 优先恢复最近一次活跃的同一默认空间
+3. `default space` 的 Phase 1 身份规则
+   - 当前本地 profile（本地档案）下固定使用同一个稳定 `spaceId`
+   - 在没有多空间 UI 之前，默认实现就是 `default-space`
+4. 主窗口与次窗口
+   - 必须通过同一个 `resolveDefaultSpace()` 入口拿到当前默认空间
+   - 若默认空间已存在，次窗口不得再次创建第二份“默认空间”
+5. Phase 1 不提供：
+   - 空间删除 UI
+   - 空间归档 UI
+   - 多空间切换管理 UI
+6. Phase 1 允许：
+   - 在模型层保留 `spaceId`
+   - 在文案与测试里显式显示当前空间标识
+7. 进入 Phase 2 之前：
+   - `default space` 必须是稳定宿主，而不是临时页面状态
+
+### 12.2.2 跨窗口共享同一 `WorkbenchSpace` 的执行契约
+
+这部分不是长期愿景描述，而是后续 `Slice C` 必须落地的执行约束。
+
+#### 共享状态（cross-window shared state）
+
+1. `spaceId`
+2. 当前空间内可见 pane 集合
+3. `SessionObject / RuntimeBinding` 的附着关系
+4. 当前运行中的 `FocusRun` 标识
+5. 最近恢复集合的版本号或快照标识
+
+#### 严格本地状态（surface-local state）
+
+1. 某个窗口当前选中的 pane
+2. 局部滚动位置
+3. inspector 展开折叠
+4. 仅服务当前窗口的临时 hover / selection / draft
+
+#### 单写者规则（single-writer rule）
+
+1. 事实层写入只能经过统一 service / runtime ingress（事件入口）
+2. 任一窗口都不能直接把本地临时状态当成空间真相源
+3. 跨窗口共享对象的改动，必须通过同一个 `WorkbenchService` 契约落盘或广播
+4. `SurfaceNavigationState.localState` 默认视为窗口本地态，不参与事实层同步
 
 ### Phase 1 runtime 支持分档
 
 1. `must ship（本阶段必须可见可用）`
    - `agent-backed session`
    - 平铺 pane 恢复
-   - `/agents/* -> /workbench` 兼容落点
+   - 至少一个 `runtime-attached non-agent pane（带运行时附着的非 agent 面板）`
+   - 当前默认来源是 `PTY / SSH`
+   - `/agents` 与 `/agents/chat/* -> /workbench` 的代表性兼容落点
 2. `should ship（本阶段优先纳管）`
-   - 现有 `PTY / SSH` 通过统一 `RuntimeBinding` 进入工作台语义
-   - 至少具备恢复、展示或附着能力之一
+   - 现有 `PTY / SSH` 通过统一 `RuntimeBinding` 深化进入工作台语义
    - 不要求在本阶段先稳定为独立 `terminal SessionKind`
+   - 也不要求在本阶段一次做完完整终端产品面
 3. `model-only（只做模型预留）`
    - `browser-runtime`
    - 只要求统一模型入口与注册语义，不作为本阶段关闭条件
@@ -1394,6 +1508,8 @@ Phase 1 不只是交付抽象模型，它必须给出人类可直接看到、可
    - 例如 `agent + PTY` 或 `agent + SSH`
    - 至少一个 pane 应来自真实运行时恢复或真实运行时挂载
    - 至少一个 pane 不是 `agent-backed session`
+   - `Slice A` 首笔实现允许先以 `workbench-modeled non-agent pane（工作台建模的非 agent pane）` 起步
+   - 但 Phase 1 关闭前必须接上真实 `PTY / SSH` 注册或恢复链路
 3. 关闭并重新打开后
    - 最近工作台能恢复
 4. 从主窗口派生一个次窗口工作面
@@ -1409,7 +1525,21 @@ Phase 1 最低人类验收清单：
 5. 桌面端打开次窗口后，两个窗口仍然指向同一空间语义
 6. 基础会话输入/输出可继续进入事实流
 7. 至少 2 个代表性旧入口仍可落到正确工作台位置
-   - 例如 `/agents/chat/*`、`/agents/pty/*`
+   - 第一批以 `/agents`、`/agents/chat/*` 为准
+   - `legacy /agents/pty/*` 归入后续路由正规化工作
+
+## 12.7 评审闭环状态
+
+下面这张表用于回答“上一轮高风险评审意见现在还剩什么”：
+
+| 评审点 | 当前状态 | 结论 |
+|---|---|---|
+| 自建窗口管理器过重 | 已收口为 `Phase 2+`，Phase 1 不做完整窗口管理器 | 已解决 |
+| 关系类型过多 | 已收口为 Phase 1 最小关系集与操作别名 | 已解决 |
+| `Signal Network` 直接并入会过重 | 已明确为长期 `projection`，Phase 1 与旧页共存 | 已解决 |
+| `default space` 生命周期未定义 | 本版补充了 Phase 1 默认空间规则 | 已解决 |
+| `EventTape` 与 `eventlog / signals` 关系不清 | 本版补充了分阶段关系，但正式落库仍留到 `Slice D` | 部分解决 |
+| `tape_events retention / compression` 未定义 | 仍未最终定稿，但不阻塞 `Slice A / B / C / E` | 延后到 `Slice D` |
 
 ---
 
@@ -1421,7 +1551,7 @@ Phase 1 最低人类验收清单：
 
 1. 新增 `WorkbenchPage.tsx`
 2. 接入 `/workbench`
-3. 建立 `/agents/*` shim
+3. 分成 `Slice A1` 与 `Slice A2`
 4. 提供固定或半固定的多 pane 布局
 
 交付标准：
@@ -1429,6 +1559,18 @@ Phase 1 最低人类验收清单：
 1. 壳层能打开
 2. 不打断当前移动端全屏与二级页面
 3. 平铺工作面能稳定显示多个 pane
+
+### `Slice A1`
+
+1. 直接访问 `/workbench`
+2. 创建或恢复 `default space`
+3. 展示一个 `agent-backed session pane + non-agent pane`
+
+### `Slice A2`
+
+1. 建立代表性旧入口 shim
+2. 优先覆盖 `/agents` 或 `/agents/chat/*` 其中之一
+3. 明确返回路径与空间落点语义
 
 ## 13.2 Slice B：统一会话与运行时注册表
 
@@ -1459,6 +1601,20 @@ Phase 1 最低人类验收清单：
 1. 可以从主窗口打开第二个工作面
 2. 新窗口能加载同一空间中的子集视图
 3. 不要求完整窗口拖放与任意停靠
+
+补充执行契约：
+
+1. 共享：
+   - `spaceId`
+   - pane membership（pane 归属）
+   - `SessionObject / RuntimeBinding` 关联
+2. 本地：
+   - `SurfaceNavigationState.localState`
+   - 当前窗口选中的 pane
+   - 当前窗口的滚动和临时 UI 状态
+3. 写入：
+   - 多窗口都通过统一 service 修改共享状态
+   - 事实层写入不能由窗口各自直接追加本地日志
 
 ## 13.4 Slice D：`FocusRun + EventTape` 基础接入
 
@@ -1505,11 +1661,16 @@ Phase 1 最低人类验收清单：
 
 ## 15. 仍保留的开放问题
 
-1. `default space` 的创建、归档、删除生命周期仍需补充
-2. `browser runtime` 是长期保持在 `RuntimeBinding` 层，还是升级为 `BrowserNodeObject`
-3. `EventTape` 与现有 `eventlog / signals` 的最终归属仍需补明确迁移关系
-4. `tape_events` 的 retention / compression / backpressure 策略仍需补充
-5. `workbench_relations` 的端点类型约束是写在 schema 还是 service 层
+## 15.1 不阻塞 `Slice A / B / C / E` 的开放问题
+
+1. `browser runtime` 是长期保持在 `RuntimeBinding` 层，还是升级为 `BrowserNodeObject`
+2. `workbench_relations` 的端点类型约束是写在 schema 还是 service 层
+
+## 15.2 `Slice D / F` 前必须收口的问题
+
+1. `EventTape` 与现有 `eventlog / signals` 的最终落库与归属关系
+2. `tape_events` 的 retention / compression / backpressure 策略
+3. `raw` 事件的序列化约定（JSON / chunk / offset / idempotency 规则）
 
 ---
 

--- a/docs/architecture/agent-workbench-shared-graph-spec.md
+++ b/docs/architecture/agent-workbench-shared-graph-spec.md
@@ -1327,6 +1327,20 @@ Phase 1 必须具备：
 7. `/agents/*` shim
    - 旧路由可以逐步映射到新的 `WorkbenchPage`
 
+### Phase 1 runtime 支持分档
+
+1. `must ship（本阶段必须可见可用）`
+   - `agent-backed session`
+   - 平铺 pane 恢复
+   - `/agents/* -> /workbench` 兼容落点
+2. `should ship（本阶段优先纳管）`
+   - 现有 `PTY / SSH` 通过统一 `RuntimeBinding` 进入工作台语义
+   - 至少具备恢复、展示或附着能力之一
+   - 不要求在本阶段先稳定为独立 `terminal SessionKind`
+3. `model-only（只做模型预留）`
+   - `browser-runtime`
+   - 只要求统一模型入口与注册语义，不作为本阶段关闭条件
+
 ## 12.3 Phase 1 明确不做
 
 1. 自由画布编排
@@ -1394,6 +1408,8 @@ Phase 1 最低人类验收清单：
 4. 重启或刷新后，最近 pane 集合能够恢复
 5. 桌面端打开次窗口后，两个窗口仍然指向同一空间语义
 6. 基础会话输入/输出可继续进入事实流
+7. 至少 2 个代表性旧入口仍可落到正确工作台位置
+   - 例如 `/agents/chat/*`、`/agents/pty/*`
 
 ---
 

--- a/docs/architecture/agent-workbench-shared-graph-spec.md
+++ b/docs/architecture/agent-workbench-shared-graph-spec.md
@@ -821,6 +821,11 @@ type DerivedArtifact = {
 8. `inspector`
 9. `outcome`
 
+说明：
+
+1. `browser` 虽然保留在长期 `ViewType` 枚举中，但不是 Phase 1 首批视图
+2. Phase 1 不以 `browser pane` 作为关闭 issue 的验收门槛
+
 ## 6.2 `work-area` 与投影模式
 
 中间主舞台统一叫 `work-area`。  
@@ -835,7 +840,10 @@ type DerivedArtifact = {
 1. `canvas` 同时表示容器、视图、派生产物
 2. `network` 同时表示页面与派生关系图
 
-## 6.3 默认产品预设
+## 6.3 长期默认产品预设（post-Phase-1）
+
+下面这组预设描述的是 Phase 1 之后的长期桌面目标，不是 Phase 1 的默认交付面。  
+Phase 1 当前默认交付面以 `Flat Workbench（平铺工作台）` 为准，优先是 `session panes + inspector / outcome`，而不是 `canvas-first`。
 
 若不另行定制，桌面端默认预设建议为：
 
@@ -899,7 +907,7 @@ type DerivedArtifact = {
 3. drawer / sheet / fullscreen 的导航状态
 4. `SurfaceSlot.localState`
 
-## 7.2 Desktop（桌面端）
+## 7.2 Desktop（桌面端，长期目标）
 
 目标：
 
@@ -912,6 +920,11 @@ type DerivedArtifact = {
 1. 完整 `container graph`
 2. 支持 `panel + tabs + floating + work-area-host`
 3. 默认三栏只是预设，不是唯一布局
+
+补充说明：
+
+1. 这部分描述的是长期桌面能力，不是 Phase 1 的默认实现范围
+2. Phase 1 桌面默认实现以平铺 pane 工作台为准，不要求先交付 `floating + work-area-host`
 
 ## 7.3 Tablet（平板端）
 
@@ -1304,7 +1317,7 @@ Phase 1 必须具备：
    - 能恢复最近使用的会话集合
 3. `SessionObject`
    - MVP 先稳定兼容现有 `agent-backed session`
-   - 同时给 `PTY / SSH / browser runtime` 预留一致纳管入口
+   - 同时给 `PTY / SSH` 稳定纳管，并给 `browser runtime` 预留一致入口
 4. `RuntimeBinding + RuntimeAttachment + SessionAnchor`
    - 统一表示运行时句柄、宿主语义与附着关系
 5. `SurfaceSlot + SurfaceNavigationState`
@@ -1337,7 +1350,8 @@ Phase 1 必须具备：
 注意：
 
 1. `browser runtime` 在 Phase 1 先作为 `RuntimeBinding.bindingType = 'browser-runtime'`
-2. 是否升级为独立 `BrowserNodeObject` 留到下一轮评审
+2. 它在 Phase 1 只要求模型预留与注册入口，不作为关闭 issue 的强制可见功能
+3. 是否升级为独立 `BrowserNodeObject` 留到下一轮评审
 
 ## 12.5 Phase 1 关键用户旅程
 
@@ -1346,13 +1360,40 @@ Phase 1 必须具备：
    - 恢复最近活跃的 `SessionObject`
    - 用平铺工作面显示多个会话 pane（面板）
 2. 在同一工作台中新增会话
-   - 用户新建 `agent / PTY / SSH / browser runtime`
+   - 用户新建 `agent / PTY / SSH`
    - 系统创建 `SessionObject`
    - 系统通过 `RuntimeBinding` 附着到底层运行时
 3. 从主窗口派生次窗口
    - 用户把某个 pane 或 view 弹到新窗口
    - 新窗口仍然属于同一 `WorkbenchSpace`
    - 共享同一底层对象、关系与事实流
+
+## 12.6 Phase 1 可见功能与人类验收
+
+Phase 1 不只是交付抽象模型，它必须给出人类可直接看到、可直接验收的功能面。
+
+最低可见功能集合：
+
+1. 访问 `/workbench`
+   - 能打开一个稳定的平铺工作台
+2. 在同一工作台中同时看到至少 2 个 session pane
+   - 例如 `agent + PTY` 或 `agent + SSH`
+   - 至少一个 pane 应来自真实运行时恢复或真实运行时挂载
+   - 至少一个 pane 不是 `agent-backed session`
+3. 关闭并重新打开后
+   - 最近工作台能恢复
+4. 从主窗口派生一个次窗口工作面
+   - 仅要求桌面端 / Tauri 路径成立
+   - 次窗口仍加载同一 `WorkbenchSpace`
+
+Phase 1 最低人类验收清单：
+
+1. 打开工作台时不是空白页或跳错页
+2. 可以从工作台新建至少一种运行时 pane
+3. 主窗口中可同时看到 2 个以上工作面，且至少有一个不是 `agent-backed session`
+4. 重启或刷新后，最近 pane 集合能够恢复
+5. 桌面端打开次窗口后，两个窗口仍然指向同一空间语义
+6. 基础会话输入/输出可继续进入事实流
 
 ---
 
@@ -1380,6 +1421,7 @@ Phase 1 必须具备：
 1. 抽 `SessionInteropAdapter`
 2. 把现有 `AgentSession` 映射到 `SessionObject`
 3. 把 `PTY / SSH / browser runtime` 收到统一 `RuntimeBinding` 语义
+   - 其中 `browser runtime` 在 Phase 1 仅要求模型预留，不要求形成首批可见 pane
 4. 消除“PTY 伪装成 agent”这类语义污染
 
 交付标准：
@@ -1441,6 +1483,7 @@ Phase 1 必须具备：
 - [ ] `EventTape` 仍是事实源，结构化层只能派生
 - [ ] `/agents/*` 必须通过兼容路由逐步迁移
 - [ ] Epic 与阶段 issue 的治理方式保持最小扩散
+- [ ] 每个阶段 issue 都对应至少一个人类可见、可手测验收的功能面
 
 ---
 

--- a/docs/plans/2026-03-30-agent-workbench-phase1-flat-workbench-design.md
+++ b/docs/plans/2026-03-30-agent-workbench-phase1-flat-workbench-design.md
@@ -82,6 +82,20 @@ Phase 1 只要求下面这组关系稳定存在：
 
 1. 这不是最终全部关系类型
 2. 但足以支撑“一个空间、多个 pane、多个运行时、多个窗口、同一事实流”
+3. 这些词是 `Phase 1 operational alias（阶段操作别名）`，不能替代长期正式模型
+
+### 3.2.1 与长期正式模型的映射
+
+1. `space_contains`
+   - 对应长期模型中的 `SpaceObjectMembership`
+2. `surface_shows`
+   - 对应 `SurfaceSlot / ViewInstance` 的承载关系
+3. `session_anchors_to`
+   - 对应 `SessionAnchor`
+4. `session_attaches_runtime`
+   - 对应 `RuntimeAttachment`
+5. `session_emits_event`
+   - 对应 `EventTape / TapeEvent`
 
 ## 3.3 核心对象图
 
@@ -290,9 +304,78 @@ flowchart LR
 1. 关闭重开后可恢复最近工作台
 2. 文档中的对象模型与实际实现结构一致
 
+## 5.6 Slice F：可见功能封板与人类验收
+
+交付：
+
+1. Phase 1 最低可见功能面全部可访问
+2. 验收入口清晰，不依赖阅读实现细节
+3. issue 中的验收项与真实工作台界面一致
+
+验收：
+
+1. 人类可直接进入 `/workbench`
+2. 人类可看见至少 2 个 pane 同时存在
+3. 人类可看见最近工作台恢复成功
+4. 人类可看见次窗口仍属于同一 `WorkbenchSpace`
+
 ---
 
-## 6. 现有代码映射
+## 6. 可见功能验收清单
+
+## 6.1 最低可见功能
+
+1. `WorkbenchPage` 可访问
+2. `Flat Workbench` 平铺布局可见
+3. 至少 2 个 session pane 可同时显示
+   - 且至少 1 个 pane 对应真实运行时恢复或真实运行时挂载
+4. 最近工作台恢复可见
+5. 桌面端 / Tauri 下的次窗口工作面可见
+6. `browser runtime` 在 Phase 1 只要求模型预留与注册入口，不作为关闭条件
+
+## 6.2 人类手测步骤
+
+1. 打开 `/workbench`
+   - 预期：进入平铺工作台，而不是旧页面空壳
+2. 新建或恢复两个会话 pane
+   - 预期：两者可同时可见
+3. 刷新或重启应用
+   - 预期：最近工作台恢复
+4. 从当前工作台弹出一个次窗口
+   - 预期：仅在桌面端 / Tauri 路径验证
+   - 预期：次窗口仍属于同一空间，且能看到该空间的子集工作面
+5. 在其中一个 pane 内继续操作
+   - 预期：事实流继续记录，不出现“切窗口后丢状态”的明显断裂
+
+## 6.3 自动化与验证建议
+
+1. 单元测试
+   - `SessionObject / RuntimeBinding / SurfaceSlot` 的状态映射与恢复逻辑
+2. 集成测试
+   - `/agents/*` shim 到 `/workbench` 的兼容导航
+3. E2E 测试
+   - `/workbench` 打开、双 pane 显示、恢复最近工作台
+4. 人类手测
+   - 桌面端 / Tauri 的次窗口同空间语义
+   - 基本 session 输入/输出仍正常
+
+## 6.4 开发纪律
+
+1. 行为变更先写失败测试，再写最小实现
+2. 每个 Slice 完成后都要做 reviewer 复核
+3. 对外宣称“完成”之前，必须有新鲜验证证据
+4. Phase 1 的“完成”必须同时满足：
+   - 自动化验证通过
+   - 人类可见功能可手测
+5. 最低验证门槛建议：
+   - `bunx tsc --noEmit`
+   - 新增或受影响的定向 `vitest`
+   - 新增或受影响的定向 Playwright / E2E
+   - 桌面端 / Tauri 的次窗口手测烟雾验证
+
+---
+
+## 7. 现有代码映射
 
 1. [AgentsPage.tsx](../../src/ui/app/pages/AgentsPage.tsx)
    - 提供多会话、PTY、详情面板、移动端入口经验
@@ -306,16 +389,17 @@ flowchart LR
 
 ---
 
-## 7. 风险与评审点
+## 8. 风险与评审点
 
-## 7.1 主要风险
+## 8.1 主要风险
 
 1. 如果 Phase 1 又偷偷回到自由画布，会拖慢交付
 2. 如果 `browser runtime` 只写进文案、不进模型，后续还会断层
 3. 如果窗口层没有“共享同一空间语义”，会退化成多个孤立页面
 4. 如果 `EventTape` 不先打通，结构化层后面会变成伪真相
+5. 如果 issue 没有明确可见验收面，阶段执行会再次滑回抽象实现
 
-## 7.2 评审时重点看什么
+## 8.2 评审时重点看什么
 
 1. 当前阶段是否真的收敛到了 `Flat Workbench`
 2. `SessionObject + RuntimeBinding` 是否已经成为统一入口
@@ -324,7 +408,7 @@ flowchart LR
 
 ---
 
-## 8. 结论
+## 9. 结论
 
 Phase 1 的正确交付物，不是一个很自由的 UI，而是一个：
 

--- a/docs/plans/2026-03-30-agent-workbench-phase1-flat-workbench-design.md
+++ b/docs/plans/2026-03-30-agent-workbench-phase1-flat-workbench-design.md
@@ -78,6 +78,7 @@
 2. `should ship`
    - 现有 `PTY / SSH` 被统一纳入 `RuntimeBinding`
    - 至少可以恢复、展示或附着到工作台
+   - 不要求在本阶段先稳定为独立 `terminal SessionKind`
 3. `model-only`
    - `browser-runtime`
    - 只要求模型预留与统一注册入口

--- a/docs/plans/2026-03-30-agent-workbench-phase1-flat-workbench-design.md
+++ b/docs/plans/2026-03-30-agent-workbench-phase1-flat-workbench-design.md
@@ -1,0 +1,338 @@
+# Agent Workbench Phase 1：平铺工作台与跨窗口联邦前置抽象
+
+> 日期：2026-03-30  
+> 状态：review pending（待评审）  
+> 类型：architecture / implementation design（架构 / 实施设计）  
+> 关联：
+> - Parent Epic: `#728`
+> - 相关：`#385`、`#535`、`#646`、`#702`
+> - 上位规格：`docs/architecture/agent-workbench-shared-graph-spec.md`
+
+---
+
+## 1. 这份文档解决什么问题
+
+这份文档不是再讨论长期愿景，而是把 `Agent Workbench` 的第一阶段收敛成可以直接开工的范围。
+
+当前判断是：
+
+1. 不先做自由画布
+2. 不先做完整窗口管理器
+3. 先做一个稳定的 `Flat Workbench（平铺工作台）`
+4. 先让 `agent / PTY / SSH / browser runtime` 能被统一纳管
+5. 先把多个窗口共享同一 `WorkbenchSpace（工作空间）` 的联邦骨架立起来
+
+一句话概括：
+
+> Phase 1 不是“先把 UI 做自由”，而是“先让多个运行时工作面在同一个工作空间里稳定存在、稳定恢复、稳定跨窗口协同”。
+
+---
+
+## 2. 目标与非目标
+
+## 2.1 目标
+
+1. 交付一个稳定的 `WorkbenchPage`
+2. 同一 `WorkbenchSpace` 下可恢复多个会话 pane
+3. `SessionObject + RuntimeBinding` 统一承载现有 `AgentSession`、PTY、SSH，并预留 `browser runtime`
+4. 新增第二窗口时，仍然工作在同一个共享空间与同一个共享对象模型上
+5. 事实层先打通 `FocusRun + EventTape`
+
+## 2.2 非目标
+
+1. 不做自由画布拖拽编排
+2. 不做完整 `network` 编辑器
+3. 不做完整插件系统
+4. 不做任意对象类型一次性统一
+5. 不做完整 browser automation（浏览器自动化）协议
+
+---
+
+## 3. Phase 1 核心对象与最小关系
+
+## 3.1 核心对象
+
+1. `WorkbenchSpace`
+   - 长期工作空间
+   - 回答“我当前在哪个工作场景里干活”
+2. `ViewInstance`
+   - 平铺 pane 的语义视图
+3. `SurfaceSlot + SurfaceNavigationState`
+   - 当前窗口/承载面的语义挂载点
+4. `SessionObject`
+   - 一次会话过程的历史容器
+5. `RuntimeBinding`
+   - 真实运行时句柄
+   - Phase 1 首批类型：`agent-session / pty / ssh / browser-runtime`
+6. `EventTape`
+   - 事实流
+   - 记录输入、输出、控制事件
+
+## 3.2 最小关系集
+
+Phase 1 只要求下面这组关系稳定存在：
+
+1. `space_contains`
+2. `surface_shows`
+3. `session_anchors_to`
+4. `session_attaches_runtime`
+5. `session_emits_event`
+
+说明：
+
+1. 这不是最终全部关系类型
+2. 但足以支撑“一个空间、多个 pane、多个运行时、多个窗口、同一事实流”
+
+## 3.3 核心对象图
+
+```mermaid
+classDiagram
+  class WorkbenchSpace {
+    +id
+    +name
+    +scope
+  }
+
+  class ViewInstance {
+    +id
+    +viewType
+    +target
+  }
+
+  class SurfaceSlot {
+    +id
+    +surfaceProfile
+    +mode
+  }
+
+  class SurfaceNavigationState {
+    +id
+    +activeSurfaceSlotId
+    +activeLeafViewId
+  }
+
+  class SessionObject {
+    +id
+    +sessionKind
+    +status
+  }
+
+  class RuntimeBinding {
+    +id
+    +bindingType
+    +runtimeRef
+    +status
+  }
+
+  class EventTape {
+    +id
+    +focusRunId
+  }
+
+  WorkbenchSpace --> ViewInstance : contains
+  WorkbenchSpace --> SurfaceSlot : mounts
+  SurfaceSlot --> SurfaceNavigationState : navigates
+  ViewInstance --> SessionObject : targets
+  SessionObject --> RuntimeBinding : attaches
+  SessionObject --> EventTape : emits
+```
+
+## 3.4 `SessionObject` 生命周期
+
+```mermaid
+stateDiagram-v2
+  [*] --> running
+  running --> waiting_input
+  waiting_input --> running
+  running --> paused
+  paused --> running
+  running --> completed
+  running --> error
+  waiting_input --> error
+  paused --> archived
+  completed --> archived
+  error --> archived
+```
+
+---
+
+## 4. 三条关键用户旅程
+
+## 4.1 打开默认工作台
+
+```mermaid
+sequenceDiagram
+  participant U as User 用户
+  participant R as Router 路由
+  participant W as WorkbenchService 工作台服务
+  participant S as SessionInteropAdapter 会话桥接
+  participant UI as Flat Workbench UI
+
+  U->>R: 打开 /workbench
+  R->>W: resolveDefaultSpace()
+  W->>S: loadRecentSessions(spaceId)
+  S-->>W: SessionObject[]
+  W-->>UI: space + panes + sessions
+  UI-->>U: 展示平铺工作台
+```
+
+用户看到的效果是：
+
+1. 不是回到一个空白页
+2. 而是回到最近工作的空间
+3. 最近活跃的多个会话以平铺 pane 的方式恢复出来
+
+## 4.2 在同一空间里新增运行时 pane
+
+1. 用户选择新建 `agent / PTY / SSH / browser runtime`
+2. 系统创建 `SessionObject`
+3. 系统创建对应 `RuntimeBinding`
+4. 新 pane 进入当前 `WorkbenchSpace`
+5. 该会话的输入/输出开始进入 `EventTape`
+
+这里的重点不是 UI，而是：
+
+1. 新运行时不再各自长一套页面语义
+2. 而是统一进入 `SessionObject + RuntimeBinding`
+
+## 4.3 从主窗口派生第二窗口
+
+```mermaid
+flowchart LR
+  MW["Main Window<br/>主窗口"] --> SS["SurfaceSlot<br/>主承载面"]
+  MW --> V1["Session Pane A"]
+  MW --> V2["Session Pane B"]
+
+  MW -->|弹出 / 派生| SW["Secondary Window<br/>次窗口"]
+  SW --> SS2["SurfaceSlot<br/>次承载面"]
+  SW --> V3["Session Pane C / Browser View"]
+
+  MW -.共享同一空间.-> WS["WorkbenchSpace"]
+  SW -.共享同一空间.-> WS
+```
+
+这里要保证：
+
+1. 两个窗口看的不是两套独立状态
+2. 而是同一 `WorkbenchSpace` 的不同投影子集
+
+---
+
+## 5. 实施切片
+
+## 5.1 Slice A：Flat Shell
+
+交付：
+
+1. `WorkbenchPage.tsx`
+2. `flat preset（平铺预设）`
+3. `/workbench` 路由入口
+4. `/agents/*` shim
+
+验收：
+
+1. 页面能打开
+2. 可稳定显示多个 pane
+3. 不破坏当前移动端二级页面
+
+## 5.2 Slice B：Session / Runtime Federation
+
+交付：
+
+1. `SessionInteropAdapter`
+2. 统一 `RuntimeBinding`
+3. `AgentSession -> SessionObject` 映射
+4. `PTY / SSH -> RuntimeBinding` 映射
+
+验收：
+
+1. 旧会话可恢复
+2. 多运行时可共存
+3. 语义上不再把 PTY 节点伪装成 agent
+
+## 5.3 Slice C：Cross-Window Skeleton
+
+交付：
+
+1. 主窗口打开次窗口的最小链路
+2. `SurfaceSlot` 与窗口承载关系
+3. 窗口间共享空间与活动会话集合
+
+验收：
+
+1. 次窗口可打开
+2. 次窗口能展示同一空间下的子集工作面
+3. 不要求任意停靠与拖拽
+
+## 5.4 Slice D：EventTape Ingress
+
+交付：
+
+1. `FocusRun` 基础接入
+2. `EventTape` 追加写入
+3. 会话输入/输出/系统控制事件入流
+
+验收：
+
+1. 基础时间线可回放
+2. 派生层有稳定来源链路
+
+## 5.5 Slice E：Recovery / Review Read Model
+
+交付：
+
+1. 会话列表 + active panes 读模型
+2. 空间恢复逻辑
+3. outcome / inspector 的基础只读面板
+
+验收：
+
+1. 关闭重开后可恢复最近工作台
+2. 文档中的对象模型与实际实现结构一致
+
+---
+
+## 6. 现有代码映射
+
+1. [AgentsPage.tsx](../../src/ui/app/pages/AgentsPage.tsx)
+   - 提供多会话、PTY、详情面板、移动端入口经验
+   - 但对象语义需要被桥接，而不是直接复用
+2. [TaskDagPage.tsx](../../src/ui/app/pages/TaskDagPage.tsx)
+   - 提供 inspector 共存与状态恢复经验
+3. [routes.tsx](../../src/routes.tsx)
+   - 需要建立 `/workbench` 与 `/agents/*` shim
+4. [issue-646-deep-analysis.md](../analysis/issue-646-deep-analysis.md)
+   - 提供多窗口、聚合、回退和状态同步研究
+
+---
+
+## 7. 风险与评审点
+
+## 7.1 主要风险
+
+1. 如果 Phase 1 又偷偷回到自由画布，会拖慢交付
+2. 如果 `browser runtime` 只写进文案、不进模型，后续还会断层
+3. 如果窗口层没有“共享同一空间语义”，会退化成多个孤立页面
+4. 如果 `EventTape` 不先打通，结构化层后面会变成伪真相
+
+## 7.2 评审时重点看什么
+
+1. 当前阶段是否真的收敛到了 `Flat Workbench`
+2. `SessionObject + RuntimeBinding` 是否已经成为统一入口
+3. 次窗口是否共享同一 `WorkbenchSpace`
+4. 文档和 issue 的阶段切分是否足够清楚
+
+---
+
+## 8. 结论
+
+Phase 1 的正确交付物，不是一个很自由的 UI，而是一个：
+
+1. 能恢复
+2. 能跨窗口
+3. 能统一纳管多运行时
+4. 能留下事实流
+
+的稳定工作台。
+
+只要这层打稳，后面的 `canvas / network / replay` 都是在同一底座上长出来，而不是另起一套产品。

--- a/docs/plans/2026-03-30-agent-workbench-phase1-flat-workbench-design.md
+++ b/docs/plans/2026-03-30-agent-workbench-phase1-flat-workbench-design.md
@@ -19,7 +19,7 @@
 1. 不先做自由画布
 2. 不先做完整窗口管理器
 3. 先做一个稳定的 `Flat Workbench（平铺工作台）`
-4. 先让 `agent / PTY / SSH / browser runtime` 能被统一纳管
+4. 先让 `agent / PTY / SSH` 能被统一纳管，并给 `browser runtime` 预留模型入口
 5. 先把多个窗口共享同一 `WorkbenchSpace（工作空间）` 的联邦骨架立起来
 
 一句话概括：
@@ -63,10 +63,24 @@
    - 一次会话过程的历史容器
 5. `RuntimeBinding`
    - 真实运行时句柄
-   - Phase 1 首批类型：`agent-session / pty / ssh / browser-runtime`
+   - Phase 1 首批闭环类型：`agent-session / pty / ssh`
+   - `browser-runtime` 保留为模型预留，不作为 Phase 1 关闭 issue 的必选范围
 6. `EventTape`
    - 事实流
    - 记录输入、输出、控制事件
+
+## 3.1.1 Phase 1 runtime 支持分档
+
+1. `must ship`
+   - `agent-backed session`
+   - 双 pane 工作面
+   - 最近工作台恢复
+2. `should ship`
+   - 现有 `PTY / SSH` 被统一纳入 `RuntimeBinding`
+   - 至少可以恢复、展示或附着到工作台
+3. `model-only`
+   - `browser-runtime`
+   - 只要求模型预留与统一注册入口
 
 ## 3.2 最小关系集
 
@@ -198,7 +212,7 @@ sequenceDiagram
 
 ## 4.2 在同一空间里新增运行时 pane
 
-1. 用户选择新建 `agent / PTY / SSH / browser runtime`
+1. 用户选择新建 `agent / PTY / SSH`
 2. 系统创建 `SessionObject`
 3. 系统创建对应 `RuntimeBinding`
 4. 新 pane 进入当前 `WorkbenchSpace`
@@ -233,6 +247,21 @@ flowchart LR
 ---
 
 ## 5. 实施切片
+
+## 5.0 推荐执行顺序
+
+1. `Slice A`
+   - 先把 `/workbench` 壳层与平铺 pane 打开
+2. `Slice B`
+   - 再统一 `SessionObject + RuntimeBinding`
+3. `Slice E`
+   - 再把恢复能力补上，让“最近工作台恢复”成为可见功能
+4. `Slice C`
+   - 然后上桌面端 / Tauri 的次窗口工作面
+5. `Slice D`
+   - 最后把 `EventTape` 接进来，避免事实层阻塞前面可见工作面
+6. `Slice F`
+   - 用于功能封板与关闭 issue 前的人类验收
 
 ## 5.1 Slice A：Flat Shell
 
@@ -315,7 +344,7 @@ flowchart LR
 验收：
 
 1. 人类可直接进入 `/workbench`
-2. 人类可看见至少 2 个 pane 同时存在
+2. 人类可看见至少 2 个 pane 同时存在，且必须跨 runtime 类型
 3. 人类可看见最近工作台恢复成功
 4. 人类可看见次窗口仍属于同一 `WorkbenchSpace`
 
@@ -329,6 +358,7 @@ flowchart LR
 2. `Flat Workbench` 平铺布局可见
 3. 至少 2 个 session pane 可同时显示
    - 且至少 1 个 pane 对应真实运行时恢复或真实运行时挂载
+   - 且至少 1 个 pane 不是 `agent-backed session`
 4. 最近工作台恢复可见
 5. 桌面端 / Tauri 下的次窗口工作面可见
 6. `browser runtime` 在 Phase 1 只要求模型预留与注册入口，不作为关闭条件
@@ -338,7 +368,7 @@ flowchart LR
 1. 打开 `/workbench`
    - 预期：进入平铺工作台，而不是旧页面空壳
 2. 新建或恢复两个会话 pane
-   - 预期：两者可同时可见
+   - 预期：两者可同时可见，且至少一者不是 `agent-backed session`
 3. 刷新或重启应用
    - 预期：最近工作台恢复
 4. 从当前工作台弹出一个次窗口
@@ -346,6 +376,28 @@ flowchart LR
    - 预期：次窗口仍属于同一空间，且能看到该空间的子集工作面
 5. 在其中一个 pane 内继续操作
    - 预期：事实流继续记录，不出现“切窗口后丢状态”的明显断裂
+6. 打开代表性旧入口
+   - 例如 `/agents/chat/*`、`/agents/pty/*`
+   - 预期：仍能落到正确的 `Workbench` pane / space / 返回路径
+
+## 6.2.1 Given / When / Then 验收模板
+
+1. Given：
+   - 已存在一个默认 `WorkbenchSpace`
+   - 已存在至少一个最近活跃的 `agent-backed session`
+   - 已存在或可新建至少一个 `PTY / SSH` 运行时
+2. When：
+   - 打开 `/workbench`
+   - 新建或恢复第二个 pane
+   - 刷新或重启应用
+   - 从桌面端 / Tauri 弹出次窗口
+3. Then：
+   - 人类能看到同一空间名称或同一空间标识
+   - 至少 2 个 pane 同时可见
+   - 至少 1 个 pane 不是 `agent-backed session`
+   - 最近工作台恢复
+   - 次窗口仍指向同一空间语义
+   - 代表性旧入口落点正确
 
 ## 6.3 自动化与验证建议
 
@@ -354,7 +406,7 @@ flowchart LR
 2. 集成测试
    - `/agents/*` shim 到 `/workbench` 的兼容导航
 3. E2E 测试
-   - `/workbench` 打开、双 pane 显示、恢复最近工作台
+   - `/workbench` 打开、跨 runtime 双 pane 显示、恢复最近工作台
 4. 人类手测
    - 桌面端 / Tauri 的次窗口同空间语义
    - 基本 session 输入/输出仍正常
@@ -372,6 +424,16 @@ flowchart LR
    - 新增或受影响的定向 `vitest`
    - 新增或受影响的定向 Playwright / E2E
    - 桌面端 / Tauri 的次窗口手测烟雾验证
+
+## 6.5 关闭 issue 前的最终门槛
+
+1. `/workbench` 可访问
+2. 至少 2 个 pane 同时可见
+   - 且至少 1 个 pane 不是 `agent-backed session`
+3. 最近工作台恢复通过
+4. 桌面端 / Tauri 的次窗口工作面通过
+5. 至少 2 个代表性旧入口兼容通过
+6. 自动化验证与人类手测都完成
 
 ---
 

--- a/docs/plans/2026-03-30-agent-workbench-phase1-flat-workbench-design.md
+++ b/docs/plans/2026-03-30-agent-workbench-phase1-flat-workbench-design.md
@@ -75,13 +75,54 @@
    - `agent-backed session`
    - 双 pane 工作面
    - 最近工作台恢复
+   - 至少一个 `runtime-attached non-agent pane`
+   - 当前默认来源是 `PTY / SSH`
 2. `should ship`
    - 现有 `PTY / SSH` 被统一纳入 `RuntimeBinding`
-   - 至少可以恢复、展示或附着到工作台
    - 不要求在本阶段先稳定为独立 `terminal SessionKind`
+   - 也不要求在本阶段一次做完完整终端产品面
 3. `model-only`
    - `browser-runtime`
    - 只要求模型预留与统一注册入口
+
+## 3.1.2 Phase 1 `default space` 生命周期
+
+1. 第一次打开 `/workbench`
+   - 若还没有空间记录，则自动创建一个 `default space`
+2. 再次打开 `/workbench`
+   - 优先恢复最近一次活跃的同一默认空间
+3. `default space` 的 Phase 1 身份规则
+   - 当前本地 profile 下固定使用一个稳定 `spaceId`
+   - 在没有多空间 UI 之前，默认实现就是 `default-space`
+4. 主窗口与次窗口
+   - 必须通过同一个 `resolveDefaultSpace()` 入口拿到当前默认空间
+   - 若默认空间已存在，次窗口不得再次创建第二份“默认空间”
+5. Phase 1 不提供：
+   - 空间删除 UI
+   - 空间归档 UI
+   - 多空间管理 UI
+6. Phase 1 必须提供：
+   - 可见的 `spaceId / spaceName`
+   - 稳定的最近工作台恢复入口
+
+## 3.1.3 跨窗口共享空间契约
+
+这部分是 `Slice C` 的执行契约，不是只停留在愿景层的口号。
+
+1. 跨窗口共享：
+   - `spaceId`
+   - pane membership（pane 归属）
+   - `SessionObject / RuntimeBinding` 关联
+   - 当前运行中的 `FocusRun` 标识
+2. 严格窗口本地：
+   - 当前窗口选中的 pane
+   - 滚动位置
+   - inspector 展开折叠
+   - 临时 hover / selection / draft
+3. 单写者规则：
+   - 共享状态必须通过统一 service 更新
+   - 事实层写入不能由窗口各自直接追加本地日志
+   - `SurfaceNavigationState.localState` 默认视为窗口本地态
 
 ## 3.2 最小关系集
 
@@ -271,13 +312,29 @@ flowchart LR
 1. `WorkbenchPage.tsx`
 2. `flat preset（平铺预设）`
 3. `/workbench` 路由入口
-4. `/agents/*` shim
+4. 代表性旧入口 shim（第一批以 `/agents`、`/agents/chat/*` 为准）
+5. `legacy /agents/pty/*` 留在后续路由正规化，不作为第一批 shim 完成标准
+
+执行备注：
+
+1. 第一个 red-green loop 只要求：
+   - `/workbench` 路由存在
+   - 平铺壳层可见
+   - 至少 2 个 pane 同时可见
+   - 且至少 1 个 pane 明确不是 `agent-backed session`
+   - 允许先以 `workbench-modeled non-agent pane（工作台建模的非 agent pane）` 起步
+   - 但 Phase 1 关闭前必须接上真实 `PTY / SSH` 注册或恢复链路
+2. 代表性旧入口 shim
+   - 允许作为 Slice A 后半段继续补齐
+   - 不要求在第一笔实现里一次覆盖全部 `/agents/*`
+   - `legacy /agents/pty/*` 不算第一笔必须覆盖项
 
 验收：
 
 1. 页面能打开
 2. 可稳定显示多个 pane
-3. 不破坏当前移动端二级页面
+3. 当前空间标识可见
+4. 不破坏当前移动端二级页面
 
 ## 5.2 Slice B：Session / Runtime Federation
 
@@ -307,6 +364,20 @@ flowchart LR
 1. 次窗口可打开
 2. 次窗口能展示同一空间下的子集工作面
 3. 不要求任意停靠与拖拽
+
+执行契约：
+
+1. 共享：
+   - `spaceId`
+   - pane membership
+   - `SessionObject / RuntimeBinding` 关联
+2. 本地：
+   - `SurfaceNavigationState.localState`
+   - 当前窗口选中的 pane
+   - 当前窗口的滚动和临时 UI 状态
+3. 写入：
+   - 多窗口都通过统一 service 修改共享状态
+   - 事实层写入不能由窗口各自直接追加本地日志
 
 ## 5.4 Slice D：EventTape Ingress
 
@@ -360,6 +431,8 @@ flowchart LR
 3. 至少 2 个 session pane 可同时显示
    - 且至少 1 个 pane 对应真实运行时恢复或真实运行时挂载
    - 且至少 1 个 pane 不是 `agent-backed session`
+   - 若当前还处在 `Slice A1`，允许先是 modeled non-agent pane
+   - 进入 `Phase 1 close` 前必须升级为真实 `PTY / SSH` 运行时链路
 4. 最近工作台恢复可见
 5. 桌面端 / Tauri 下的次窗口工作面可见
 6. `browser runtime` 在 Phase 1 只要求模型预留与注册入口，不作为关闭条件
@@ -378,7 +451,8 @@ flowchart LR
 5. 在其中一个 pane 内继续操作
    - 预期：事实流继续记录，不出现“切窗口后丢状态”的明显断裂
 6. 打开代表性旧入口
-   - 例如 `/agents/chat/*`、`/agents/pty/*`
+   - 第一批以 `/agents`、`/agents/chat/*` 为准
+   - `legacy /agents/pty/*` 归入后续路由正规化
    - 预期：仍能落到正确的 `Workbench` pane / space / 返回路径
 
 ## 6.2.1 Given / When / Then 验收模板
@@ -403,11 +477,14 @@ flowchart LR
 ## 6.3 自动化与验证建议
 
 1. 单元测试
+   - `default space / recent panes` 恢复逻辑
    - `SessionObject / RuntimeBinding / SurfaceSlot` 的状态映射与恢复逻辑
 2. 集成测试
-   - `/agents/*` shim 到 `/workbench` 的兼容导航
+   - 代表性旧入口到 `/workbench` 的兼容导航
 3. E2E 测试
-   - `/workbench` 打开、跨 runtime 双 pane 显示、恢复最近工作台
+   - `/workbench` 打开
+   - 跨 runtime 双 pane 显示
+   - 最近工作台恢复
 4. 人类手测
    - 桌面端 / Tauri 的次窗口同空间语义
    - 基本 session 输入/输出仍正常
@@ -468,6 +545,17 @@ flowchart LR
 2. `SessionObject + RuntimeBinding` 是否已经成为统一入口
 3. 次窗口是否共享同一 `WorkbenchSpace`
 4. 文档和 issue 的阶段切分是否足够清楚
+
+## 8.3 对上一轮评审的闭环结论
+
+1. “不要自建窗口管理器”
+   - 已收敛，Phase 1 不做完整窗口管理器
+2. “`default space` 生命周期要说清楚”
+   - 已在本版补充默认空间规则
+3. “`EventTape` 与现有事件系统关系要讲清”
+   - 已明确：`Slice A / B / C / E` 先桥接，`Slice D` 再正式收口
+4. “每个阶段必须有人类可见验收”
+   - 已转成 Given / When / Then 和关闭 issue 门槛
 
 ---
 

--- a/src/config/workbench-legacy-shim-enabled.ts
+++ b/src/config/workbench-legacy-shim-enabled.ts
@@ -1,0 +1,17 @@
+const WORKBENCH_LEGACY_SHIM_ENABLED_STORAGE_KEY = 'exomind:workbenchLegacyShimEnabled';
+
+export function getWorkbenchLegacyShimEnabled(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return window.localStorage.getItem(WORKBENCH_LEGACY_SHIM_ENABLED_STORAGE_KEY) === 'true';
+}
+
+export function setWorkbenchLegacyShimEnabled(enabled: boolean): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.setItem(WORKBENCH_LEGACY_SHIM_ENABLED_STORAGE_KEY, String(enabled));
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -133,6 +133,11 @@ const AgentsPage = lazy(async () => {
   return { default: module.AgentsPage };
 });
 
+const WorkbenchPage = lazy(async () => {
+  const module = await import('@/ui/app/pages/workbench/WorkbenchPage');
+  return { default: module.WorkbenchPage };
+});
+
 const GoalsPage = lazy(async () => {
   const module = await import('@/ui/app/pages/goals/GoalsPage');
   return { default: module.GoalsPage };
@@ -937,6 +942,18 @@ const newAgentsRoute = createRoute({
   },
 });
 
+const newWorkbenchRoute = createRoute({
+  getParentRoute: () => newRootRoute,
+  path: '/workbench',
+  component: function NewWorkbench() {
+    return (
+      <LazyPage>
+        <WorkbenchPage />
+      </LazyPage>
+    );
+  },
+});
+
 const newUpdateRoute = createRoute({
   getParentRoute: () => newRootRoute,
   path: '/update',
@@ -1033,6 +1050,7 @@ const newRouteTree = newRootRoute.addChildren([
   newVolcanoAsrTestRoute,
   newSyncTestRoute,
   newAgentsRoute,
+  newWorkbenchRoute,
   newUpdateRoute,
   newAgentDetailRoute,
   newActorDetailRoute,
@@ -1044,5 +1062,4 @@ const newRouteTree = newRootRoute.addChildren([
 const appRouter = createRouter({ routeTree: newRouteTree });
 
 export { appRouter };
-
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils';
 import { getAgentPageEnabled, subscribeAgentPageEnabledChanges } from '@/config/agent-page-enabled';
 import { getMePageEnabled, subscribeMePageEnabledChanges } from '@/config/me-page-enabled';
 import { getGoalsPageEnabled, subscribeGoalsPageEnabledChanges } from '@/config/goals-page-enabled';
+import { getWorkbenchLegacyShimEnabled } from '@/config/workbench-legacy-shim-enabled';
 import { getDesktopAdaptiveEnabled, subscribeDesktopAdaptiveChanges } from '@/config/desktop-adaptive';
 import { getDeveloperModeEnabled, subscribeDeveloperModeChanges } from '@/config/developer-mode';
 import { getCommandPaletteEnabled, subscribeCommandPaletteEnabledChanges } from '@/config/command-palette-enabled';
@@ -183,6 +184,36 @@ function PageFallback() {
 
 function LazyPage({ children }: { children: React.ReactNode }) {
   return <Suspense fallback={<PageFallback />}>{children}</Suspense>;
+}
+
+function LegacyWorkbenchShim({
+  enabled,
+  search,
+  children,
+}: {
+  enabled: boolean;
+  search: Record<string, string>;
+  children: React.ReactNode;
+}) {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    void navigate({
+      to: '/workbench',
+      search,
+      replace: true,
+    });
+  }, [enabled, navigate, search]);
+
+  if (enabled) {
+    return null;
+  }
+
+  return <>{children}</>;
 }
 
 function resolveRuntimePlatform(): 'web' | 'tauri' | 'unknown' {
@@ -935,9 +966,14 @@ const newAgentsRoute = createRoute({
   path: '/agents',
   component: function NewAgents() {
     return (
-      <LazyPage>
-        <AgentsPage />
-      </LazyPage>
+      <LegacyWorkbenchShim
+        enabled={getWorkbenchLegacyShimEnabled()}
+        search={{ legacySource: 'agents-hub' }}
+      >
+        <LazyPage>
+          <AgentsPage />
+        </LazyPage>
+      </LegacyWorkbenchShim>
     );
   },
 });
@@ -1009,10 +1045,19 @@ const newAgentConversationRoute = createRoute({
   path: '/agents/chat/$agentId',
   component: function NewAgentConversation() {
     const { agentId } = useParams({ strict: false }) as { agentId?: string };
+    const legacyShimEnabled = getWorkbenchLegacyShimEnabled();
     return (
-      <LazyPage>
-        <AgentConversationPage agentId={agentId} />
-      </LazyPage>
+      <LegacyWorkbenchShim
+        enabled={legacyShimEnabled && Boolean(agentId)}
+        search={{
+          legacySource: 'agent-chat',
+          agentId: agentId ?? '',
+        }}
+      >
+        <LazyPage>
+          <AgentConversationPage agentId={agentId} />
+        </LazyPage>
+      </LegacyWorkbenchShim>
     );
   },
 });
@@ -1062,4 +1107,3 @@ const newRouteTree = newRootRoute.addChildren([
 const appRouter = createRouter({ routeTree: newRouteTree });
 
 export { appRouter };
-

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,6 +1,6 @@
 import { createRootRoute, createRouter, createRoute, Outlet, Link, useLocation, useNavigate, useParams, type ErrorComponentProps } from '@tanstack/react-router';
 import { Suspense, lazy, useEffect, useMemo, useState } from 'react';
-import { Target, Settings, Waypoints, SquareCheckBig, UserRound, Brain, PanelLeftClose, PanelLeftOpen, Orbit, type LucideIcon } from 'lucide-react';
+import { Target, Settings, Waypoints, SquareCheckBig, UserRound, Brain, PanelLeftClose, PanelLeftOpen, Orbit, FlaskConical, type LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { getAgentPageEnabled, subscribeAgentPageEnabledChanges } from '@/config/agent-page-enabled';
 import { getMePageEnabled, subscribeMePageEnabledChanges } from '@/config/me-page-enabled';
@@ -288,6 +288,7 @@ function MobileShell({
                   || (item.path === '/me' && locationPath.startsWith('/me'))
                   || (item.path === '/goals' && locationPath.startsWith('/goals'))
                   || (item.path === '/agents' && locationPath.startsWith('/agents'))
+                  || (item.path === '/workbench' && locationPath.startsWith('/workbench'))
                   || (item.path === '/settings' && locationPath.startsWith('/settings'));
                 return (
                   <Link
@@ -350,6 +351,13 @@ function DesktopSidebar({
       icon: Waypoints,
       match: (path: string) => path === '/agents' || path.startsWith('/agents/'),
     }] : []),
+    {
+      key: 'workbench-test',
+      title: '工作台测试',
+      path: '/workbench',
+      icon: FlaskConical,
+      match: (path: string) => path === '/workbench' || path.startsWith('/workbench/'),
+    },
     { key: 'settings', title: '设置', path: '/settings', icon: Settings, match: (path: string) => path === '/settings' || path.startsWith('/settings/') },
   ];
 
@@ -617,6 +625,7 @@ function NewLayout() {
     ...(goalsPageEnabled ? [{ title: '目标', path: '/goals', icon: Orbit }] : []),
     ...(mePageEnabled ? [{ title: 'Me', path: '/me', icon: UserRound }] : []),
     ...(agentPageEnabled ? [{ title: '网络', path: '/agents', icon: Waypoints }] : []),
+    { title: '工作台测试', path: '/workbench', icon: FlaskConical },
     { title: '设置', path: '/settings', icon: Settings },
   ];
   const selectedShell = resolveAppShellMode({

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -196,9 +196,14 @@ function LegacyWorkbenchShim({
   children: React.ReactNode;
 }) {
   const navigate = useNavigate();
+  const location = useLocation();
+  const bypassWorkbenchShim = useMemo(
+    () => new URLSearchParams(location.searchStr ?? '').get('workbenchBypass') === 'true',
+    [location.searchStr],
+  );
 
   useEffect(() => {
-    if (!enabled) {
+    if (!enabled || bypassWorkbenchShim) {
       return;
     }
 
@@ -207,9 +212,9 @@ function LegacyWorkbenchShim({
       search,
       replace: true,
     });
-  }, [enabled, navigate, search]);
+  }, [bypassWorkbenchShim, enabled, navigate, search]);
 
-  if (enabled) {
+  if (enabled && !bypassWorkbenchShim) {
     return null;
   }
 

--- a/src/ui/app/layout/shell-mode.ts
+++ b/src/ui/app/layout/shell-mode.ts
@@ -14,6 +14,8 @@ export function isDesktopAdaptiveShellPath(pathname: string): boolean {
     || pathname.startsWith('/settings/')
     || pathname === '/agents'
     || pathname.startsWith('/agents/')
+    || pathname === '/workbench'
+    || pathname.startsWith('/workbench/')
     || pathname === '/goals'
     || pathname.startsWith('/goals/');
 }

--- a/src/ui/app/pages/workbench/WorkbenchPage.tsx
+++ b/src/ui/app/pages/workbench/WorkbenchPage.tsx
@@ -1,10 +1,13 @@
+import { useLocation } from '@tanstack/react-router';
 import { Bot, Network, TerminalSquare } from 'lucide-react';
 import { useMemo } from 'react';
 
 import { useIsDesktop } from '@/ui/app/hooks/useIsDesktop';
 
 import {
+  applyWorkbenchLegacyIntent,
   readOrCreateWorkbenchFlatState,
+  resolveWorkbenchLegacyIntent,
   type WorkbenchBindingType,
   type WorkbenchPaneState,
 } from './workbench-storage';
@@ -87,7 +90,15 @@ function WorkbenchPaneCard({ pane }: { pane: WorkbenchPaneState }) {
 
 export function WorkbenchPage() {
   const isDesktop = useIsDesktop(1024);
-  const state = useMemo(() => readOrCreateWorkbenchFlatState(), []);
+  const location = useLocation();
+  const legacyIntent = useMemo(
+    () => resolveWorkbenchLegacyIntent(location.searchStr ?? ''),
+    [location.searchStr],
+  );
+  const state = useMemo(
+    () => applyWorkbenchLegacyIntent(readOrCreateWorkbenchFlatState(), legacyIntent),
+    [legacyIntent],
+  );
 
   return (
     <div
@@ -144,6 +155,15 @@ export function WorkbenchPage() {
             </div>
           </div>
         </header>
+
+        {legacyIntent ? (
+          <section
+            data-testid="workbench-legacy-entry"
+            className="rounded-[20px] border border-[#E9D5FF] bg-[#FAF5FF] px-4 py-3 text-sm text-[#6B21A8] shadow-[0_12px_36px_-30px_rgba(109,40,217,0.45)] dark:border-[#4C1D95] dark:bg-[#1E1433] dark:text-[#E9D5FF]"
+          >
+            Legacy route handoff / 旧入口接力：<code>{legacyIntent.route}</code>
+          </section>
+        ) : null}
 
         <section
           data-testid="workbench-pane-grid"

--- a/src/ui/app/pages/workbench/WorkbenchPage.tsx
+++ b/src/ui/app/pages/workbench/WorkbenchPage.tsx
@@ -1,0 +1,159 @@
+import { Bot, Network, TerminalSquare } from 'lucide-react';
+import { useMemo } from 'react';
+
+import { useIsDesktop } from '@/ui/app/hooks/useIsDesktop';
+
+import {
+  readOrCreateWorkbenchFlatState,
+  type WorkbenchBindingType,
+  type WorkbenchPaneState,
+} from './workbench-storage';
+
+type PanePresentation = {
+  badge: string;
+  icon: typeof Bot;
+  accentClassName: string;
+};
+
+const PANE_PRESENTATIONS: Record<WorkbenchBindingType, PanePresentation> = {
+  'agent-session': {
+    badge: 'Agent Session / Agent 会话',
+    icon: Bot,
+    accentClassName: 'border-[#C75B3A]/30 bg-[#FFF7F2] text-[#9A3412]',
+  },
+  'pty-runtime': {
+    badge: 'PTY Runtime / PTY 终端',
+    icon: TerminalSquare,
+    accentClassName: 'border-[#1D4ED8]/30 bg-[#EFF6FF] text-[#1D4ED8]',
+  },
+  'ssh-runtime': {
+    badge: 'SSH Runtime / SSH 终端',
+    icon: TerminalSquare,
+    accentClassName: 'border-[#0F766E]/30 bg-[#F0FDFA] text-[#115E59]',
+  },
+  'browser-runtime': {
+    badge: 'Browser Runtime / 浏览器运行时',
+    icon: Network,
+    accentClassName: 'border-[#7C3AED]/30 bg-[#F5F3FF] text-[#6D28D9]',
+  },
+};
+
+function WorkbenchPaneCard({ pane }: { pane: WorkbenchPaneState }) {
+  const presentation = PANE_PRESENTATIONS[pane.bindingType];
+  const Icon = presentation.icon;
+
+  return (
+    <article
+      data-testid={`workbench-pane-${pane.bindingType}`}
+      className="flex min-h-[220px] flex-col gap-4 rounded-[24px] border border-[#E7E0D8] bg-white/95 p-5 shadow-[0_20px_50px_-34px_rgba(28,25,23,0.28)] dark:border-[#2A2523] dark:bg-[#171312]"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-2">
+          <span
+            className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[11px] font-semibold ${presentation.accentClassName}`}
+          >
+            <Icon size={14} />
+            {presentation.badge}
+          </span>
+          <div>
+            <h2 className="text-base font-semibold text-[#1C1917] dark:text-[#FAFAF9]">
+              {pane.title}
+            </h2>
+            <p className="mt-1 text-sm text-[#57534E] dark:text-[#D6D3D1]">
+              {pane.description}
+            </p>
+          </div>
+        </div>
+        <span className="rounded-full bg-[#F5F0ED] px-2.5 py-1 text-[11px] font-medium text-[#57534E] dark:bg-[#26211F] dark:text-[#D6D3D1]">
+          {pane.status}
+        </span>
+      </div>
+
+      <div className="flex flex-1 flex-col justify-between rounded-[18px] border border-dashed border-[#DED6CF] bg-[#FAF7F5] p-4 dark:border-[#332D2A] dark:bg-[#120F0E]">
+        <div className="flex items-center gap-2 text-sm font-medium text-[#292524] dark:text-[#F5F5F4]">
+          <Network size={14} />
+          Phase 1 Flat Workbench / 平铺工作台
+        </div>
+        <div className="mt-4 space-y-2 text-xs leading-5 text-[#78716C] dark:text-[#A8A29E]">
+          <p>View kind（视图类型）: <code>{pane.viewKind}</code></p>
+          <p>Binding type（绑定类型）: <code>{pane.bindingType}</code></p>
+          <p>Source of truth（事实源）: EventTape ready / 事实层预留</p>
+          <p>Current focus（当前焦点）: visible pane / 当前可见工作面</p>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export function WorkbenchPage() {
+  const isDesktop = useIsDesktop(1024);
+  const state = useMemo(() => readOrCreateWorkbenchFlatState(), []);
+
+  return (
+    <div
+      data-testid="workbench-page"
+      className="min-h-full bg-[radial-gradient(circle_at_top_left,rgba(199,91,58,0.12),transparent_28%),linear-gradient(180deg,#FBF7F4_0%,#F5EFEA_100%)] px-4 py-5 text-[#1C1917] dark:bg-[radial-gradient(circle_at_top_left,rgba(234,88,12,0.12),transparent_28%),linear-gradient(180deg,#120F0E_0%,#0C0A09_100%)] dark:text-[#FAFAF9] md:px-6"
+    >
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-5">
+        <header className="rounded-[28px] border border-[#E7E0D8] bg-white/90 p-5 shadow-[0_22px_60px_-38px_rgba(28,25,23,0.3)] dark:border-[#2A2523] dark:bg-[#171312]/90">
+          <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[#A16207] dark:text-[#F59E0B]">
+                Phase 1 / Flat Workbench
+              </p>
+              <div>
+                <h1 className="text-2xl font-semibold md:text-3xl">
+                  Agent Workbench / Agent 工作台
+                </h1>
+                <p className="mt-2 max-w-3xl text-sm leading-6 text-[#57534E] dark:text-[#D6D3D1]">
+                  先交付一个稳定的多 pane 工作面，把 agent session 与 SSH runtime 放进同一个共享空间语义里。
+                </p>
+              </div>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="rounded-[20px] border border-[#E7E0D8] bg-[#FAF7F5] px-4 py-3 dark:border-[#302A27] dark:bg-[#120F0E]">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#A8A29E]">
+                  Current Space
+                </div>
+                <div
+                  data-testid="workbench-space-name"
+                  className="mt-1 text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]"
+                >
+                  {state.space.name}
+                </div>
+                <div className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
+                  {state.space.id}
+                </div>
+                <div className="mt-1 text-[11px] text-[#A8A29E]">
+                  {state.surface.id} / {state.surface.layoutPreset}
+                </div>
+              </div>
+
+              <div className="rounded-[20px] border border-[#E7E0D8] bg-[#FAF7F5] px-4 py-3 dark:border-[#302A27] dark:bg-[#120F0E]">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#A8A29E]">
+                  Restore Marker
+                </div>
+                <div className="mt-1 text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">
+                  Recent panes ready
+                </div>
+                <div className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
+                  {state.space.restoredAt}
+                </div>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <section
+          data-testid="workbench-pane-grid"
+          className={isDesktop ? 'grid grid-cols-2 gap-5' : 'grid grid-cols-1 gap-4'}
+        >
+          {state.panes.map((pane) => (
+            <WorkbenchPaneCard key={pane.id} pane={pane} />
+          ))}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/app/pages/workbench/WorkbenchPage.tsx
+++ b/src/ui/app/pages/workbench/WorkbenchPage.tsx
@@ -1,13 +1,22 @@
 import { useLocation } from '@tanstack/react-router';
-import { Bot, Network, TerminalSquare } from 'lucide-react';
-import { useMemo } from 'react';
+import { Bot, ExternalLink, Network, TerminalSquare } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
 
+import {
+  getSelectedRuntimeTarget,
+  subscribeRuntimeTargetChanges,
+  toRuntimeBaseUrl,
+  type RuntimeTarget,
+} from '@/config/runtime-target';
+import { useSessionStream } from '@/hooks/useSessionStream';
 import { useIsDesktop } from '@/ui/app/hooks/useIsDesktop';
 
 import {
   applyWorkbenchLegacyIntent,
+  buildWorkbenchPanesFromSessions,
   readOrCreateWorkbenchFlatState,
   resolveWorkbenchLegacyIntent,
+  writeWorkbenchFlatState,
   type WorkbenchBindingType,
   type WorkbenchPaneState,
 } from './workbench-storage';
@@ -41,6 +50,15 @@ const PANE_PRESENTATIONS: Record<WorkbenchBindingType, PanePresentation> = {
   },
 };
 
+function openWorkbenchPane(path: string | undefined) {
+  if (!path || typeof window === 'undefined') {
+    return;
+  }
+
+  window.history.pushState({}, '', path);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
+
 function WorkbenchPaneCard({ pane }: { pane: WorkbenchPaneState }) {
   const presentation = PANE_PRESENTATIONS[pane.bindingType];
   const Icon = presentation.icon;
@@ -48,7 +66,7 @@ function WorkbenchPaneCard({ pane }: { pane: WorkbenchPaneState }) {
   return (
     <article
       data-testid={`workbench-pane-${pane.bindingType}`}
-      className="flex min-h-[220px] flex-col gap-4 rounded-[24px] border border-[#E7E0D8] bg-white/95 p-5 shadow-[0_20px_50px_-34px_rgba(28,25,23,0.28)] dark:border-[#2A2523] dark:bg-[#171312]"
+      className="flex min-h-[240px] flex-col gap-4 rounded-[24px] border border-[#E7E0D8] bg-white/95 p-5 shadow-[0_20px_50px_-34px_rgba(28,25,23,0.28)] dark:border-[#2A2523] dark:bg-[#171312]"
     >
       <div className="flex items-start justify-between gap-3">
         <div className="space-y-2">
@@ -78,12 +96,31 @@ function WorkbenchPaneCard({ pane }: { pane: WorkbenchPaneState }) {
           Phase 1 Flat Workbench / 平铺工作台
         </div>
         <div className="mt-4 space-y-2 text-xs leading-5 text-[#78716C] dark:text-[#A8A29E]">
-          <p>View kind（视图类型）: <code>{pane.viewKind}</code></p>
-          <p>Binding type（绑定类型）: <code>{pane.bindingType}</code></p>
-          <p>Source of truth（事实源）: EventTape ready / 事实层预留</p>
-          <p>Current focus（当前焦点）: visible pane / 当前可见工作面</p>
+          <p>
+            View kind（视图类型）: <code>{pane.viewKind}</code>
+          </p>
+          <p>
+            Binding type（绑定类型）: <code>{pane.bindingType}</code>
+          </p>
+          <p>
+            Session id（会话 ID）: <code>{pane.sessionId ?? 'fallback-pane'}</code>
+          </p>
+          <p>
+            Destination（目标页）: <code>{pane.openPath ?? 'not available / 暂不可跳转'}</code>
+          </p>
         </div>
       </div>
+
+      <button
+        type="button"
+        data-testid={`workbench-pane-open-${pane.id}`}
+        onClick={() => openWorkbenchPane(pane.openPath)}
+        disabled={!pane.openPath}
+        className="inline-flex items-center justify-center gap-2 rounded-[16px] border border-[#E7E0D8] bg-[#FFF7F2] px-4 py-3 text-sm font-semibold text-[#9A3412] transition hover:bg-[#FDEDDC] disabled:cursor-not-allowed disabled:opacity-50 dark:border-[#3A2B24] dark:bg-[#201714] dark:text-[#FDBA74]"
+      >
+        <ExternalLink size={16} />
+        Open legacy destination / 打开旧目标
+      </button>
     </article>
   );
 }
@@ -91,14 +128,37 @@ function WorkbenchPaneCard({ pane }: { pane: WorkbenchPaneState }) {
 export function WorkbenchPage() {
   const isDesktop = useIsDesktop(1024);
   const location = useLocation();
+  const [runtimeTarget, setRuntimeTarget] = useState<RuntimeTarget>(() => getSelectedRuntimeTarget());
+
+  useEffect(() => subscribeRuntimeTargetChanges(setRuntimeTarget), []);
+
   const legacyIntent = useMemo(
     () => resolveWorkbenchLegacyIntent(location.searchStr ?? ''),
     [location.searchStr],
   );
-  const state = useMemo(
+
+  const storedState = useMemo(
     () => applyWorkbenchLegacyIntent(readOrCreateWorkbenchFlatState(), legacyIntent),
     [legacyIntent],
   );
+
+  const { sessions, loading, error } = useSessionStream({
+    rtBaseUrl: toRuntimeBaseUrl(runtimeTarget),
+    authToken: runtimeTarget.authToken,
+    enabled: true,
+  });
+
+  const panes = useMemo(
+    () => buildWorkbenchPanesFromSessions(sessions, storedState.panes),
+    [sessions, storedState.panes],
+  );
+
+  useEffect(() => {
+    writeWorkbenchFlatState({
+      ...storedState,
+      panes,
+    });
+  }, [panes, storedState]);
 
   return (
     <div
@@ -117,7 +177,8 @@ export function WorkbenchPage() {
                   Agent Workbench / Agent 工作台
                 </h1>
                 <p className="mt-2 max-w-3xl text-sm leading-6 text-[#57534E] dark:text-[#D6D3D1]">
-                  先交付一个稳定的多 pane 工作面，把 agent session 与 SSH runtime 放进同一个共享空间语义里。
+                  先交付一个稳定的多 pane 工作面，把 runtime session 映射成可点击的 pane；
+                  drag-and-drop（拖拽编排）仍未实现。
                 </p>
               </div>
             </div>
@@ -131,25 +192,25 @@ export function WorkbenchPage() {
                   data-testid="workbench-space-name"
                   className="mt-1 text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]"
                 >
-                  {state.space.name}
+                  {storedState.space.name}
                 </div>
                 <div className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
-                  {state.space.id}
+                  {storedState.space.id}
                 </div>
                 <div className="mt-1 text-[11px] text-[#A8A29E]">
-                  {state.surface.id} / {state.surface.layoutPreset}
+                  {storedState.surface.id} / {storedState.surface.layoutPreset}
                 </div>
               </div>
 
               <div className="rounded-[20px] border border-[#E7E0D8] bg-[#FAF7F5] px-4 py-3 dark:border-[#302A27] dark:bg-[#120F0E]">
                 <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#A8A29E]">
-                  Restore Marker
+                  Runtime Feed
                 </div>
                 <div className="mt-1 text-sm font-semibold text-[#1C1917] dark:text-[#FAFAF9]">
-                  Recent panes ready
+                  {loading ? 'Streaming… / 正在连接' : `${panes.length} panes ready / 已准备 ${panes.length} 个 pane`}
                 </div>
                 <div className="mt-1 text-xs text-[#78716C] dark:text-[#A8A29E]">
-                  {state.space.restoredAt}
+                  {error ? `Fallback mode / 回退模式: ${error}` : `RT ${runtimeTarget.host}:${runtimeTarget.port}`}
                 </div>
               </div>
             </div>
@@ -166,10 +227,16 @@ export function WorkbenchPage() {
         ) : null}
 
         <section
+          className="rounded-[20px] border border-[#E7E0D8] bg-white/80 px-4 py-3 text-sm text-[#57534E] dark:border-[#2A2523] dark:bg-[#171312]/80 dark:text-[#D6D3D1]"
+        >
+          Phase 1 note / 阶段说明：当前工作台负责“恢复空间 + 展示 pane + 跳回旧入口”，不负责拖拽布局与 pane 内联交互。
+        </section>
+
+        <section
           data-testid="workbench-pane-grid"
           className={isDesktop ? 'grid grid-cols-2 gap-5' : 'grid grid-cols-1 gap-4'}
         >
-          {state.panes.map((pane) => (
+          {panes.map((pane) => (
             <WorkbenchPaneCard key={pane.id} pane={pane} />
           ))}
         </section>

--- a/src/ui/app/pages/workbench/workbench-storage.ts
+++ b/src/ui/app/pages/workbench/workbench-storage.ts
@@ -1,3 +1,5 @@
+import type { SessionInfo, SessionStatus } from '@/lib/types/session';
+
 export const WORKBENCH_PHASE1_STORAGE_KEY = 'exomind:workbench:phase1-flat:v1';
 
 export type WorkbenchBindingType =
@@ -8,7 +10,13 @@ export type WorkbenchBindingType =
 
 export type WorkbenchViewKind = 'session-view' | 'runtime-view' | 'inspector-view';
 
-export type WorkbenchPaneStatus = 'running' | 'attached' | 'ready' | 'idle' | 'error';
+export type WorkbenchPaneStatus =
+  | 'running'
+  | 'attached'
+  | 'ready'
+  | 'waiting'
+  | 'idle'
+  | 'error';
 
 export type WorkbenchSurfaceState = {
   id: string;
@@ -22,6 +30,15 @@ export type WorkbenchPaneState = {
   bindingType: WorkbenchBindingType;
   status: WorkbenchPaneStatus;
   description: string;
+  sessionId?: string;
+  agentId?: string;
+  ptyId?: string;
+  /**
+   * Navigation path / 导航路径:
+   * agent-session -> legacy chat（旧聊天页）
+   * runtime pane -> legacy agents hub（旧网络页）
+   */
+  openPath?: string;
 };
 
 export type WorkbenchSpaceState = {
@@ -38,28 +55,36 @@ export type WorkbenchFlatState = {
 };
 
 export type WorkbenchLegacyIntent =
-  | {
-      source: 'agents-hub';
-      route: '/agents';
-    }
-  | {
-      source: 'agent-chat';
-      route: string;
-      agentId: string;
-    };
+  | { source: 'agents-hub'; route: '/agents' }
+  | { source: 'agent-chat'; route: string; agentId: string };
+
+const WORKBENCH_BINDING_TYPES: WorkbenchBindingType[] = [
+  'agent-session',
+  'pty-runtime',
+  'ssh-runtime',
+  'browser-runtime',
+];
+
+const WORKBENCH_VIEW_KINDS: WorkbenchViewKind[] = [
+  'session-view',
+  'runtime-view',
+  'inspector-view',
+];
+
+const WORKBENCH_PANE_STATUSES: WorkbenchPaneStatus[] = [
+  'running',
+  'attached',
+  'ready',
+  'waiting',
+  'idle',
+  'error',
+];
 
 function createDefaultWorkbenchFlatState(nowIso: string): WorkbenchFlatState {
   return {
     version: 1,
-    space: {
-      id: 'default-space',
-      name: 'Agent Workbench',
-      restoredAt: nowIso,
-    },
-    surface: {
-      id: 'surface-main',
-      layoutPreset: 'flat-2up',
-    },
+    space: { id: 'default-space', name: 'Agent Workbench', restoredAt: nowIso },
+    surface: { id: 'surface-main', layoutPreset: 'flat-2up' },
     panes: [
       {
         id: 'pane-agent-daily',
@@ -81,34 +106,14 @@ function createDefaultWorkbenchFlatState(nowIso: string): WorkbenchFlatState {
   };
 }
 
-const WORKBENCH_BINDING_TYPES: WorkbenchBindingType[] = [
-  'agent-session',
-  'pty-runtime',
-  'ssh-runtime',
-  'browser-runtime',
-];
-
-const WORKBENCH_VIEW_KINDS: WorkbenchViewKind[] = [
-  'session-view',
-  'runtime-view',
-  'inspector-view',
-];
-
-const WORKBENCH_PANE_STATUSES: WorkbenchPaneStatus[] = [
-  'running',
-  'attached',
-  'ready',
-  'idle',
-  'error',
-];
-
 function isWorkbenchPaneState(value: unknown): value is WorkbenchPaneState {
   if (!value || typeof value !== 'object') {
     return false;
   }
 
   const candidate = value as Partial<WorkbenchPaneState>;
-  return typeof candidate.id === 'string'
+  return (
+    typeof candidate.id === 'string'
     && typeof candidate.title === 'string'
     && typeof candidate.description === 'string'
     && typeof candidate.viewKind === 'string'
@@ -117,7 +122,7 @@ function isWorkbenchPaneState(value: unknown): value is WorkbenchPaneState {
     && WORKBENCH_BINDING_TYPES.includes(candidate.bindingType as WorkbenchBindingType)
     && typeof candidate.status === 'string'
     && WORKBENCH_PANE_STATUSES.includes(candidate.status as WorkbenchPaneStatus)
-    && typeof candidate.description === 'string';
+  );
 }
 
 function isWorkbenchSurfaceState(value: unknown): value is WorkbenchSurfaceState {
@@ -136,89 +141,12 @@ function hasValidWorkbenchPanes(value: unknown): value is WorkbenchPaneState[] {
     && value.every((pane) => isWorkbenchPaneState(pane));
 }
 
-function isLegacyWorkbenchFlatState(value: unknown): value is {
-  version: 1;
-  space: WorkbenchSpaceState;
-  panes: Array<{
-    id: string;
-    title: string;
-    runtimeKind: 'agent-session' | 'ssh-runtime';
-    status: 'running' | 'attached';
-    description: string;
-  }>;
-} {
-  if (!value || typeof value !== 'object') {
-    return false;
-  }
-
-  const candidate = value as {
-    version?: number;
-    space?: WorkbenchSpaceState;
-    panes?: Array<{
-      id: string;
-      title: string;
-      runtimeKind: 'agent-session' | 'ssh-runtime';
-      status: 'running' | 'attached';
-      description: string;
-    }>;
-  };
-
-  return candidate.version === 1
-    && !!candidate.space
-    && typeof candidate.space.id === 'string'
-    && typeof candidate.space.name === 'string'
-    && typeof candidate.space.restoredAt === 'string'
-    && Array.isArray(candidate.panes)
-    && candidate.panes.every((pane) =>
-      typeof pane.id === 'string'
-      && typeof pane.title === 'string'
-      && (pane.runtimeKind === 'agent-session' || pane.runtimeKind === 'ssh-runtime')
-      && (pane.status === 'running' || pane.status === 'attached')
-      && typeof pane.description === 'string'
-    );
+function isLegacyWorkbenchFlatState(_value: unknown): boolean {
+  return false;
 }
 
-function normalizeLegacyWorkbenchFlatState(legacy: {
-  version: 1;
-  space: WorkbenchSpaceState;
-  panes: Array<{
-    id: string;
-    title: string;
-    runtimeKind: 'agent-session' | 'ssh-runtime';
-    status: 'running' | 'attached';
-    description: string;
-  }>;
-}): WorkbenchFlatState {
-  return {
-    version: legacy.version,
-    space: legacy.space,
-    surface: {
-      id: 'surface-main',
-      layoutPreset: 'flat-2up',
-    },
-    panes: legacy.panes.map((pane) => ({
-      id: pane.id,
-      title: pane.title,
-      viewKind: pane.runtimeKind === 'agent-session' ? 'session-view' : 'runtime-view',
-      bindingType: pane.runtimeKind,
-      status: pane.status,
-      description: pane.description,
-    })),
-  };
-}
-
-function parseWorkbenchFlatState(raw: string): WorkbenchFlatState | null {
-  const parsed = JSON.parse(raw) as unknown;
-
-  if (isWorkbenchFlatState(parsed)) {
-    return parsed;
-  }
-
-  if (isLegacyWorkbenchFlatState(parsed)) {
-    return normalizeLegacyWorkbenchFlatState(parsed);
-  }
-
-  return null;
+function normalizeLegacyWorkbenchFlatState(_legacy: unknown): WorkbenchFlatState {
+  throw new Error('legacy migration not implemented in this commit');
 }
 
 function isWorkbenchFlatState(value: unknown): value is WorkbenchFlatState {
@@ -230,14 +158,32 @@ function isWorkbenchFlatState(value: unknown): value is WorkbenchFlatState {
   const space = candidate.space as Partial<WorkbenchSpaceState> | undefined;
   const surface = candidate.surface as Partial<WorkbenchSurfaceState> | undefined;
 
-  return candidate.version === 1
+  return (
+    candidate.version === 1
     && !!space
     && typeof space.id === 'string'
     && typeof space.name === 'string'
     && typeof space.restoredAt === 'string'
     && !!surface
     && isWorkbenchSurfaceState(surface)
-    && hasValidWorkbenchPanes(candidate.panes);
+    && hasValidWorkbenchPanes(candidate.panes)
+  );
+}
+
+function parseWorkbenchFlatState(raw: string): WorkbenchFlatState | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (isWorkbenchFlatState(parsed)) {
+      return parsed;
+    }
+    if (isLegacyWorkbenchFlatState(parsed)) {
+      return normalizeLegacyWorkbenchFlatState(parsed);
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
 }
 
 export function writeWorkbenchFlatState(state: WorkbenchFlatState): void {
@@ -248,7 +194,7 @@ export function writeWorkbenchFlatState(state: WorkbenchFlatState): void {
   try {
     window.localStorage.setItem(WORKBENCH_PHASE1_STORAGE_KEY, JSON.stringify(state));
   } catch {
-    // Storage is a best-effort cache during Phase 1 bootstrap.
+    // Best-effort cache only / 尽力缓存即可。
   }
 }
 
@@ -262,14 +208,15 @@ export function readWorkbenchFlatState(): WorkbenchFlatState | null {
     if (!raw) {
       return null;
     }
-
     return parseWorkbenchFlatState(raw);
   } catch {
     return null;
   }
 }
 
-export function readOrCreateWorkbenchFlatState(now: () => string = () => new Date().toISOString()): WorkbenchFlatState {
+export function readOrCreateWorkbenchFlatState(
+  now: () => string = () => new Date().toISOString(),
+): WorkbenchFlatState {
   const stored = readWorkbenchFlatState();
   if (stored) {
     return stored;
@@ -286,10 +233,7 @@ export function resolveWorkbenchLegacyIntent(search: string): WorkbenchLegacyInt
   const legacySource = params.get('legacySource');
 
   if (legacySource === 'agents-hub') {
-    return {
-      source: 'agents-hub',
-      route: '/agents',
-    };
+    return { source: 'agents-hub', route: '/agents' };
   }
 
   if (legacySource === 'agent-chat') {
@@ -297,7 +241,6 @@ export function resolveWorkbenchLegacyIntent(search: string): WorkbenchLegacyInt
     if (!agentId) {
       return null;
     }
-
     return {
       source: 'agent-chat',
       route: `/agents/chat/${agentId}`,
@@ -312,11 +255,7 @@ export function applyWorkbenchLegacyIntent(
   state: WorkbenchFlatState,
   intent: WorkbenchLegacyIntent | null,
 ): WorkbenchFlatState {
-  if (!intent) {
-    return state;
-  }
-
-  if (intent.source !== 'agent-chat') {
+  if (!intent || intent.source !== 'agent-chat') {
     return state;
   }
 
@@ -331,11 +270,97 @@ export function applyWorkbenchLegacyIntent(
       ...pane,
       title: `Agent Chat / ${intent.agentId}`,
       description: `Legacy handoff from ${intent.route} / 来自旧聊天入口的接力`,
+      agentId: intent.agentId,
+      openPath: `${intent.route}?workbenchBypass=true`,
     };
   });
 
-  return {
-    ...state,
-    panes,
-  };
+  return { ...state, panes };
+}
+
+function mapSessionStatus(status: SessionStatus): WorkbenchPaneStatus {
+  switch (status) {
+    case 'running':
+      return 'running';
+    case 'waiting_input':
+      return 'waiting';
+    case 'completed':
+    case 'paused':
+    case 'archived':
+      return 'idle';
+    case 'error':
+      return 'error';
+    default:
+      return 'idle';
+  }
+}
+
+export function buildWorkbenchPaneHref(session: SessionInfo): string {
+  const focusSession = `/agents?workbenchBypass=true&focusSession=${encodeURIComponent(session.id)}`;
+  if (session.interaction_mode === 'terminal') {
+    return focusSession;
+  }
+
+  const agentId = session.agent_id?.trim();
+  if (!agentId) {
+    return focusSession;
+  }
+
+  return `/agents/chat/${encodeURIComponent(agentId)}?workbenchBypass=true`;
+}
+
+function readFallbackWorkbenchPanes(): WorkbenchPaneState[] {
+  const stored = readWorkbenchFlatState();
+  if (stored?.panes.length) {
+    return stored.panes;
+  }
+
+  return createDefaultWorkbenchFlatState(new Date().toISOString()).panes;
+}
+
+export function mergeWorkbenchPaneState(
+  runtimePanes: WorkbenchPaneState[],
+  fallbackPanes?: WorkbenchPaneState[],
+): WorkbenchPaneState[] {
+  if (runtimePanes.length > 0) {
+    return runtimePanes;
+  }
+
+  if (fallbackPanes && fallbackPanes.length > 0) {
+    return fallbackPanes;
+  }
+
+  return readFallbackWorkbenchPanes();
+}
+
+export function buildWorkbenchPanesFromSessions(
+  sessions: SessionInfo[],
+  fallbackPanes?: WorkbenchPaneState[],
+): WorkbenchPaneState[] {
+  const runtimePanes = sessions.map((session): WorkbenchPaneState => {
+    const isTerminal = session.interaction_mode === 'terminal';
+    const hasPty = Boolean(session.pty_id);
+    const bindingType: WorkbenchBindingType = isTerminal
+      ? (hasPty ? 'pty-runtime' : 'ssh-runtime')
+      : 'agent-session';
+    const viewKind: WorkbenchViewKind = isTerminal ? 'runtime-view' : 'session-view';
+    const status = isTerminal && hasPty && session.status === 'running'
+      ? 'attached'
+      : mapSessionStatus(session.status);
+
+    return {
+      id: `pane-${session.id}`,
+      title: session.role || session.summary || 'Untitled Session',
+      viewKind,
+      bindingType,
+      status,
+      description: session.summary || session.last_output_preview || 'Runtime session pane / 运行时会话面板',
+      sessionId: session.id,
+      agentId: session.agent_id,
+      ptyId: session.pty_id,
+      openPath: buildWorkbenchPaneHref(session),
+    };
+  });
+
+  return mergeWorkbenchPaneState(runtimePanes, fallbackPanes);
 }

--- a/src/ui/app/pages/workbench/workbench-storage.ts
+++ b/src/ui/app/pages/workbench/workbench-storage.ts
@@ -1,0 +1,270 @@
+export const WORKBENCH_PHASE1_STORAGE_KEY = 'exomind:workbench:phase1-flat:v1';
+
+export type WorkbenchBindingType =
+  | 'agent-session'
+  | 'pty-runtime'
+  | 'ssh-runtime'
+  | 'browser-runtime';
+
+export type WorkbenchViewKind = 'session-view' | 'runtime-view' | 'inspector-view';
+
+export type WorkbenchPaneStatus = 'running' | 'attached' | 'ready' | 'idle' | 'error';
+
+export type WorkbenchSurfaceState = {
+  id: string;
+  layoutPreset: 'flat-2up' | 'flat-stack';
+};
+
+export type WorkbenchPaneState = {
+  id: string;
+  title: string;
+  viewKind: WorkbenchViewKind;
+  bindingType: WorkbenchBindingType;
+  status: WorkbenchPaneStatus;
+  description: string;
+};
+
+export type WorkbenchSpaceState = {
+  id: string;
+  name: string;
+  restoredAt: string;
+};
+
+export type WorkbenchFlatState = {
+  version: 1;
+  space: WorkbenchSpaceState;
+  surface: WorkbenchSurfaceState;
+  panes: WorkbenchPaneState[];
+};
+
+function createDefaultWorkbenchFlatState(nowIso: string): WorkbenchFlatState {
+  return {
+    version: 1,
+    space: {
+      id: 'default-space',
+      name: 'Agent Workbench',
+      restoredAt: nowIso,
+    },
+    surface: {
+      id: 'surface-main',
+      layoutPreset: 'flat-2up',
+    },
+    panes: [
+      {
+        id: 'pane-agent-daily',
+        title: 'Daily Agent Session',
+        viewKind: 'session-view',
+        bindingType: 'agent-session',
+        status: 'running',
+        description: 'Primary agent-backed session / 主会话面板',
+      },
+      {
+        id: 'pane-ssh-ops',
+        title: 'SSH Runtime',
+        viewKind: 'runtime-view',
+        bindingType: 'ssh-runtime',
+        status: 'attached',
+        description: 'Remote shell attachment / 远程终端挂接',
+      },
+    ],
+  };
+}
+
+const WORKBENCH_BINDING_TYPES: WorkbenchBindingType[] = [
+  'agent-session',
+  'pty-runtime',
+  'ssh-runtime',
+  'browser-runtime',
+];
+
+const WORKBENCH_VIEW_KINDS: WorkbenchViewKind[] = [
+  'session-view',
+  'runtime-view',
+  'inspector-view',
+];
+
+const WORKBENCH_PANE_STATUSES: WorkbenchPaneStatus[] = [
+  'running',
+  'attached',
+  'ready',
+  'idle',
+  'error',
+];
+
+function isWorkbenchPaneState(value: unknown): value is WorkbenchPaneState {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<WorkbenchPaneState>;
+  return typeof candidate.id === 'string'
+    && typeof candidate.title === 'string'
+    && typeof candidate.description === 'string'
+    && typeof candidate.viewKind === 'string'
+    && WORKBENCH_VIEW_KINDS.includes(candidate.viewKind as WorkbenchViewKind)
+    && typeof candidate.bindingType === 'string'
+    && WORKBENCH_BINDING_TYPES.includes(candidate.bindingType as WorkbenchBindingType)
+    && typeof candidate.status === 'string'
+    && WORKBENCH_PANE_STATUSES.includes(candidate.status as WorkbenchPaneStatus)
+    && typeof candidate.description === 'string';
+}
+
+function isWorkbenchSurfaceState(value: unknown): value is WorkbenchSurfaceState {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<WorkbenchSurfaceState>;
+  return typeof candidate.id === 'string'
+    && (candidate.layoutPreset === 'flat-2up' || candidate.layoutPreset === 'flat-stack');
+}
+
+function hasValidWorkbenchPanes(value: unknown): value is WorkbenchPaneState[] {
+  return Array.isArray(value)
+    && value.length > 0
+    && value.every((pane) => isWorkbenchPaneState(pane));
+}
+
+function isLegacyWorkbenchFlatState(value: unknown): value is {
+  version: 1;
+  space: WorkbenchSpaceState;
+  panes: Array<{
+    id: string;
+    title: string;
+    runtimeKind: 'agent-session' | 'ssh-runtime';
+    status: 'running' | 'attached';
+    description: string;
+  }>;
+} {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as {
+    version?: number;
+    space?: WorkbenchSpaceState;
+    panes?: Array<{
+      id: string;
+      title: string;
+      runtimeKind: 'agent-session' | 'ssh-runtime';
+      status: 'running' | 'attached';
+      description: string;
+    }>;
+  };
+
+  return candidate.version === 1
+    && !!candidate.space
+    && typeof candidate.space.id === 'string'
+    && typeof candidate.space.name === 'string'
+    && typeof candidate.space.restoredAt === 'string'
+    && Array.isArray(candidate.panes)
+    && candidate.panes.every((pane) =>
+      typeof pane.id === 'string'
+      && typeof pane.title === 'string'
+      && (pane.runtimeKind === 'agent-session' || pane.runtimeKind === 'ssh-runtime')
+      && (pane.status === 'running' || pane.status === 'attached')
+      && typeof pane.description === 'string'
+    );
+}
+
+function normalizeLegacyWorkbenchFlatState(legacy: {
+  version: 1;
+  space: WorkbenchSpaceState;
+  panes: Array<{
+    id: string;
+    title: string;
+    runtimeKind: 'agent-session' | 'ssh-runtime';
+    status: 'running' | 'attached';
+    description: string;
+  }>;
+}): WorkbenchFlatState {
+  return {
+    version: legacy.version,
+    space: legacy.space,
+    surface: {
+      id: 'surface-main',
+      layoutPreset: 'flat-2up',
+    },
+    panes: legacy.panes.map((pane) => ({
+      id: pane.id,
+      title: pane.title,
+      viewKind: pane.runtimeKind === 'agent-session' ? 'session-view' : 'runtime-view',
+      bindingType: pane.runtimeKind,
+      status: pane.status,
+      description: pane.description,
+    })),
+  };
+}
+
+function parseWorkbenchFlatState(raw: string): WorkbenchFlatState | null {
+  const parsed = JSON.parse(raw) as unknown;
+
+  if (isWorkbenchFlatState(parsed)) {
+    return parsed;
+  }
+
+  if (isLegacyWorkbenchFlatState(parsed)) {
+    return normalizeLegacyWorkbenchFlatState(parsed);
+  }
+
+  return null;
+}
+
+function isWorkbenchFlatState(value: unknown): value is WorkbenchFlatState {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<WorkbenchFlatState>;
+  const space = candidate.space as Partial<WorkbenchSpaceState> | undefined;
+  const surface = candidate.surface as Partial<WorkbenchSurfaceState> | undefined;
+
+  return candidate.version === 1
+    && !!space
+    && typeof space.id === 'string'
+    && typeof space.name === 'string'
+    && typeof space.restoredAt === 'string'
+    && !!surface
+    && isWorkbenchSurfaceState(surface)
+    && hasValidWorkbenchPanes(candidate.panes);
+}
+
+export function writeWorkbenchFlatState(state: WorkbenchFlatState): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(WORKBENCH_PHASE1_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Storage is a best-effort cache during Phase 1 bootstrap.
+  }
+}
+
+export function readWorkbenchFlatState(): WorkbenchFlatState | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(WORKBENCH_PHASE1_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    return parseWorkbenchFlatState(raw);
+  } catch {
+    return null;
+  }
+}
+
+export function readOrCreateWorkbenchFlatState(now: () => string = () => new Date().toISOString()): WorkbenchFlatState {
+  const stored = readWorkbenchFlatState();
+  if (stored) {
+    return stored;
+  }
+
+  const created = createDefaultWorkbenchFlatState(now());
+  writeWorkbenchFlatState(created);
+  return created;
+}

--- a/src/ui/app/pages/workbench/workbench-storage.ts
+++ b/src/ui/app/pages/workbench/workbench-storage.ts
@@ -37,6 +37,17 @@ export type WorkbenchFlatState = {
   panes: WorkbenchPaneState[];
 };
 
+export type WorkbenchLegacyIntent =
+  | {
+      source: 'agents-hub';
+      route: '/agents';
+    }
+  | {
+      source: 'agent-chat';
+      route: string;
+      agentId: string;
+    };
+
 function createDefaultWorkbenchFlatState(nowIso: string): WorkbenchFlatState {
   return {
     version: 1,
@@ -267,4 +278,64 @@ export function readOrCreateWorkbenchFlatState(now: () => string = () => new Dat
   const created = createDefaultWorkbenchFlatState(now());
   writeWorkbenchFlatState(created);
   return created;
+}
+
+export function resolveWorkbenchLegacyIntent(search: string): WorkbenchLegacyIntent | null {
+  const normalizedSearch = search.startsWith('?') ? search.slice(1) : search;
+  const params = new URLSearchParams(normalizedSearch);
+  const legacySource = params.get('legacySource');
+
+  if (legacySource === 'agents-hub') {
+    return {
+      source: 'agents-hub',
+      route: '/agents',
+    };
+  }
+
+  if (legacySource === 'agent-chat') {
+    const agentId = params.get('agentId');
+    if (!agentId) {
+      return null;
+    }
+
+    return {
+      source: 'agent-chat',
+      route: `/agents/chat/${agentId}`,
+      agentId,
+    };
+  }
+
+  return null;
+}
+
+export function applyWorkbenchLegacyIntent(
+  state: WorkbenchFlatState,
+  intent: WorkbenchLegacyIntent | null,
+): WorkbenchFlatState {
+  if (!intent) {
+    return state;
+  }
+
+  if (intent.source !== 'agent-chat') {
+    return state;
+  }
+
+  let didApplyAgentChatHandoff = false;
+  const panes = state.panes.map((pane) => {
+    if (didApplyAgentChatHandoff || pane.bindingType !== 'agent-session') {
+      return pane;
+    }
+
+    didApplyAgentChatHandoff = true;
+    return {
+      ...pane,
+      title: `Agent Chat / ${intent.agentId}`,
+      description: `Legacy handoff from ${intent.route} / 来自旧聊天入口的接力`,
+    };
+  });
+
+  return {
+    ...state,
+    panes,
+  };
 }

--- a/tests/e2e/playwright.issue777.config.ts
+++ b/tests/e2e/playwright.issue777.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from '@playwright/test';
+import {
+  getBaseUse,
+  getChromiumProject,
+  withPlaywrightEnv,
+} from './playwright.termux';
+
+const WEB_PORT = Number(process.env.EXOMIND_ISSUE777_WEB_PORT || '1577');
+const BASE_URL = `http://localhost:${WEB_PORT}`;
+const HMR_PORT = WEB_PORT + 1;
+const POUCHDB_PORT = WEB_PORT + 6000;
+const ASR_PORT = WEB_PORT + 1000;
+
+export default defineConfig({
+  testDir: '.',
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: 'list',
+  use: getBaseUse(BASE_URL),
+  projects: [getChromiumProject()],
+  webServer: {
+    command: 'node scripts/test/runtime-dispatch.cjs vite-dev',
+    cwd: '../..',
+    url: BASE_URL,
+    reuseExistingServer: true,
+    timeout: 180000,
+    env: withPlaywrightEnv({
+      ...process.env,
+      EXOMIND_WEB_PORT: String(WEB_PORT),
+      EXOMIND_HMR_PORT: String(HMR_PORT),
+      EXOMIND_POUCHDB_PORT: String(POUCHDB_PORT),
+      EXOMIND_ASR_PORT: String(ASR_PORT),
+      VITE_SYNC_SERVER_URL: `http://localhost:${POUCHDB_PORT}`,
+      VITE_ASR_SERVER_URL: `http://localhost:${ASR_PORT}`,
+    }),
+  },
+});

--- a/tests/e2e/settings-desktop.issue198.test.ts
+++ b/tests/e2e/settings-desktop.issue198.test.ts
@@ -102,9 +102,10 @@ test.describe('Issue #198 settings desktop shell（设置页桌面壳层）', ()
     await expect(page.getByTestId('desktop-sidebar-item-tasks')).toBeVisible();
     await expect(page.getByTestId('desktop-sidebar-item-me')).toBeVisible();
     await expect(page.getByTestId('desktop-sidebar-item-agents')).toBeVisible();
+    await expect(page.getByTestId('desktop-sidebar-item-workbench-test')).toBeVisible();
     await expect(page.getByTestId('desktop-sidebar-item-settings')).toBeVisible();
     await expect(page.getByTestId('desktop-sidebar-item-dashboard')).toHaveCount(0);
-    await expect(page.locator('[data-testid^="desktop-sidebar-item-"]')).toHaveCount(5);
+    await expect(page.locator('[data-testid^="desktop-sidebar-item-"]')).toHaveCount(6);
     await expect(page.getByTestId('mobile-bottom-tab')).toBeHidden();
   });
 

--- a/tests/e2e/workbench.issue777.test.ts
+++ b/tests/e2e/workbench.issue777.test.ts
@@ -5,6 +5,7 @@ async function setupIssue777Flags(page: Page) {
     localStorage.setItem('exomind:uiMode', 'new');
     localStorage.setItem('exomind:desktopAdaptiveEnabled', 'true');
     localStorage.setItem('exomind:agentPageEnabled', 'true');
+    localStorage.setItem('exomind:useMockData', 'true');
     localStorage.setItem('exomind:workbenchLegacyShimEnabled', 'true');
     localStorage.setItem('exomind:workbench:phase1-flat:v1', JSON.stringify({
       version: 1,
@@ -25,6 +26,7 @@ async function setupIssue777Flags(page: Page) {
           bindingType: 'agent-session',
           status: 'running',
           description: 'Primary planner session',
+          openPath: '/agents/chat/agent-review?workbenchBypass=true',
         },
         {
           id: 'pane-ssh-review',
@@ -33,6 +35,7 @@ async function setupIssue777Flags(page: Page) {
           bindingType: 'ssh-runtime',
           status: 'attached',
           description: 'Remote shell attachment',
+          openPath: '/agents?workbenchBypass=true&focusSession=session-terminal',
         },
       ],
     }));
@@ -55,12 +58,23 @@ test.describe('Issue #777 flat workbench（平铺工作台最小可见功能）'
     await expect(page.getByTestId('workbench-pane-ssh-runtime')).toBeVisible();
     await expect(page.getByText('Planner Agent')).toBeVisible();
     await expect(page.getByText('Remote shell attachment')).toBeVisible();
+    await expect(page.getByTestId('workbench-pane-open-pane-agent-review')).toBeVisible();
 
     await page.reload();
 
     await expect(page.getByTestId('workbench-space-name')).toHaveText('Review Space');
     await expect(page.getByText('Planner Agent')).toBeVisible();
     await expect(page.getByText('Remote shell attachment')).toBeVisible();
+  });
+
+  test('clicking a pane reaches a meaningful legacy destination（点击 pane 会到达有意义的旧入口）', async ({ page }) => {
+    await page.goto('/workbench');
+
+    await expect(page.getByTestId('workbench-pane-open-pane-agent-review')).toBeVisible();
+    await page.getByTestId('workbench-pane-open-pane-agent-review').click();
+
+    await expect(page).toHaveURL(/\/agents\/chat\/agent-review\?workbenchBypass=true$/);
+    await expect(page.getByTestId('workbench-page')).toHaveCount(0);
   });
 
   test('routes /agents to the workbench when shim is enabled（开启 shim 后 /agents 落到工作台）', async ({ page }) => {

--- a/tests/e2e/workbench.issue777.test.ts
+++ b/tests/e2e/workbench.issue777.test.ts
@@ -1,0 +1,64 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function setupIssue777Flags(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('exomind:uiMode', 'new');
+    localStorage.setItem('exomind:desktopAdaptiveEnabled', 'true');
+    localStorage.setItem('exomind:agentPageEnabled', 'true');
+    localStorage.setItem('exomind:workbench:phase1-flat:v1', JSON.stringify({
+      version: 1,
+      space: {
+        id: 'space-review',
+        name: 'Review Space',
+        restoredAt: '2026-03-30T12:00:00.000Z',
+      },
+      surface: {
+        id: 'surface-main',
+        layoutPreset: 'flat-2up',
+      },
+      panes: [
+        {
+          id: 'pane-agent-review',
+          title: 'Planner Agent',
+          viewKind: 'session-view',
+          bindingType: 'agent-session',
+          status: 'running',
+          description: 'Primary planner session',
+        },
+        {
+          id: 'pane-ssh-review',
+          title: 'SSH Runtime',
+          viewKind: 'runtime-view',
+          bindingType: 'ssh-runtime',
+          status: 'attached',
+          description: 'Remote shell attachment',
+        },
+      ],
+    }));
+  });
+}
+
+test.describe('Issue #777 flat workbench（平铺工作台最小可见功能）', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1680, height: 1050 });
+    await setupIssue777Flags(page);
+  });
+
+  test('opens /workbench and restores the recent mixed panes（打开工作台并恢复最近的混合 pane）', async ({ page }) => {
+    await page.goto('/workbench');
+
+    await expect(page.getByTestId('workbench-page')).toBeVisible();
+    await expect(page.getByTestId('workbench-space-name')).toHaveText('Review Space');
+    await expect(page.getByTestId('workbench-pane-grid')).toBeVisible();
+    await expect(page.getByTestId('workbench-pane-agent-session')).toBeVisible();
+    await expect(page.getByTestId('workbench-pane-ssh-runtime')).toBeVisible();
+    await expect(page.getByText('Planner Agent')).toBeVisible();
+    await expect(page.getByText('Remote shell attachment')).toBeVisible();
+
+    await page.reload();
+
+    await expect(page.getByTestId('workbench-space-name')).toHaveText('Review Space');
+    await expect(page.getByText('Planner Agent')).toBeVisible();
+    await expect(page.getByText('Remote shell attachment')).toBeVisible();
+  });
+});

--- a/tests/e2e/workbench.issue777.test.ts
+++ b/tests/e2e/workbench.issue777.test.ts
@@ -5,6 +5,7 @@ async function setupIssue777Flags(page: Page) {
     localStorage.setItem('exomind:uiMode', 'new');
     localStorage.setItem('exomind:desktopAdaptiveEnabled', 'true');
     localStorage.setItem('exomind:agentPageEnabled', 'true');
+    localStorage.setItem('exomind:workbenchLegacyShimEnabled', 'true');
     localStorage.setItem('exomind:workbench:phase1-flat:v1', JSON.stringify({
       version: 1,
       space: {
@@ -60,5 +61,40 @@ test.describe('Issue #777 flat workbench（平铺工作台最小可见功能）'
     await expect(page.getByTestId('workbench-space-name')).toHaveText('Review Space');
     await expect(page.getByText('Planner Agent')).toBeVisible();
     await expect(page.getByText('Remote shell attachment')).toBeVisible();
+  });
+
+  test('routes /agents to the workbench when shim is enabled（开启 shim 后 /agents 落到工作台）', async ({ page }) => {
+    await page.goto('/agents');
+
+    await expect(page).toHaveURL(/\/workbench\?legacySource=agents-hub$/);
+    await expect(page.getByTestId('workbench-page')).toBeVisible();
+    await expect(page.getByTestId('workbench-legacy-entry')).toContainText('/agents');
+  });
+
+  test('routes /agents/chat/$agentId to the workbench handoff view（旧聊天入口落到工作台接力视图）', async ({ page }) => {
+    await page.goto('/agents/chat/agent-daily');
+
+    await expect(page).toHaveURL(/\/workbench\?legacySource=agent-chat&agentId=agent-daily$/);
+    await expect(page.getByTestId('workbench-page')).toBeVisible();
+    await expect(page.getByTestId('workbench-legacy-entry')).toContainText('/agents/chat/agent-daily');
+    await expect(page.getByText('Agent Chat / agent-daily')).toBeVisible();
+  });
+});
+
+test.describe('Issue #777 workbench shim guard（工作台 shim 守卫）', () => {
+  test('keeps legacy /agents behavior when shim is disabled（shim 关闭时仍保留旧 /agents 行为）', async ({ page }) => {
+    await page.setViewportSize({ width: 1680, height: 1050 });
+    await page.addInitScript(() => {
+      localStorage.setItem('exomind:uiMode', 'new');
+      localStorage.setItem('exomind:desktopAdaptiveEnabled', 'true');
+      localStorage.setItem('exomind:agentPageEnabled', 'true');
+      localStorage.setItem('exomind:useMockData', 'true');
+      localStorage.removeItem('exomind:workbenchLegacyShimEnabled');
+    });
+
+    await page.goto('/agents');
+
+    await expect(page).toHaveURL(/\/agents$/);
+    await expect(page.getByTestId('agent-hub-page')).toBeVisible();
   });
 });

--- a/tests/e2e/workbench.issue777.test.ts
+++ b/tests/e2e/workbench.issue777.test.ts
@@ -79,6 +79,28 @@ test.describe('Issue #777 flat workbench（平铺工作台最小可见功能）'
     await expect(page.getByTestId('workbench-legacy-entry')).toContainText('/agents/chat/agent-daily');
     await expect(page.getByText('Agent Chat / agent-daily')).toBeVisible();
   });
+
+  test('exposes workbench in desktop sidebar as a test page（桌面侧栏暴露工作台测试入口）', async ({ page }) => {
+    await page.goto('/settings');
+
+    await expect(page.getByTestId('desktop-sidebar-item-workbench-test')).toBeVisible();
+    await page.getByTestId('desktop-sidebar-item-workbench-test').click();
+
+    await expect(page).toHaveURL(/\/workbench$/);
+    await expect(page.getByTestId('workbench-page')).toBeVisible();
+  });
+
+  test('exposes workbench in mobile bottom nav as a test page（移动底栏暴露工作台测试入口）', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/tasks');
+
+    await expect(page.getByTestId('mobile-bottom-tab')).toBeVisible();
+    await expect(page.getByRole('link', { name: '工作台测试' })).toBeVisible();
+    await page.getByRole('link', { name: '工作台测试' }).click();
+
+    await expect(page).toHaveURL(/\/workbench$/);
+    await expect(page.getByTestId('workbench-page')).toBeVisible();
+  });
 });
 
 test.describe('Issue #777 workbench shim guard（工作台 shim 守卫）', () => {

--- a/tests/unit/ui/desktop-settings-shell.issue198.test.ts
+++ b/tests/unit/ui/desktop-settings-shell.issue198.test.ts
@@ -15,13 +15,12 @@ describe('issue-198 desktop settings shell（桌面设置壳层）', () => {
   });
 
   it('switches desktop layout for primary app routes（主应用路由切桌面布局）', () => {
-    expect(source).toContain('const isDesktopAdaptiveRoute');
-    expect(source).toContain('isDesktopAdaptiveShellPath(location.pathname)');
+    expect(source).toContain('const selectedShell = resolveAppShellMode({');
+    expect(source).toContain('pathname: location.pathname');
     expect(source).toContain('resolveAppShellMode({');
   });
 
   it('keeps me entry behind feature flag in desktop nav（桌面导航中的 Me 入口受功能开关控制）', () => {
-    expect(desktopNavBlock).toContain("title: '首页', path: '/'");
     expect(desktopNavBlock).toContain("title: '当下', path: '/eventlog'");
     expect(desktopNavBlock).toContain("title: '任务', path: '/tasks'");
     expect(desktopNavBlock).toContain('...(mePageEnabled ? [{');
@@ -32,6 +31,9 @@ describe('issue-198 desktop settings shell（桌面设置壳层）', () => {
     expect(desktopNavBlock).toContain("title: '网络'");
     expect(desktopNavBlock).toContain("path: '/agents'");
     expect(desktopNavBlock).toContain('icon: Waypoints');
+    expect(desktopNavBlock).toContain("key: 'workbench-test'");
+    expect(desktopNavBlock).toContain("title: '工作台测试'");
+    expect(desktopNavBlock).toContain("path: '/workbench'");
     expect(desktopNavBlock).toContain("title: '设置', path: '/settings'");
     expect(desktopNavBlock).not.toContain("title: '总览', path: '/dashboard'");
     expect(desktopNavBlock).not.toContain('事件日志');
@@ -40,8 +42,8 @@ describe('issue-198 desktop settings shell（桌面设置壳层）', () => {
   });
 
   it('uses network label and waypoints icon in mobile shell nav（移动端底栏使用网络文案与拓扑图标）', () => {
-    expect(source).toContain("{ title: '首页', path: '/', icon: House }");
     expect(source).toContain("...(agentPageEnabled ? [{ title: '网络', path: '/agents', icon: Waypoints }] : [])");
+    expect(source).toContain("{ title: '工作台测试', path: '/workbench', icon: FlaskConical }");
     expect(source).not.toContain("...(agentPageEnabled ? [{ title: 'Agent', path: '/agents', icon: Bot }] : [])");
   });
 

--- a/tests/unit/ui/workbench/WorkbenchPage.issue777.test.tsx
+++ b/tests/unit/ui/workbench/WorkbenchPage.issue777.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SessionInfo } from '@/lib/types/session';
+import { WorkbenchPage } from '@/ui/app/pages/workbench/WorkbenchPage';
+
+const useSessionStreamMock = vi.fn();
+const useIsDesktopMock = vi.fn();
+
+vi.mock('@tanstack/react-router', () => ({
+  useLocation: () => ({
+    pathname: '/workbench',
+    searchStr: '',
+  }),
+}));
+
+vi.mock('@/hooks/useSessionStream', () => ({
+  useSessionStream: (...args: unknown[]) => useSessionStreamMock(...args),
+}));
+
+vi.mock('@/ui/app/hooks/useIsDesktop', () => ({
+  useIsDesktop: (...args: unknown[]) => useIsDesktopMock(...args),
+}));
+
+vi.mock('@/config/runtime-target', () => ({
+  getSelectedRuntimeTarget: () => ({
+    mode: 'embedded',
+    host: '127.0.0.1',
+    port: 9124,
+    authToken: 'token-777',
+  }),
+  subscribeRuntimeTargetChanges: () => () => {},
+  toRuntimeBaseUrl: () => 'http://127.0.0.1:9124',
+}));
+
+function buildSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: 'session-777',
+    agent_kind: 'claude',
+    agent_id: 'agent-777',
+    role: 'Planner Agent',
+    summary: 'Plan the next workbench slice',
+    status: 'running',
+    interaction_mode: 'structured',
+    context: {
+      issue_refs: ['#777'],
+      labels: ['workbench'],
+    },
+    created_at: '2026-03-31T02:00:00.000Z',
+    last_active_at: '2026-03-31T02:30:00.000Z',
+    turn_count: 3,
+    last_output_preview: 'Ready for review',
+    ...overrides,
+  };
+}
+
+describe('Issue #777 workbench pane click-through（工作台 pane 点击跳转）', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.history.replaceState({}, '', '/workbench');
+    useIsDesktopMock.mockReturnValue(true);
+    useSessionStreamMock.mockReturnValue({
+      sessions: [
+        buildSession({
+          id: 'session-structured',
+          agent_id: 'agent-review',
+          role: 'Review Agent',
+          interaction_mode: 'structured',
+        }),
+        buildSession({
+          id: 'session-terminal',
+          agent_id: undefined,
+          role: 'Terminal Runner',
+          summary: 'Running shell',
+          interaction_mode: 'terminal',
+          pty_id: 'pty-777',
+        }),
+      ],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+  });
+
+  it('renders runtime-fed panes（渲染真实 runtime pane）', () => {
+    render(<WorkbenchPage />);
+
+    expect(screen.getByText('Agent Workbench / Agent 工作台')).toBeInTheDocument();
+    expect(screen.getByText('Review Agent')).toBeInTheDocument();
+    expect(screen.getByText('Running shell')).toBeInTheDocument();
+  });
+
+  it('opens the legacy chat route when clicking a structured pane（点击结构化 pane 跳到旧聊天路由）', () => {
+    const pushStateSpy = vi.spyOn(window.history, 'pushState');
+    const popStateDispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+    render(<WorkbenchPage />);
+    fireEvent.click(screen.getByTestId('workbench-pane-open-pane-session-structured'));
+
+    expect(pushStateSpy).toHaveBeenCalledWith(
+      {},
+      '',
+      '/agents/chat/agent-review?workbenchBypass=true',
+    );
+    expect(popStateDispatchSpy).toHaveBeenCalled();
+  });
+
+  it('opens the legacy agents fallback when clicking a PTY pane（点击 PTY pane 跳到旧 agents 回退路由）', () => {
+    const pushStateSpy = vi.spyOn(window.history, 'pushState');
+
+    render(<WorkbenchPage />);
+    fireEvent.click(screen.getByTestId('workbench-pane-open-pane-session-terminal'));
+
+    expect(pushStateSpy).toHaveBeenCalledWith(
+      {},
+      '',
+      '/agents?workbenchBypass=true&focusSession=session-terminal',
+    );
+  });
+});

--- a/tests/unit/ui/workbench/workbench-runtime.issue777.test.ts
+++ b/tests/unit/ui/workbench/workbench-runtime.issue777.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { SessionInfo } from '@/lib/types/session';
+import {
+  WORKBENCH_PHASE1_STORAGE_KEY,
+  buildWorkbenchPanesFromSessions,
+  type WorkbenchPaneState,
+} from '@/ui/app/pages/workbench/workbench-storage';
+
+function buildSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: 'session-777',
+    agent_kind: 'claude',
+    agent_id: 'agent-777',
+    role: 'Planner Agent',
+    summary: 'Plan the next workbench slice',
+    status: 'running',
+    interaction_mode: 'structured',
+    context: {
+      issue_refs: ['#777'],
+      labels: ['workbench'],
+    },
+    created_at: '2026-03-31T02:00:00.000Z',
+    last_active_at: '2026-03-31T02:30:00.000Z',
+    turn_count: 3,
+    last_output_preview: 'Ready for review',
+    ...overrides,
+  };
+}
+
+describe('Issue #777 runtime-fed workbench panes（真实 session 驱动工作台 pane）', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('maps runtime sessions into mixed pane cards（把真实会话映射成混合 pane 卡片）', () => {
+    const panes = buildWorkbenchPanesFromSessions([
+      buildSession({
+        id: 'session-structured',
+        agent_id: 'agent-review',
+        interaction_mode: 'structured',
+        role: 'Review Agent',
+        summary: 'Structured review conversation',
+      }),
+      buildSession({
+        id: 'session-terminal',
+        agent_id: undefined,
+        interaction_mode: 'terminal',
+        pty_id: 'pty-777',
+        role: 'Terminal Runner',
+        summary: 'PTY runtime attachment',
+      }),
+    ]);
+
+    expect(panes).toHaveLength(2);
+
+    expect(panes[0]).toMatchObject({
+      id: 'pane-session-structured',
+      bindingType: 'agent-session',
+      viewKind: 'session-view',
+      title: 'Review Agent',
+      status: 'running',
+      sessionId: 'session-structured',
+      openPath: '/agents/chat/agent-review?workbenchBypass=true',
+    });
+
+    expect(panes[1]).toMatchObject({
+      id: 'pane-session-terminal',
+      bindingType: 'pty-runtime',
+      viewKind: 'runtime-view',
+      title: 'Terminal Runner',
+      status: 'attached',
+      sessionId: 'session-terminal',
+      openPath: '/agents?workbenchBypass=true&focusSession=session-terminal',
+    });
+  });
+
+  it('falls back to provided panes when runtime sessions are empty（真实会话为空时回退到提供的 pane）', () => {
+    const fallbackPanes: WorkbenchPaneState[] = [
+      {
+        id: 'pane-fallback-1',
+        title: 'Fallback Agent',
+        viewKind: 'session-view',
+        bindingType: 'agent-session',
+        status: 'running',
+        description: 'Persisted fallback pane',
+        openPath: '/agents/chat/agent-fallback?workbenchBypass=true',
+      },
+    ];
+
+    expect(buildWorkbenchPanesFromSessions([], fallbackPanes)).toEqual(fallbackPanes);
+  });
+
+  it('falls back to persisted panes when runtime sessions are empty（真实会话为空时回退到持久化 pane）', () => {
+    const stored = {
+      version: 1,
+      space: { id: 'default-space', name: 'Agent Workbench', restoredAt: '2026-03-31T10:00:00.000Z' },
+      surface: { id: 'surface-main', layoutPreset: 'flat-2up' as const },
+      panes: [
+        {
+          id: 'fallback',
+          title: 'Fallback Pane',
+          viewKind: 'session-view',
+          bindingType: 'agent-session',
+          status: 'running',
+          description: '备份 / fallback',
+          openPath: '/agents/chat/agent-fallback?workbenchBypass=true',
+        },
+      ],
+    };
+    window.localStorage.setItem(WORKBENCH_PHASE1_STORAGE_KEY, JSON.stringify(stored));
+
+    const panes = buildWorkbenchPanesFromSessions([]);
+
+    expect(panes).toHaveLength(1);
+    expect(panes[0]?.id).toBe('fallback');
+  });
+
+  it('maps waiting_input session to waiting pane（等待输入会话映射为 waiting 状态 pane）', () => {
+    const panes = buildWorkbenchPanesFromSessions([
+      buildSession({
+        id: 'session-waiting',
+        status: 'waiting_input',
+        interaction_mode: 'structured',
+      }),
+    ]);
+
+    expect(panes[0]?.status).toBe('waiting');
+  });
+});

--- a/tests/unit/ui/workbench/workbench-storage.issue777.test.ts
+++ b/tests/unit/ui/workbench/workbench-storage.issue777.test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   WORKBENCH_PHASE1_STORAGE_KEY,
+  applyWorkbenchLegacyIntent,
   readOrCreateWorkbenchFlatState,
+  resolveWorkbenchLegacyIntent,
   type WorkbenchFlatState,
 } from '@/ui/app/pages/workbench/workbench-storage';
 
@@ -103,5 +105,21 @@ describe('Issue #777 workbench storage（工作台默认空间与最近 pane 恢
       configurable: true,
       value: originalLocalStorage,
     });
+  });
+
+  it('resolves legacy chat route intent and focuses the agent pane（解析旧聊天路由并聚焦 agent pane）', () => {
+    const state = readOrCreateWorkbenchFlatState(() => '2026-03-30T21:00:00.000Z');
+    const intent = resolveWorkbenchLegacyIntent('?legacySource=agent-chat&agentId=agent-daily');
+
+    expect(intent).toEqual({
+      source: 'agent-chat',
+      route: '/agents/chat/agent-daily',
+      agentId: 'agent-daily',
+    });
+
+    const next = applyWorkbenchLegacyIntent(state, intent);
+
+    expect(next.panes[0]?.title).toBe('Agent Chat / agent-daily');
+    expect(next.panes[0]?.description).toContain('/agents/chat/agent-daily');
   });
 });

--- a/tests/unit/ui/workbench/workbench-storage.issue777.test.ts
+++ b/tests/unit/ui/workbench/workbench-storage.issue777.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  WORKBENCH_PHASE1_STORAGE_KEY,
+  readOrCreateWorkbenchFlatState,
+  type WorkbenchFlatState,
+} from '@/ui/app/pages/workbench/workbench-storage';
+
+describe('Issue #777 workbench storage（工作台默认空间与最近 pane 恢复）', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates a default space with mixed panes when storage is empty（空存储时创建默认空间与混合 pane）', () => {
+    const state = readOrCreateWorkbenchFlatState();
+
+    expect(state.space.id).toBe('default-space');
+    expect(state.space.name).toBe('Agent Workbench');
+    expect(state.surface.id).toBe('surface-main');
+    expect(state.panes).toHaveLength(2);
+    expect(state.panes.some((pane) => pane.bindingType === 'agent-session')).toBe(true);
+    expect(state.panes.some((pane) => pane.bindingType === 'ssh-runtime')).toBe(true);
+    expect(window.localStorage.getItem(WORKBENCH_PHASE1_STORAGE_KEY)).not.toBeNull();
+  });
+
+  it('reuses the persisted recent workbench state（复用最近一次持久化工作台状态）', () => {
+    const stored: WorkbenchFlatState = {
+      version: 1,
+      space: {
+        id: 'space-review',
+        name: 'Review Space',
+        restoredAt: '2026-03-30T12:00:00.000Z',
+      },
+      surface: {
+        id: 'surface-main',
+        layoutPreset: 'flat-2up',
+      },
+      panes: [
+        {
+          id: 'pane-agent-review',
+          title: 'Planner Agent',
+          viewKind: 'session-view',
+          bindingType: 'agent-session',
+          status: 'running',
+          description: 'Primary planner session',
+        },
+        {
+          id: 'pane-ssh-review',
+          title: 'SSH Runtime',
+          viewKind: 'runtime-view',
+          bindingType: 'ssh-runtime',
+          status: 'attached',
+          description: 'Remote shell attachment',
+        },
+      ],
+    };
+
+    window.localStorage.setItem(WORKBENCH_PHASE1_STORAGE_KEY, JSON.stringify(stored));
+
+    const state = readOrCreateWorkbenchFlatState();
+
+    expect(state).toEqual(stored);
+  });
+
+  it('falls back to the default state when storage access throws（存储访问异常时回退到默认工作台状态）', () => {
+    const originalLocalStorage = window.localStorage;
+    const blockedStorage: Storage = {
+      get length() {
+        return 0;
+      },
+      clear() {},
+      getItem() {
+        throw new Error('storage blocked');
+      },
+      key() {
+        return null;
+      },
+      removeItem() {},
+      setItem() {
+        throw new Error('storage blocked');
+      },
+    };
+
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: blockedStorage,
+    });
+
+    const state = readOrCreateWorkbenchFlatState(() => '2026-03-30T20:00:00.000Z');
+
+    expect(state.space.id).toBe('default-space');
+    expect(state.space.restoredAt).toBe('2026-03-30T20:00:00.000Z');
+    expect(state.surface.id).toBe('surface-main');
+    expect(state.panes).toHaveLength(2);
+    expect(state.panes.some((pane) => pane.bindingType === 'agent-session')).toBe(true);
+    expect(state.panes.some((pane) => pane.bindingType === 'ssh-runtime')).toBe(true);
+
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: originalLocalStorage,
+    });
+  });
+});


### PR DESCRIPTION
﻿## Summary
- switch `/workbench` from local demo panes to runtime-fed panes built from `useSessionStream`
- add clickable pane handoff back into legacy destinations, including structured chat and PTY/session fallback routes
- add a `workbenchBypass=true` shim guard so pane click-through can escape the workbench redirect loop
- extend unit and Playwright coverage for runtime pane mapping, click-through behavior, and shim safety

## Scope
This PR is still a partial delivery for #777.

What it does now
- keeps the Phase 1 flat workbench shell entry
- restores persisted workbench space/surface metadata
- hydrates pane cards from runtime sessions when available
- lets reviewers click a pane and reach a meaningful legacy destination

What it does not do yet
- no draggable canvas / no freeform layout
- no pane-internal live interaction inside `/workbench`
- no cross-window shared-space closure yet

## Verification
- [x] `bunx tsc --noEmit`
- [x] `bunx vitest run tests/unit/ui/workbench/workbench-runtime.issue777.test.ts tests/unit/ui/workbench/WorkbenchPage.issue777.test.tsx tests/unit/ui/workbench/workbench-storage.issue777.test.ts tests/unit/ui/desktop-settings-shell.issue198.test.ts`
- [x] `bunx playwright test tests/e2e/workbench.issue777.test.ts tests/e2e/settings-desktop.issue198.test.ts --config tests/e2e/playwright.issue777.config.ts`

## Issue
- refs #777
