### PR TITLE
feat(cli): add RT-native connect-first CLI shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +163,21 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -496,6 +561,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +769,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +816,12 @@ checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -982,6 +1104,12 @@ dependencies = [
  "rustc_version",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -1309,6 +1437,22 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "exomind-cli"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "chrono",
+ "clap",
+ "dirs 5.0.1",
+ "exomind-runtime",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -2428,6 +2572,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3268,6 +3418,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3723,6 +3879,33 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -5608,6 +5791,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6248,6 +6437,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6306,6 +6501,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
+ "libc",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
  "libc",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,7 @@ name = "exomind-cli"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "axum",
  "chrono",
  "clap",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["src-tauri", "crates/exomind-runtime"]
+members = ["src-tauri", "crates/exomind-runtime", "crates/exomind-cli"]
 resolver = "2"
 
 [profile.release]

--- a/crates/exomind-cli/Cargo.toml
+++ b/crates/exomind-cli/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "exomind-cli"
+version = "0.1.0"
+edition = "2024"
+default-run = "exomind"
+
+[[bin]]
+name = "exomind"
+path = "src/main.rs"
+
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive"] }
+dirs = "5"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+exomind-runtime = { path = "../exomind-runtime" }
+
+[dev-dependencies]
+assert_cmd = "2"

--- a/crates/exomind-cli/Cargo.toml
+++ b/crates/exomind-cli/Cargo.toml
@@ -21,3 +21,4 @@ exomind-runtime = { path = "../exomind-runtime" }
 
 [dev-dependencies]
 assert_cmd = "2"
+axum = "0.7"

--- a/crates/exomind-cli/src/cli.rs
+++ b/crates/exomind-cli/src/cli.rs
@@ -1,0 +1,181 @@
+use clap::{Args, Parser, Subcommand};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "exomind",
+    about = "ExoMind RT client shell (RT 客户端外壳)",
+    long_about = "ExoMind RT client shell (RT 客户端外壳) with connect-first defaults."
+)]
+pub struct Cli {
+    #[arg(long, global = true)]
+    pub target: Option<String>,
+
+    #[arg(long, global = true)]
+    pub profile: Option<String>,
+
+    #[arg(long = "user-id", global = true)]
+    pub user_id: Option<String>,
+
+    #[arg(long, global = true)]
+    pub json: bool,
+
+    #[arg(long = "spawn-if-missing", global = true)]
+    pub spawn_if_missing: bool,
+
+    #[command(subcommand)]
+    pub command: Option<RootCommand>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum RootCommand {
+    #[command(subcommand)]
+    Eventlog(EventlogCommand),
+    #[command(subcommand)]
+    Task(TaskCommand),
+    #[command(subcommand)]
+    Proposal(ProposalCommand),
+    #[command(subcommand)]
+    Rt(RtCommand),
+    Examples,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum EventlogCommand {
+    Add(EventlogAddArgs),
+    List(EventlogListArgs),
+    Get(EventlogGetArgs),
+    Watch(EventlogWatchArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct EventlogAddArgs {
+    #[arg(long)]
+    pub content: String,
+
+    #[arg(long = "tag")]
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct EventlogListArgs {
+    #[arg(long)]
+    pub limit: Option<usize>,
+
+    #[arg(long = "tag")]
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct EventlogGetArgs {
+    pub event_id: String,
+}
+
+#[derive(Debug, Args)]
+pub struct EventlogWatchArgs {
+    #[arg(long = "since-id")]
+    pub since_id: Option<String>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum TaskCommand {
+    Add(TaskAddArgs),
+    List(TaskListArgs),
+    Get(TaskGetArgs),
+    Update(TaskUpdateArgs),
+    Start(TaskIdArgs),
+    Complete(TaskIdArgs),
+    Cancel(TaskIdArgs),
+    Suspend(TaskIdArgs),
+    Resume(TaskIdArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct TaskAddArgs {
+    #[arg(long)]
+    pub title: String,
+}
+
+#[derive(Debug, Args)]
+pub struct TaskListArgs {
+    #[arg(long)]
+    pub status: Option<String>,
+
+    #[arg(long = "tag")]
+    pub tags: Vec<String>,
+
+    #[arg(long = "parent-id")]
+    pub parent_id: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct TaskGetArgs {
+    pub task_id: String,
+}
+
+#[derive(Debug, Args)]
+pub struct TaskUpdateArgs {
+    pub task_id: String,
+
+    #[arg(long)]
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct TaskIdArgs {
+    pub task_id: String,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ProposalCommand {
+    Add(ProposalAddArgs),
+    List(ProposalListArgs),
+    Get(ProposalIdArgs),
+    Approve(ProposalIdArgs),
+    Reject(ProposalIdArgs),
+    Snooze(ProposalIdArgs),
+    Comment(ProposalCommentArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct ProposalAddArgs {
+    #[arg(long)]
+    pub action: String,
+
+    #[arg(long)]
+    pub title: String,
+
+    #[arg(long = "params-file")]
+    pub params_file: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct ProposalListArgs {
+    #[arg(long)]
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct ProposalIdArgs {
+    pub proposal_id: u64,
+}
+
+#[derive(Debug, Args)]
+pub struct ProposalCommentArgs {
+    pub proposal_id: u64,
+
+    #[arg(long)]
+    pub content: String,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum RtCommand {
+    Status,
+    Probe,
+    Use(RtUseArgs),
+    ClearDefault,
+}
+
+#[derive(Debug, Args)]
+pub struct RtUseArgs {
+    pub target: String,
+}

--- a/crates/exomind-cli/src/cli.rs
+++ b/crates/exomind-cli/src/cli.rs
@@ -26,6 +26,27 @@ pub struct Cli {
     pub command: Option<RootCommand>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GlobalOptions {
+    pub target: Option<String>,
+    pub profile: Option<String>,
+    pub user_id: Option<String>,
+    pub json: bool,
+    pub spawn_if_missing: bool,
+}
+
+impl From<&Cli> for GlobalOptions {
+    fn from(value: &Cli) -> Self {
+        Self {
+            target: value.target.clone(),
+            profile: value.profile.clone(),
+            user_id: value.user_id.clone(),
+            json: value.json,
+            spawn_if_missing: value.spawn_if_missing,
+        }
+    }
+}
+
 #[derive(Debug, Subcommand)]
 pub enum RootCommand {
     #[command(subcommand)]
@@ -93,6 +114,12 @@ pub enum TaskCommand {
 pub struct TaskAddArgs {
     #[arg(long)]
     pub title: String,
+
+    #[arg(long)]
+    pub priority: Option<String>,
+
+    #[arg(long = "tag")]
+    pub tags: Vec<String>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/exomind-cli/src/commands/eventlog.rs
+++ b/crates/exomind-cli/src/commands/eventlog.rs
@@ -1,0 +1,127 @@
+use chrono::Utc;
+use serde_json::Value;
+use serde_json::json;
+
+use crate::cli::{
+    EventlogAddArgs, EventlogCommand, EventlogGetArgs, EventlogListArgs, EventlogWatchArgs,
+    GlobalOptions,
+};
+use crate::commands::resolve_command_context;
+use crate::error::CliError;
+use crate::output;
+
+pub async fn handle(command: EventlogCommand, global: &GlobalOptions) -> Result<(), CliError> {
+    match command {
+        EventlogCommand::Add(args) => {
+            let created = add_event(global, &args).await?;
+            print_value(global, &created)
+        }
+        EventlogCommand::List(args) => {
+            let events = list_events(global, &args).await?;
+            print_list(global, &events)
+        }
+        EventlogCommand::Get(args) => {
+            let event = get_event(global, &args).await?;
+            print_value(global, &event)
+        }
+        EventlogCommand::Watch(args) => {
+            let events = watch_events(global, &args).await?;
+            print_list(global, &events)
+        }
+    }
+}
+
+pub async fn add_event(global: &GlobalOptions, args: &EventlogAddArgs) -> Result<Value, CliError> {
+    let context = resolve_command_context(global)?;
+    let path = scoped_eventlog_path("/eventlog", context.scope.as_ref());
+    let payload = json!({
+        "timestamp": Utc::now().timestamp_millis(),
+        "content": args.content,
+        "tags": args.tags,
+    });
+
+    context.client.post_json(&path, &payload).await
+}
+
+pub async fn list_events(
+    global: &GlobalOptions,
+    args: &EventlogListArgs,
+) -> Result<Vec<Value>, CliError> {
+    let context = resolve_command_context(global)?;
+    let mut path = scoped_eventlog_path("/eventlog", context.scope.as_ref());
+    let mut extra_pairs = Vec::new();
+    if let Some(limit) = args.limit {
+        extra_pairs.push(("limit".to_string(), limit.to_string()));
+    }
+    if !args.tags.is_empty() {
+        extra_pairs.push(("tags".to_string(), args.tags.join(",")));
+    }
+    if !extra_pairs.is_empty() {
+        path = context.client.with_scope(&path, &extra_pairs);
+    }
+
+    context.client.get_json(&path).await
+}
+
+pub async fn get_event(global: &GlobalOptions, args: &EventlogGetArgs) -> Result<Value, CliError> {
+    let context = resolve_command_context(global)?;
+    let path = scoped_eventlog_path(&format!("/eventlog/{}", args.event_id), context.scope.as_ref());
+
+    context.client.get_json(&path).await
+}
+
+pub async fn watch_events(
+    global: &GlobalOptions,
+    args: &EventlogWatchArgs,
+) -> Result<Vec<Value>, CliError> {
+    let context = resolve_command_context(global)?;
+    let mut path = scoped_eventlog_path("/eventlog/watch", context.scope.as_ref());
+    if let Some(since_id) = &args.since_id {
+        path = context
+            .client
+            .with_scope(&path, &[("since_id".to_string(), since_id.clone())]);
+    }
+
+    context.client.get_json(&path).await
+}
+
+fn scoped_eventlog_path(path: &str, scope: Option<&crate::profile_scope::ProfileScope>) -> String {
+    if let Some(scope) = scope {
+        let client = crate::runtime_client::RuntimeClient::from_target("127.0.0.1:0", None)
+            .expect("temporary runtime client for query formatting");
+        client.with_scope(path, &scope.eventlog_query_pairs())
+    } else {
+        path.to_string()
+    }
+}
+
+fn print_value(global: &GlobalOptions, value: &Value) -> Result<(), CliError> {
+    if global.json {
+        output::print_json(value).map_err(CliError::Message)?;
+    } else {
+        println!(
+            "{} [{}]",
+            value["content"].as_str().unwrap_or_default(),
+            value["id"].as_str().unwrap_or_default()
+        );
+    }
+
+    Ok(())
+}
+
+fn print_list(global: &GlobalOptions, values: &[Value]) -> Result<(), CliError> {
+    if global.json {
+        let payload = serde_json::to_value(values).map_err(|error| CliError::Message(error.to_string()))?;
+        output::print_json(&payload).map_err(CliError::Message)?;
+    } else {
+        for value in values {
+            println!(
+                "{} [{}]",
+                value["content"].as_str().unwrap_or_default(),
+                value["id"].as_str().unwrap_or_default()
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/exomind-cli/src/commands/mod.rs
+++ b/crates/exomind-cli/src/commands/mod.rs
@@ -1,0 +1,47 @@
+use crate::cli::GlobalOptions;
+use crate::error::CliError;
+use crate::profile_scope::ProfileScope;
+use crate::runtime_client::RuntimeClient;
+use crate::state::CliState;
+use crate::target::{candidate_ports, resolve_target};
+
+pub mod eventlog;
+pub mod proposal;
+pub mod rt;
+pub mod task;
+
+pub(crate) struct CommandContext {
+    pub client: RuntimeClient,
+    pub scope: Option<ProfileScope>,
+}
+
+pub(crate) fn resolve_command_context(global: &GlobalOptions) -> Result<CommandContext, CliError> {
+    let state = CliState::load(&CliState::resolve_path())?;
+    let ports = candidate_ports();
+    let resolved = resolve_target(global.target.as_deref(), &state, &ports, |candidate| {
+        std::net::TcpStream::connect(candidate).is_ok()
+    })
+    .ok_or_else(|| {
+        if global.spawn_if_missing {
+            CliError::Message(
+                "spawn-if-missing is not implemented yet (显式 RT 自启尚未实现)".to_string(),
+            )
+        } else {
+            CliError::Message("no RT target resolved (未解析到 RT 目标)".to_string())
+        }
+    })?;
+
+    let scope = ProfileScope::from_flags(global.profile.as_deref(), global.user_id.as_deref())
+        .or_else(|| {
+            state
+                .target_state(&resolved.target)
+                .and_then(|entry| entry.default_profile.as_deref())
+                .and_then(|profile| ProfileScope::from_flags(Some(profile), None))
+        });
+    let token = state
+        .target_state(&resolved.target)
+        .and_then(|entry| entry.auth_token.clone());
+    let client = RuntimeClient::from_target(resolved.target, token)?;
+
+    Ok(CommandContext { client, scope })
+}

--- a/crates/exomind-cli/src/commands/proposal.rs
+++ b/crates/exomind-cli/src/commands/proposal.rs
@@ -1,0 +1,173 @@
+use std::fs;
+use std::io::Read;
+
+use serde_json::Value;
+use serde_json::json;
+
+use crate::cli::{GlobalOptions, ProposalAddArgs, ProposalCommentArgs, ProposalCommand, ProposalIdArgs, ProposalListArgs};
+use crate::commands::resolve_command_context;
+use crate::error::CliError;
+use crate::output;
+
+pub async fn handle(command: ProposalCommand, global: &GlobalOptions) -> Result<(), CliError> {
+    match command {
+        ProposalCommand::Add(args) => print_value(global, &add_proposal(global, &args).await?),
+        ProposalCommand::List(args) => print_list(global, &list_proposals(global, &args).await?),
+        ProposalCommand::Get(args) => print_value(global, &get_proposal(global, &args).await?),
+        ProposalCommand::Approve(args) => print_value(global, &approve_proposal(global, &args).await?),
+        ProposalCommand::Reject(args) => print_value(global, &reject_proposal(global, &args).await?),
+        ProposalCommand::Snooze(args) => print_value(global, &snooze_proposal(global, &args).await?),
+        ProposalCommand::Comment(args) => print_value(global, &comment_proposal(global, &args).await?),
+    }
+}
+
+pub async fn add_proposal(global: &GlobalOptions, args: &ProposalAddArgs) -> Result<Value, CliError> {
+    let context = resolve_command_context(global)?;
+    let path = scoped_proposal_path("/api/proposals", context.scope.as_ref());
+    let action_params = read_params_json(args.params_file.as_deref())?;
+    let payload = json!({
+        "title": args.title,
+        "body": "",
+        "action_type": args.action,
+        "action_params": action_params,
+        "publisher": default_publisher(),
+    });
+
+    context.client.post_json(&path, &payload).await
+}
+
+pub async fn list_proposals(
+    global: &GlobalOptions,
+    args: &ProposalListArgs,
+) -> Result<Vec<Value>, CliError> {
+    let context = resolve_command_context(global)?;
+    let mut path = scoped_proposal_path("/api/proposals", context.scope.as_ref());
+    if let Some(status) = &args.status {
+        path = context
+            .client
+            .with_scope(&path, &[("status".to_string(), status.clone())]);
+    }
+
+    context.client.get_json(&path).await
+}
+
+pub async fn get_proposal(global: &GlobalOptions, args: &ProposalIdArgs) -> Result<Value, CliError> {
+    let context = resolve_command_context(global)?;
+    let path = scoped_proposal_path(
+        &format!("/api/proposals/{}", args.proposal_id),
+        context.scope.as_ref(),
+    );
+
+    context.client.get_json(&path).await
+}
+
+pub async fn approve_proposal(global: &GlobalOptions, args: &ProposalIdArgs) -> Result<Value, CliError> {
+    update_status(global, args, "approved").await
+}
+
+pub async fn reject_proposal(global: &GlobalOptions, args: &ProposalIdArgs) -> Result<Value, CliError> {
+    update_status(global, args, "rejected").await
+}
+
+pub async fn snooze_proposal(global: &GlobalOptions, args: &ProposalIdArgs) -> Result<Value, CliError> {
+    update_status(global, args, "snoozed").await
+}
+
+pub async fn comment_proposal(
+    global: &GlobalOptions,
+    args: &ProposalCommentArgs,
+) -> Result<Value, CliError> {
+    let context = resolve_command_context(global)?;
+    let path = scoped_proposal_path(
+        &format!("/api/proposals/{}/comments", args.proposal_id),
+        context.scope.as_ref(),
+    );
+    let payload = json!({
+        "author": default_publisher(),
+        "content": args.content,
+    });
+
+    context.client.post_json(&path, &payload).await
+}
+
+async fn update_status(
+    global: &GlobalOptions,
+    args: &ProposalIdArgs,
+    status: &str,
+) -> Result<Value, CliError> {
+    let context = resolve_command_context(global)?;
+    let path = scoped_proposal_path(
+        &format!("/api/proposals/{}", args.proposal_id),
+        context.scope.as_ref(),
+    );
+    let payload = json!({ "status": status });
+
+    context.client.patch_json(&path, &payload).await
+}
+
+fn scoped_proposal_path(path: &str, scope: Option<&crate::profile_scope::ProfileScope>) -> String {
+    if let Some(scope) = scope {
+        let client = crate::runtime_client::RuntimeClient::from_target("127.0.0.1:0", None)
+            .expect("temporary runtime client for query formatting");
+        client.with_scope(path, &scope.proposal_query_pairs())
+    } else {
+        path.to_string()
+    }
+}
+
+fn read_params_json(path: Option<&str>) -> Result<Value, CliError> {
+    let Some(path) = path else {
+        return Ok(json!({}));
+    };
+
+    let raw = if path == "-" {
+        let mut buffer = String::new();
+        std::io::stdin().read_to_string(&mut buffer)?;
+        buffer
+    } else {
+        fs::read_to_string(path)?
+    };
+
+    serde_json::from_str(&raw).map_err(|error| CliError::Message(error.to_string()))
+}
+
+fn default_publisher() -> Value {
+    json!({
+        "publisher_type": "agent",
+        "id": "exomind-cli",
+        "name": "ExoMind CLI",
+    })
+}
+
+fn print_value(global: &GlobalOptions, value: &Value) -> Result<(), CliError> {
+    if global.json {
+        output::print_json(value).map_err(CliError::Message)?;
+    } else {
+        println!(
+            "{} [{}] {}",
+            value["title"].as_str().unwrap_or_default(),
+            value["id"].as_u64().unwrap_or_default(),
+            value["status"].as_str().unwrap_or_default()
+        );
+    }
+
+    Ok(())
+}
+
+fn print_list(global: &GlobalOptions, values: &[Value]) -> Result<(), CliError> {
+    if global.json {
+        let payload = serde_json::to_value(values).map_err(|error| CliError::Message(error.to_string()))?;
+        output::print_json(&payload).map_err(CliError::Message)?;
+    } else {
+        for value in values {
+            println!(
+                "{} [{}] {}",
+                value["title"].as_str().unwrap_or_default(),
+                value["id"].as_u64().unwrap_or_default(),
+                value["status"].as_str().unwrap_or_default()
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/exomind-cli/src/commands/rt.rs
+++ b/crates/exomind-cli/src/commands/rt.rs
@@ -1,0 +1,140 @@
+use serde_json::json;
+
+use crate::cli::{GlobalOptions, RtCommand, RtUseArgs};
+use crate::error::CliError;
+use crate::output;
+use crate::runtime_client::RuntimeClient;
+use crate::state::CliState;
+use crate::target::{TargetProbeStatus, TargetResolutionSource, candidate_ports, probe_targets, resolve_target};
+
+pub async fn handle(command: RtCommand, global: &GlobalOptions) -> Result<(), CliError> {
+    match command {
+        RtCommand::Status => rt_status(global).await,
+        RtCommand::Probe => rt_probe(global).await,
+        RtCommand::Use(args) => rt_use(global, args),
+        RtCommand::ClearDefault => rt_clear_default(global),
+    }
+}
+
+async fn rt_status(global: &GlobalOptions) -> Result<(), CliError> {
+    let payload = status_payload(global).await?;
+
+    if global.json {
+        output::print_json(&payload).map_err(CliError::Message)?;
+    } else {
+        println!("Selected target: {}", payload["target"].as_str().unwrap_or_default());
+        println!("Source: {}", payload["source"].as_str().unwrap_or_default());
+        println!("Health: ok");
+    }
+
+    Ok(())
+}
+
+async fn rt_probe(global: &GlobalOptions) -> Result<(), CliError> {
+    let statuses = probe_payload().await?;
+
+    let payload = serde_json::to_value(&statuses).map_err(|error| CliError::Message(error.to_string()))?;
+    if global.json {
+        output::print_json(&payload).map_err(CliError::Message)?;
+    } else {
+        for status in &statuses {
+            let label = if status.healthy { "healthy" } else { "unreachable" };
+            println!("{} [{label}]", status.target);
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn status_payload(global: &GlobalOptions) -> Result<serde_json::Value, CliError> {
+    let state = CliState::load(&CliState::resolve_path())?;
+    let ports = candidate_ports();
+    let resolved = resolve_target(global.target.as_deref(), &state, &ports, |candidate| {
+        std::net::TcpStream::connect(candidate).is_ok()
+    })
+    .ok_or_else(|| CliError::Message("no RT target resolved (未解析到 RT 目标)".to_string()))?;
+
+    let client = RuntimeClient::from_target(
+        resolved.target.clone(),
+        state
+            .target_state(&resolved.target)
+            .and_then(|entry| entry.auth_token.clone()),
+    )?;
+    let health = client.health().await?;
+
+    Ok(json!({
+        "target": resolved.target,
+        "source": source_label(resolved.source),
+        "healthy": true,
+        "health": health,
+    }))
+}
+
+pub async fn probe_payload() -> Result<Vec<TargetProbeStatus>, CliError> {
+    let ports = candidate_ports();
+    let mut statuses = Vec::with_capacity(ports.len());
+
+    for target in probe_targets(&ports, |_| false)
+        .into_iter()
+        .map(|status| status.target)
+    {
+        let healthy = match RuntimeClient::from_target(target.clone(), None) {
+            Ok(client) => client.health().await.is_ok(),
+            Err(_) => false,
+        };
+        statuses.push(TargetProbeStatus { target, healthy });
+    }
+
+    Ok(statuses)
+}
+
+fn rt_use(global: &GlobalOptions, args: RtUseArgs) -> Result<(), CliError> {
+    let state_path = CliState::resolve_path();
+    let mut state = CliState::load(&state_path)?;
+    state.default_target = Some(args.target.clone());
+    state.save(&state_path)?;
+
+    let payload = json!({
+        "default_target": args.target,
+        "state_path": state_path,
+    });
+
+    if global.json {
+        output::print_json(&payload).map_err(CliError::Message)?;
+    } else {
+        println!(
+            "Default RT target saved (默认 RT 目标已保存): {}",
+            payload["default_target"].as_str().unwrap_or_default()
+        );
+    }
+
+    Ok(())
+}
+
+fn rt_clear_default(global: &GlobalOptions) -> Result<(), CliError> {
+    let state_path = CliState::resolve_path();
+    let mut state = CliState::load(&state_path)?;
+    state.default_target = None;
+    state.save(&state_path)?;
+
+    let payload = json!({
+        "default_target": serde_json::Value::Null,
+        "state_path": state_path,
+    });
+
+    if global.json {
+        output::print_json(&payload).map_err(CliError::Message)?;
+    } else {
+        println!("Default RT target cleared (默认 RT 目标已清除)");
+    }
+
+    Ok(())
+}
+
+fn source_label(source: TargetResolutionSource) -> &'static str {
+    match source {
+        TargetResolutionSource::Explicit => "explicit",
+        TargetResolutionSource::SavedDefault => "saved_default",
+        TargetResolutionSource::Probed => "probed",
+    }
+}

--- a/crates/exomind-cli/src/commands/task.rs
+++ b/crates/exomind-cli/src/commands/task.rs
@@ -1,0 +1,160 @@
+use serde_json::Value;
+use serde_json::json;
+
+use crate::cli::{GlobalOptions, TaskAddArgs, TaskCommand, TaskIdArgs, TaskListArgs, TaskUpdateArgs};
+use crate::commands::resolve_command_context;
+use crate::error::CliError;
+use crate::output;
+
+pub async fn handle(command: TaskCommand, global: &GlobalOptions) -> Result<(), CliError> {
+    match command {
+        TaskCommand::Add(args) => print_value(global, &add_task(global, &args).await?),
+        TaskCommand::List(args) => print_list(global, &list_tasks(global, &args).await?),
+        TaskCommand::Get(args) => print_value(global, &get_task(global, &TaskIdArgs { task_id: args.task_id }).await?),
+        TaskCommand::Update(args) => print_value(global, &update_task(global, &args).await?),
+        TaskCommand::Start(args) => print_value(global, &start_task(global, &args).await?),
+        TaskCommand::Complete(args) => print_value(global, &complete_task(global, &args).await?),
+        TaskCommand::Cancel(args) => print_value(global, &cancel_task(global, &args).await?),
+        TaskCommand::Suspend(args) => print_value(global, &suspend_task(global, &args).await?),
+        TaskCommand::Resume(args) => print_value(global, &resume_task(global, &args).await?),
+    }
+}
+
+pub async fn add_task(global: &GlobalOptions, args: &TaskAddArgs) -> Result<Value, CliError> {
+    let context = resolve_command_context(global)?;
+    let path = scoped_task_path("/tasks", context.scope.as_ref());
+    let payload = json!({
+        "title": args.title,
+        "priority": args.priority,
+        "tags": args.tags,
+    });
+
+    context.client.post_json(&path, &payload).await
+}
+
+pub async fn list_tasks(global: &GlobalOptions, args: &TaskListArgs) -> Result<Vec<Value>, CliError> {
+    let context = resolve_command_context(global)?;
+    let mut path = scoped_task_path("/tasks", context.scope.as_ref());
+    let mut extra_pairs = Vec::new();
+    if let Some(status) = &args.status {
+        extra_pairs.push(("status".to_string(), status.clone()));
+    }
+    if let Some(tag) = args.tags.first() {
+        extra_pairs.push(("tag".to_string(), tag.clone()));
+    }
+    if let Some(parent_id) = &args.parent_id {
+        extra_pairs.push(("parent_id".to_string(), parent_id.clone()));
+    }
+    if !extra_pairs.is_empty() {
+        path = context.client.with_scope(&path, &extra_pairs);
+    }
+
+    context.client.get_json(&path).await
+}
+
+pub async fn get_task(global: &GlobalOptions, args: &TaskIdArgs) -> Result<Value, CliError> {
+    let context = resolve_command_context(global)?;
+    let path = scoped_task_path(&format!("/tasks/{}", args.task_id), context.scope.as_ref());
+
+    context.client.get_json(&path).await
+}
+
+pub async fn update_task(global: &GlobalOptions, args: &TaskUpdateArgs) -> Result<Value, CliError> {
+    let context = resolve_command_context(global)?;
+    let path = scoped_task_path(&format!("/tasks/{}", args.task_id), context.scope.as_ref());
+    let payload = json!({
+        "title": args.title,
+    });
+
+    context.client.put_json(&path, &payload).await
+}
+
+pub async fn start_task(global: &GlobalOptions, args: &TaskIdArgs) -> Result<Value, CliError> {
+    transition_task(global, args, "in_progress", false).await
+}
+
+pub async fn suspend_task(global: &GlobalOptions, args: &TaskIdArgs) -> Result<Value, CliError> {
+    transition_task(global, args, "suspended", false).await
+}
+
+pub async fn resume_task(global: &GlobalOptions, args: &TaskIdArgs) -> Result<Value, CliError> {
+    transition_task(global, args, "in_progress", false).await
+}
+
+pub async fn complete_task(global: &GlobalOptions, args: &TaskIdArgs) -> Result<Value, CliError> {
+    transition_task(global, args, "completed", true).await
+}
+
+pub async fn cancel_task(global: &GlobalOptions, args: &TaskIdArgs) -> Result<Value, CliError> {
+    let context = resolve_command_context(global)?;
+    let path = scoped_task_path(
+        &format!("/tasks/{}/cancel", args.task_id),
+        context.scope.as_ref(),
+    );
+
+    context.client.post_json(&path, &json!({})).await
+}
+
+async fn transition_task(
+    global: &GlobalOptions,
+    args: &TaskIdArgs,
+    status: &str,
+    shortcut: bool,
+) -> Result<Value, CliError> {
+    let context = resolve_command_context(global)?;
+    let mut path = scoped_task_path(
+        &format!("/tasks/{}/transition", args.task_id),
+        context.scope.as_ref(),
+    );
+    if shortcut {
+        path = context
+            .client
+            .with_scope(&path, &[("shortcut".to_string(), "true".to_string())]);
+    }
+    let payload = json!({ "status": status });
+
+    context.client.post_json(&path, &payload).await
+}
+
+fn scoped_task_path(path: &str, scope: Option<&crate::profile_scope::ProfileScope>) -> String {
+    if let Some(scope) = scope {
+        let client = crate::runtime_client::RuntimeClient::from_target("127.0.0.1:0", None)
+            .expect("temporary runtime client for query formatting");
+        client.with_scope(path, &scope.task_query_pairs())
+    } else {
+        path.to_string()
+    }
+}
+
+fn print_value(global: &GlobalOptions, value: &Value) -> Result<(), CliError> {
+    if global.json {
+        output::print_json(value).map_err(CliError::Message)?;
+    } else {
+        println!(
+            "{} [{}] {}",
+            value["title"].as_str().unwrap_or_default(),
+            value["id"].as_str().unwrap_or_default(),
+            value["status"].as_str().unwrap_or_default()
+        );
+    }
+
+    Ok(())
+}
+
+fn print_list(global: &GlobalOptions, values: &[Value]) -> Result<(), CliError> {
+    if global.json {
+        let payload = serde_json::to_value(values).map_err(|error| CliError::Message(error.to_string()))?;
+        output::print_json(&payload).map_err(CliError::Message)?;
+    } else {
+        for value in values {
+            println!(
+                "{} [{}] {}",
+                value["title"].as_str().unwrap_or_default(),
+                value["id"].as_str().unwrap_or_default(),
+                value["status"].as_str().unwrap_or_default()
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/exomind-cli/src/error.rs
+++ b/crates/exomind-cli/src/error.rs
@@ -1,0 +1,27 @@
+use reqwest::StatusCode;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CliError {
+    #[error("io error (IO 错误): {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("request failed (请求失败): {0}")]
+    Transport(#[from] reqwest::Error),
+
+    #[error("rt returned HTTP {status}: {body_preview}")]
+    HttpResponse {
+        status: StatusCode,
+        body_preview: String,
+    },
+
+    #[error("invalid json response (JSON 响应解析失败): {source}; body={body_preview}")]
+    JsonResponse {
+        #[source]
+        source: serde_json::Error,
+        body_preview: String,
+    },
+
+    #[error("{0}")]
+    Message(String),
+}

--- a/crates/exomind-cli/src/examples.rs
+++ b/crates/exomind-cli/src/examples.rs
@@ -1,0 +1,14 @@
+pub const HUMAN_EXAMPLES: &[&str] = &[
+    "exomind rt status",
+    "exomind rt probe",
+    "exomind task add --profile argon --title \"整理浏览器标签\"",
+    "exomind task list --profile argon --status pending",
+    "exomind proposal approve --profile argon 12",
+    "exomind eventlog add --profile argon --content \"补记今天的口述\"",
+];
+
+pub const AGENT_EXAMPLES: &[&str] = &[
+    "exomind task list --profile argon --status pending --json",
+    "exomind proposal add --profile argon --action create_task --title \"建议：整理标签\" --params-file -",
+    "exomind eventlog add --profile argon --content \"补记今天的口述\" --json",
+];

--- a/crates/exomind-cli/src/lib.rs
+++ b/crates/exomind-cli/src/lib.rs
@@ -1,19 +1,25 @@
 pub mod cli;
+pub mod commands;
+pub mod error;
 pub mod examples;
 pub mod output;
 pub mod profile_scope;
+pub mod runtime_client;
 pub mod state;
 pub mod target;
 
 use clap::Parser;
-use cli::{Cli, RootCommand};
+use cli::{Cli, GlobalOptions, RootCommand};
+use error::CliError;
 
-pub async fn run() -> Result<(), String> {
+pub async fn run() -> Result<(), CliError> {
     let cli = Cli::parse();
     dispatch(cli).await
 }
 
-pub async fn dispatch(cli: Cli) -> Result<(), String> {
+pub async fn dispatch(cli: Cli) -> Result<(), CliError> {
+    let global = GlobalOptions::from(&cli);
+
     match cli.command {
         None => {
             print!("{}", output::homepage_text());
@@ -23,9 +29,9 @@ pub async fn dispatch(cli: Cli) -> Result<(), String> {
             print!("{}", output::examples_text());
             Ok(())
         }
-        Some(command) => {
-            print!("{}", output::placeholder_command_text(&command));
-            Ok(())
-        }
+        Some(RootCommand::Eventlog(command)) => commands::eventlog::handle(command, &global).await,
+        Some(RootCommand::Proposal(command)) => commands::proposal::handle(command, &global).await,
+        Some(RootCommand::Rt(command)) => commands::rt::handle(command, &global).await,
+        Some(RootCommand::Task(command)) => commands::task::handle(command, &global).await,
     }
 }

--- a/crates/exomind-cli/src/lib.rs
+++ b/crates/exomind-cli/src/lib.rs
@@ -1,6 +1,9 @@
 pub mod cli;
 pub mod examples;
 pub mod output;
+pub mod profile_scope;
+pub mod state;
+pub mod target;
 
 use clap::Parser;
 use cli::{Cli, RootCommand};

--- a/crates/exomind-cli/src/lib.rs
+++ b/crates/exomind-cli/src/lib.rs
@@ -1,0 +1,28 @@
+pub mod cli;
+pub mod examples;
+pub mod output;
+
+use clap::Parser;
+use cli::{Cli, RootCommand};
+
+pub async fn run() -> Result<(), String> {
+    let cli = Cli::parse();
+    dispatch(cli).await
+}
+
+pub async fn dispatch(cli: Cli) -> Result<(), String> {
+    match cli.command {
+        None => {
+            print!("{}", output::homepage_text());
+            Ok(())
+        }
+        Some(RootCommand::Examples) => {
+            print!("{}", output::examples_text());
+            Ok(())
+        }
+        Some(command) => {
+            print!("{}", output::placeholder_command_text(&command));
+            Ok(())
+        }
+    }
+}

--- a/crates/exomind-cli/src/main.rs
+++ b/crates/exomind-cli/src/main.rs
@@ -1,0 +1,7 @@
+#[tokio::main]
+async fn main() {
+    if let Err(error) = exomind_cli::run().await {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}

--- a/crates/exomind-cli/src/output.rs
+++ b/crates/exomind-cli/src/output.rs
@@ -1,0 +1,58 @@
+use crate::cli::RootCommand;
+use crate::examples::{AGENT_EXAMPLES, HUMAN_EXAMPLES};
+
+pub fn homepage_text() -> String {
+    format!(
+        concat!(
+            "ExoMind CLI\n",
+            "RT client shell (RT 客户端外壳) for task / proposal / eventlog\n",
+            "\n",
+            "Default behavior (默认行为):\n",
+            "  - connect-first (优先连接)\n",
+            "  - do not spawn RT unless explicitly requested\n",
+            "\n",
+            "Common examples:\n",
+            "{human_examples}\n",
+            "Agent-friendly usage:\n",
+            "{agent_examples}\n",
+            "More:\n",
+            "  exomind examples\n",
+            "  exomind task --help\n",
+            "  exomind proposal --help\n",
+            "  exomind eventlog --help\n",
+            "  exomind rt --help\n"
+        ),
+        human_examples = format_examples(HUMAN_EXAMPLES),
+        agent_examples = format_examples(AGENT_EXAMPLES),
+    )
+}
+
+pub fn examples_text() -> String {
+    format!(
+        concat!(
+            "ExoMind CLI examples (命令样例)\n",
+            "\n",
+            "Human usage:\n",
+            "{human_examples}\n",
+            "Agent-friendly usage:\n",
+            "{agent_examples}"
+        ),
+        human_examples = format_examples(HUMAN_EXAMPLES),
+        agent_examples = format_examples(AGENT_EXAMPLES),
+    )
+}
+
+pub fn placeholder_command_text(command: &RootCommand) -> String {
+    format!(
+        "Command placeholder (占位输出): {command:?}\nUse `exomind examples` for current samples.\n"
+    )
+}
+
+fn format_examples(examples: &[&str]) -> String {
+    examples
+        .iter()
+        .map(|example| format!("  {example}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n\n"
+}

--- a/crates/exomind-cli/src/output.rs
+++ b/crates/exomind-cli/src/output.rs
@@ -1,6 +1,12 @@
 use crate::cli::RootCommand;
 use crate::examples::{AGENT_EXAMPLES, HUMAN_EXAMPLES};
 
+pub fn print_json(value: &serde_json::Value) -> Result<(), String> {
+    let rendered = serde_json::to_string_pretty(value).map_err(|error| error.to_string())?;
+    println!("{rendered}");
+    Ok(())
+}
+
 pub fn homepage_text() -> String {
     format!(
         concat!(

--- a/crates/exomind-cli/src/profile_scope.rs
+++ b/crates/exomind-cli/src/profile_scope.rs
@@ -1,0 +1,70 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ScopeSource {
+    Profile,
+    UserId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProfileScope {
+    scope_key: String,
+    source: ScopeSource,
+}
+
+impl ProfileScope {
+    pub fn from_flags(profile: Option<&str>, user_id: Option<&str>) -> Option<Self> {
+        if let Some(profile) = normalize_profile(profile) {
+            return Some(Self {
+                scope_key: profile,
+                source: ScopeSource::Profile,
+            });
+        }
+
+        normalize_user_id(user_id).map(|user_id| Self {
+            scope_key: user_id,
+            source: ScopeSource::UserId,
+        })
+    }
+
+    pub fn scope_key(&self) -> Option<&str> {
+        Some(&self.scope_key)
+    }
+
+    pub fn task_query_pairs(&self) -> Vec<(String, String)> {
+        match self.source {
+            ScopeSource::Profile => {
+                vec![("profile_id".to_string(), self.scope_key.clone())]
+            }
+            ScopeSource::UserId => vec![("user_id".to_string(), self.scope_key.clone())],
+        }
+    }
+
+    pub fn proposal_query_pairs(&self) -> Vec<(String, String)> {
+        self.task_query_pairs()
+    }
+
+    pub fn eventlog_query_pairs(&self) -> Vec<(String, String)> {
+        vec![("user_id".to_string(), self.scope_key.clone())]
+    }
+}
+
+fn normalize_profile(value: Option<&str>) -> Option<String> {
+    let value = value?.trim();
+    if value.is_empty() {
+        return None;
+    }
+
+    if value.starts_with("profile-") {
+        Some(value.to_string())
+    } else {
+        Some(format!("profile-{value}"))
+    }
+}
+
+fn normalize_user_id(value: Option<&str>) -> Option<String> {
+    let value = value?.trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}

--- a/crates/exomind-cli/src/runtime_client.rs
+++ b/crates/exomind-cli/src/runtime_client.rs
@@ -1,0 +1,150 @@
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::error::CliError;
+
+#[derive(Debug, Clone)]
+pub struct RuntimeClient {
+    target: String,
+    base_url: String,
+    auth_token: Option<String>,
+    http: reqwest::Client,
+}
+
+impl RuntimeClient {
+    pub fn new(
+        target: impl Into<String>,
+        base_url: impl Into<String>,
+        auth_token: Option<String>,
+    ) -> Result<Self, CliError> {
+        Ok(Self {
+            target: target.into(),
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            auth_token,
+            http: reqwest::Client::builder().build()?,
+        })
+    }
+
+    pub fn from_target(
+        target: impl Into<String>,
+        auth_token: Option<String>,
+    ) -> Result<Self, CliError> {
+        let target = target.into();
+        let base_url = format!("http://{target}");
+        Self::new(target, base_url, auth_token)
+    }
+
+    pub fn target(&self) -> &str {
+        &self.target
+    }
+
+    pub async fn health(&self) -> Result<serde_json::Value, CliError> {
+        self.get_json("/health").await
+    }
+
+    pub async fn get_json<T>(&self, path: &str) -> Result<T, CliError>
+    where
+        T: DeserializeOwned,
+    {
+        self.send_json(self.request(reqwest::Method::GET, path)?).await
+    }
+
+    pub async fn post_json<T, B>(&self, path: &str, body: &B) -> Result<T, CliError>
+    where
+        T: DeserializeOwned,
+        B: Serialize + ?Sized,
+    {
+        self.send_json(self.request(reqwest::Method::POST, path)?.json(body))
+            .await
+    }
+
+    pub async fn put_json<T, B>(&self, path: &str, body: &B) -> Result<T, CliError>
+    where
+        T: DeserializeOwned,
+        B: Serialize + ?Sized,
+    {
+        self.send_json(self.request(reqwest::Method::PUT, path)?.json(body))
+            .await
+    }
+
+    pub async fn patch_json<T, B>(&self, path: &str, body: &B) -> Result<T, CliError>
+    where
+        T: DeserializeOwned,
+        B: Serialize + ?Sized,
+    {
+        self.send_json(self.request(reqwest::Method::PATCH, path)?.json(body))
+            .await
+    }
+
+    pub async fn delete_json<T>(&self, path: &str) -> Result<T, CliError>
+    where
+        T: DeserializeOwned,
+    {
+        self.send_json(self.request(reqwest::Method::DELETE, path)?)
+            .await
+    }
+
+    pub fn with_scope(&self, path: &str, scope_pairs: &[(String, String)]) -> String {
+        if scope_pairs.is_empty() {
+            return path.to_string();
+        }
+
+        let separator = if path.contains('?') { '&' } else { '?' };
+        let query = scope_pairs
+            .iter()
+            .map(|(key, value)| format!("{key}={value}"))
+            .collect::<Vec<_>>()
+            .join("&");
+        format!("{path}{separator}{query}")
+    }
+
+    fn request(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+    ) -> Result<reqwest::RequestBuilder, CliError> {
+        let url = format!("{}{}", self.base_url, normalize_path(path));
+        let mut builder = self.http.request(method, url);
+
+        if let Some(token) = &self.auth_token {
+            builder = builder.bearer_auth(token);
+        }
+
+        Ok(builder)
+    }
+
+    async fn send_json<T>(&self, builder: reqwest::RequestBuilder) -> Result<T, CliError>
+    where
+        T: DeserializeOwned,
+    {
+        let response = builder.send().await?;
+        let status = response.status();
+        let body = response.text().await?;
+
+        if !status.is_success() {
+            return Err(CliError::HttpResponse {
+                status,
+                body_preview: preview(&body),
+            });
+        }
+
+        serde_json::from_str(&body).map_err(|source| CliError::JsonResponse {
+            source,
+            body_preview: preview(&body),
+        })
+    }
+}
+
+fn normalize_path(path: &str) -> String {
+    if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    }
+}
+
+fn preview(body: &str) -> String {
+    const MAX_LEN: usize = 200;
+    let compact = body.replace('\n', " ").replace('\r', " ");
+    compact.chars().take(MAX_LEN).collect()
+}

--- a/crates/exomind-cli/src/state.rs
+++ b/crates/exomind-cli/src/state.rs
@@ -1,0 +1,55 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct CliState {
+    pub default_target: Option<String>,
+    #[serde(default)]
+    pub targets: BTreeMap<String, TargetState>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct TargetState {
+    pub default_profile: Option<String>,
+    pub auth_token: Option<String>,
+    pub last_seen_at: Option<DateTime<Utc>>,
+}
+
+impl CliState {
+    pub fn config_path() -> Option<PathBuf> {
+        dirs::config_dir().map(|dir| dir.join("ExoMind").join("cli-state.json"))
+    }
+
+    pub fn load(path: &Path) -> io::Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+
+        let raw = fs::read_to_string(path)?;
+        serde_json::from_str(&raw)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+    }
+
+    pub fn save(&self, path: &Path) -> io::Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let raw = serde_json::to_string_pretty(self)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        fs::write(path, raw)
+    }
+
+    pub fn target_state(&self, target: &str) -> Option<&TargetState> {
+        self.targets.get(target)
+    }
+
+    pub fn target_state_mut(&mut self, target: &str) -> &mut TargetState {
+        self.targets.entry(target.to_string()).or_default()
+    }
+}

--- a/crates/exomind-cli/src/state.rs
+++ b/crates/exomind-cli/src/state.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::env;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -21,8 +22,21 @@ pub struct TargetState {
 }
 
 impl CliState {
+    pub const STATE_PATH_ENV: &str = "EXOMIND_CLI_STATE_PATH";
+
     pub fn config_path() -> Option<PathBuf> {
         dirs::config_dir().map(|dir| dir.join("ExoMind").join("cli-state.json"))
+    }
+
+    pub fn resolve_path() -> PathBuf {
+        if let Ok(value) = env::var(Self::STATE_PATH_ENV) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return PathBuf::from(trimmed);
+            }
+        }
+
+        Self::config_path().unwrap_or_else(|| PathBuf::from(".exomind/cli-state.json"))
     }
 
     pub fn load(path: &Path) -> io::Result<Self> {

--- a/crates/exomind-cli/src/target.rs
+++ b/crates/exomind-cli/src/target.rs
@@ -1,0 +1,67 @@
+use crate::state::CliState;
+
+pub const DEFAULT_CANDIDATE_PORTS: [u16; 3] = [9124, 1950, 1949];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TargetResolution {
+    pub target: String,
+    pub source: TargetResolutionSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetResolutionSource {
+    Explicit,
+    SavedDefault,
+    Probed,
+}
+
+pub fn resolve_target<F>(
+    explicit_target: Option<&str>,
+    state: &CliState,
+    candidate_ports: &[u16],
+    mut probe: F,
+) -> Option<TargetResolution>
+where
+    F: FnMut(&str) -> bool,
+{
+    if let Some(target) = normalize_target(explicit_target) {
+        return Some(TargetResolution {
+            target,
+            source: TargetResolutionSource::Explicit,
+        });
+    }
+
+    if let Some(target) = normalize_target(state.default_target.as_deref()) {
+        if probe(&target) {
+            return Some(TargetResolution {
+                target,
+                source: TargetResolutionSource::SavedDefault,
+            });
+        }
+    }
+
+    for port in candidate_ports {
+        let target = loopback_target(*port);
+        if probe(&target) {
+            return Some(TargetResolution {
+                target,
+                source: TargetResolutionSource::Probed,
+            });
+        }
+    }
+
+    None
+}
+
+pub fn loopback_target(port: u16) -> String {
+    format!("127.0.0.1:{port}")
+}
+
+fn normalize_target(value: Option<&str>) -> Option<String> {
+    let value = value?.trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}

--- a/crates/exomind-cli/src/target.rs
+++ b/crates/exomind-cli/src/target.rs
@@ -1,6 +1,8 @@
 use crate::state::CliState;
+use serde::Serialize;
 
 pub const DEFAULT_CANDIDATE_PORTS: [u16; 3] = [9124, 1950, 1949];
+pub const CANDIDATE_PORTS_ENV: &str = "EXOMIND_CLI_CANDIDATE_PORTS";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TargetResolution {
@@ -13,6 +15,12 @@ pub enum TargetResolutionSource {
     Explicit,
     SavedDefault,
     Probed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TargetProbeStatus {
+    pub target: String,
+    pub healthy: bool,
 }
 
 pub fn resolve_target<F>(
@@ -55,6 +63,33 @@ where
 
 pub fn loopback_target(port: u16) -> String {
     format!("127.0.0.1:{port}")
+}
+
+pub fn candidate_ports() -> Vec<u16> {
+    std::env::var(CANDIDATE_PORTS_ENV)
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .filter_map(|segment| segment.trim().parse::<u16>().ok())
+                .collect::<Vec<_>>()
+        })
+        .filter(|ports| !ports.is_empty())
+        .unwrap_or_else(|| DEFAULT_CANDIDATE_PORTS.to_vec())
+}
+
+pub fn probe_targets<F>(candidate_ports: &[u16], mut probe: F) -> Vec<TargetProbeStatus>
+where
+    F: FnMut(&str) -> bool,
+{
+    candidate_ports
+        .iter()
+        .map(|port| {
+            let target = loopback_target(*port);
+            let healthy = probe(&target);
+            TargetProbeStatus { target, healthy }
+        })
+        .collect()
 }
 
 fn normalize_target(value: Option<&str>) -> Option<String> {

--- a/crates/exomind-cli/tests/cli_parse.rs
+++ b/crates/exomind-cli/tests/cli_parse.rs
@@ -1,0 +1,67 @@
+use clap::{CommandFactory, Parser};
+use exomind_cli::cli::{Cli, EventlogCommand, ProposalCommand, RootCommand, TaskCommand};
+
+#[test]
+fn global_target_and_profile_flags_parse() {
+    let cli = Cli::try_parse_from([
+        "exomind",
+        "--target",
+        "127.0.0.1:9124",
+        "--profile",
+        "argon",
+        "task",
+        "list",
+        "--status",
+        "pending",
+    ])
+    .expect("cli should parse");
+
+    assert_eq!(cli.target.as_deref(), Some("127.0.0.1:9124"));
+    assert_eq!(cli.profile.as_deref(), Some("argon"));
+    assert!(!cli.json);
+
+    match cli.command.expect("task command") {
+        RootCommand::Task(TaskCommand::List(args)) => {
+            assert_eq!(args.status.as_deref(), Some("pending"));
+        }
+        other => panic!("expected task list command, got {other:?}"),
+    }
+}
+
+#[test]
+fn proposal_approve_parses_numeric_id() {
+    let cli = Cli::try_parse_from(["exomind", "proposal", "approve", "12"])
+        .expect("proposal approve should parse");
+
+    match cli.command.expect("proposal command") {
+        RootCommand::Proposal(ProposalCommand::Approve(args)) => {
+            assert_eq!(args.proposal_id, 12);
+        }
+        other => panic!("expected proposal approve command, got {other:?}"),
+    }
+}
+
+#[test]
+fn root_help_mentions_eventlog_task_proposal_rt_and_examples() {
+    let mut command = Cli::command();
+    let rendered = command.render_long_help().to_string();
+
+    assert!(rendered.contains("eventlog"));
+    assert!(rendered.contains("task"));
+    assert!(rendered.contains("proposal"));
+    assert!(rendered.contains("rt"));
+    assert!(rendered.contains("examples"));
+}
+
+#[test]
+fn eventlog_get_parses_event_id() {
+    let cli =
+        Cli::try_parse_from(["exomind", "eventlog", "get", "evt-123"]).expect("eventlog get");
+
+    match cli.command.expect("eventlog command") {
+        RootCommand::Eventlog(EventlogCommand::Get(args)) => {
+            assert_eq!(args.event_id, "evt-123");
+        }
+        other => panic!("expected eventlog get command, got {other:?}"),
+    }
+}

--- a/crates/exomind-cli/tests/eventlog_smoke.rs
+++ b/crates/exomind-cli/tests/eventlog_smoke.rs
@@ -1,0 +1,215 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use axum::extract::{Path, Query, State};
+use axum::routing::get;
+use axum::{Json, Router};
+use exomind_cli::cli::{EventlogAddArgs, EventlogGetArgs, EventlogListArgs, EventlogWatchArgs, GlobalOptions};
+use exomind_cli::commands::eventlog::{add_event, get_event, list_events, watch_events};
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+
+#[derive(Clone, Default)]
+struct EventlogTestState {
+    captured: Arc<Mutex<Vec<CapturedRequest>>>,
+}
+
+#[derive(Debug, Clone)]
+struct CapturedRequest {
+    path: String,
+    query: HashMap<String, String>,
+    body: Value,
+}
+
+#[tokio::test]
+async fn eventlog_add_posts_to_scoped_rt_endpoint() {
+    let state = EventlogTestState::default();
+    let target = spawn_eventlog_server(state.clone()).await;
+    let global = GlobalOptions {
+        target: Some(target),
+        profile: Some("argon".to_string()),
+        user_id: None,
+        json: true,
+        spawn_if_missing: false,
+    };
+
+    let created = add_event(
+        &global,
+        &EventlogAddArgs {
+            content: "补记今天的口述".to_string(),
+            tags: vec!["note".to_string(), "voice".to_string()],
+        },
+    )
+    .await
+    .expect("eventlog add");
+
+    assert_eq!(created["id"], "evt-from-rt");
+    let captured = state.captured.lock().expect("captured requests");
+    let latest = captured.last().expect("captured add request");
+    assert_eq!(latest.path, "/eventlog");
+    assert_eq!(latest.query.get("user_id"), Some(&"profile-argon".to_string()));
+    assert_eq!(latest.body["content"], "补记今天的口述");
+    assert_eq!(latest.body["tags"], json!(["note", "voice"]));
+}
+
+#[tokio::test]
+async fn eventlog_list_reads_latest_first() {
+    let state = EventlogTestState::default();
+    let target = spawn_eventlog_server(state).await;
+    let global = GlobalOptions {
+        target: Some(target),
+        profile: Some("argon".to_string()),
+        user_id: None,
+        json: true,
+        spawn_if_missing: false,
+    };
+
+    let events = list_events(
+        &global,
+        &EventlogListArgs {
+            limit: Some(2),
+            tags: vec!["note".to_string()],
+        },
+    )
+    .await
+    .expect("eventlog list");
+
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0]["id"], "evt-2");
+    assert_eq!(events[1]["id"], "evt-1");
+}
+
+#[tokio::test]
+async fn eventlog_watch_polls_for_new_events() {
+    let state = EventlogTestState::default();
+    let target = spawn_eventlog_server(state).await;
+    let global = GlobalOptions {
+        target: Some(target),
+        profile: Some("argon".to_string()),
+        user_id: None,
+        json: true,
+        spawn_if_missing: false,
+    };
+
+    let events = watch_events(
+        &global,
+        &EventlogWatchArgs {
+            since_id: Some("evt-1".to_string()),
+        },
+    )
+    .await
+    .expect("eventlog watch");
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["id"], "evt-watch");
+}
+
+#[tokio::test]
+async fn eventlog_get_reads_single_item() {
+    let state = EventlogTestState::default();
+    let target = spawn_eventlog_server(state).await;
+    let global = GlobalOptions {
+        target: Some(target),
+        profile: Some("argon".to_string()),
+        user_id: None,
+        json: true,
+        spawn_if_missing: false,
+    };
+
+    let event = get_event(
+        &global,
+        &EventlogGetArgs {
+            event_id: "evt-1".to_string(),
+        },
+    )
+    .await
+    .expect("eventlog get");
+
+    assert_eq!(event["id"], "evt-1");
+    assert_eq!(event["content"], "older event");
+}
+
+async fn spawn_eventlog_server(state: EventlogTestState) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let address = listener.local_addr().expect("listener addr");
+    let app = Router::new()
+        .route("/health", get(|| async { Json(json!({ "status": "ok" })) }))
+        .route("/eventlog", get(list_handler).post(add_handler))
+        .route("/eventlog/watch", get(watch_handler))
+        .route("/eventlog/:id", get(get_handler))
+        .with_state(state);
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve eventlog test app");
+    });
+
+    address.to_string()
+}
+
+async fn add_handler(
+    State(state): State<EventlogTestState>,
+    Query(query): Query<HashMap<String, String>>,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    state
+        .captured
+        .lock()
+        .expect("captured requests")
+        .push(CapturedRequest {
+            path: "/eventlog".to_string(),
+            query,
+            body: body.clone(),
+        });
+
+    Json(json!({
+        "id": "evt-from-rt",
+        "timestamp": body["timestamp"],
+        "content": body["content"],
+        "tags": body["tags"],
+    }))
+}
+
+async fn list_handler(Query(query): Query<HashMap<String, String>>) -> Json<Value> {
+    assert_eq!(query.get("user_id"), Some(&"profile-argon".to_string()));
+    Json(json!([
+        {
+            "id": "evt-2",
+            "timestamp": 2000,
+            "content": "latest event",
+            "tags": ["note"]
+        },
+        {
+            "id": "evt-1",
+            "timestamp": 1000,
+            "content": "older event",
+            "tags": ["note"]
+        }
+    ]))
+}
+
+async fn watch_handler(Query(query): Query<HashMap<String, String>>) -> Json<Value> {
+    assert_eq!(query.get("since_id"), Some(&"evt-1".to_string()));
+    Json(json!([
+        {
+            "id": "evt-watch",
+            "timestamp": 3000,
+            "content": "watch event",
+            "tags": ["note"]
+        }
+    ]))
+}
+
+async fn get_handler(
+    Path(event_id): Path<String>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Json<Value> {
+    assert_eq!(query.get("user_id"), Some(&"profile-argon".to_string()));
+    Json(json!({
+        "id": event_id,
+        "timestamp": 1000,
+        "content": "older event",
+        "tags": ["note"]
+    }))
+}

--- a/crates/exomind-cli/tests/help_output.rs
+++ b/crates/exomind-cli/tests/help_output.rs
@@ -1,0 +1,31 @@
+use assert_cmd::Command;
+
+#[test]
+fn running_without_args_renders_homepage_help() {
+    let assert = Command::cargo_bin("exomind")
+        .expect("exomind binary should exist")
+        .assert()
+        .success();
+
+    let output = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    assert!(output.contains("ExoMind CLI"));
+    assert!(output.contains("connect-first"));
+    assert!(output.contains("Common examples"));
+    assert!(output.contains("Agent-friendly usage"));
+}
+
+#[test]
+fn examples_command_lists_human_and_agent_examples() {
+    let assert = Command::cargo_bin("exomind")
+        .expect("exomind binary should exist")
+        .args(["examples"])
+        .assert()
+        .success();
+
+    let output = String::from_utf8(assert.get_output().stdout.clone()).expect("utf8 stdout");
+    assert!(output.contains("task add"));
+    assert!(output.contains("proposal approve"));
+    assert!(output.contains("eventlog add"));
+    assert!(output.contains("--json"));
+    assert!(output.contains("--params-file"));
+}

--- a/crates/exomind-cli/tests/proposal_smoke.rs
+++ b/crates/exomind-cli/tests/proposal_smoke.rs
@@ -1,0 +1,329 @@
+use std::collections::HashMap;
+use std::fs;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::{Path, Query, State};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use exomind_cli::cli::{GlobalOptions, ProposalAddArgs, ProposalCommentArgs, ProposalIdArgs, ProposalListArgs};
+use exomind_cli::commands::proposal::{
+    add_proposal, approve_proposal, comment_proposal, get_proposal, list_proposals, reject_proposal,
+    snooze_proposal,
+};
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+
+#[derive(Clone, Default)]
+struct ProposalTestState {
+    captured: Arc<Mutex<Vec<CapturedRequest>>>,
+}
+
+#[derive(Debug, Clone)]
+struct CapturedRequest {
+    method: String,
+    path: String,
+    query: HashMap<String, String>,
+    body: Option<Value>,
+}
+
+#[tokio::test]
+async fn proposal_add_posts_pending_proposal() {
+    let state = ProposalTestState::default();
+    let target = spawn_proposal_server(state.clone()).await;
+    let params_file = temp_json_file("{\"title\":\"整理浏览器标签\",\"tags\":[\"cleanup\"]}");
+    let global = GlobalOptions {
+        target: Some(target),
+        profile: Some("argon".to_string()),
+        user_id: None,
+        json: true,
+        spawn_if_missing: false,
+    };
+
+    let created = add_proposal(
+        &global,
+        &ProposalAddArgs {
+            action: "create_task".to_string(),
+            title: "建议：整理浏览器标签".to_string(),
+            params_file: Some(params_file.to_string_lossy().to_string()),
+        },
+    )
+    .await
+    .expect("proposal add");
+
+    assert_eq!(created["status"], "pending");
+    let captured = state.captured.lock().expect("captured requests");
+    let latest = captured.last().expect("captured add request");
+    assert_eq!(latest.method, "POST");
+    assert_eq!(latest.path, "/api/proposals");
+    assert_eq!(latest.query.get("profile_id"), Some(&"profile-argon".to_string()));
+    let body = latest.body.as_ref().expect("proposal add body");
+    assert_eq!(body["action_type"], "create_task");
+    assert_eq!(body["action_params"]["title"], "整理浏览器标签");
+
+    let _ = fs::remove_file(params_file);
+}
+
+#[tokio::test]
+async fn proposal_approve_patches_status_to_approved() {
+    let state = ProposalTestState::default();
+    let target = spawn_proposal_server(state.clone()).await;
+    let global = GlobalOptions {
+        target: Some(target),
+        profile: Some("argon".to_string()),
+        user_id: None,
+        json: true,
+        spawn_if_missing: false,
+    };
+
+    let approved = approve_proposal(
+        &global,
+        &ProposalIdArgs { proposal_id: 12 },
+    )
+    .await
+    .expect("proposal approve");
+
+    assert_eq!(approved["status"], "approved");
+    let captured = state.captured.lock().expect("captured requests");
+    let latest = captured.last().expect("captured approve request");
+    assert_eq!(latest.method, "PATCH");
+    assert_eq!(latest.path, "/api/proposals/12");
+    assert_eq!(latest.body.as_ref().expect("approve body")["status"], "approved");
+}
+
+#[tokio::test]
+async fn proposal_comment_posts_discussion_entry() {
+    let state = ProposalTestState::default();
+    let target = spawn_proposal_server(state.clone()).await;
+    let global = GlobalOptions {
+        target: Some(target),
+        profile: Some("argon".to_string()),
+        user_id: None,
+        json: true,
+        spawn_if_missing: false,
+    };
+
+    let proposal = comment_proposal(
+        &global,
+        &ProposalCommentArgs {
+            proposal_id: 12,
+            content: "先改成低优先级".to_string(),
+        },
+    )
+    .await
+    .expect("proposal comment");
+
+    assert_eq!(proposal["comments"][0]["content"], "先改成低优先级");
+    let captured = state.captured.lock().expect("captured requests");
+    let latest = captured.last().expect("captured comment request");
+    assert_eq!(latest.method, "POST");
+    assert_eq!(latest.path, "/api/proposals/12/comments");
+}
+
+#[tokio::test]
+async fn proposal_list_get_reject_and_snooze_use_rt_contracts() {
+    let state = ProposalTestState::default();
+    let target = spawn_proposal_server(state.clone()).await;
+    let global = GlobalOptions {
+        target: Some(target),
+        profile: Some("argon".to_string()),
+        user_id: None,
+        json: true,
+        spawn_if_missing: false,
+    };
+
+    let listed = list_proposals(
+        &global,
+        &ProposalListArgs {
+            status: Some("pending".to_string()),
+        },
+    )
+    .await
+    .expect("proposal list");
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0]["id"], 12);
+
+    let loaded = get_proposal(&global, &ProposalIdArgs { proposal_id: 12 })
+        .await
+        .expect("proposal get");
+    assert_eq!(loaded["id"], 12);
+
+    let rejected = reject_proposal(&global, &ProposalIdArgs { proposal_id: 12 })
+        .await
+        .expect("proposal reject");
+    assert_eq!(rejected["status"], "rejected");
+
+    let snoozed = snooze_proposal(&global, &ProposalIdArgs { proposal_id: 12 })
+        .await
+        .expect("proposal snooze");
+    assert_eq!(snoozed["status"], "snoozed");
+}
+
+async fn spawn_proposal_server(state: ProposalTestState) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let address = listener.local_addr().expect("listener addr");
+    let app = Router::new()
+        .route("/health", get(|| async { Json(json!({ "status": "ok" })) }))
+        .route("/api/proposals", get(list_handler).post(add_handler))
+        .route("/api/proposals/:id", get(get_handler).patch(update_handler))
+        .route("/api/proposals/:id/comments", post(comment_handler))
+        .with_state(state);
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve proposal test app");
+    });
+
+    address.to_string()
+}
+
+async fn add_handler(
+    State(state): State<ProposalTestState>,
+    Query(query): Query<HashMap<String, String>>,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    capture_request(&state, "POST", "/api/proposals", query, Some(body.clone()));
+    Json(json!({
+        "id": 12,
+        "title": body["title"],
+        "body": "",
+        "action_type": body["action_type"],
+        "action_params": body["action_params"],
+        "references": [],
+        "status": "pending",
+        "publisher": body["publisher"],
+        "comments": []
+    }))
+}
+
+async fn list_handler(
+    State(state): State<ProposalTestState>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Json<Value> {
+    capture_request(&state, "GET", "/api/proposals", query, None);
+    Json(json!([
+        {
+            "id": 12,
+            "title": "建议：整理浏览器标签",
+            "body": "",
+            "action_type": "create_task",
+            "action_params": { "title": "整理浏览器标签" },
+            "references": [],
+            "status": "pending",
+            "publisher": { "publisher_type": "agent", "id": "exomind-cli", "name": "ExoMind CLI" },
+            "comments": []
+        }
+    ]))
+}
+
+async fn get_handler(
+    State(state): State<ProposalTestState>,
+    Path(proposal_id): Path<u64>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Json<Value> {
+    capture_request(
+        &state,
+        "GET",
+        &format!("/api/proposals/{proposal_id}"),
+        query,
+        None,
+    );
+    Json(json!({
+        "id": proposal_id,
+        "title": "建议：整理浏览器标签",
+        "body": "",
+        "action_type": "create_task",
+        "action_params": { "title": "整理浏览器标签" },
+        "references": [],
+        "status": "pending",
+        "publisher": { "publisher_type": "agent", "id": "exomind-cli", "name": "ExoMind CLI" },
+        "comments": []
+    }))
+}
+
+async fn update_handler(
+    State(state): State<ProposalTestState>,
+    Path(proposal_id): Path<u64>,
+    Query(query): Query<HashMap<String, String>>,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    capture_request(
+        &state,
+        "PATCH",
+        &format!("/api/proposals/{proposal_id}"),
+        query,
+        Some(body.clone()),
+    );
+    Json(json!({
+        "id": proposal_id,
+        "title": "建议：整理浏览器标签",
+        "body": "",
+        "action_type": "create_task",
+        "action_params": { "title": "整理浏览器标签" },
+        "references": [],
+        "status": body["status"],
+        "publisher": { "publisher_type": "agent", "id": "exomind-cli", "name": "ExoMind CLI" },
+        "comments": []
+    }))
+}
+
+async fn comment_handler(
+    State(state): State<ProposalTestState>,
+    Path(proposal_id): Path<u64>,
+    Query(query): Query<HashMap<String, String>>,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    capture_request(
+        &state,
+        "POST",
+        &format!("/api/proposals/{proposal_id}/comments"),
+        query,
+        Some(body.clone()),
+    );
+    Json(json!({
+        "id": proposal_id,
+        "title": "建议：整理浏览器标签",
+        "body": "",
+        "action_type": "create_task",
+        "action_params": { "title": "整理浏览器标签" },
+        "references": [],
+        "status": "pending",
+        "publisher": { "publisher_type": "agent", "id": "exomind-cli", "name": "ExoMind CLI" },
+        "comments": [
+            {
+                "author": body["author"],
+                "content": body["content"]
+            }
+        ]
+    }))
+}
+
+fn capture_request(
+    state: &ProposalTestState,
+    method: &str,
+    path: &str,
+    query: HashMap<String, String>,
+    body: Option<Value>,
+) {
+    state
+        .captured
+        .lock()
+        .expect("captured requests")
+        .push(CapturedRequest {
+            method: method.to_string(),
+            path: path.to_string(),
+            query,
+            body,
+        });
+}
+
+fn temp_json_file(content: &str) -> std::path::PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("exomind-cli-proposal-{suffix}.json"));
+    fs::write(&path, content).expect("write params file");
+    path
+}

--- a/crates/exomind-cli/tests/rt_commands.rs
+++ b/crates/exomind-cli/tests/rt_commands.rs
@@ -1,0 +1,93 @@
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use assert_cmd::Command;
+use axum::routing::get;
+use axum::{Json, Router};
+use exomind_cli::cli::GlobalOptions;
+use exomind_cli::commands::rt::{probe_payload, status_payload};
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+
+#[test]
+fn rt_use_sets_default_target() {
+    let state_path = temp_state_path("rt-use");
+
+    Command::cargo_bin("exomind")
+        .expect("exomind binary")
+        .env("EXOMIND_CLI_STATE_PATH", &state_path)
+        .args(["rt", "use", "127.0.0.1:9124"])
+        .assert()
+        .success();
+
+    let raw = fs::read_to_string(&state_path).expect("state file");
+    let state: Value = serde_json::from_str(&raw).expect("state json");
+    assert_eq!(state["default_target"], "127.0.0.1:9124");
+
+    let _ = fs::remove_file(state_path);
+}
+
+#[tokio::test]
+async fn rt_status_reports_selected_target() {
+    let target = spawn_health_server().await;
+    let payload = status_payload(&GlobalOptions {
+        target: Some(target.clone()),
+        profile: None,
+        user_id: None,
+        json: true,
+        spawn_if_missing: false,
+    })
+    .await
+    .expect("status payload");
+
+    assert_eq!(payload["target"], target);
+    assert_eq!(payload["healthy"], true);
+    assert_eq!(payload["source"], "explicit");
+}
+
+#[tokio::test]
+async fn rt_probe_lists_candidate_ports() {
+    let target = spawn_health_server().await;
+    let port = target
+        .split(':')
+        .next_back()
+        .expect("port segment")
+        .to_string();
+    unsafe {
+        std::env::set_var("EXOMIND_CLI_CANDIDATE_PORTS", &port);
+    }
+    let payload = probe_payload().await.expect("probe payload");
+    unsafe {
+        std::env::remove_var("EXOMIND_CLI_CANDIDATE_PORTS");
+    }
+
+    assert_eq!(payload.len(), 1);
+    assert_eq!(payload[0].target, target);
+    assert!(payload[0].healthy);
+}
+
+async fn spawn_health_server() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let address = listener.local_addr().expect("listener addr");
+    let app = Router::new().route(
+        "/health",
+        get(|| async { Json(json!({ "status": "ok", "version": "test" })) }),
+    );
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve health app");
+    });
+
+    address.to_string()
+}
+
+fn temp_state_path(label: &str) -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    std::env::temp_dir().join(format!("exomind-cli-{label}-{suffix}.json"))
+}

--- a/crates/exomind-cli/tests/runtime_client_smoke.rs
+++ b/crates/exomind-cli/tests/runtime_client_smoke.rs
@@ -1,0 +1,110 @@
+use std::collections::HashMap;
+use std::net::SocketAddr;
+
+use axum::extract::{Query, State};
+use axum::http::HeaderMap;
+use axum::routing::get;
+use axum::{Json, Router};
+use exomind_cli::error::CliError;
+use exomind_cli::profile_scope::ProfileScope;
+use exomind_cli::runtime_client::RuntimeClient;
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+
+#[derive(Clone, Default)]
+struct TestState;
+
+#[tokio::test]
+async fn runtime_client_health_and_scope_helpers_attach_token() {
+    let base_url = spawn_test_server().await;
+    let client = RuntimeClient::new("127.0.0.1:0", base_url.clone(), Some("secret-token".into()))
+        .expect("runtime client");
+    let scope = ProfileScope::from_flags(Some("argon"), None).expect("profile scope");
+
+    let health = client.health().await.expect("health");
+    assert_eq!(health["status"], "ok");
+
+    let task_value: Value = client
+        .get_json(&client.with_scope("/tasks", &scope.task_query_pairs()))
+        .await
+        .expect("task query");
+    assert_eq!(task_value["query"]["profile_id"], "profile-argon");
+    assert_eq!(task_value["auth"], "Bearer secret-token");
+
+    let eventlog_value: Value = client
+        .get_json(&client.with_scope("/eventlog", &scope.eventlog_query_pairs()))
+        .await
+        .expect("eventlog query");
+    assert_eq!(eventlog_value["query"]["user_id"], "profile-argon");
+    assert_eq!(eventlog_value["auth"], "Bearer secret-token");
+}
+
+#[tokio::test]
+async fn runtime_client_returns_status_and_body_preview() {
+    let base_url = spawn_test_server().await;
+    let client = RuntimeClient::new("127.0.0.1:0", base_url, None).expect("runtime client");
+
+    let error = client
+        .get_json::<Value>("/error")
+        .await
+        .expect_err("error response should bubble up");
+
+    match error {
+        CliError::HttpResponse {
+            status,
+            body_preview,
+        } => {
+            assert_eq!(status.as_u16(), 409);
+            assert!(body_preview.contains("rt conflict"));
+        }
+        other => panic!("expected http response error, got {other:?}"),
+    }
+}
+
+async fn spawn_test_server() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener addr");
+    let app = Router::new()
+        .route("/health", get(health_handler))
+        .route("/tasks", get(echo_handler))
+        .route("/eventlog", get(echo_handler))
+        .route("/error", get(error_handler))
+        .with_state(TestState);
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test app");
+    });
+
+    format!("http://{}", socket_to_string(address))
+}
+
+fn socket_to_string(address: SocketAddr) -> String {
+    address.to_string()
+}
+
+async fn health_handler() -> Json<Value> {
+    Json(json!({
+        "status": "ok",
+        "version": "test"
+    }))
+}
+
+async fn echo_handler(
+    State(_state): State<TestState>,
+    headers: HeaderMap,
+    Query(query): Query<HashMap<String, String>>,
+) -> Json<Value> {
+    Json(json!({
+        "query": query,
+        "auth": headers
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+    }))
+}
+
+async fn error_handler() -> (axum::http::StatusCode, &'static str) {
+    (axum::http::StatusCode::CONFLICT, "rt conflict")
+}

--- a/crates/exomind-cli/tests/target_resolution.rs
+++ b/crates/exomind-cli/tests/target_resolution.rs
@@ -1,0 +1,66 @@
+use exomind_cli::profile_scope::ProfileScope;
+use exomind_cli::state::CliState;
+use exomind_cli::target::{TargetResolutionSource, resolve_target};
+
+#[test]
+fn explicit_target_wins_over_saved_target() {
+    let mut state = CliState::default();
+    state.default_target = Some("127.0.0.1:1950".to_string());
+
+    let resolved = resolve_target(
+        Some("127.0.0.1:9124"),
+        &state,
+        &[9124, 1950, 1949],
+        |_| true,
+    )
+    .expect("target should resolve");
+
+    assert_eq!(resolved.target, "127.0.0.1:9124");
+    assert_eq!(resolved.source, TargetResolutionSource::Explicit);
+}
+
+#[test]
+fn saved_target_wins_over_local_probe() {
+    let mut state = CliState::default();
+    state.default_target = Some("127.0.0.1:1950".to_string());
+
+    let resolved = resolve_target(None, &state, &[9124, 1950, 1949], |candidate| {
+        matches!(candidate, "127.0.0.1:9124" | "127.0.0.1:1950")
+    })
+    .expect("target should resolve");
+
+    assert_eq!(resolved.target, "127.0.0.1:1950");
+    assert_eq!(resolved.source, TargetResolutionSource::SavedDefault);
+}
+
+#[test]
+fn profile_flag_becomes_profile_scope_key() {
+    let scope = ProfileScope::from_flags(Some("argon"), None).expect("profile scope");
+
+    assert_eq!(scope.scope_key(), Some("profile-argon"));
+    assert_eq!(
+        scope.task_query_pairs(),
+        vec![("profile_id".to_string(), "profile-argon".to_string())]
+    );
+}
+
+#[test]
+fn profile_scope_is_not_double_prefixed() {
+    let scope = ProfileScope::from_flags(Some("profile-argon"), None).expect("profile scope");
+
+    assert_eq!(scope.scope_key(), Some("profile-argon"));
+    assert_eq!(
+        scope.task_query_pairs(),
+        vec![("profile_id".to_string(), "profile-argon".to_string())]
+    );
+}
+
+#[test]
+fn eventlog_scope_maps_profile_to_user_id_query() {
+    let scope = ProfileScope::from_flags(Some("argon"), None).expect("profile scope");
+
+    assert_eq!(
+        scope.eventlog_query_pairs(),
+        vec![("user_id".to_string(), "profile-argon".to_string())]
+    );
+}

--- a/crates/exomind-cli/tests/task_smoke.rs
+++ b/crates/exomind-cli/tests/task_smoke.rs
@@ -1,0 +1,324 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use axum::extract::{Path, Query, State};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use exomind_cli::cli::{GlobalOptions, TaskAddArgs, TaskIdArgs, TaskListArgs, TaskUpdateArgs};
+use exomind_cli::commands::task::{
+    add_task, cancel_task, complete_task, get_task, list_tasks, start_task, update_task,
+};
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+
+#[derive(Clone, Default)]
+struct TaskTestState {
+    captured: Arc<Mutex<Vec<CapturedRequest>>>,
+}
+
+#[derive(Debug, Clone)]
+struct CapturedRequest {
+    method: String,
+    path: String,
+    query: HashMap<String, String>,
+    body: Option<Value>,
+}
+
+#[tokio::test]
+async fn task_add_posts_create_task_payload() {
+    let state = TaskTestState::default();
+    let target = spawn_task_server(state.clone()).await;
+    let global = GlobalOptions {
+        target: Some(target),
+        profile: Some("argon".to_string()),
+        user_id: None,
+        json: true,
+        spawn_if_missing: false,
+    };
+
+    let created = add_task(
+        &global,
+        &TaskAddArgs {
+            title: "整理浏览器标签".to_string(),
+            priority: Some("high".to_string()),
+            tags: vec!["cleanup".to_string()],
+        },
+    )
+    .await
+    .expect("task add");
+
+    assert_eq!(created["title"], "整理浏览器标签");
+    let captured = state.captured.lock().expect("captured requests");
+    let latest = captured.last().expect("captured add request");
+    assert_eq!(latest.method, "POST");
+    assert_eq!(latest.path, "/tasks");
+    assert_eq!(latest.query.get("profile_id"), Some(&"profile-argon".to_string()));
+    let body = latest.body.as_ref().expect("task add body");
+    assert_eq!(body["title"], "整理浏览器标签");
+    assert_eq!(body["priority"], "high");
+    assert_eq!(body["tags"], json!(["cleanup"]));
+}
+
+#[tokio::test]
+async fn task_cancel_hides_pending_to_in_progress_transition_detail() {
+    let state = TaskTestState::default();
+    let target = spawn_task_server(state.clone()).await;
+    let global = GlobalOptions {
+        target: Some(target),
+        profile: Some("argon".to_string()),
+        user_id: None,
+        json: true,
+        spawn_if_missing: false,
+    };
+
+    let cancelled = cancel_task(
+        &global,
+        &TaskIdArgs {
+            task_id: "task-1".to_string(),
+        },
+    )
+    .await
+    .expect("task cancel");
+
+    assert_eq!(cancelled["status"], "cancelled");
+    let captured = state.captured.lock().expect("captured requests");
+    let latest = captured.last().expect("captured cancel request");
+    assert_eq!(latest.method, "POST");
+    assert_eq!(latest.path, "/tasks/task-1/cancel");
+}
+
+#[tokio::test]
+async fn task_complete_uses_transition_shortcut_path() {
+    let state = TaskTestState::default();
+    let target = spawn_task_server(state.clone()).await;
+    let global = GlobalOptions {
+        target: Some(target),
+        profile: Some("argon".to_string()),
+        user_id: None,
+        json: true,
+        spawn_if_missing: false,
+    };
+
+    let completed = complete_task(
+        &global,
+        &TaskIdArgs {
+            task_id: "task-1".to_string(),
+        },
+    )
+    .await
+    .expect("task complete");
+
+    assert_eq!(completed["status"], "completed");
+    let captured = state.captured.lock().expect("captured requests");
+    let latest = captured.last().expect("captured complete request");
+    assert_eq!(latest.method, "POST");
+    assert_eq!(latest.path, "/tasks/task-1/transition");
+    assert_eq!(latest.query.get("shortcut"), Some(&"true".to_string()));
+    assert_eq!(
+        latest.body.as_ref().expect("transition body")["status"],
+        "completed"
+    );
+}
+
+#[tokio::test]
+async fn task_list_get_update_and_start_use_rt_contracts() {
+    let state = TaskTestState::default();
+    let target = spawn_task_server(state.clone()).await;
+    let global = GlobalOptions {
+        target: Some(target),
+        profile: Some("argon".to_string()),
+        user_id: None,
+        json: true,
+        spawn_if_missing: false,
+    };
+
+    let listed = list_tasks(
+        &global,
+        &TaskListArgs {
+            status: Some("pending".to_string()),
+            tags: vec!["cleanup".to_string()],
+            parent_id: Some("parent-1".to_string()),
+        },
+    )
+    .await
+    .expect("task list");
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0]["id"], "task-1");
+
+    let loaded = get_task(
+        &global,
+        &TaskIdArgs {
+            task_id: "task-1".to_string(),
+        },
+    )
+    .await
+    .expect("task get");
+    assert_eq!(loaded["id"], "task-1");
+
+    let updated = update_task(
+        &global,
+        &TaskUpdateArgs {
+            task_id: "task-1".to_string(),
+            title: Some("整理三个屏幕程序".to_string()),
+        },
+    )
+    .await
+    .expect("task update");
+    assert_eq!(updated["title"], "整理三个屏幕程序");
+
+    let started = start_task(
+        &global,
+        &TaskIdArgs {
+            task_id: "task-1".to_string(),
+        },
+    )
+    .await
+    .expect("task start");
+    assert_eq!(started["status"], "in_progress");
+}
+
+async fn spawn_task_server(state: TaskTestState) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let address = listener.local_addr().expect("listener addr");
+    let app = Router::new()
+        .route("/health", get(|| async { Json(json!({ "status": "ok" })) }))
+        .route("/tasks", get(list_handler).post(add_handler))
+        .route("/tasks/:id", get(get_handler).put(update_handler).patch(update_handler))
+        .route("/tasks/:id/transition", post(transition_handler))
+        .route("/tasks/:id/cancel", post(cancel_handler))
+        .with_state(state);
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve task test app");
+    });
+
+    address.to_string()
+}
+
+async fn add_handler(
+    State(state): State<TaskTestState>,
+    Query(query): Query<HashMap<String, String>>,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    capture_request(&state, "POST", "/tasks", query, Some(body.clone()));
+    Json(json!({
+        "id": "task-1",
+        "title": body["title"],
+        "status": "pending",
+        "priority": body["priority"],
+        "tags": body["tags"]
+    }))
+}
+
+async fn list_handler(
+    State(state): State<TaskTestState>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Json<Value> {
+    capture_request(&state, "GET", "/tasks", query, None);
+    Json(json!([
+        {
+            "id": "task-1",
+            "title": "整理浏览器标签",
+            "status": "pending"
+        }
+    ]))
+}
+
+async fn get_handler(
+    State(state): State<TaskTestState>,
+    Path(task_id): Path<String>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Json<Value> {
+    capture_request(
+        &state,
+        "GET",
+        &format!("/tasks/{task_id}"),
+        query,
+        None,
+    );
+    Json(json!({
+        "id": task_id,
+        "title": "整理浏览器标签",
+        "status": "pending"
+    }))
+}
+
+async fn update_handler(
+    State(state): State<TaskTestState>,
+    Path(task_id): Path<String>,
+    Query(query): Query<HashMap<String, String>>,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    capture_request(
+        &state,
+        "PUT",
+        &format!("/tasks/{task_id}"),
+        query,
+        Some(body.clone()),
+    );
+    Json(json!({
+        "id": task_id,
+        "title": body["title"],
+        "status": "pending"
+    }))
+}
+
+async fn transition_handler(
+    State(state): State<TaskTestState>,
+    Path(task_id): Path<String>,
+    Query(query): Query<HashMap<String, String>>,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    capture_request(
+        &state,
+        "POST",
+        &format!("/tasks/{task_id}/transition"),
+        query,
+        Some(body.clone()),
+    );
+    Json(json!({
+        "id": task_id,
+        "title": "整理浏览器标签",
+        "status": body["status"]
+    }))
+}
+
+async fn cancel_handler(
+    State(state): State<TaskTestState>,
+    Path(task_id): Path<String>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Json<Value> {
+    capture_request(
+        &state,
+        "POST",
+        &format!("/tasks/{task_id}/cancel"),
+        query,
+        None,
+    );
+    Json(json!({
+        "id": task_id,
+        "title": "整理浏览器标签",
+        "status": "cancelled"
+    }))
+}
+
+fn capture_request(
+    state: &TaskTestState,
+    method: &str,
+    path: &str,
+    query: HashMap<String, String>,
+    body: Option<Value>,
+) {
+    state
+        .captured
+        .lock()
+        .expect("captured requests")
+        .push(CapturedRequest {
+            method: method.to_string(),
+            path: path.to_string(),
+            query,
+            body,
+        });
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@
 - [快速上手](development/quickstart.md) -- 开发环境搭建指南
 - [前端设计规范](development/ui-spec.md) -- ExoMind 前端 UI 统一规范，含 token、页面分类、例外边界与评审清单
 - [设备配对流程](development/device-pairing-flow.md) -- node-first 配对、地址解析、Android 模拟器特殊规则
+- [ExoMind CLI](development/exomind-cli.md) -- RT client shell（RT 客户端外壳）使用说明，含 connect-first 规则与命令样例
 - [Git 规范](development/git-spec.md) -- Git 工作流规范（权威版）
 - [Runtime Agent API](development/exomind-runtime-agents-api.md) -- Runtime Agent HTTP/SSE 接口说明
 - [Issue 追踪罗盘](development/issue-tracking-compass.md) -- Issue 去重/决策/新建/追加流程

--- a/docs/development/exomind-cli.md
+++ b/docs/development/exomind-cli.md
@@ -1,0 +1,140 @@
+# ExoMind CLI（RT Client Shell，RT 客户端外壳）
+
+## 目标
+
+`exomind` 是 ExoMind 的 **RT client shell（RT 客户端外壳）**。
+
+它不是直接改 store（存储）的旁路工具，而是通过现有 RT HTTP contract（运行时 HTTP 契约）访问：
+
+- `eventlog`
+- `task`
+- `proposal`
+- `rt`
+
+Phase 1 的设计重点：
+
+1. 默认 `connect-first（优先连接）`
+2. 默认不静默自启 RT
+3. 零参数直接显示首页帮助
+4. 对人类可读，对 Agent 可稳定调用
+
+## 默认行为
+
+目标解析顺序：
+
+1. `--target host:port`
+2. CLI 本地状态中的 `default_target`
+3. 本机候选端口探测：`9124`、`1950`、`1949`
+4. 若仍未找到，且显式要求 `--spawn-if-missing`
+5. 否则报错
+
+当前实现仍坚持：
+
+- 普通业务命令不静默拉起新的 RT
+- `eventlog` 内部使用 `user_id`
+- `task / proposal` 内部优先使用 `profile_id`
+
+## 首页帮助
+
+直接运行：
+
+```bash
+exomind
+```
+
+会显示：
+
+- CLI 的定位说明
+- `connect-first` 默认行为
+- 常用命令样例
+- Agent-friendly usage（Agent 友好调用样例）
+
+## 命令样例
+
+### RT
+
+```bash
+exomind rt status
+exomind rt probe
+exomind rt use 127.0.0.1:9124
+```
+
+### EventLog
+
+```bash
+exomind eventlog add --profile argon --content "补记今天的口述" --tag note --tag voice
+exomind eventlog list --profile argon --limit 20
+exomind eventlog get --profile argon evt-123
+exomind eventlog watch --profile argon --since-id evt-123
+```
+
+### Task
+
+```bash
+exomind task add --profile argon --title "整理浏览器标签" --priority high --tag cleanup
+exomind task list --profile argon --status pending --tag cleanup
+exomind task get --profile argon task-123
+exomind task update --profile argon task-123 --title "整理三个屏幕程序"
+exomind task start --profile argon task-123
+exomind task complete --profile argon task-123
+exomind task cancel --profile argon task-123
+```
+
+### Proposal
+
+```bash
+exomind proposal add --profile argon --action create_task --title "建议：整理浏览器标签" --params-file proposal.json
+exomind proposal list --profile argon --status pending
+exomind proposal get --profile argon 12
+exomind proposal approve --profile argon 12
+exomind proposal reject --profile argon 12
+exomind proposal snooze --profile argon 12
+exomind proposal comment --profile argon 12 --content "先改成低优先级"
+```
+
+## Agent 调用建议
+
+推荐 Agent / skill / 脚本使用：
+
+```bash
+exomind task list --profile argon --status pending --json
+exomind proposal add --profile argon --action create_task --title "建议：整理标签" --params-file -
+exomind eventlog add --profile argon --content "补记今天的口述" --json
+```
+
+建议遵循：
+
+1. 显式传 `--profile` 或 `--user-id`
+2. 需要结构化结果时加 `--json`
+3. 需要稳定输入时优先 `--params-file`，必要时用 `-` 从 stdin 读入
+
+## 本地状态
+
+CLI 维护一份轻量客户端状态（client state，客户端状态），默认保存在：
+
+- Windows: `%APPDATA%/ExoMind/cli-state.json`
+- 测试时可用 `EXOMIND_CLI_STATE_PATH` 覆盖
+
+状态内容属于客户端偏好，不是业务数据：
+
+- `default_target`
+- 每个 target 的 `default_profile`
+- 每个 target 的 `auth_token`
+- 每个 target 的 `last_seen_at`
+
+## 当前范围说明
+
+Phase 1 当前已覆盖：
+
+- 顶层首页帮助
+- `examples`
+- `rt status / probe / use / clear-default`
+- `eventlog add / list / get / watch`
+- `task add / list / get / update / start / complete / cancel / suspend / resume`
+- `proposal add / list / get / approve / reject / snooze / comment`
+
+后续如继续扩展，应继续保持：
+
+- `CLI = RT client shell`
+- `connect-first`
+- 不绕过 RT 直接碰 store

--- a/docs/plans/2026-04-03-issue-825-rt-native-cli-phase1-plan.md
+++ b/docs/plans/2026-04-03-issue-825-rt-native-cli-phase1-plan.md
@@ -1,0 +1,803 @@
+# ExoMind RT Client CLI Phase 1 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a Rust-native ExoMind CLI that acts as the third client shell beside Web and Tauri, with Phase 1 covering `task / proposal / eventlog` and giving both humans and notebook skills one stable command surface over a running RT.
+
+**Architecture:** Add a new workspace crate `crates/exomind-cli` that behaves as an RT client shell, not a store-side bypass tool. The CLI defaults to `connect-first` by resolving and connecting to an existing local RT, supports explicit `--target host:port`, and only spawns a local RT when the user explicitly asks or enables `--spawn-if-missing`. The top-level UX is homepage-first: running `exomind` without arguments shows a readable help homepage with examples, while `--json` keeps the same commands stable for Agent / script use.
+
+**Tech Stack:** Rust 2024, `clap` derive parsing, `reqwest`, `serde`, `serde_json`, `tokio`, `chrono`, `thiserror`, `dirs`, existing `exomind-runtime` route/domain types
+
+---
+
+## Scope
+
+### In Scope
+
+- Add a new workspace crate and binary for ExoMind CLI
+- Define CLI as **client shell（客户端外壳）**, not direct SQLite/store editor
+- Default topology: one machine, one primary local RT
+- Phase 1 command families:
+  - `eventlog add / list / get / watch`
+  - `task add / list / get / update / start / complete / cancel / suspend / resume`
+  - `proposal add / list / get / approve / reject / snooze / comment`
+  - `rt status / probe / use / clear-default`
+  - `examples`
+- Explicit target selection via `--target host:port`
+- Explicit scope selection via `--profile` / `--user-id`
+- Lightweight local CLI state for default target / default profile / auth token caching
+- Optional local RT bootstrap when explicitly requested
+- Homepage-style zero-arg help with examples for humans and Agents
+- `--json` output path for stable machine-readable invocation
+- Docs/examples for downstream notebook skill invocation
+
+### Out of Scope
+
+- No TUI in this phase
+- No PTY / terminal agent workbench
+- No full mirror of every RT route
+- No multi-RT sync orchestration in Phase 1
+- No notebook-repo code changes in this plan
+- No silent background RT spawn by default
+
+## Architecture Principles
+
+1. **Connect-first（优先连接）**
+   - CLI first tries to connect to an existing RT
+   - It does not silently create a second RT by default
+
+2. **CLI = RT client shell（CLI 是 RT 客户端外壳）**
+   - Business actions go through RT HTTP contracts
+   - CLI does not directly mutate stores as the normal path
+
+3. **Single local RT first（单机单主 RT 优先）**
+   - Default local usage assumes one primary RT on the machine
+   - Multi-RT is an explicit advanced mode, not baseline behavior
+
+4. **Human-first homepage, Agent-first contract（首页对人友好，契约对 Agent 稳定）**
+   - `exomind` with no args prints a usable homepage with examples
+   - `--json` keeps command outputs deterministic for automation
+
+5. **RT remains source of truth（RT 是真相源）**
+   - Signal emission, session behavior, proposal execution, watches, and auth all stay in RT
+   - CLI should not bypass those semantics by touching stores directly
+
+## Default Target Resolution
+
+Phase 1 should resolve the target in this order:
+
+1. `--target host:port`
+2. saved default target in CLI state
+3. local discovery over candidate ports:
+   - `9124`
+   - `1950`
+   - `1949`
+4. if not found and `--spawn-if-missing` is set:
+   - start a local RT via `exomind-rt`
+   - wait for `/health`
+   - connect
+5. otherwise fail with a clear message
+
+## Local CLI State
+
+The CLI should maintain a small local state file, for example:
+
+```json
+{
+  "default_target": "127.0.0.1:9124",
+  "targets": {
+    "127.0.0.1:9124": {
+      "default_profile": "profile-argon",
+      "auth_token": "optional",
+      "last_seen_at": "2026-04-03T11:20:00Z"
+    }
+  }
+}
+```
+
+This is **client state（客户端状态）**, not new business data.
+
+## UX Shape
+
+### Zero-arg homepage
+
+```text
+exomind
+```
+
+Should print:
+
+- what the CLI is
+- `connect-first` default behavior
+- common human examples
+- Agent / script examples with `--json`
+- pointers to `exomind examples`, `exomind task`, `exomind proposal`, `exomind eventlog`, `exomind rt`
+
+### Example command surface
+
+```text
+exomind rt status
+exomind rt probe
+exomind rt use 127.0.0.1:9124
+exomind examples
+
+exomind task add --profile argon --title "整理浏览器标签" --tag cleanup --priority high
+exomind task list --profile argon --status pending
+exomind task get --profile argon <task-id>
+exomind task update --profile argon <task-id> --title "整理三个屏幕程序"
+exomind task start --profile argon <task-id>
+exomind task complete --profile argon <task-id>
+exomind task cancel --profile argon <task-id>
+
+exomind proposal add --profile argon --action create_task --title "建议：整理浏览器标签" --params-file proposal.json
+exomind proposal list --profile argon --status pending
+exomind proposal get --profile argon <proposal-id>
+exomind proposal approve --profile argon <proposal-id>
+exomind proposal reject --profile argon <proposal-id>
+exomind proposal snooze --profile argon <proposal-id>
+exomind proposal comment --profile argon <proposal-id> --content "先改成低优先级"
+
+exomind eventlog add --profile argon --content "补记今天的口述" --tag note --tag voice
+exomind eventlog list --profile argon --limit 20
+exomind eventlog get --profile argon <event-id>
+exomind eventlog watch --profile argon --since-id <event-id>
+```
+
+### Important route compatibility note
+
+- `task / proposal` routes already accept `profile_id` and `user_id`
+- `eventlog` currently only accepts `user_id`
+- CLI should keep a single public flag surface and map internally to the current RT contracts
+- `eventlog add` should trust the RT-generated event ID returned by the server
+
+## File Map
+
+### Create
+
+- `crates/exomind-cli/Cargo.toml`
+- `crates/exomind-cli/src/lib.rs`
+- `crates/exomind-cli/src/main.rs`
+- `crates/exomind-cli/src/cli.rs`
+- `crates/exomind-cli/src/error.rs`
+- `crates/exomind-cli/src/output.rs`
+- `crates/exomind-cli/src/examples.rs`
+- `crates/exomind-cli/src/state.rs`
+- `crates/exomind-cli/src/profile_scope.rs`
+- `crates/exomind-cli/src/target.rs`
+- `crates/exomind-cli/src/runtime_client.rs`
+- `crates/exomind-cli/src/commands/mod.rs`
+- `crates/exomind-cli/src/commands/eventlog.rs`
+- `crates/exomind-cli/src/commands/task.rs`
+- `crates/exomind-cli/src/commands/proposal.rs`
+- `crates/exomind-cli/src/commands/rt.rs`
+- `crates/exomind-cli/tests/cli_parse.rs`
+- `crates/exomind-cli/tests/help_output.rs`
+- `crates/exomind-cli/tests/target_resolution.rs`
+- `crates/exomind-cli/tests/eventlog_smoke.rs`
+- `crates/exomind-cli/tests/task_smoke.rs`
+- `crates/exomind-cli/tests/proposal_smoke.rs`
+- `docs/development/exomind-cli.md`
+
+### Modify
+
+- `Cargo.toml`
+- `docs/README.md`
+
+---
+
+### Task 1: Scaffold the workspace crate, homepage help, and root command tree
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `crates/exomind-cli/Cargo.toml`
+- Create: `crates/exomind-cli/src/lib.rs`
+- Create: `crates/exomind-cli/src/main.rs`
+- Create: `crates/exomind-cli/src/cli.rs`
+- Create: `crates/exomind-cli/src/output.rs`
+- Create: `crates/exomind-cli/src/examples.rs`
+- Create: `crates/exomind-cli/tests/cli_parse.rs`
+- Create: `crates/exomind-cli/tests/help_output.rs`
+
+**Step 1: Write failing parser and homepage tests**
+
+Add tests that expect:
+
+```rust
+#[test]
+fn root_help_mentions_eventlog_task_proposal_rt_and_examples() {}
+
+#[test]
+fn running_without_args_renders_homepage_help() {}
+
+#[test]
+fn examples_command_lists_human_and_agent_examples() {}
+
+#[test]
+fn global_target_and_profile_flags_parse() {}
+
+#[test]
+fn proposal_approve_parses_numeric_id() {}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p exomind-cli --test cli_parse --test help_output
+```
+
+Expected: fail because the crate does not exist yet.
+
+**Step 3: Implement the crate skeleton**
+
+- Add `crates/exomind-cli` to workspace members
+- Add dependencies:
+  - `clap = { version = "4", features = ["derive"] }`
+  - `reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }`
+  - `serde`, `serde_json`, `tokio`, `chrono`, `thiserror`, `dirs`
+  - `exomind-runtime = { path = "../exomind-runtime" }`
+- Define root command tree:
+  - global: `--target`, `--profile`, `--user-id`, `--json`, `--spawn-if-missing`
+  - subcommands: `eventlog`, `task`, `proposal`, `rt`, `examples`
+- Make `exomind` with no args print homepage help instead of missing-args failure
+- Put examples in a single reusable registry
+
+**Step 4: Run parser and help tests**
+
+Run:
+
+```bash
+cargo test -p exomind-cli --test cli_parse --test help_output
+```
+
+Expected: pass.
+
+**Step 5: Commit**
+
+```bash
+git add Cargo.toml crates/exomind-cli docs/plans/2026-04-03-issue-825-rt-native-cli-phase1-plan.md
+git commit -m "feat(cli): scaffold rt client cli crate"
+```
+
+**Step 6: Push branch and open draft PR**
+
+Run:
+
+```bash
+git push -u origin feature/issue-825-rt-native-cli-phase1
+gh pr create --draft --base dev --head feature/issue-825-rt-native-cli-phase1 --title "feat(cli): add RT-native connect-first CLI shell" --body-file docs/plans/2026-04-03-issue-825-rt-native-cli-phase1-plan.md
+```
+
+Expected:
+
+- branch pushed
+- draft PR created against `dev`
+
+---
+
+### Task 2: Add CLI local state, target resolution, and scope normalization
+
+**Files:**
+- Create: `crates/exomind-cli/src/state.rs`
+- Create: `crates/exomind-cli/src/target.rs`
+- Create: `crates/exomind-cli/src/profile_scope.rs`
+- Create: `crates/exomind-cli/tests/target_resolution.rs`
+
+**Step 1: Write failing resolution tests**
+
+Add tests for:
+
+```rust
+#[test]
+fn explicit_target_wins_over_saved_target() {}
+
+#[test]
+fn saved_target_wins_over_local_probe() {}
+
+#[test]
+fn profile_flag_becomes_profile_scope_key() {}
+
+#[test]
+fn profile_scope_is_not_double_prefixed() {}
+
+#[test]
+fn eventlog_scope_maps_profile_to_user_id_query() {}
+```
+
+**Step 2: Run the failing tests**
+
+Run:
+
+```bash
+cargo test -p exomind-cli --test target_resolution
+```
+
+Expected: fail because state/target helpers do not exist.
+
+**Step 3: Implement local state**
+
+Define a small persisted state file under a standard client config path, for example:
+
+- Windows: `%APPDATA%/ExoMind/cli-state.json`
+- fallback: project-local temp path in tests
+
+State should include:
+
+- `default_target`
+- `targets[target].default_profile`
+- `targets[target].auth_token`
+- `targets[target].last_seen_at`
+
+**Step 4: Implement target resolution and scope normalization**
+
+Resolution order:
+
+1. explicit `--target`
+2. saved default target
+3. local probe over `9124`, `1950`, `1949`
+4. optional spawn path if `--spawn-if-missing`
+
+Profile resolution:
+
+- `--profile argon` -> `profile-argon`
+- `--profile profile-argon` stays `profile-argon`
+- `--user-id profile-argon` stays exact
+- `eventlog` routes should receive the resolved scope through `user_id`
+
+**Step 5: Run tests**
+
+Run:
+
+```bash
+cargo test -p exomind-cli --test target_resolution
+```
+
+Expected: pass.
+
+**Step 6: Commit**
+
+```bash
+git add crates/exomind-cli/src/state.rs crates/exomind-cli/src/target.rs crates/exomind-cli/src/profile_scope.rs crates/exomind-cli/tests/target_resolution.rs
+git commit -m "feat(cli): add target resolution and client state"
+```
+
+---
+
+### Task 3: Implement the shared RT HTTP client, errors, and output modes
+
+**Files:**
+- Create: `crates/exomind-cli/src/runtime_client.rs`
+- Create: `crates/exomind-cli/src/error.rs`
+- Modify: `crates/exomind-cli/src/output.rs`
+- Modify: `crates/exomind-cli/src/main.rs`
+
+**Step 1: Write a failing smoke test for health resolution**
+
+Add a test that spins up a tiny mock HTTP server and asserts the client:
+
+- resolves a healthy RT target
+- attaches saved auth token correctly
+- appends scope query helpers correctly
+- preserves clean JSON output mode
+
+**Step 2: Run the failing test**
+
+Run:
+
+```bash
+cargo test -p exomind-cli --test target_resolution
+```
+
+Expected: fail because the HTTP client does not exist yet.
+
+**Step 3: Implement `RuntimeClient`**
+
+Required helpers:
+
+- `health()`
+- `get_json(path)`
+- `post_json(path, body)`
+- `put_json(path, body)`
+- `patch_json(path, body)`
+- `delete_json(path)`
+- `with_scope(path, scope_query)`
+
+Requirements:
+
+- respect optional saved token
+- support `--json` output cleanly
+- return structured errors with status code + body preview
+
+**Step 4: Run tests**
+
+Run:
+
+```bash
+cargo test -p exomind-cli --test target_resolution
+```
+
+Expected: pass.
+
+**Step 5: Commit**
+
+```bash
+git add crates/exomind-cli/src/runtime_client.rs crates/exomind-cli/src/error.rs crates/exomind-cli/src/output.rs crates/exomind-cli/src/main.rs
+git commit -m "feat(cli): add shared runtime http client"
+```
+
+---
+
+### Task 4: Implement `rt` commands for inspect, connect, and explicit bootstrap
+
+**Files:**
+- Create: `crates/exomind-cli/src/commands/rt.rs`
+- Modify: `crates/exomind-cli/src/cli.rs`
+- Modify: `crates/exomind-cli/tests/target_resolution.rs`
+
+**Step 1: Write failing tests for RT control commands**
+
+Add tests for:
+
+```rust
+#[test]
+fn rt_status_reports_selected_target() {}
+
+#[test]
+fn rt_use_sets_default_target() {}
+
+#[test]
+fn rt_probe_lists_candidate_ports() {}
+```
+
+**Step 2: Run the failing tests**
+
+Run:
+
+```bash
+cargo test -p exomind-cli --test target_resolution
+```
+
+Expected: fail because `rt` subcommands are missing.
+
+**Step 3: Implement `rt` command family**
+
+Phase 1 commands:
+
+- `rt status`
+- `rt probe`
+- `rt use <host:port>`
+- `rt clear-default`
+
+Optional, only if straightforward:
+
+- `rt ensure --spawn-if-missing`
+
+Important:
+
+- if spawn is implemented in Phase 1, it must be explicit
+- do not make ordinary business commands silently launch a new RT
+
+**Step 4: Run tests**
+
+Run:
+
+```bash
+cargo test -p exomind-cli --test target_resolution
+```
+
+Expected: pass.
+
+**Step 5: Commit**
+
+```bash
+git add crates/exomind-cli/src/commands/rt.rs crates/exomind-cli/src/cli.rs crates/exomind-cli/tests/target_resolution.rs
+git commit -m "feat(cli): add rt target management commands"
+```
+
+---
+
+### Task 5: Implement eventlog commands over RT routes
+
+**Files:**
+- Create: `crates/exomind-cli/src/commands/eventlog.rs`
+- Create: `crates/exomind-cli/tests/eventlog_smoke.rs`
+
+**Step 1: Write failing eventlog smoke tests**
+
+Add tests for:
+
+```rust
+#[test]
+fn eventlog_add_posts_to_scoped_rt_endpoint() {}
+
+#[test]
+fn eventlog_list_reads_latest_first() {}
+
+#[test]
+fn eventlog_watch_polls_for_new_events() {}
+```
+
+**Step 2: Run the failing tests**
+
+Run:
+
+```bash
+cargo test -p exomind-cli --test eventlog_smoke
+```
+
+Expected: fail because command handlers do not exist.
+
+**Step 3: Implement `eventlog add / list / get / watch`**
+
+Requirements:
+
+- `add`
+  - sends timestamp/content/tags to RT
+  - trusts the RT-generated event ID returned by the server
+  - supports repeated `--tag`
+- `list`
+  - supports `--limit`
+  - supports `--tag`
+- `get`
+  - fetches one event by id
+- `watch`
+  - uses RT `/eventlog/watch`
+  - supports `--since-id`
+- scope should be sent through `user_id`
+
+**Step 4: Run tests**
+
+Run:
+
+```bash
+cargo test -p exomind-cli --test eventlog_smoke
+```
+
+Expected: pass.
+
+**Step 5: Commit**
+
+```bash
+git add crates/exomind-cli/src/commands/eventlog.rs crates/exomind-cli/tests/eventlog_smoke.rs
+git commit -m "feat(cli): add eventlog command family"
+```
+
+---
+
+### Task 6: Implement task commands over RT routes with high-level wrappers
+
+**Files:**
+- Create: `crates/exomind-cli/src/commands/task.rs`
+- Create: `crates/exomind-cli/tests/task_smoke.rs`
+
+**Step 1: Write failing task smoke tests**
+
+Add tests for:
+
+```rust
+#[test]
+fn task_add_posts_create_task_payload() {}
+
+#[test]
+fn task_cancel_hides_pending_to_in_progress_transition_detail() {}
+
+#[test]
+fn task_complete_uses_transition_shortcut_path() {}
+```
+
+**Step 2: Run the failing tests**
+
+Run:
+
+```bash
+cargo test -p exomind-cli --test task_smoke
+```
+
+Expected: fail because handlers do not exist.
+
+**Step 3: Implement `task` command family**
+
+Required commands:
+
+- `add`
+- `list`
+- `get`
+- `update`
+- `start`
+- `suspend`
+- `resume`
+- `complete`
+- `cancel`
+
+Implementation rules:
+
+- prefer application-level verbs
+- CLI may internally call `/tasks/:id/transition?shortcut=true`
+- user should not need to remember raw RT transition constraints
+- support `--status`, `--tag`, `--parent-id` on list
+
+**Step 4: Run tests**
+
+Run:
+
+```bash
+cargo test -p exomind-cli --test task_smoke
+```
+
+Expected: pass.
+
+**Step 5: Commit**
+
+```bash
+git add crates/exomind-cli/src/commands/task.rs crates/exomind-cli/tests/task_smoke.rs
+git commit -m "feat(cli): add task command family"
+```
+
+---
+
+### Task 7: Implement proposal commands over RT routes
+
+**Files:**
+- Create: `crates/exomind-cli/src/commands/proposal.rs`
+- Create: `crates/exomind-cli/tests/proposal_smoke.rs`
+
+**Step 1: Write failing proposal smoke tests**
+
+Add tests for:
+
+```rust
+#[test]
+fn proposal_add_posts_pending_proposal() {}
+
+#[test]
+fn proposal_approve_patches_status_to_approved() {}
+
+#[test]
+fn proposal_comment_posts_discussion_entry() {}
+```
+
+**Step 2: Run the failing tests**
+
+Run:
+
+```bash
+cargo test -p exomind-cli --test proposal_smoke
+```
+
+Expected: fail because handlers do not exist.
+
+**Step 3: Implement `proposal add / list / get / approve / reject / snooze / comment`**
+
+Requirements:
+
+- `add`
+  - supports `--action create_task|append_event|start_timeblock`
+  - supports `--params-json` or `--params-file`
+- `approve`
+  - sends patch to RT; RT executes the approved proposal
+- `reject`
+  - patch status to rejected
+- `snooze`
+  - patch status to snoozed
+- `comment`
+  - supports content + optional author override
+
+**Step 4: Run tests**
+
+Run:
+
+```bash
+cargo test -p exomind-cli --test proposal_smoke
+```
+
+Expected: pass.
+
+**Step 5: Commit**
+
+```bash
+git add crates/exomind-cli/src/commands/proposal.rs crates/exomind-cli/tests/proposal_smoke.rs
+git commit -m "feat(cli): add proposal command family"
+```
+
+---
+
+### Task 8: Persist target-scoped defaults, finalize docs, and verify CLI UX
+
+**Files:**
+- Modify: `crates/exomind-cli/src/state.rs`
+- Modify: `crates/exomind-cli/src/target.rs`
+- Modify: `crates/exomind-cli/src/output.rs`
+- Create: `docs/development/exomind-cli.md`
+- Modify: `docs/README.md`
+
+**Step 1: Write failing tests for target-scoped defaults**
+
+Add tests for:
+
+```rust
+#[test]
+fn saved_default_profile_is_reused_for_same_target() {}
+
+#[test]
+fn saved_token_is_attached_only_for_matching_target() {}
+```
+
+**Step 2: Run the failing tests**
+
+Run:
+
+```bash
+cargo test -p exomind-cli --test target_resolution
+```
+
+Expected: fail until state wiring is complete.
+
+**Step 3: Implement state persistence polish**
+
+- allow saving default profile per target
+- allow storing optional auth token per target
+- ensure explicit flags override saved values
+- make homepage/examples output reflect final command surface
+
+**Step 4: Write user-facing documentation**
+
+Document:
+
+- how target resolution works
+- why CLI defaults to connect-first
+- how to set a default target
+- how notebook skills should call the CLI
+- examples for `task / proposal / eventlog`
+- how `--spawn-if-missing` differs from default behavior
+- how zero-arg homepage help and `examples` command work
+
+**Step 5: Run final verification**
+
+Run:
+
+```bash
+cargo test -p exomind-cli
+cargo run -p exomind-cli
+cargo run -p exomind-cli -- examples
+cargo run -p exomind-cli -- rt status
+cargo run -p exomind-cli -- task --help
+cargo run -p exomind-cli -- proposal --help
+cargo run -p exomind-cli -- eventlog --help
+```
+
+Expected:
+
+- all CLI tests pass
+- zero-arg homepage renders
+- examples command renders all samples
+- help output renders
+- docs reflect connect-first topology
+
+**Step 6: Commit**
+
+```bash
+git add crates/exomind-cli docs/development/exomind-cli.md docs/README.md
+git commit -m "docs(cli): finalize connect-first rt client guide"
+```
+
+---
+
+## Verification Checklist
+
+- `cargo test -p exomind-cli`
+- `cargo run -p exomind-cli`
+- `cargo run -p exomind-cli -- examples`
+- `cargo run -p exomind-cli -- rt probe`
+- `cargo run -p exomind-cli -- task --help`
+- `cargo run -p exomind-cli -- proposal --help`
+- `cargo run -p exomind-cli -- eventlog --help`
+
+## Notes for Implementers
+
+- Keep `CLI = RT client shell` as the first principle
+- Do not bypass RT runtime behavior by directly editing stores as the default path
+- Do not silently spawn an RT for ordinary commands
+- Keep multi-RT support explicit and minimal in Phase 1
+- Treat issue #825 as the concrete implementation track and #74 as the broader CLI umbrella
+- Keep the public command surface stable for notebook skills and other automation


### PR DESCRIPTION
## Summary

Build the first-phase RT-native CLI inside the `exomind` workspace as a connect-first RT client shell, not a store-side bypass tool.

Current status in this draft PR:
- scaffolded new workspace crate `crates/exomind-cli`
- added zero-arg homepage help for `exomind`
- added `examples` command with human and Agent invocation samples
- added initial root command tree for `task / proposal / eventlog / rt / examples`
- saved the updated execution plan to `docs/plans/2026-04-03-issue-825-rt-native-cli-phase1-plan.md`

## Verification

- `cargo test -p exomind-cli --test cli_parse --test help_output`
- `cargo run -p exomind-cli`
- `cargo run -p exomind-cli -- examples`

## Tracking

- Closes #825
- Follows the connect-first RT client shell direction discussed under #74
