### PR TITLE
feat(workbench): start session-runtime federation for issue 789

### DIFF
--- a/src/config/workbench-test-page-enabled.ts
+++ b/src/config/workbench-test-page-enabled.ts
@@ -1,0 +1,43 @@
+const WORKBENCH_TEST_PAGE_ENABLED_STORAGE_KEY = 'exomind:workbenchTestPageEnabled';
+const WORKBENCH_TEST_PAGE_ENABLED_CHANGED_EVENT = 'exomind:workbench-test-page-enabled-changed';
+
+function normalizeBoolean(rawValue: string | null | undefined): boolean {
+  return rawValue === 'true';
+}
+
+export function getWorkbenchTestPageEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  return normalizeBoolean(window.localStorage.getItem(WORKBENCH_TEST_PAGE_ENABLED_STORAGE_KEY));
+}
+
+export function setWorkbenchTestPageEnabled(enabled: boolean): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(WORKBENCH_TEST_PAGE_ENABLED_STORAGE_KEY, String(enabled));
+  window.dispatchEvent(new CustomEvent<boolean>(WORKBENCH_TEST_PAGE_ENABLED_CHANGED_EVENT, { detail: enabled }));
+}
+
+export function subscribeWorkbenchTestPageEnabledChanges(
+  listener: (enabled: boolean) => void,
+): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key !== WORKBENCH_TEST_PAGE_ENABLED_STORAGE_KEY) return;
+    listener(normalizeBoolean(event.newValue));
+  };
+
+  const handleCustomEvent = (event: Event) => {
+    const customEvent = event as CustomEvent<boolean>;
+    listener(Boolean(customEvent.detail));
+  };
+
+  window.addEventListener('storage', handleStorage);
+  window.addEventListener(WORKBENCH_TEST_PAGE_ENABLED_CHANGED_EVENT, handleCustomEvent);
+
+  return () => {
+    window.removeEventListener('storage', handleStorage);
+    window.removeEventListener(WORKBENCH_TEST_PAGE_ENABLED_CHANGED_EVENT, handleCustomEvent);
+  };
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -528,7 +528,6 @@ function NewLayout() {
   const [goalsPageEnabled, setGoalsPageEnabled] = useState(() => getGoalsPageEnabled());
   const [desktopSidebarCollapsed, setDesktopSidebarCollapsed] = useState(() => getPersistedDesktopSidebarCollapsed());
   const [workbenchTestPageEnabled, setWorkbenchTestPageEnabled] = useState(() => getWorkbenchTestPageEnabled());
-  const [desktopSidebarCollapsed, setDesktopSidebarCollapsed] = useState(() => getPersistedDesktopSidebarCollapsed());
   const [desktopAdaptiveEnabled, setDesktopAdaptiveEnabledState] = useState(() => getDesktopAdaptiveEnabled());
   const [developerModeEnabled, setDeveloperModeEnabled] = useState(() => getDeveloperModeEnabled());
   const [commandPaletteEnabled, setCommandPaletteEnabled] = useState(() => getCommandPaletteEnabled());

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -13,6 +13,7 @@ import {
   getDesktopSidebarCollapsed as getPersistedDesktopSidebarCollapsed,
   setDesktopSidebarCollapsed as setPersistedDesktopSidebarCollapsed,
 } from '@/config/desktop-sidebar-preferences';
+import { getWorkbenchTestPageEnabled, subscribeWorkbenchTestPageEnabledChanges } from '@/config/workbench-test-page-enabled';
 import { getCommandRegistryService } from '@/lib/services/command-registry.service';
 import { getCommandPaletteService } from '@/lib/services/command-palette.service';
 import { createCoreNavigationCommands, type CoreNavigationPath } from '@/lib/services/command-palette.commands';
@@ -300,6 +301,7 @@ function DesktopSidebar({
   agentPageEnabled,
   mePageEnabled,
   goalsPageEnabled,
+  workbenchTestPageEnabled,
   collapsed,
   onToggleCollapsed,
 }: {
@@ -307,6 +309,7 @@ function DesktopSidebar({
   agentPageEnabled: boolean;
   mePageEnabled: boolean;
   goalsPageEnabled: boolean;
+  workbenchTestPageEnabled: boolean;
   collapsed: boolean;
   onToggleCollapsed: () => void;
 }) {
@@ -334,13 +337,13 @@ function DesktopSidebar({
       icon: Waypoints,
       match: (path: string) => path === '/agents' || path.startsWith('/agents/'),
     }] : []),
-    {
+    ...(workbenchTestPageEnabled ? [{
       key: 'workbench-test',
       title: '工作台测试',
       path: '/workbench',
       icon: FlaskConical,
       match: (path: string) => path === '/workbench' || path.startsWith('/workbench/'),
-    },
+    }] : []),
     { key: 'settings', title: '设置', path: '/settings', icon: Settings, match: (path: string) => path === '/settings' || path.startsWith('/settings/') },
   ];
 
@@ -432,6 +435,7 @@ function DesktopLayout({
   agentPageEnabled,
   mePageEnabled,
   goalsPageEnabled,
+  workbenchTestPageEnabled,
   collapsed,
   onToggleCollapsed,
 }: {
@@ -439,6 +443,7 @@ function DesktopLayout({
   agentPageEnabled: boolean;
   mePageEnabled: boolean;
   goalsPageEnabled: boolean;
+  workbenchTestPageEnabled: boolean;
   collapsed: boolean;
   onToggleCollapsed: () => void;
 }) {
@@ -450,6 +455,7 @@ function DesktopLayout({
           agentPageEnabled={agentPageEnabled}
           mePageEnabled={mePageEnabled}
           goalsPageEnabled={goalsPageEnabled}
+          workbenchTestPageEnabled={workbenchTestPageEnabled}
           collapsed={collapsed}
           onToggleCollapsed={onToggleCollapsed}
         />
@@ -521,6 +527,8 @@ function NewLayout() {
   const [mePageEnabled, setMePageEnabled] = useState(() => getMePageEnabled());
   const [goalsPageEnabled, setGoalsPageEnabled] = useState(() => getGoalsPageEnabled());
   const [desktopSidebarCollapsed, setDesktopSidebarCollapsed] = useState(() => getPersistedDesktopSidebarCollapsed());
+  const [workbenchTestPageEnabled, setWorkbenchTestPageEnabled] = useState(() => getWorkbenchTestPageEnabled());
+  const [desktopSidebarCollapsed, setDesktopSidebarCollapsed] = useState(() => getPersistedDesktopSidebarCollapsed());
   const [desktopAdaptiveEnabled, setDesktopAdaptiveEnabledState] = useState(() => getDesktopAdaptiveEnabled());
   const [developerModeEnabled, setDeveloperModeEnabled] = useState(() => getDeveloperModeEnabled());
   const [commandPaletteEnabled, setCommandPaletteEnabled] = useState(() => getCommandPaletteEnabled());
@@ -536,6 +544,9 @@ function NewLayout() {
   }, []);
   useEffect(() => {
     return subscribeGoalsPageEnabledChanges(setGoalsPageEnabled);
+  }, []);
+  useEffect(() => {
+    return subscribeWorkbenchTestPageEnabledChanges(setWorkbenchTestPageEnabled);
   }, []);
   useEffect(() => {
     return subscribeDesktopAdaptiveChanges(setDesktopAdaptiveEnabledState);
@@ -608,7 +619,7 @@ function NewLayout() {
     ...(goalsPageEnabled ? [{ title: '目标', path: '/goals', icon: Orbit }] : []),
     ...(mePageEnabled ? [{ title: 'Me', path: '/me', icon: UserRound }] : []),
     ...(agentPageEnabled ? [{ title: '网络', path: '/agents', icon: Waypoints }] : []),
-    { title: '工作台测试', path: '/workbench', icon: FlaskConical },
+    ...(workbenchTestPageEnabled ? [{ title: '工作台测试', path: '/workbench', icon: FlaskConical }] : []),
     { title: '设置', path: '/settings', icon: Settings },
   ];
   const selectedShell = resolveAppShellMode({
@@ -625,6 +636,7 @@ function NewLayout() {
           agentPageEnabled={agentPageEnabled}
           mePageEnabled={mePageEnabled}
           goalsPageEnabled={goalsPageEnabled}
+          workbenchTestPageEnabled={workbenchTestPageEnabled}
           collapsed={desktopSidebarCollapsed}
           onToggleCollapsed={() => setDesktopSidebarCollapsed((current) => !current)}
         />

--- a/src/ui/app/config/settings/settings-registry.ts
+++ b/src/ui/app/config/settings/settings-registry.ts
@@ -98,6 +98,11 @@ import {
   subscribeCommandPaletteEnabledChanges,
 } from '@/config/command-palette-enabled';
 import {
+  getWorkbenchTestPageEnabled,
+  setWorkbenchTestPageEnabled,
+  subscribeWorkbenchTestPageEnabledChanges,
+} from '@/config/workbench-test-page-enabled';
+import {
   getVoiceTranscriptSendMode,
   setVoiceTranscriptSendMode,
   subscribeVoiceTranscriptSendModeChanges,
@@ -604,6 +609,7 @@ export const FEATURE_TOGGLE_SETTING_IDS = [
   'goals-page-enabled',
   'desktop-adaptive',
   'command-palette-enabled',
+  'workbench-test-page-enabled',
 ] as const;
 
 export const FEATURE_TOGGLE_SETTINGS = [
@@ -656,6 +662,16 @@ export const FEATURE_TOGGLE_SETTINGS = [
     get: getCommandPaletteEnabled,
     set: setCommandPaletteEnabled,
     subscribe: subscribeCommandPaletteEnabledChanges,
+  },
+  {
+    id: 'workbench-test-page-enabled',
+    label: '工作台测试',
+    icon: Bot,
+    rowTestId: 'feature-toggle-workbench-test-row',
+    controlTestId: 'feature-toggle-workbench-test-switch',
+    get: getWorkbenchTestPageEnabled,
+    set: setWorkbenchTestPageEnabled,
+    subscribe: subscribeWorkbenchTestPageEnabledChanges,
   },
 ] as const;
 
@@ -1491,29 +1507,19 @@ export const SETTINGS_REGISTRY: SettingsItem[] = [
     set: setDevtoolsEnabledWithSync,
     subscribe: subscribeDevtoolsChanges,
   },
-  {
-    id: 'feature-toggles',
-    label: '功能开关',
-    icon: Bot,
-    category: 'developer',
-    type: 'group',
-    groupStyle: 'adaptive-overlay',
-    dialogTitle: '功能开关',
-    dialogDescription: '启用或关闭实验性功能',
+  ...FEATURE_TOGGLE_SETTINGS.map((setting) => ({
+    id: setting.id,
+    label: setting.label,
+    icon: setting.icon,
+    category: 'developer' as const,
+    type: 'boolean' as const,
     visible: devOnly,
-    children: FEATURE_TOGGLE_SETTINGS.map((setting) => ({
-      id: setting.id,
-      label: setting.label,
-      icon: setting.icon,
-      category: 'developer',
-      type: 'boolean' as const,
-      rowTestId: setting.rowTestId,
-      controlTestId: setting.controlTestId,
-      get: setting.get,
-      set: setting.set,
-      subscribe: setting.subscribe,
-    })),
-  },
+    rowTestId: setting.rowTestId,
+    controlTestId: setting.controlTestId,
+    get: setting.get,
+    set: setting.set,
+    subscribe: setting.subscribe,
+  })),
   {
     id: 'instance-diagnostics',
     label: '实例诊断信息',

--- a/src/ui/app/pages/AgentsPage.tsx
+++ b/src/ui/app/pages/AgentsPage.tsx
@@ -175,6 +175,12 @@ function TabBar({
   );
 }
 
+function readFocusSessionHandoff(): string | null {
+  if (typeof window === 'undefined') return null;
+  const params = new URLSearchParams(window.location.search);
+  return params.get('focusSession');
+}
+
 
 export function AgentsPage() {
   const supportsInlineRightPanel = useIsDesktop(1024);
@@ -1015,6 +1021,17 @@ export function AgentsPage() {
     () => (useMockData ? MOCK_SESSIONS : liveSessions),
     [liveSessions, useMockData],
   );
+
+  useEffect(() => {
+    const focusSessionId = readFocusSessionHandoff();
+    if (!focusSessionId) return;
+
+    const targetSession = dashboardSessions.find((session) => session.id === focusSessionId);
+    if (!targetSession?.pty_id) return;
+    if (rightPanel.state === 'PTY_TERMINAL' && activePtyId === targetSession.pty_id) return;
+
+    openPtyTerminal(targetSession.pty_id, targetSession.source_host_id);
+  }, [activePtyId, dashboardSessions, rightPanel.state]);
 
   const applyRuntimeSnapshot = (snapshot: { hosts: RuntimeHostSnapshot[]; agents: RuntimeAggregatedAgent[] }) => {
     setRuntimeHostSnapshots(snapshot.hosts);

--- a/src/ui/app/pages/workbench/WorkbenchPage.tsx
+++ b/src/ui/app/pages/workbench/WorkbenchPage.tsx
@@ -13,13 +13,17 @@ import { useIsDesktop } from '@/ui/app/hooks/useIsDesktop';
 
 import {
   applyWorkbenchLegacyIntent,
-  buildWorkbenchPanesFromSessions,
+  buildWorkbenchPanesFromProjection,
   readOrCreateWorkbenchFlatState,
   resolveWorkbenchLegacyIntent,
   writeWorkbenchFlatState,
   type WorkbenchBindingType,
   type WorkbenchPaneState,
 } from './workbench-storage';
+import {
+  buildWorkbenchSessionProjection,
+  mergeWorkbenchLegacyIntentIntoProjection,
+} from './workbench-session-interop';
 
 type PanePresentation = {
   badge: string;
@@ -148,10 +152,13 @@ export function WorkbenchPage() {
     enabled: true,
   });
 
-  const panes = useMemo(
-    () => buildWorkbenchPanesFromSessions(sessions, storedState.panes),
-    [sessions, storedState.panes],
-  );
+  const panes = useMemo(() => {
+    const projection = mergeWorkbenchLegacyIntentIntoProjection(
+      buildWorkbenchSessionProjection(sessions),
+      legacyIntent,
+    );
+    return buildWorkbenchPanesFromProjection(projection, storedState.panes);
+  }, [legacyIntent, sessions, storedState.panes]);
 
   useEffect(() => {
     writeWorkbenchFlatState({

--- a/src/ui/app/pages/workbench/workbench-session-interop.ts
+++ b/src/ui/app/pages/workbench/workbench-session-interop.ts
@@ -1,0 +1,158 @@
+import type { SessionInfo } from '@/lib/types/session';
+
+export type WorkbenchLegacyIntent =
+  | { source: 'agents-hub'; route: '/agents' }
+  | { source: 'agent-chat'; route: string; agentId: string };
+
+export type WorkbenchSessionStatus = 'running' | 'waiting' | 'idle' | 'error';
+
+export type WorkbenchSessionKind = 'agent' | 'terminal';
+
+export type WorkbenchSessionObjectReadModel = {
+  id: string;
+  sessionKind: WorkbenchSessionKind;
+  interactionMode: SessionInfo['interaction_mode'];
+  title: string;
+  summary: string;
+  status: WorkbenchSessionStatus;
+  agentId?: string;
+  ptyId?: string;
+  sourceHostId?: string;
+  sourceHostAddress?: string;
+  legacyIntent?: {
+    route: string;
+    agentId: string;
+  };
+};
+
+export type WorkbenchRuntimeBindingReadModel = {
+  sessionId: string;
+  bindingType: 'agent-session' | 'pty-runtime' | 'ssh-runtime';
+  runtimeRef: string;
+  runtimeKey: string;
+  hostId?: string;
+  hostAddress?: string;
+};
+
+export type WorkbenchSessionProjection = {
+  sessions: WorkbenchSessionObjectReadModel[];
+  bindings: WorkbenchRuntimeBindingReadModel[];
+  activeLegacySessionId?: string;
+};
+
+function mapSessionStatus(status: SessionInfo['status']): WorkbenchSessionStatus {
+  switch (status) {
+    case 'running':
+      return 'running';
+    case 'waiting_input':
+      return 'waiting';
+    case 'error':
+      return 'error';
+    case 'completed':
+    case 'paused':
+    case 'archived':
+    default:
+      return 'idle';
+  }
+}
+
+function buildRuntimeKey(hostId: string | undefined, runtimeRef: string): string {
+  return `${hostId ?? 'default'}::${runtimeRef}`;
+}
+
+export function mapSessionInfoToSessionObject(
+  session: SessionInfo,
+): WorkbenchSessionObjectReadModel {
+  return {
+    id: session.id,
+    sessionKind: session.interaction_mode === 'terminal' ? 'terminal' : 'agent',
+    interactionMode: session.interaction_mode,
+    title: session.role || session.summary || 'Untitled Session',
+    summary: session.summary || session.last_output_preview || '',
+    status: mapSessionStatus(session.status),
+    agentId: session.agent_id,
+    ptyId: session.pty_id,
+    sourceHostId: session.source_host_id,
+    sourceHostAddress: session.source_host_address,
+  };
+}
+
+export function mapSessionInfoToRuntimeBinding(
+  session: SessionInfo,
+): WorkbenchRuntimeBindingReadModel {
+  if (session.interaction_mode === 'terminal' && session.pty_id) {
+    return {
+      sessionId: session.id,
+      bindingType: 'pty-runtime',
+      runtimeRef: session.pty_id,
+      runtimeKey: buildRuntimeKey(session.source_host_id, session.pty_id),
+      hostId: session.source_host_id,
+      hostAddress: session.source_host_address,
+    };
+  }
+
+  if (session.interaction_mode === 'terminal') {
+    const runtimeRef = `session:${session.id}`;
+    return {
+      sessionId: session.id,
+      bindingType: 'ssh-runtime',
+      runtimeRef,
+      runtimeKey: buildRuntimeKey(session.source_host_id, session.id),
+      hostId: session.source_host_id,
+      hostAddress: session.source_host_address,
+    };
+  }
+
+  const runtimeRef = `agent:${session.agent_id ?? session.id}`;
+  return {
+    sessionId: session.id,
+    bindingType: 'agent-session',
+    runtimeRef,
+    runtimeKey: buildRuntimeKey(session.source_host_id, runtimeRef),
+    hostId: session.source_host_id,
+    hostAddress: session.source_host_address,
+  };
+}
+
+export function buildWorkbenchSessionProjection(
+  sessions: SessionInfo[],
+): WorkbenchSessionProjection {
+  return {
+    sessions: sessions.map(mapSessionInfoToSessionObject),
+    bindings: sessions.map(mapSessionInfoToRuntimeBinding),
+  };
+}
+
+export function mergeWorkbenchLegacyIntentIntoProjection(
+  projection: WorkbenchSessionProjection,
+  legacyIntent: WorkbenchLegacyIntent | null,
+): WorkbenchSessionProjection {
+  if (!legacyIntent || legacyIntent.source !== 'agent-chat') {
+    return projection;
+  }
+
+  const activeLegacySession = projection.sessions.find((session) => (
+    session.agentId === legacyIntent.agentId
+  ));
+
+  if (!activeLegacySession) {
+    return projection;
+  }
+
+  return {
+    ...projection,
+    activeLegacySessionId: activeLegacySession.id,
+    sessions: projection.sessions.map((session) => (
+      session.id === activeLegacySession.id
+        ? {
+            ...session,
+            title: `Agent Chat / ${legacyIntent.agentId}`,
+            legacyIntent: {
+              route: legacyIntent.route,
+              agentId: legacyIntent.agentId,
+            },
+          }
+        : session
+    )),
+  };
+}

--- a/src/ui/app/pages/workbench/workbench-storage.ts
+++ b/src/ui/app/pages/workbench/workbench-storage.ts
@@ -1,4 +1,8 @@
-import type { SessionInfo, SessionStatus } from '@/lib/types/session';
+import type { SessionInfo } from '@/lib/types/session';
+import {
+  buildWorkbenchSessionProjection,
+  type WorkbenchSessionProjection,
+} from './workbench-session-interop';
 
 export const WORKBENCH_PHASE1_STORAGE_KEY = 'exomind:workbench:phase1-flat:v1';
 
@@ -278,23 +282,6 @@ export function applyWorkbenchLegacyIntent(
   return { ...state, panes };
 }
 
-function mapSessionStatus(status: SessionStatus): WorkbenchPaneStatus {
-  switch (status) {
-    case 'running':
-      return 'running';
-    case 'waiting_input':
-      return 'waiting';
-    case 'completed':
-    case 'paused':
-    case 'archived':
-      return 'idle';
-    case 'error':
-      return 'error';
-    default:
-      return 'idle';
-  }
-}
-
 export function buildWorkbenchPaneHref(session: SessionInfo): string {
   const focusSession = `/agents?workbenchBypass=true&focusSession=${encodeURIComponent(session.id)}`;
   if (session.interaction_mode === 'terminal') {
@@ -333,34 +320,47 @@ export function mergeWorkbenchPaneState(
   return readFallbackWorkbenchPanes();
 }
 
-export function buildWorkbenchPanesFromSessions(
-  sessions: SessionInfo[],
+export function buildWorkbenchPanesFromProjection(
+  projection: WorkbenchSessionProjection,
   fallbackPanes?: WorkbenchPaneState[],
 ): WorkbenchPaneState[] {
-  const runtimePanes = sessions.map((session): WorkbenchPaneState => {
-    const isTerminal = session.interaction_mode === 'terminal';
-    const hasPty = Boolean(session.pty_id);
-    const bindingType: WorkbenchBindingType = isTerminal
-      ? (hasPty ? 'pty-runtime' : 'ssh-runtime')
-      : 'agent-session';
-    const viewKind: WorkbenchViewKind = isTerminal ? 'runtime-view' : 'session-view';
-    const status = isTerminal && hasPty && session.status === 'running'
+  const runtimePanes = projection.sessions.map((session): WorkbenchPaneState => {
+    const binding = projection.bindings.find((candidate) => candidate.sessionId === session.id);
+    const bindingType = binding?.bindingType ?? 'agent-session';
+    const viewKind: WorkbenchViewKind = bindingType === 'agent-session'
+      ? 'session-view'
+      : 'runtime-view';
+    const status: WorkbenchPaneStatus = bindingType === 'pty-runtime' && session.status === 'running'
       ? 'attached'
-      : mapSessionStatus(session.status);
+      : session.status;
 
     return {
       id: `pane-${session.id}`,
-      title: session.role || session.summary || 'Untitled Session',
+      title: session.title,
       viewKind,
       bindingType,
       status,
-      description: session.summary || session.last_output_preview || 'Runtime session pane / 运行时会话面板',
+      description: session.legacyIntent
+        ? `Legacy handoff from ${session.legacyIntent.route} / 来自旧聊天入口的接力`
+        : (session.summary || 'Runtime session pane / 运行时会话面板'),
       sessionId: session.id,
-      agentId: session.agent_id,
-      ptyId: session.pty_id,
-      openPath: buildWorkbenchPaneHref(session),
+      agentId: session.agentId,
+      ptyId: session.ptyId,
+      openPath: bindingType === 'agent-session'
+        ? `/agents/chat/${encodeURIComponent(session.agentId ?? session.id)}?workbenchBypass=true`
+        : `/agents?workbenchBypass=true&focusSession=${encodeURIComponent(session.id)}`,
     };
   });
 
   return mergeWorkbenchPaneState(runtimePanes, fallbackPanes);
+}
+
+export function buildWorkbenchPanesFromSessions(
+  sessions: SessionInfo[],
+  fallbackPanes?: WorkbenchPaneState[],
+): WorkbenchPaneState[] {
+  return buildWorkbenchPanesFromProjection(
+    buildWorkbenchSessionProjection(sessions),
+    fallbackPanes,
+  );
 }

--- a/tests/e2e/agents-page.issue201.test.ts
+++ b/tests/e2e/agents-page.issue201.test.ts
@@ -9,7 +9,7 @@ async function setupIssue201Flags(page: Page) {
   await page.addInitScript(() => {
     localStorage.setItem('exomind:uiMode', 'new');
     localStorage.setItem('exomind:agentPageEnabled', 'true');
-    localStorage.setItem('exomind:useMockData', 'true');
+    localStorage.setItem('exomind:useMockData', 'false');
   });
 }
 
@@ -46,12 +46,17 @@ test.describe('Issue #201 AgentsPage runtime aggregation（真实 runtime 多主
       if (request.url === '/topology') {
         response.writeHead(200, { 'Content-Type': 'application/json', ...corsHeaders });
         response.end(JSON.stringify({
+          host_id: 'runtime-host-201',
           hostname: 'local-runtime',
           os: 'Windows 11',
           arch: 'x86_64',
           uptime_secs: 99,
           version: '0.1.0',
           port: RUNTIME_PORT,
+          capabilities: {
+            agent_kinds: ['claude_cli', 'codex_cli', 'api'],
+            api_providers: ['openai', 'anthropic'],
+          },
         }));
         return;
       }
@@ -85,7 +90,7 @@ test.describe('Issue #201 AgentsPage runtime aggregation（真实 runtime 多主
 
   test('aggregates runtime list and switches to offline after server stop（聚合渲染并在服务关闭后显示 offline）', async ({ page }) => {
     await page.goto('/agents');
-    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId('agent-hub-page')).toBeVisible();
 
     await page.getByTestId('agent-add-node-button').click();
     await page.getByTestId('agent-add-node-option-device').click();

--- a/tests/e2e/settings-desktop.issue198.test.ts
+++ b/tests/e2e/settings-desktop.issue198.test.ts
@@ -116,10 +116,10 @@ test.describe('Issue #198 settings desktop shell（设置页桌面壳层）', ()
     await expect(page.getByTestId('desktop-sidebar-item-tasks')).toBeVisible();
     await expect(page.getByTestId('desktop-sidebar-item-me')).toBeVisible();
     await expect(page.getByTestId('desktop-sidebar-item-agents')).toBeVisible();
-    await expect(page.getByTestId('desktop-sidebar-item-workbench-test')).toBeVisible();
+    await expect(page.getByTestId('desktop-sidebar-item-workbench-test')).toHaveCount(0);
     await expect(page.getByTestId('desktop-sidebar-item-settings')).toBeVisible();
     await expect(page.getByTestId('desktop-sidebar-item-dashboard')).toHaveCount(0);
-    await expect(page.locator('[data-testid^="desktop-sidebar-item-"]')).toHaveCount(6);
+    await expect(page.locator('[data-testid^="desktop-sidebar-item-"]')).toHaveCount(5);
     await expect(page.getByTestId('mobile-bottom-tab')).toBeHidden();
   });
 
@@ -244,16 +244,20 @@ test.describe('Issue #198 settings desktop shell（设置页桌面壳层）', ()
     await page.goto('/settings');
     await expect(page.getByTestId('desktop-sidebar')).toBeVisible();
 
-    await expect(page.getByTestId('desktop-sidebar')).toBeVisible();
-
-    const featureTogglesRow = page.getByText('功能开关');
-    await featureTogglesRow.scrollIntoViewIfNeeded();
-    await featureTogglesRow.click();
-
     await page.getByTestId('new-settings-desktop-adaptive-switch').click();
 
     await expect(page.getByTestId('desktop-sidebar')).toBeHidden();
     await expect(page.getByTestId('mobile-bottom-tab')).toBeVisible();
+  });
+
+  test('developer setting can expose the workbench test nav entry（开发者设置可直接暴露工作台测试入口）', async ({ page }) => {
+    await page.goto('/settings');
+
+    await expect(page.getByTestId('desktop-sidebar-item-workbench-test')).toHaveCount(0);
+
+    await page.getByTestId('feature-toggle-workbench-test-switch').click();
+
+    await expect(page.getByTestId('desktop-sidebar-item-workbench-test')).toBeVisible();
   });
 
   test('desktop sidebar nav keeps desktop shell on non-settings route（桌面侧栏跳转非设置后保持桌面壳层）', async ({ page }) => {

--- a/tests/e2e/workbench.issue777.test.ts
+++ b/tests/e2e/workbench.issue777.test.ts
@@ -5,6 +5,8 @@ async function setupIssue777Flags(page: Page) {
     localStorage.setItem('exomind:uiMode', 'new');
     localStorage.setItem('exomind:desktopAdaptiveEnabled', 'true');
     localStorage.setItem('exomind:agentPageEnabled', 'true');
+    localStorage.setItem('exomind:developerMode', 'true');
+    localStorage.setItem('exomind:workbenchTestPageEnabled', 'true');
     localStorage.setItem('exomind:useMockData', 'true');
     localStorage.setItem('exomind:workbenchLegacyShimEnabled', 'true');
     localStorage.setItem('exomind:workbench:phase1-flat:v1', JSON.stringify({
@@ -114,6 +116,22 @@ test.describe('Issue #777 flat workbench（平铺工作台最小可见功能）'
 
     await expect(page).toHaveURL(/\/workbench$/);
     await expect(page.getByTestId('workbench-page')).toBeVisible();
+  });
+
+  test('keeps workbench test nav hidden until the flag is enabled（未开启开关前隐藏工作台测试入口）', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('exomind:uiMode', 'new');
+      localStorage.setItem('exomind:desktopAdaptiveEnabled', 'true');
+      localStorage.setItem('exomind:agentPageEnabled', 'true');
+      localStorage.setItem('exomind:developerMode', 'true');
+      localStorage.removeItem('exomind:workbenchTestPageEnabled');
+    });
+
+    await page.goto('/settings');
+
+    await expect(page.getByTestId('desktop-sidebar-item-workbench-test')).toHaveCount(0);
+    await page.getByTestId('feature-toggle-workbench-test-switch').click();
+    await expect(page.getByTestId('desktop-sidebar-item-workbench-test')).toBeVisible();
   });
 });
 

--- a/tests/unit/components/settings/DesktopAdaptiveToggle.test.tsx
+++ b/tests/unit/components/settings/DesktopAdaptiveToggle.test.tsx
@@ -30,49 +30,32 @@ beforeEach(() => {
 });
 
 describe('SettingsPage - Desktop adaptive toggle（桌面适配开关）', () => {
-  it('renders desktop adaptive switch in feature toggles drawer（在功能开关抽屉渲染桌面适配开关）', () => {
+  it('renders desktop adaptive switch directly in developer section（在开发者区域直接渲染桌面适配开关）', () => {
     render(<SettingsPage />);
-    fireEvent.click(screen.getByText('功能开关'));
     expect(screen.getByText('桌面端适配')).toBeInTheDocument();
     expect(screen.getByTestId('new-settings-desktop-adaptive-switch')).toBeInTheDocument();
     expect(screen.getByTestId('feature-toggle-desktop-adaptive-row').querySelector('svg')).not.toBeNull();
   });
 
-  it('uses dialog in landscape mode and drawer in portrait mode for feature toggles group', () => {
+  it('does not open a second dialog or drawer for desktop adaptive toggle', () => {
     mockMatchMedia({ isDesktop: true, isLandscape: true });
 
-    const { unmount } = render(<SettingsPage />);
-    fireEvent.click(screen.getByText('功能开关'));
-
-    expect(screen.getByTestId('dialog')).toBeInTheDocument();
-    expect(screen.queryByTestId('drawer')).toBeNull();
-
-    unmount();
-
-    mockMatchMedia({ isDesktop: false, isLandscape: false });
-
     render(<SettingsPage />);
-    fireEvent.click(screen.getByText('功能开关'));
-
-    expect(screen.getByTestId('drawer')).toBeInTheDocument();
     expect(screen.queryByTestId('dialog')).toBeNull();
+    expect(screen.queryByTestId('dialog')).toBeNull();
+    expect(screen.queryByTestId('drawer')).toBeNull();
   });
 
   it('updates desktop adaptive config on toggle（切换时写入桌面适配配置）', () => {
     render(<SettingsPage />);
-    fireEvent.click(screen.getByText('功能开关'));
     fireEvent.click(screen.getByTestId('new-settings-desktop-adaptive-switch'));
     expect(vi.mocked(setDesktopAdaptiveEnabled)).toHaveBeenCalledWith(false);
   });
 
-  it('uses developer section toneColor inside the feature toggles drawer（功能开关抽屉继承开发者主题色）', () => {
+  it('uses developer section toneColor on the direct desktop adaptive switch（直接开关继承开发者主题色）', () => {
     render(<SettingsPage />);
-    fireEvent.click(screen.getByText('功能开关'));
-
-    const drawerContent = screen.getByTestId('feature-toggles-drawer-content');
     const toggle = screen.getByTestId('new-settings-desktop-adaptive-switch');
 
-    expect(drawerContent.getAttribute('style') ?? '').toContain('--settings-tone-color: var(--settings-tone-developer)');
     expect(toggle.getAttribute('style') ?? '').toContain(
       '--switch-checked-bg: var(--settings-tone-color, var(--settings-tone-default))',
     );

--- a/tests/unit/components/settings/DeveloperSection.test.tsx
+++ b/tests/unit/components/settings/DeveloperSection.test.tsx
@@ -10,6 +10,7 @@ import { getDeveloperModeEnabled } from '@/config/developer-mode';
 import { setDevtoolsEnabled } from '@/config/devtools-mode';
 import { setCommandPaletteEnabled } from '@/config/command-palette-enabled';
 import { setMePageEnabled } from '@/config/me-page-enabled';
+import { setWorkbenchTestPageEnabled } from '@/config/workbench-test-page-enabled';
 import { syncDevtoolsWithSettings } from '@/lib/debug/devtools-runtime';
 import { SettingsPage } from '@/ui/app/pages/SettingsPage';
 
@@ -18,15 +19,17 @@ beforeEach(() => {
 });
 
 describe('SettingsPage - Developer Section (developerMode=true)', () => {
-  it('renders feature toggles row', () => {
+  it('renders flattened developer feature toggles directly', () => {
     render(<SettingsPage />);
-    expect(screen.getByText('功能开关')).toBeInTheDocument();
+    expect(screen.queryByText('功能开关')).not.toBeInTheDocument();
+    expect(screen.getByText('Me 页面')).toBeInTheDocument();
+    expect(screen.getByText('网络页面')).toBeInTheDocument();
+    expect(screen.getByText('命令面板')).toBeInTheDocument();
+    expect(screen.getByText('工作台测试')).toBeInTheDocument();
   });
 
-  it('opens feature toggles drawer on click', () => {
+  it('renders feature toggles without opening a second drawer', () => {
     render(<SettingsPage />);
-    const row = screen.getByText('功能开关');
-    fireEvent.click(row);
     expect(screen.getByText('Me 页面')).toBeInTheDocument();
     expect(screen.getByText('网络页面')).toBeInTheDocument();
     expect(screen.getByText('命令面板')).toBeInTheDocument();
@@ -50,9 +53,8 @@ describe('SettingsPage - Developer Section (developerMode=true)', () => {
     expect(vi.mocked(syncDevtoolsWithSettings)).toHaveBeenCalled();
   });
 
-  it('updates command palette state inside feature toggles drawer', () => {
+  it('updates command palette state directly in developer section', () => {
     render(<SettingsPage />);
-    fireEvent.click(screen.getByText('功能开关'));
 
     const toggle = screen.getByTestId('feature-toggle-command-palette-switch');
     fireEvent.click(toggle);
@@ -60,13 +62,21 @@ describe('SettingsPage - Developer Section (developerMode=true)', () => {
     expect(vi.mocked(setCommandPaletteEnabled)).toHaveBeenCalledWith(true);
   });
 
-  it('updates me page state inside feature toggles drawer', () => {
+  it('updates me page state directly in developer section', () => {
     render(<SettingsPage />);
-    fireEvent.click(screen.getByText('功能开关'));
 
     const toggle = screen.getByTestId('feature-toggle-me-page-switch');
     fireEvent.click(toggle);
 
     expect(vi.mocked(setMePageEnabled)).toHaveBeenCalledWith(true);
+  });
+
+  it('updates workbench test page state directly in developer section', () => {
+    render(<SettingsPage />);
+
+    const toggle = screen.getByTestId('feature-toggle-workbench-test-switch');
+    fireEvent.click(toggle);
+
+    expect(vi.mocked(setWorkbenchTestPageEnabled)).toHaveBeenCalledWith(true);
   });
 });

--- a/tests/unit/components/settings/setup-settings-mocks.tsx
+++ b/tests/unit/components/settings/setup-settings-mocks.tsx
@@ -96,6 +96,7 @@ export const settingsPagePreferenceState = {
   developerMode: false,
   agentPageEnabled: false,
   mePageEnabled: false,
+  workbenchTestPageEnabled: false,
   desktopAdaptiveEnabled: true,
   isTauriWindow: false,
   isDesktopOperatingSystem: false,
@@ -203,6 +204,12 @@ vi.mock('@/config/desktop-adaptive', () => ({
   getDesktopAdaptiveEnabled: vi.fn(() => settingsPagePreferenceState.desktopAdaptiveEnabled),
   setDesktopAdaptiveEnabled: vi.fn(),
   subscribeDesktopAdaptiveChanges: vi.fn(() => () => {}),
+}));
+
+vi.mock('@/config/workbench-test-page-enabled', () => ({
+  getWorkbenchTestPageEnabled: vi.fn(() => settingsPagePreferenceState.workbenchTestPageEnabled),
+  setWorkbenchTestPageEnabled: vi.fn(),
+  subscribeWorkbenchTestPageEnabledChanges: vi.fn(() => () => {}),
 }));
 
 vi.mock('@/config/runtime-target', async (importOriginal) => {

--- a/tests/unit/settings/settings-registry-coverage.test.ts
+++ b/tests/unit/settings/settings-registry-coverage.test.ts
@@ -40,6 +40,7 @@ const AUDITED_SETTINGS_IDS = [
   'voice-overlay-bottom-offset',
   'now-workbench-overlay-enabled',
   'volcano-engine-key',
+  'volcano-usage-summary',
   'volcano-endpoint',
   'volcano-resource-model',
   'volcano-resource-id',
@@ -70,7 +71,12 @@ const AUDITED_SETTINGS_IDS = [
   'developer-mode',
   'use-mock-data',
   'devtools',
-  'feature-toggles',
+  'me-page-enabled',
+  'agent-page-enabled',
+  'goals-page-enabled',
+  'desktop-adaptive',
+  'command-palette-enabled',
+  'workbench-test-page-enabled',
   'instance-diagnostics',
   'device-pairing',
   'clear-local-cache',
@@ -113,6 +119,12 @@ const BOOLEAN_IDS = [
   'developer-mode',
   'use-mock-data',
   'devtools',
+  'me-page-enabled',
+  'agent-page-enabled',
+  'goals-page-enabled',
+  'desktop-adaptive',
+  'command-palette-enabled',
+  'workbench-test-page-enabled',
 ] as const;
 
 const NUMBER_IDS = [
@@ -147,6 +159,7 @@ const CUSTOM_ITEM_IDS = [
   'sound-preset',
   'focus-bgm',
   'volcano-engine-key',
+  'volcano-usage-summary',
   'moss-voice-test',
   'volcano-asr-test',
   'ai-registry',
@@ -155,18 +168,22 @@ const CUSTOM_ITEM_IDS = [
   'device-pairing',
 ] as const;
 
+const DEV_ONLY_IDS = [
+  'use-mock-data',
+  'devtools',
+  'me-page-enabled',
+  'agent-page-enabled',
+  'goals-page-enabled',
+  'desktop-adaptive',
+  'command-palette-enabled',
+  'workbench-test-page-enabled',
+  'instance-diagnostics',
+  'device-pairing',
+] as const;
 const TAURI_DEV_ONLY_IDS = [
   'eventlog-backend-mode',
   'task-backend-mode',
   'timeblock-backend-mode',
-] as const;
-
-const DEV_ONLY_IDS = [
-  'use-mock-data',
-  'devtools',
-  'feature-toggles',
-  'instance-diagnostics',
-  'device-pairing',
 ] as const;
 
 function getItem<T extends typeof SETTINGS_REGISTRY[number]['type']>(
@@ -270,6 +287,9 @@ describe('settings registry coverage audit', () => {
     const volcanoEngineKey = getItem('volcano-engine-key', 'custom');
     expect(volcanoEngineKey.label).toBe('火山引擎 Key');
 
+    const volcanoUsageSummary = getItem('volcano-usage-summary', 'custom');
+    expect(volcanoUsageSummary.label).toBe('火山用量概览');
+
     const volcanoResourceId = getItem('volcano-resource-id', 'string');
     expect(volcanoResourceId.stringStyle).toBe('dialog');
     expect(volcanoResourceId.dialogFieldKind).toBe('plain');
@@ -300,15 +320,13 @@ describe('settings registry coverage audit', () => {
       ...getBaseCtx(),
       isTauriWindow: true,
     })).toBe(true);
-
-    const featureToggles = getItem('feature-toggles', 'group');
-    expect(featureToggles.groupStyle).toBe('adaptive-overlay');
-    expect(featureToggles.children.map((child) => child.id)).toEqual([
+    expect(FEATURE_TOGGLE_SETTING_IDS).toEqual([
       'me-page-enabled',
       'agent-page-enabled',
       'goals-page-enabled',
       'desktop-adaptive',
       'command-palette-enabled',
+      'workbench-test-page-enabled',
     ]);
 
     const clearLocalCache = getItem('clear-local-cache', 'action');
@@ -361,6 +379,11 @@ describe('settings registry coverage audit', () => {
       expect(tauriDeveloperIds).toContain(id);
     });
 
+    TAURI_DEV_ONLY_IDS.forEach((id) => {
+      expect(baseIds).not.toContain(id);
+      expect(developerIds).not.toContain(id);
+    });
+
     expect(baseIds).toContain('moss-api-token');
     expect(developerIds).toContain('moss-api-token');
     expect(volcanoIds).not.toContain('moss-api-token');
@@ -407,6 +430,12 @@ describe('settings registry coverage audit', () => {
         isDesktop: true,
         isTauriWindow: true,
         developerMode: true,
+      },
+      {
+        ...getBaseCtx(),
+        isDesktop: true,
+        isTauriWindow: true,
+        developerMode: true,
         voiceShortcutAsrProvider: 'volcano',
       },
     ];
@@ -427,6 +456,7 @@ describe('settings registry coverage audit', () => {
       'goals-page-enabled',
       'desktop-adaptive',
       'command-palette-enabled',
+      'workbench-test-page-enabled',
     ]);
     expect(FEATURE_TOGGLE_SETTINGS.map((item) => item.id)).toEqual(FEATURE_TOGGLE_SETTING_IDS);
     FEATURE_TOGGLE_SETTINGS.forEach((item) => {

--- a/tests/unit/ui/agent-hub/agents-page.focus-session.issue789.test.tsx
+++ b/tests/unit/ui/agent-hub/agents-page.focus-session.issue789.test.tsx
@@ -1,0 +1,256 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { AgentsPage } from '@/ui/app/pages/AgentsPage';
+import type { SignalRoute } from '@/lib/types/signal-pool';
+import type { SessionInfo } from '@/lib/types/session';
+
+const serviceMocks = vi.hoisted(() => ({
+  getDeviceView: vi.fn(),
+  getAgentDetail: vi.fn(),
+  getActorDetail: vi.fn(),
+  getConversation: vi.fn(),
+  streamConversation: vi.fn(),
+}));
+
+const runtimeManagerMocks = vi.hoisted(() => ({
+  refreshSnapshot: vi.fn(),
+  retryHost: vi.fn(),
+  addHost: vi.fn(),
+  addHostFromAddress: vi.fn(),
+  removeHost: vi.fn(),
+}));
+
+const runtimeControlMocks = vi.hoisted(() => ({
+  startRuntime: vi.fn(),
+  stopRuntime: vi.fn(),
+  getStatus: vi.fn(),
+}));
+
+const runtimeClientMocks = vi.hoisted(() => ({
+  streamAgentConversation: vi.fn(),
+  getTopology: vi.fn(),
+  getAgents: vi.fn(),
+  getAllEnergy: vi.fn(),
+  createAgent: vi.fn(),
+  deleteAgent: vi.fn(),
+  stopPtyAgent: vi.fn(),
+  submitQuickAction: vi.fn(),
+  markSessionWaiting: vi.fn(),
+}));
+
+const sessionStreamState = vi.hoisted(() => ({
+  sessions: [] as SessionInfo[],
+}));
+
+vi.mock('@xyflow/react', () => ({
+  ReactFlow: ({ nodes, children, onNodeClick }: { nodes?: Array<{ id: string; data?: { label?: string } }>; children?: unknown; onNodeClick?: (event: unknown, node: { id: string }) => void; }) => (
+    <div data-testid="mock-react-flow">
+      {(nodes ?? []).map((node) => (
+        <button key={node.id} type="button" data-testid={`mock-react-flow-node-${node.id}`} onClick={() => onNodeClick?.({}, node)}>
+          {node.data?.label ?? node.id}
+        </button>
+      ))}
+      {children}
+    </div>
+  ),
+  Background: () => <div data-testid="mock-react-flow-background" />,
+  Controls: () => <div data-testid="mock-react-flow-controls" />,
+  Handle: () => null,
+  Position: { Left: 'left', Right: 'right' },
+  useNodesState: <T,>(initialNodes: T[]) => [initialNodes, vi.fn(), vi.fn()] as const,
+  MarkerType: { ArrowClosed: 'arrowclosed' },
+}));
+
+vi.mock('@/lib/services', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/services')>();
+  return {
+    ...actual,
+    getAgentHubService: () => ({
+      getDeviceView: serviceMocks.getDeviceView,
+      getAgentDetail: serviceMocks.getAgentDetail,
+      getActorDetail: serviceMocks.getActorDetail,
+      getConversation: serviceMocks.getConversation,
+      streamConversation: serviceMocks.streamConversation,
+    }),
+  };
+});
+
+vi.mock('@/services/runtime-manager', () => ({
+  getRuntimeManager: () => runtimeManagerMocks,
+  findPreferredRuntimeHostForAgent: vi.fn(() => null),
+}));
+
+vi.mock('@/lib/services/runtime-control.service', () => ({
+  getRuntimeControlService: () => runtimeControlMocks,
+}));
+
+vi.mock('@/hooks/useSessionStream', () => ({
+  useSessionStream: () => ({
+    sessions: sessionStreamState.sessions,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('@/services/runtime-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/runtime-client')>();
+  class RuntimeClientMock {
+    streamAgentConversation = runtimeClientMocks.streamAgentConversation;
+    getTopology = runtimeClientMocks.getTopology;
+    getAgents = runtimeClientMocks.getAgents;
+    getAllEnergy = runtimeClientMocks.getAllEnergy;
+    createAgent = runtimeClientMocks.createAgent;
+    deleteAgent = runtimeClientMocks.deleteAgent;
+    stopPtyAgent = runtimeClientMocks.stopPtyAgent;
+    submitQuickAction = runtimeClientMocks.submitQuickAction;
+    markSessionWaiting = runtimeClientMocks.markSessionWaiting;
+  }
+  return {
+    ...actual,
+    RuntimeClient: RuntimeClientMock,
+  };
+});
+
+function buildSession(overrides: Partial<SessionInfo>): SessionInfo {
+  return {
+    id: 'session-789',
+    agent_kind: 'claude',
+    role: 'Session 789',
+    summary: '',
+    status: 'running',
+    interaction_mode: 'structured',
+    context: {
+      issue_refs: [],
+      labels: [],
+    },
+    created_at: '2026-03-31T00:00:00.000Z',
+    last_active_at: '2026-03-31T00:00:00.000Z',
+    turn_count: 0,
+    ...overrides,
+  };
+}
+
+function buildRuntimeSnapshot() {
+  return {
+    updatedAt: '2026-03-31T10:00:00.000Z',
+    agents: [],
+    hosts: [
+      {
+        host: {
+          id: 'host-789',
+          name: '127.0.0.1:1919',
+          host: '127.0.0.1',
+          port: 1919,
+          status: 'unknown' as const,
+          createdAt: '2026-03-31T00:00:00.000Z',
+          updatedAt: '2026-03-31T00:00:00.000Z',
+        },
+        connectionState: 'online' as const,
+        agents: [],
+        topology: {
+          host_id: 'runtime-host-789',
+          hostname: 'runtime-host-789',
+          os: 'Windows 11',
+          arch: 'x64',
+          uptime_secs: 90,
+          version: '0.3.6',
+          port: 1919,
+          capabilities: {
+            agent_kinds: ['claude_cli', 'codex_cli', 'api'],
+            api_providers: ['openai', 'anthropic'],
+          },
+        },
+      },
+    ],
+  };
+}
+
+class MockEventSource {
+  constructor(_url: string) {}
+  addEventListener() {}
+  removeEventListener() {}
+  close() {}
+}
+
+describe('agents page focusSession handoff issue-789（Agent Hub 消费 workbench focusSession）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    window.history.replaceState({}, '', '/agents?workbenchBypass=true&focusSession=session-terminal');
+    vi.stubGlobal('EventSource', MockEventSource as unknown as typeof EventSource);
+
+    runtimeControlMocks.getStatus.mockResolvedValue({
+      running: true,
+      host: '127.0.0.1',
+      port: 1919,
+    });
+    runtimeManagerMocks.refreshSnapshot.mockResolvedValue(buildRuntimeSnapshot());
+    serviceMocks.getDeviceView.mockResolvedValue([]);
+    serviceMocks.getAgentDetail.mockResolvedValue(null);
+    serviceMocks.getActorDetail.mockResolvedValue(null);
+    serviceMocks.getConversation.mockResolvedValue([]);
+    serviceMocks.streamConversation.mockImplementation(async function* () {
+      yield { messageId: 'fallback-1', delta: 'fallback', done: true };
+    });
+    runtimeClientMocks.streamAgentConversation.mockImplementation(async function* () {
+      yield { type: 'done', content: '', done: true };
+    });
+    runtimeClientMocks.getTopology.mockResolvedValue({
+      ok: true,
+      data: buildRuntimeSnapshot().hosts[0]!.topology,
+    });
+    runtimeClientMocks.getAgents.mockResolvedValue({ ok: true, data: [] });
+    runtimeClientMocks.getAllEnergy.mockResolvedValue({ ok: true, data: [] });
+    runtimeClientMocks.createAgent.mockResolvedValue({
+      ok: true,
+      data: { id: 'agent-789' },
+    });
+    runtimeClientMocks.deleteAgent.mockResolvedValue({
+      ok: true,
+      data: { status: 'stopped', id: 'agent-789' },
+    });
+    runtimeClientMocks.stopPtyAgent.mockResolvedValue({
+      ok: true,
+      data: {
+        id: 'pty-789',
+        name: 'Terminal Agent',
+        session_id: null,
+        workdir: 'D:/project/exomind',
+        command: 'claude',
+        status: 'stopped',
+        created_at: '2026-03-31T00:00:00.000Z',
+      },
+    });
+    runtimeClientMocks.submitQuickAction.mockResolvedValue({
+      ok: true,
+      data: buildSession({ id: 'session-quick' }),
+    });
+    runtimeClientMocks.markSessionWaiting.mockResolvedValue({
+      ok: true,
+      data: buildSession({ id: 'session-waiting', status: 'waiting_input' }),
+    });
+
+    sessionStreamState.sessions = [
+      buildSession({
+        id: 'session-terminal',
+        role: 'Terminal Session',
+        summary: 'Running shell',
+        interaction_mode: 'terminal',
+        pty_id: 'pty-789',
+        source_host_id: 'host-789',
+      }),
+    ];
+  });
+
+  it('opens the PTY terminal panel from focusSession query（通过 focusSession 自动打开 PTY 面板）', async () => {
+    render(<AgentsPage />);
+
+    await waitFor(() => {
+      const shell = screen.getByTestId('agent-rightpanel-shell');
+      expect(shell).toBeInTheDocument();
+      expect(within(shell).getByTestId('agent-rightpanel-pty-terminal')).toBeInTheDocument();
+      expect(within(shell).getByTestId('agent-rightpanel-stop-pty')).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/unit/ui/desktop-settings-shell.issue198.test.ts
+++ b/tests/unit/ui/desktop-settings-shell.issue198.test.ts
@@ -34,6 +34,7 @@ describe('issue-198 desktop settings shell（桌面设置壳层）', () => {
     expect(desktopNavBlock).toContain("title: '网络'");
     expect(desktopNavBlock).toContain("path: '/agents'");
     expect(desktopNavBlock).toContain('icon: Waypoints');
+    expect(desktopNavBlock).toContain('...(workbenchTestPageEnabled ? [{');
     expect(desktopNavBlock).toContain("key: 'workbench-test'");
     expect(desktopNavBlock).toContain("title: '工作台测试'");
     expect(desktopNavBlock).toContain("path: '/workbench'");
@@ -48,6 +49,7 @@ describe('issue-198 desktop settings shell（桌面设置壳层）', () => {
   it('uses network label and waypoints icon in mobile shell nav（移动端底栏使用网络文案与拓扑图标）', () => {
     expect(source).toContain("{ title: '当下', path: '/eventlog', icon: Target }");
     expect(source).toContain("...(agentPageEnabled ? [{ title: '网络', path: '/agents', icon: Waypoints }] : [])");
+    expect(source).toContain("...(workbenchTestPageEnabled ? [{ title: '工作台测试', path: '/workbench', icon: FlaskConical }] : [])");
     expect(source).not.toContain("...(agentPageEnabled ? [{ title: 'Agent', path: '/agents', icon: Bot }] : [])");
   });
 

--- a/tests/unit/ui/workbench/WorkbenchPage.issue789.test.tsx
+++ b/tests/unit/ui/workbench/WorkbenchPage.issue789.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SessionInfo } from '@/lib/types/session';
+import { WorkbenchPage } from '@/ui/app/pages/workbench/WorkbenchPage';
+
+const useSessionStreamMock = vi.fn();
+const useIsDesktopMock = vi.fn();
+const useLocationMock = vi.fn();
+
+vi.mock('@tanstack/react-router', () => ({
+  useLocation: () => useLocationMock(),
+}));
+
+vi.mock('@/hooks/useSessionStream', () => ({
+  useSessionStream: (...args: unknown[]) => useSessionStreamMock(...args),
+}));
+
+vi.mock('@/ui/app/hooks/useIsDesktop', () => ({
+  useIsDesktop: (...args: unknown[]) => useIsDesktopMock(...args),
+}));
+
+vi.mock('@/config/runtime-target', () => ({
+  getSelectedRuntimeTarget: () => ({
+    mode: 'embedded',
+    host: '127.0.0.1',
+    port: 9124,
+    authToken: 'token-789',
+  }),
+  subscribeRuntimeTargetChanges: () => () => {},
+  toRuntimeBaseUrl: () => 'http://127.0.0.1:9124',
+}));
+
+function buildSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: 'session-789',
+    agent_kind: 'claude',
+    agent_id: 'agent-review',
+    role: 'Review Agent',
+    summary: 'Reviewing code',
+    status: 'running',
+    interaction_mode: 'structured',
+    context: {
+      issue_refs: ['#789'],
+      labels: ['workbench'],
+    },
+    created_at: '2026-03-31T09:00:00.000Z',
+    last_active_at: '2026-03-31T09:15:00.000Z',
+    turn_count: 4,
+    last_output_preview: 'Please confirm merge',
+    ...overrides,
+  };
+}
+
+describe('Issue #789 legacy handoff preservation（保留旧入口 handoff 语义）', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    useIsDesktopMock.mockReturnValue(true);
+    useLocationMock.mockReturnValue({
+      pathname: '/workbench',
+      searchStr: '?legacySource=agent-chat&agentId=agent-review',
+    });
+    useSessionStreamMock.mockReturnValue({
+      sessions: [
+        buildSession({
+          id: 'session-review',
+          agent_id: 'agent-review',
+          role: 'Review Agent',
+        }),
+        buildSession({
+          id: 'session-terminal',
+          agent_id: undefined,
+          interaction_mode: 'terminal',
+          pty_id: 'pty-789',
+          role: 'Terminal Runner',
+          summary: 'Running shell',
+        }),
+      ],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    });
+  });
+
+  it('keeps agent chat handoff visible even when runtime panes exist（runtime pane 存在时仍显示 agent chat handoff）', () => {
+    render(<WorkbenchPage />);
+
+    expect(screen.getByTestId('workbench-legacy-entry')).toContainHTML('/agents/chat/agent-review');
+    expect(screen.getByText('Agent Chat / agent-review')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/ui/workbench/workbench-session-interop.issue789.test.ts
+++ b/tests/unit/ui/workbench/workbench-session-interop.issue789.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SessionInfo } from '@/lib/types/session';
+import {
+  buildWorkbenchSessionProjection,
+  mergeWorkbenchLegacyIntentIntoProjection,
+  type WorkbenchLegacyIntent,
+} from '@/ui/app/pages/workbench/workbench-session-interop';
+
+function buildSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: 'session-789',
+    agent_kind: 'claude',
+    agent_id: 'agent-789',
+    role: 'Planner Agent',
+    summary: 'Plan the next workbench slice',
+    status: 'running',
+    interaction_mode: 'structured',
+    context: {
+      issue_refs: ['#789'],
+      labels: ['workbench'],
+    },
+    created_at: '2026-03-31T09:00:00.000Z',
+    last_active_at: '2026-03-31T09:30:00.000Z',
+    turn_count: 5,
+    last_output_preview: 'Adapter ready',
+    ...overrides,
+  };
+}
+
+describe('Issue #789 session-runtime federation（会话/运行时联邦桥接）', () => {
+  it('maps structured sessions into session objects with agent-session bindings（结构化会话映射为 SessionObject 和 agent-session 绑定）', () => {
+    const projection = buildWorkbenchSessionProjection([
+      buildSession({
+        id: 'session-structured',
+        role: 'Review Agent',
+        agent_id: 'agent-review',
+        interaction_mode: 'structured',
+      }),
+    ]);
+
+    expect(projection.sessions).toHaveLength(1);
+    expect(projection.sessions[0]).toMatchObject({
+      id: 'session-structured',
+      sessionKind: 'agent',
+      interactionMode: 'structured',
+      title: 'Review Agent',
+      status: 'running',
+    });
+
+    expect(projection.bindings).toHaveLength(1);
+    expect(projection.bindings[0]).toMatchObject({
+      sessionId: 'session-structured',
+      bindingType: 'agent-session',
+      runtimeRef: 'agent:agent-review',
+      hostId: undefined,
+    });
+  });
+
+  it('maps terminal PTY sessions into runtime bindings（终端 PTY 会话映射为运行时绑定）', () => {
+    const projection = buildWorkbenchSessionProjection([
+      buildSession({
+        id: 'session-terminal',
+        interaction_mode: 'terminal',
+        pty_id: 'pty-789',
+        source_host_id: 'host-a',
+        source_host_address: '127.0.0.1:9124',
+        agent_id: undefined,
+        role: 'Terminal Runner',
+      }),
+    ]);
+
+    expect(projection.sessions[0]).toMatchObject({
+      id: 'session-terminal',
+      sessionKind: 'terminal',
+      interactionMode: 'terminal',
+      title: 'Terminal Runner',
+    });
+
+    expect(projection.bindings[0]).toMatchObject({
+      sessionId: 'session-terminal',
+      bindingType: 'pty-runtime',
+      runtimeRef: 'pty-789',
+      runtimeKey: 'host-a::pty-789',
+      hostId: 'host-a',
+      hostAddress: '127.0.0.1:9124',
+    });
+  });
+
+  it('maps terminal non-PTY sessions into ssh bindings（无 PTY 的终端会话映射为 SSH 绑定）', () => {
+    const projection = buildWorkbenchSessionProjection([
+      buildSession({
+        id: 'session-ssh',
+        interaction_mode: 'terminal',
+        pty_id: undefined,
+        source_host_id: 'host-b',
+        source_host_address: '192.168.1.40:1949',
+        agent_id: undefined,
+        role: 'SSH Session',
+      }),
+    ]);
+
+    expect(projection.bindings[0]).toMatchObject({
+      sessionId: 'session-ssh',
+      bindingType: 'ssh-runtime',
+      runtimeRef: 'session:session-ssh',
+      runtimeKey: 'host-b::session-ssh',
+      hostId: 'host-b',
+    });
+  });
+
+  it('preserves legacy chat handoff when runtime sessions are non-empty（runtime 非空时仍保留旧聊天 handoff）', () => {
+    const legacyIntent: WorkbenchLegacyIntent = {
+      source: 'agent-chat',
+      route: '/agents/chat/agent-review',
+      agentId: 'agent-review',
+    };
+
+    const projection = mergeWorkbenchLegacyIntentIntoProjection(
+      buildWorkbenchSessionProjection([
+        buildSession({
+          id: 'session-review',
+          role: 'Review Agent',
+          agent_id: 'agent-review',
+        }),
+        buildSession({
+          id: 'session-terminal',
+          interaction_mode: 'terminal',
+          pty_id: 'pty-789',
+          agent_id: undefined,
+          role: 'Terminal Runner',
+        }),
+      ]),
+      legacyIntent,
+    );
+
+    expect(projection.activeLegacySessionId).toBe('session-review');
+    expect(projection.sessions[0]).toMatchObject({
+      id: 'session-review',
+      title: 'Agent Chat / agent-review',
+      legacyIntent: {
+        route: '/agents/chat/agent-review',
+        agentId: 'agent-review',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a `SessionInteropAdapter / 会话桥接适配层` for workbench session/runtime projection
- preserve legacy chat handoff when runtime panes exist and make `focusSession` work in `AgentsPage`
- move `工作台测试 / Workbench test` exposure behind a direct developer-mode setting instead of the old feature-toggle overlay
- refresh related unit and Playwright coverage, including current runtime aggregation fixture contracts

## Scope
This PR starts `#789` as the next step after merged `#781`.

Included in this batch
- `SessionInfo -> SessionObject` read-model bridge on the front end
- `PTY / SSH -> RuntimeBinding` projection for workbench semantics
- `workbench -> agents` handoff completion for terminal focus
- developer settings flattening for feature toggles and workbench test visibility

Not included yet
- drag-and-drop
- cross-window federation
- EventTape formal runtime persistence
- full `AgentsPage.tsx` decomposition from `#535`

## Verification
- [x] `bunx tsc --noEmit`
- [x] `bunx vitest run tests/unit/settings/settings-registry-coverage.test.ts tests/unit/components/settings/DeveloperSection.test.tsx tests/unit/components/settings/DesktopAdaptiveToggle.test.tsx tests/unit/ui/desktop-settings-shell.issue198.test.ts tests/unit/ui/agent-hub/agents-page.focus-session.issue789.test.tsx tests/unit/ui/agent-hub/agents-page.session-actions.issue523.test.tsx tests/unit/ui/workbench/WorkbenchPage.issue789.test.tsx tests/unit/ui/workbench/WorkbenchPage.issue777.test.tsx tests/unit/ui/workbench/workbench-session-interop.issue789.test.ts tests/unit/ui/workbench/workbench-runtime.issue777.test.ts`
- [x] `bunx playwright test tests/e2e/settings-desktop.issue198.test.ts tests/e2e/workbench.issue777.test.ts tests/e2e/agents-page.issue201.test.ts --config tests/e2e/playwright.issue777.config.ts`

## Issues
- refs #789
- continues #777
