### PR TITLE
feat(agent-hub): add API Agent tab test console on network page

### DIFF
--- a/docs/development/tauri-mcp-windows-playbook.md
+++ b/docs/development/tauri-mcp-windows-playbook.md
@@ -2211,3 +2211,86 @@
    - `HTTP 401`
    - `unauthorized runtime request`
    - `peer .* export failed`
+### 阶段补记：#823 API Agent Tab 真机闭环（2026-04-08）
+
+#### 阶段目标
+
+- 在 `网络 / API Agent` 顶部 tab 中完成最小可用真机验收。
+- 不只确认 tab 已挂上，还要确认：
+  - `天气示例`
+  - `发送首轮 / 继续`
+  - `继续执行 Tool Results`
+  - `读取`
+  这些关键按钮都能真实命中 `/agent-sessions`。
+
+#### 观察结果
+
+- 当前桌面实例：
+  - 主窗口标题：`ExoMind [feature/api-agent-tab-minimal] [Web:36648 RT:36651]`
+  - Tauri MCP bridge：`44451`
+- `driver_session start --host 127.0.0.1 --port 44451` 可稳定连通。
+- 当前这轮可用的 MCP 能力：
+  - `manage_window list`
+  - `webview_dom_snapshot`
+  - `webview_execute_js`
+  - `webview_interact`
+- 页面真实可见：
+  - `网络` 顶部 `API Agent` tab
+  - 请求编排 / 轮次结果 / 工具续跑 / 会话读取 / 调试证据 五块分区
+
+#### 关键发现
+
+- 首版默认把 `recent_events` preset 打开，但后端对这个 preset 有明确约束：
+  - `scope_key is required for preset recent_events`
+- 结果就是：
+  - 页面初次进入后直接点 `发送首轮 / 继续`
+  - 会命中 `POST /agent-sessions`
+  - 返回 `400`
+- 这不是 RT 不可用，也不是按钮没绑好，而是前端默认态和后端约束冲突。
+
+#### 本轮修正结论
+
+- API Agent 实验页要做到“开箱可测”，前端需要：
+  - 默认关闭 `recent_events`
+  - 当用户手动开启 `recent_events` 且没填 `Scope Key` 时，直接前端禁用发送/续跑并展示提示
+- 这样能把“默认 UX 断点”与“后端真实不可用”拆开。
+
+#### 真机闭环链路
+
+1. 起本地 fake provider：
+   - `node .tmp/fake-api-agent-provider.mjs`
+   - 监听：`127.0.0.1:36701`
+2. 给当前 RT 写入最小 provider 配置：
+   - `exomind:agentApiProvider=openai`
+   - `exomind:agentApiModel=gpt-4o-mini`
+   - `exomind:agentApiBaseUrl=http://127.0.0.1:36701`
+   - `exomind:agentApiApiKey=stub-key`
+3. 在 Tauri 页面点击：
+   - `天气示例`
+   - `发送首轮 / 继续`
+4. 真实观察：
+   - `201 /agent-sessions`
+   - 页面进入 `needs_tool_calls`
+   - 返回 `tool-weather-1 / get_weather`
+5. 填入 tool result 后点击：
+   - `继续执行 Tool Results`
+6. 真实观察：
+   - 第二次 `201 /agent-sessions`
+   - 页面进入 `completed`
+   - 页面显示最终回答
+7. 把返回的 `sessionId` 填入读取框，点击：
+   - `读取`
+8. 真实观察：
+   - `200 /agent-sessions/:id`
+   - 页面成功回显持久化结果
+
+#### 可复用操作套路
+
+1. API Agent 页先测 RT HTTP，再测桌面按钮，不要反过来。
+2. 遇到“按钮点了没反应”，先在页面里 patch `window.fetch`，记录：
+   - URL
+   - method
+   - status
+   - response body
+3. 对 toggle / 预置按钮，`webview_interact click` 往往比普通 DOM `.click()` 更稳。
+4. 需要稳定复现 Agent API 时，优先接本地 fake provider，不要一开始就依赖真实远程模型。

--- a/src/config/api-agent-tab-enabled.ts
+++ b/src/config/api-agent-tab-enabled.ts
@@ -1,0 +1,33 @@
+import { createConfigModule } from './config-factory';
+
+const API_AGENT_TAB_ENABLED_STORAGE_KEY = 'exomind:apiAgentTabEnabled'; // API Agent tab 开关存储键
+const API_AGENT_TAB_ENABLED_CHANGED_EVENT = 'exomind:api-agent-tab-enabled-changed'; // API Agent tab 开关事件
+
+function normalizeBoolean(rawValue: string | null | undefined): boolean {
+  return rawValue === 'true';
+}
+
+const apiAgentTabEnabledModule = createConfigModule<boolean>({
+  storageKey: API_AGENT_TAB_ENABLED_STORAGE_KEY,
+  eventName: API_AGENT_TAB_ENABLED_CHANGED_EVENT,
+  defaultValue: false,
+  normalize: normalizeBoolean,
+  serialize: (value) => String(Boolean(value)),
+  persistMode: 'runtime-preferred',
+});
+
+export function getApiAgentTabEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  return apiAgentTabEnabledModule.get();
+}
+
+export function setApiAgentTabEnabled(enabled: boolean): void {
+  if (typeof window === 'undefined') return;
+  apiAgentTabEnabledModule.set(enabled);
+}
+
+export function subscribeApiAgentTabEnabledChanges(
+  listener: (enabled: boolean) => void,
+): () => void {
+  return apiAgentTabEnabledModule.subscribe(listener);
+}

--- a/src/lib/adapters/agent-session-rt-adapter.ts
+++ b/src/lib/adapters/agent-session-rt-adapter.ts
@@ -1,0 +1,222 @@
+import {
+  buildRuntimeAuthHeaders,
+  getSelectedRuntimeTarget,
+  toRuntimeBaseUrl,
+  type RuntimeTarget,
+} from '@/config/runtime-target';
+import type {
+  ApiAgentSessionRecord,
+  ApiAgentTurnItem,
+  RunApiAgentSessionInput,
+} from '@/lib/types/agent-session';
+import { appendRuntimeProfileScope } from './runtime-profile-scope';
+
+type RuntimeFetch = typeof fetch;
+
+interface RuntimeAgentToolCallPayload {
+  id: string;
+  name: string;
+  input: unknown;
+}
+
+interface RuntimeAssistantTurnPayload {
+  content: string;
+  toolCalls?: RuntimeAgentToolCallPayload[];
+}
+
+interface RuntimeAgentToolCallRecordPayload {
+  toolName: string;
+  input: unknown;
+  output?: string;
+}
+
+interface RuntimeAgentSessionRecordPayload {
+  sessionId: string;
+  triggerSource: string;
+  provider: string;
+  model: string;
+  prompt?: string | null;
+  content: string;
+  assistantTurn: RuntimeAssistantTurnPayload;
+  toolCalls: RuntimeAgentToolCallRecordPayload[];
+  status: string;
+  errorMessage?: string | null;
+  createdAt: string;
+  completedAt: string;
+}
+
+export interface AgentSessionRtAdapterOptions {
+  fetchImpl?: RuntimeFetch;
+  resolveTarget?: () => RuntimeTarget;
+  timeoutMs?: number;
+}
+
+export class AgentSessionRtError extends Error {
+  readonly status: number;
+  readonly responseBody?: string;
+
+  constructor(message: string, status: number, responseBody?: string) {
+    super(message);
+    this.name = 'AgentSessionRtError';
+    this.status = status;
+    this.responseBody = responseBody;
+  }
+}
+
+const AGENT_SESSION_API_BASE_PATH = '/agent-sessions';
+const DEFAULT_AGENT_SESSION_RT_TIMEOUT_MS = 10_000;
+
+function normalizeTurnHistory(history: RunApiAgentSessionInput['history']): ApiAgentTurnItem[] {
+  return (history ?? []).map((item) => {
+    if (item.role === 'assistant') {
+      return {
+        role: 'assistant',
+        content: item.content,
+        toolCalls: item.toolCalls ?? [],
+      } as const;
+    }
+    return item;
+  });
+}
+
+function normalizeSessionRecord(
+  payload: RuntimeAgentSessionRecordPayload,
+): ApiAgentSessionRecord {
+  return {
+    sessionId: payload.sessionId,
+    triggerSource: payload.triggerSource,
+    provider: payload.provider,
+    model: payload.model,
+    ...(payload.prompt ? { prompt: payload.prompt } : {}),
+    content: payload.content,
+    assistantTurn: {
+      content: payload.assistantTurn?.content ?? '',
+      toolCalls: payload.assistantTurn?.toolCalls ?? [],
+    },
+    toolCalls: payload.toolCalls ?? [],
+    status: payload.status,
+    ...(payload.errorMessage ? { errorMessage: payload.errorMessage } : {}),
+    createdAt: payload.createdAt,
+    completedAt: payload.completedAt,
+  };
+}
+
+function toRuntimeRequestPayload(input: RunApiAgentSessionInput): Record<string, unknown> {
+  return {
+    ...(input.providerProfile
+      ? {
+          providerProfile: {
+            provider: input.providerProfile.provider,
+            model: input.providerProfile.model,
+            ...(input.providerProfile.baseUrl
+              ? { baseUrl: input.providerProfile.baseUrl }
+              : {}),
+            apiKey: input.providerProfile.apiKey,
+          },
+        }
+      : {}),
+    ...(input.systemPrompt?.trim()
+      ? { systemPrompt: input.systemPrompt.trim() }
+      : {}),
+    tools: input.tools ?? [],
+    presets: input.presets ?? [],
+    ...(input.scopeKey?.trim() ? { scopeKey: input.scopeKey.trim() } : {}),
+    history: normalizeTurnHistory(input.history),
+    ...(input.newUserMessage?.trim()
+      ? { newUserMessage: input.newUserMessage.trim() }
+      : {}),
+  };
+}
+
+export class AgentSessionRtAdapter {
+  private readonly fetchImpl: RuntimeFetch;
+  private readonly resolveTarget: () => RuntimeTarget;
+  private readonly timeoutMs: number;
+
+  constructor(options: AgentSessionRtAdapterOptions = {}) {
+    this.fetchImpl = options.fetchImpl ?? ((input, init) => globalThis.fetch(input, init));
+    this.resolveTarget = options.resolveTarget ?? (() => getSelectedRuntimeTarget());
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_AGENT_SESSION_RT_TIMEOUT_MS;
+  }
+
+  async runSession(input: RunApiAgentSessionInput): Promise<ApiAgentSessionRecord> {
+    const payload = await this.requestJson<RuntimeAgentSessionRecordPayload>(
+      AGENT_SESSION_API_BASE_PATH,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(toRuntimeRequestPayload(input)),
+      },
+    );
+    return normalizeSessionRecord(payload);
+  }
+
+  async getSession(sessionId: string): Promise<ApiAgentSessionRecord | null> {
+    const target = this.resolveTarget();
+    const response = await this.fetchWithTimeout(
+      this.url(`${AGENT_SESSION_API_BASE_PATH}/${encodeURIComponent(sessionId)}`, target),
+      {
+        method: 'GET',
+        headers: buildRuntimeAuthHeaders(target, { Accept: 'application/json' }),
+      },
+    );
+    if (response.status === 404) {
+      return null;
+    }
+    if (!response.ok) {
+      throw await this.toRtError(
+        response,
+        `RT agent session get failed: ${response.status}（获取 API Agent 会话失败）`,
+      );
+    }
+    return normalizeSessionRecord(await response.json() as RuntimeAgentSessionRecordPayload);
+  }
+
+  private async requestJson<T>(
+    path: string,
+    init?: RequestInit,
+  ): Promise<T> {
+    const target = this.resolveTarget();
+    const response = await this.fetchWithTimeout(this.url(path, target), {
+      ...init,
+      headers: buildRuntimeAuthHeaders(target, init?.headers),
+    });
+    if (!response.ok) {
+      throw await this.toRtError(
+        response,
+        `RT agent session request failed: ${response.status}（API Agent 会话请求失败）`,
+      );
+    }
+    return await response.json() as T;
+  }
+
+  private async fetchWithTimeout(input: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      return await this.fetchImpl(input, {
+        ...init,
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private async toRtError(response: Response, message: string): Promise<AgentSessionRtError> {
+    let responseBody: string | undefined;
+    try {
+      responseBody = await response.text();
+    } catch {
+      responseBody = undefined;
+    }
+    return new AgentSessionRtError(message, response.status, responseBody);
+  }
+
+  private url(path: string, target = this.resolveTarget()): string {
+    return `${toRuntimeBaseUrl(target)}${appendRuntimeProfileScope(path)}`;
+  }
+}

--- a/src/lib/types/agent-hub.ts
+++ b/src/lib/types/agent-hub.ts
@@ -11,7 +11,7 @@ export type {
 export type { AgentMarketCategory, AgentMarketItem } from './agent-hub-market';
 
 // Agent Hub view modes（视图模式）
-export const AGENT_HUB_VIEW_MODES = ['topology', 'sessions', 'tiled', 'list', 'history', 'routes', 'device'] as const;
+export const AGENT_HUB_VIEW_MODES = ['topology', 'sessions', 'tiled', 'list', 'history', 'routes', 'device', 'api-agent'] as const;
 export type AgentHubViewMode = (typeof AGENT_HUB_VIEW_MODES)[number];
 
 // 右侧栏状态机

--- a/src/lib/types/agent-session.ts
+++ b/src/lib/types/agent-session.ts
@@ -1,0 +1,68 @@
+import type { ProviderProfileSnapshot } from '@/lib/agent-provider/types';
+
+export interface ApiAgentToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: unknown;
+}
+
+export interface ApiAgentToolCall {
+  id: string;
+  name: string;
+  input: unknown;
+}
+
+export interface ApiAgentAssistantTurn {
+  content: string;
+  toolCalls: ApiAgentToolCall[];
+}
+
+export interface ApiAgentToolCallRecord {
+  toolName: string;
+  input: unknown;
+  output?: string;
+}
+
+export type ApiAgentSessionStatus = 'needs_tool_calls' | 'completed' | string;
+
+export type ApiAgentTurnItem =
+  | {
+      role: 'user';
+      content: string;
+    }
+  | {
+      role: 'assistant';
+      content: string;
+      toolCalls?: ApiAgentToolCall[];
+    }
+  | {
+      role: 'tool';
+      toolCallId: string;
+      toolName: string;
+      content: string;
+    };
+
+export interface RunApiAgentSessionInput {
+  providerProfile?: ProviderProfileSnapshot | null;
+  systemPrompt?: string;
+  tools?: ApiAgentToolDefinition[];
+  presets?: string[];
+  scopeKey?: string;
+  history?: ApiAgentTurnItem[];
+  newUserMessage?: string;
+}
+
+export interface ApiAgentSessionRecord {
+  sessionId: string;
+  triggerSource: string;
+  provider: string;
+  model: string;
+  prompt?: string;
+  content: string;
+  assistantTurn: ApiAgentAssistantTurn;
+  toolCalls: ApiAgentToolCallRecord[];
+  status: ApiAgentSessionStatus;
+  errorMessage?: string;
+  createdAt: string;
+  completedAt: string;
+}

--- a/src/ui/app/config/settings/settings-registry.ts
+++ b/src/ui/app/config/settings/settings-registry.ts
@@ -71,6 +71,11 @@ import {
   subscribeAgentPageEnabledChanges,
 } from '@/config/agent-page-enabled';
 import {
+  getApiAgentTabEnabled,
+  setApiAgentTabEnabled,
+  subscribeApiAgentTabEnabledChanges,
+} from '@/config/api-agent-tab-enabled';
+import {
   getMePageEnabled,
   setMePageEnabled,
   subscribeMePageEnabledChanges,
@@ -1751,6 +1756,19 @@ export const SETTINGS_REGISTRY: SettingsItem[] = [
     get: () => getDevtoolsEnabled(),
     set: setDevtoolsEnabledWithSync,
     subscribe: subscribeDevtoolsChanges,
+  },
+  {
+    id: 'api-agent-tab-enabled',
+    label: 'API Agent Tab',
+    description: '???????? API Agent ????',
+    icon: Bot,
+    category: 'developer',
+    controlTestId: 'new-settings-api-agent-tab-switch',
+    type: 'boolean',
+    visible: devOnly,
+    get: () => getApiAgentTabEnabled(),
+    set: setApiAgentTabEnabled,
+    subscribe: subscribeApiAgentTabEnabledChanges,
   },
   ...FEATURE_TOGGLE_SETTINGS.map((setting) => ({
     id: setting.id,

--- a/src/ui/app/pages/AgentsPage.tsx
+++ b/src/ui/app/pages/AgentsPage.tsx
@@ -32,6 +32,10 @@ import {
   type RuntimeTargetMode,
 } from '@/config/runtime-target';
 import { resolveLocalServiceHost } from '@/config/local-service-host';
+import {
+  getApiAgentTabEnabled,
+  subscribeApiAgentTabEnabledChanges,
+} from '@/config/api-agent-tab-enabled';
 import { setPersistedEmbeddedRuntimeNetworkMode } from '@/config/runtime-open-mode';
 import {
   setPersistedRuntimeExternalAddress,
@@ -212,6 +216,7 @@ import { AddNodeSheet, AgentCreateSheet, RuntimeHostManagerSheet } from './agent
 import { RoutesTabView } from './agents/RoutesTabView';
 import { ListTabView, type NodeFilterType } from './agents/NodesTabView';
 import { SignalHistoryTabView } from './agents/SignalHistoryTabView';
+import { ApiAgentTabView } from './agents/ApiAgentTabView';
 import { PeerPairingDialog } from '@/ui/app/components/PeerPairingDialog';
 
 export {
@@ -851,9 +856,11 @@ function mergeSignalHistoryEvents(...eventGroups: SignalEvent[][]): SignalEvent[
 }
 
 function TabBar({
+  items,
   value,
   onChange,
 }: {
+  items: typeof VIEW_ITEMS;
   value: AgentHubViewMode;
   onChange: (value: AgentHubViewMode) => void;
 }) {
@@ -862,7 +869,7 @@ function TabBar({
       mode="buttons"
       activeId={value}
       onChange={onChange}
-      items={VIEW_ITEMS.map((item) => ({
+      items={items.map((item) => ({
         id: item.id,
         label: item.label,
         icon: item.icon,
@@ -876,11 +883,16 @@ function TabBar({
 export function AgentsPage() {
   const supportsInlineRightPanel = useIsDesktop(1024);
   const initialRuntimeTarget = getSelectedRuntimeTarget();
+  const initialApiAgentTabEnabled = getApiAgentTabEnabled();
   const initialTiledWorkbenchState = useMemo(() => readAgentsTiledWorkbenchPersistState(), []);
   const initialTiledLayoutRecord = initialTiledWorkbenchState.layouts[initialTiledWorkbenchState.activeLayoutId]
     ?? Object.values(initialTiledWorkbenchState.layouts)[0];
   const initialTiledState = useMemo(() => readAgentsTiledPersistState(), []);
-  const [viewMode, setViewMode] = useState<AgentHubViewMode>(() => readAgentsViewModePersistState());
+  const [apiAgentTabEnabled, setApiAgentTabEnabled] = useState(initialApiAgentTabEnabled);
+  const [viewMode, setViewMode] = useState<AgentHubViewMode>(() => {
+    const persisted = readAgentsViewModePersistState();
+    return persisted === 'api-agent' && !initialApiAgentTabEnabled ? 'topology' : persisted;
+  });
   const [nodesFilter, setNodesFilter] = useState<NodeFilterType>('all');
   const [topologyLayoutMode, setTopologyLayoutMode] = useState<TopologyLayoutMode>('manual');
   const [topologyLayoutStore, setTopologyLayoutStore] = useState<TopologyLayoutStore>(() => readTopologyLayoutStore());
@@ -2027,6 +2039,19 @@ export function AgentsPage() {
   const [ptySpawnTargetSlotId, setPtySpawnTargetSlotId] = useState<string | null>(null);
   const [ptySpawnTargetLayoutId, setPtySpawnTargetLayoutId] = useState<string | null>(null);
   const [peerPairingOpen, setPeerPairingOpen] = useState(false);
+
+  useEffect(() => subscribeApiAgentTabEnabledChanges(setApiAgentTabEnabled), []);
+
+  useEffect(() => {
+    if (!apiAgentTabEnabled && viewMode === 'api-agent') {
+      setViewMode('topology');
+    }
+  }, [apiAgentTabEnabled, viewMode]);
+
+  const visibleViewItems = useMemo(
+    () => (apiAgentTabEnabled ? VIEW_ITEMS : VIEW_ITEMS.filter((item) => item.id !== 'api-agent')),
+    [apiAgentTabEnabled],
+  );
 
   const openPtyTerminal = useCallback((
     ptyId: string,
@@ -6670,6 +6695,9 @@ export function AgentsPage() {
         />
       );
     }
+    if (viewMode === 'api-agent') {
+      return <ApiAgentTabView />;
+    }
     return (
       <TopologyView
         graph={signalGraph}
@@ -6756,6 +6784,7 @@ export function AgentsPage() {
     runtimeTargetModeValue,
     runtimeExternalAddressDraft,
     runtimeServiceStatus,
+    apiAgentTabEnabled,
     nodesFilter,
     dashboardSessions,
     sessionLoading,
@@ -6845,7 +6874,7 @@ export function AgentsPage() {
               </div>
             </div>
             {/* Tab Bar（桌面端内嵌到 header，移动端显示在 header 下方） */}
-            <TabBar value={viewMode} onChange={handleTabChange} />
+            <TabBar items={visibleViewItems} value={viewMode} onChange={handleTabChange} />
           </header>
         </>
       ) : null}

--- a/src/ui/app/pages/agents/ApiAgentTabView.tsx
+++ b/src/ui/app/pages/agents/ApiAgentTabView.tsx
@@ -1,0 +1,701 @@
+import { Bot, RefreshCw, Send, Sparkles, Wrench } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { listProviderProfiles, resolveProviderProfile } from '@/lib/agent-provider/provider-profile-storage';
+import { AgentSessionRtAdapter } from '@/lib/adapters/agent-session-rt-adapter';
+import type {
+  ApiAgentSessionRecord,
+  ApiAgentToolDefinition,
+  ApiAgentTurnItem,
+} from '@/lib/types/agent-session';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+
+const DEFAULT_SYSTEM_PROMPT = 'You are ExoMind API Agent tester.'; // API Agent 调试系统提示词
+const DEFAULT_TOOLS_JSON = JSON.stringify([], null, 2);
+const WEATHER_TOOL_JSON = JSON.stringify([
+  {
+    name: 'get_weather',
+    description: 'Read current weather snapshot',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        city: { type: 'string' },
+      },
+      required: ['city'],
+    },
+  },
+], null, 2);
+
+function formatJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+function buildNextHistory(
+  previousHistory: ApiAgentTurnItem[],
+  response: ApiAgentSessionRecord,
+): ApiAgentTurnItem[] {
+  return [
+    ...previousHistory,
+    {
+      role: 'assistant',
+      content: response.assistantTurn.content,
+      toolCalls: response.assistantTurn.toolCalls,
+    },
+  ];
+}
+
+function tryParseToolsJson(rawValue: string): ApiAgentToolDefinition[] {
+  const trimmed = rawValue.trim();
+  if (!trimmed) {
+    return [];
+  }
+  const parsed = JSON.parse(trimmed) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error('Tools JSON must be an array（Tools JSON 必须是数组）');
+  }
+  return parsed.map((item, index) => {
+    if (typeof item !== 'object' || item === null) {
+      throw new Error(`Tool #${index + 1} must be an object（工具定义必须是对象）`);
+    }
+    const record = item as Record<string, unknown>;
+    if (typeof record.name !== 'string' || !record.name.trim()) {
+      throw new Error(`Tool #${index + 1} name is required（工具名称不能为空）`);
+    }
+    if (typeof record.description !== 'string') {
+      throw new Error(`Tool #${index + 1} description is required（工具描述不能为空）`);
+    }
+    return {
+      name: record.name,
+      description: record.description,
+      inputSchema: record.inputSchema ?? {},
+    };
+  });
+}
+
+function resolveStatusTone(status: string | undefined): string {
+  if (status === 'completed') {
+    return 'bg-[#DCFCE7] text-[#166534] dark:bg-[#14532D] dark:text-[#86EFAC]';
+  }
+  if (status === 'needs_tool_calls') {
+    return 'bg-[#FEF3C7] text-[#B45309] dark:bg-[#78350F] dark:text-[#FCD34D]';
+  }
+  return 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]';
+}
+
+function SectionCard({
+  title,
+  description,
+  action,
+  children,
+}: {
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-3xl border border-[#E7E5E4] bg-white p-5 shadow-sm dark:border-[#292524] dark:bg-[#1C1917]">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-base font-semibold text-[#1C1917] dark:text-[#FAFAF9]">{title}</h3>
+          {description ? (
+            <p className="mt-1 text-sm text-[#78716C] dark:text-[#A8A29E]">{description}</p>
+          ) : null}
+        </div>
+        {action}
+      </div>
+      <div className="mt-4 space-y-4">{children}</div>
+    </section>
+  );
+}
+
+function DataMetric({
+  label,
+  value,
+  accent = 'default',
+}: {
+  label: string;
+  value: string;
+  accent?: 'default' | 'brand' | 'warning';
+}) {
+  const tone = accent === 'brand'
+    ? 'bg-[#FCE7D8] text-[#9A3412] dark:bg-[#7C2D12]/50 dark:text-[#FDBA74]'
+    : accent === 'warning'
+      ? 'bg-[#FEF3C7] text-[#92400E] dark:bg-[#78350F] dark:text-[#FCD34D]'
+      : 'bg-[#F5F0ED] text-[#44403C] dark:bg-[#120F0D] dark:text-[#D6D3D1]';
+  return (
+    <div className="rounded-2xl border border-[#F0ECE8] bg-[#FCFBFA] p-3 dark:border-[#292524] dark:bg-[#120F0D]">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[#A8A29E]">{label}</div>
+      <div className={`mt-2 inline-flex rounded-full px-2.5 py-1 text-sm font-medium ${tone}`}>{value}</div>
+    </div>
+  );
+}
+
+export function ApiAgentTabView() {
+  const adapter = useMemo(() => new AgentSessionRtAdapter(), []);
+  const providerProfiles = useMemo(
+    () => [...listProviderProfiles()].sort((left, right) => {
+      const leftTime = left.lastUsedAt ?? left.updatedAt;
+      const rightTime = right.lastUsedAt ?? right.updatedAt;
+      return rightTime.localeCompare(leftTime);
+    }),
+    [],
+  );
+  const [selectedProfileId, setSelectedProfileId] = useState(providerProfiles[0]?.profileId ?? '');
+  const [systemPrompt, setSystemPrompt] = useState(DEFAULT_SYSTEM_PROMPT);
+  const [newUserMessage, setNewUserMessage] = useState('');
+  const [scopeKey, setScopeKey] = useState('');
+  const [toolsJson, setToolsJson] = useState(DEFAULT_TOOLS_JSON);
+  const [recentEventsPresetEnabled, setRecentEventsPresetEnabled] = useState(false);
+  const [proposalToolsPresetEnabled, setProposalToolsPresetEnabled] = useState(false);
+  const [historyDraft, setHistoryDraft] = useState<ApiAgentTurnItem[]>([]);
+  const [sessionLookupId, setSessionLookupId] = useState('');
+  const [toolResultDrafts, setToolResultDrafts] = useState<Record<string, string>>({});
+  const [currentRecord, setCurrentRecord] = useState<ApiAgentSessionRecord | null>(null);
+  const [lastRequestJson, setLastRequestJson] = useState('');
+  const [lastResponseJson, setLastResponseJson] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const selectedProfile = selectedProfileId ? resolveProviderProfile(selectedProfileId) : null;
+  const presets = [
+    ...(recentEventsPresetEnabled ? ['recent_events'] : []),
+    ...(proposalToolsPresetEnabled ? ['proposal_tools'] : []),
+  ];
+  const toolPreview = useMemo(() => {
+    try {
+      return tryParseToolsJson(toolsJson);
+    } catch {
+      return null;
+    }
+  }, [toolsJson]);
+  const pendingToolCalls = currentRecord?.assistantTurn.toolCalls ?? [];
+  const missingPresetScopeKey = recentEventsPresetEnabled && !scopeKey.trim();
+
+  const applyRecord = (
+    record: ApiAgentSessionRecord,
+    nextHistory: ApiAgentTurnItem[],
+    requestPayload: Record<string, unknown>,
+  ) => {
+    setCurrentRecord(record);
+    setHistoryDraft(nextHistory);
+    setSessionLookupId(record.sessionId);
+    setLastRequestJson(formatJson(requestPayload));
+    setLastResponseJson(formatJson(record));
+    setToolResultDrafts(
+      Object.fromEntries(
+        record.assistantTurn.toolCalls.map((toolCall) => [toolCall.id, '']),
+      ),
+    );
+  };
+
+  const submitTurn = async () => {
+    if (missingPresetScopeKey) {
+      setErrorMessage('recent_events 需要 Scope Key（启用 recent_events 时请先填写作用域键）');
+      return;
+    }
+    setErrorMessage('');
+    setIsSubmitting(true);
+    try {
+      const tools = tryParseToolsJson(toolsJson);
+      const requestPayload: Record<string, unknown> = {
+        ...(selectedProfile ? { providerProfile: selectedProfile } : {}),
+        systemPrompt,
+        tools,
+        presets,
+        scopeKey,
+        history: historyDraft,
+        newUserMessage,
+      };
+      const response = await adapter.runSession({
+        providerProfile: selectedProfile,
+        systemPrompt,
+        tools,
+        presets,
+        scopeKey,
+        history: historyDraft,
+        newUserMessage,
+      });
+      const nextHistory = buildNextHistory(
+        [
+          ...historyDraft,
+          ...(newUserMessage.trim()
+            ? [{ role: 'user', content: newUserMessage.trim() } satisfies ApiAgentTurnItem]
+            : []),
+        ],
+        response,
+      );
+      applyRecord(response, nextHistory, requestPayload);
+      setNewUserMessage('');
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const continueWithToolResults = async () => {
+    if (!pendingToolCalls.length) {
+      setErrorMessage('当前没有待续跑的 tool calls（没有待执行工具调用）');
+      return;
+    }
+    if (missingPresetScopeKey) {
+      setErrorMessage('recent_events 需要 Scope Key（启用 recent_events 时请先填写作用域键）');
+      return;
+    }
+
+    setErrorMessage('');
+    setIsSubmitting(true);
+    try {
+      const tools = tryParseToolsJson(toolsJson);
+      const toolResults = pendingToolCalls.map((toolCall) => {
+        const content = toolResultDrafts[toolCall.id]?.trim() ?? '';
+        if (!content) {
+          throw new Error(`Tool ${toolCall.name} result is required（工具结果不能为空）`);
+        }
+        return {
+          role: 'tool' as const,
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+          content,
+        };
+      });
+
+      const nextRequestHistory = [...historyDraft, ...toolResults];
+      const requestPayload: Record<string, unknown> = {
+        ...(selectedProfile ? { providerProfile: selectedProfile } : {}),
+        systemPrompt,
+        tools,
+        presets,
+        scopeKey,
+        history: nextRequestHistory,
+      };
+      const response = await adapter.runSession({
+        providerProfile: selectedProfile,
+        systemPrompt,
+        tools,
+        presets,
+        scopeKey,
+        history: nextRequestHistory,
+      });
+      const nextHistory = buildNextHistory(nextRequestHistory, response);
+      applyRecord(response, nextHistory, requestPayload);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const loadSession = async () => {
+    if (!sessionLookupId.trim()) {
+      setErrorMessage('请输入 sessionId（会话 ID）');
+      return;
+    }
+    setErrorMessage('');
+    setIsSubmitting(true);
+    try {
+      const record = await adapter.getSession(sessionLookupId.trim());
+      if (!record) {
+        setErrorMessage('未找到对应会话（session 不存在）');
+        return;
+      }
+      setCurrentRecord(record);
+      setLastResponseJson(formatJson(record));
+      setToolResultDrafts(
+        Object.fromEntries(
+          record.assistantTurn.toolCalls.map((toolCall) => [toolCall.id, '']),
+        ),
+      );
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const resetDraft = () => {
+    setHistoryDraft([]);
+    setCurrentRecord(null);
+    setToolResultDrafts({});
+    setNewUserMessage('');
+    setSessionLookupId('');
+    setLastRequestJson('');
+    setLastResponseJson('');
+    setErrorMessage('');
+  };
+
+  return (
+    <div className="space-y-4 pb-2" data-testid="api-agent-tab-view">
+      <section className="overflow-hidden rounded-[28px] border border-[#E7E5E4] bg-white shadow-sm dark:border-[#292524] dark:bg-[#1C1917]">
+        <div className="border-b border-[#F0ECE8] bg-[linear-gradient(135deg,#FCFBFA_0%,#F5F0ED_48%,#FCE7D8_100%)] px-5 py-5 dark:border-[#292524] dark:bg-[linear-gradient(135deg,rgba(28,25,23,1)_0%,rgba(24,18,15,1)_60%,rgba(124,45,18,0.35)_100%)]">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div className="max-w-2xl">
+              <div className="inline-flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-3 py-1 text-xs font-medium text-[#9A3412] shadow-sm backdrop-blur dark:border-[#3F2D24] dark:bg-[#120F0D]/80 dark:text-[#FDBA74]">
+                <Sparkles size={14} />
+                API Agent Broker Console
+              </div>
+              <h2 className="mt-3 text-xl font-semibold text-[#1C1917] dark:text-[#FAFAF9]">
+                在网络页里直接验证 `/agent-sessions`
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-[#57534E] dark:text-[#D6D3D1]">
+                这不是另一套页面系统，而是网络页顶部 `API Agent` tab 的专用实验面板。
+                现在可以直接验证 provider profile、tool preset、history 续跑和持久化 session 读取。
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <Badge variant="secondary">Issue #823</Badge>
+                <Badge variant="outline">RT Broker</Badge>
+                <Badge className={resolveStatusTone(currentRecord?.status)}>
+                  {currentRecord?.status ?? 'idle'}
+                </Badge>
+              </div>
+            </div>
+
+            <div className="grid min-w-[260px] gap-3 sm:grid-cols-3 lg:w-[360px] lg:grid-cols-1 xl:grid-cols-3">
+              <DataMetric
+                label="Profile"
+                value={selectedProfile?.name ?? 'RT default'}
+                accent="brand"
+              />
+              <DataMetric
+                label="History"
+                value={`${historyDraft.length} turns`}
+              />
+              <DataMetric
+                label="Pending"
+                value={`${pendingToolCalls.length} tools`}
+                accent={pendingToolCalls.length > 0 ? 'warning' : 'default'}
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {errorMessage ? (
+        <div
+          data-testid="api-agent-error-banner"
+          className="rounded-2xl border border-[#FECACA] bg-[#FEF2F2] px-4 py-3 text-sm text-[#B91C1C] dark:border-[#7F1D1D] dark:bg-[#3F0A0A] dark:text-[#FCA5A5]"
+        >
+          {errorMessage}
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
+        <div className="space-y-4">
+          <SectionCard
+            title="请求编排"
+            description="统一配置 Provider、Prompt、Preset 和 Tool Definitions。首版继续保持 JSON 透明度，但把层级整理成正式页面结构。"
+            action={<Bot size={16} className="text-[#78716C] dark:text-[#A8A29E]" />}
+          >
+            <div className="grid gap-4 lg:grid-cols-2">
+              <label className="space-y-2">
+                <span className="block text-xs font-medium text-[#57534E] dark:text-[#D6D3D1]">
+                  Provider Profile（供应商档案）
+                </span>
+                <select
+                  className="flex h-11 w-full rounded-2xl border border-[#E7E5E4] bg-[#FCFBFA] px-3 text-sm text-[#1C1917] outline-none transition-colors focus:border-[#C75B3A] dark:border-[#292524] dark:bg-[#120F0D] dark:text-[#FAFAF9]"
+                  value={selectedProfileId}
+                  onChange={(event) => setSelectedProfileId(event.target.value)}
+                >
+                  <option value="">RT 默认配置（Runtime default）</option>
+                  {providerProfiles.map((profile) => (
+                    <option key={profile.profileId} value={profile.profileId}>
+                      {profile.name} / {profile.provider} / {profile.model}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="space-y-2">
+                <span className="block text-xs font-medium text-[#57534E] dark:text-[#D6D3D1]">
+                  Scope Key（作用域键）
+                </span>
+                <Input
+                  value={scopeKey}
+                  onChange={(event) => setScopeKey(event.target.value)}
+                  placeholder="例如：issue-823 / profile-alpha"
+                  className="rounded-2xl"
+                />
+              </label>
+            </div>
+
+            <label className="space-y-2">
+              <span className="block text-xs font-medium text-[#57534E] dark:text-[#D6D3D1]">
+                System Prompt（系统提示词）
+              </span>
+              <Textarea
+                value={systemPrompt}
+                onChange={(event) => setSystemPrompt(event.target.value)}
+                rows={3}
+                className="rounded-2xl"
+                placeholder="You are ExoMind API Agent tester."
+              />
+            </label>
+
+            <label className="space-y-2">
+              <span className="block text-xs font-medium text-[#57534E] dark:text-[#D6D3D1]">
+                New User Message（新的用户消息）
+              </span>
+              <Textarea
+                value={newUserMessage}
+                onChange={(event) => setNewUserMessage(event.target.value)}
+                rows={5}
+                className="rounded-2xl"
+                placeholder="输入本轮用户消息，点击“发送首轮 / 继续”"
+              />
+            </label>
+
+            <div className="rounded-2xl border border-[#F0ECE8] bg-[#FCFBFA] p-4 dark:border-[#292524] dark:bg-[#120F0D]">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-xs font-medium text-[#57534E] dark:text-[#D6D3D1]">
+                  Presets（预置工具组）
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setRecentEventsPresetEnabled((prev) => !prev)}
+                  className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                    recentEventsPresetEnabled
+                      ? 'bg-[#C75B3A] text-white'
+                      : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'
+                  }`}
+                >
+                  recent_events
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setProposalToolsPresetEnabled((prev) => !prev)}
+                  className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                    proposalToolsPresetEnabled
+                      ? 'bg-[#0D9488] text-white'
+                      : 'bg-[#F5F0ED] text-[#78716C] dark:bg-[#292524] dark:text-[#A8A29E]'
+                  }`}
+                >
+                  proposal_tools
+                </button>
+              </div>
+              <p className="mt-2 text-xs leading-5 text-[#A8A29E]">
+                当前会附带 {presets.length} 个 preset。第一版先固定聚焦 `recent_events / proposal_tools`。
+                {missingPresetScopeKey ? ' recent_events 已启用，发送前请先填写 Scope Key。' : ''}
+              </p>
+            </div>
+
+            <div className="rounded-2xl border border-[#F0ECE8] bg-[#FCFBFA] p-4 dark:border-[#292524] dark:bg-[#120F0D]">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <span className="text-xs font-medium text-[#57534E] dark:text-[#D6D3D1]">
+                  Tools JSON（工具定义 JSON）
+                </span>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setToolsJson(DEFAULT_TOOLS_JSON)}
+                    className="rounded-full bg-[#F5F0ED] px-3 py-1 text-[11px] font-medium text-[#57534E] dark:bg-[#292524] dark:text-[#D6D3D1]"
+                  >
+                    清空
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setToolsJson(WEATHER_TOOL_JSON)}
+                    className="rounded-full bg-[#DBEAFE] px-3 py-1 text-[11px] font-medium text-[#1D4ED8] dark:bg-[#1E3A8A]/40 dark:text-[#93C5FD]"
+                  >
+                    天气示例
+                  </button>
+                </div>
+              </div>
+              <Textarea
+                value={toolsJson}
+                onChange={(event) => setToolsJson(event.target.value)}
+                rows={10}
+                className="mt-3 rounded-2xl font-mono text-xs"
+                placeholder='[{"name":"get_weather","description":"Weather lookup","inputSchema":{"type":"object"}}]'
+              />
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Badge variant="outline">
+                  parsed tools: {toolPreview ? toolPreview.length : 'invalid'}
+                </Badge>
+                {toolPreview?.slice(0, 3).map((tool) => (
+                  <Badge key={tool.name} variant="secondary">{tool.name}</Badge>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                data-testid="api-agent-run-button"
+                onClick={() => {
+                  void submitTurn();
+                }}
+                disabled={isSubmitting || missingPresetScopeKey}
+                className="rounded-full bg-[#C75B3A] hover:bg-[#B45309]"
+              >
+                <Send className="mr-1 h-4 w-4" />
+                发送首轮 / 继续
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                data-testid="api-agent-reset-button"
+                onClick={resetDraft}
+                disabled={isSubmitting}
+                className="rounded-full"
+              >
+                重置草稿
+              </Button>
+            </div>
+          </SectionCard>
+
+          <SectionCard
+            title="轮次结果"
+            description="把 broker 返回值拆成状态、正文、tool calls 和原始响应，保持可读又可追溯。"
+            action={currentRecord ? <Badge className={resolveStatusTone(currentRecord.status)}>{currentRecord.status}</Badge> : null}
+          >
+            {currentRecord ? (
+              <>
+                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                  <DataMetric label="sessionId" value={currentRecord.sessionId} accent="brand" />
+                  <DataMetric label="provider" value={currentRecord.provider} />
+                  <DataMetric label="model" value={currentRecord.model} />
+                </div>
+
+                <div className="rounded-2xl border border-[#F0ECE8] bg-[#FCFBFA] p-4 dark:border-[#292524] dark:bg-[#120F0D]">
+                  <div className="text-xs font-medium text-[#57534E] dark:text-[#D6D3D1]">
+                    assistantTurn.content
+                  </div>
+                  <pre className="mt-3 whitespace-pre-wrap break-words text-sm leading-6 text-[#1C1917] dark:text-[#FAFAF9]">
+                    {currentRecord.assistantTurn.content || '(empty)'}
+                  </pre>
+                </div>
+
+                <div className="rounded-2xl border border-[#F0ECE8] bg-[#FCFBFA] p-4 dark:border-[#292524] dark:bg-[#120F0D]">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="text-xs font-medium text-[#57534E] dark:text-[#D6D3D1]">toolCalls</div>
+                    <Badge variant="outline">{pendingToolCalls.length} pending</Badge>
+                  </div>
+                  <pre className="mt-3 overflow-x-auto rounded-2xl bg-[#FAF7F5] p-3 text-[11px] text-[#57534E] dark:bg-[#1C1917] dark:text-[#D6D3D1]">
+                    {formatJson(currentRecord.assistantTurn.toolCalls)}
+                  </pre>
+                </div>
+              </>
+            ) : (
+              <div className="rounded-2xl border border-dashed border-[#D6D3D1] bg-[#FCFBFA] px-4 py-8 text-center text-sm text-[#78716C] dark:border-[#44403C] dark:bg-[#120F0D] dark:text-[#A8A29E]">
+                还没有返回结果。先发一轮请求，再在这里看 `sessionId / status / toolCalls`。
+              </div>
+            )}
+          </SectionCard>
+        </div>
+
+        <div className="space-y-4">
+          <SectionCard
+            title="工具续跑"
+            description="只在 `needs_tool_calls` 时出现待执行工具。填入 tool result 后继续调用 broker。"
+            action={<Wrench size={16} className="text-[#78716C] dark:text-[#A8A29E]" />}
+          >
+            {pendingToolCalls.length ? (
+              <>
+                {pendingToolCalls.map((toolCall) => (
+                  <label
+                    key={toolCall.id}
+                    className="block rounded-2xl border border-[#F0ECE8] bg-[#FCFBFA] p-4 dark:border-[#292524] dark:bg-[#120F0D]"
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant="secondary">{toolCall.name}</Badge>
+                      <span className="font-mono text-[11px] text-[#A8A29E]">{toolCall.id}</span>
+                    </div>
+                    <pre className="mt-3 overflow-x-auto rounded-2xl bg-[#FAF7F5] p-3 text-[11px] text-[#57534E] dark:bg-[#1C1917] dark:text-[#D6D3D1]">
+                      {formatJson(toolCall.input)}
+                    </pre>
+                    <Textarea
+                      value={toolResultDrafts[toolCall.id] ?? ''}
+                      onChange={(event) => setToolResultDrafts((prev) => ({
+                        ...prev,
+                        [toolCall.id]: event.target.value,
+                      }))}
+                      rows={4}
+                      className="mt-3 rounded-2xl"
+                      placeholder="输入该工具的结果文本，续跑时会转成 tool history。"
+                    />
+                  </label>
+                ))}
+
+                <Button
+                  type="button"
+                  variant="secondary"
+                  data-testid="api-agent-continue-tools-button"
+                  onClick={() => {
+                    void continueWithToolResults();
+                  }}
+                  disabled={isSubmitting || missingPresetScopeKey}
+                  className="rounded-full"
+                >
+                  继续执行 Tool Results
+                </Button>
+              </>
+            ) : (
+              <div className="rounded-2xl border border-dashed border-[#D6D3D1] bg-[#FCFBFA] px-4 py-6 text-sm text-[#78716C] dark:border-[#44403C] dark:bg-[#120F0D] dark:text-[#A8A29E]">
+                当前没有待填的 tool calls。
+              </div>
+            )}
+          </SectionCard>
+
+          <SectionCard
+            title="会话读取"
+            description="从 `/agent-sessions/:id` 回读持久化记录，验证前端与 RT 落库结果一致。"
+            action={<RefreshCw size={16} className="text-[#78716C] dark:text-[#A8A29E]" />}
+          >
+            <div className="flex gap-2">
+              <Input
+                value={sessionLookupId}
+                onChange={(event) => setSessionLookupId(event.target.value)}
+                placeholder="输入 sessionId"
+                className="rounded-2xl"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                data-testid="api-agent-load-session-button"
+                onClick={() => {
+                  void loadSession();
+                }}
+                disabled={isSubmitting}
+                className="rounded-full"
+              >
+                <RefreshCw className="mr-1 h-4 w-4" />
+                读取
+              </Button>
+            </div>
+          </SectionCard>
+
+          <SectionCard
+            title="调试证据"
+            description="把前端当前拼装的 history、最后一次请求和响应都留在页面内，方便对照排查。"
+          >
+            <div className="space-y-3">
+              <div className="rounded-2xl border border-[#F0ECE8] bg-[#FCFBFA] p-4 dark:border-[#292524] dark:bg-[#120F0D]">
+                <div className="text-xs font-medium text-[#57534E] dark:text-[#D6D3D1]">history draft</div>
+                <pre className="mt-3 overflow-x-auto rounded-2xl bg-[#FAF7F5] p-3 text-[11px] text-[#57534E] dark:bg-[#1C1917] dark:text-[#D6D3D1]">
+                  {formatJson(historyDraft)}
+                </pre>
+              </div>
+
+              <div className="rounded-2xl border border-[#F0ECE8] bg-[#FCFBFA] p-4 dark:border-[#292524] dark:bg-[#120F0D]">
+                <div className="text-xs font-medium text-[#57534E] dark:text-[#D6D3D1]">last request</div>
+                <pre className="mt-3 overflow-x-auto rounded-2xl bg-[#FAF7F5] p-3 text-[11px] text-[#57534E] dark:bg-[#1C1917] dark:text-[#D6D3D1]">
+                  {lastRequestJson || '(empty)'}
+                </pre>
+              </div>
+
+              <div className="rounded-2xl border border-[#F0ECE8] bg-[#FCFBFA] p-4 dark:border-[#292524] dark:bg-[#120F0D]">
+                <div className="text-xs font-medium text-[#57534E] dark:text-[#D6D3D1]">last response</div>
+                <pre className="mt-3 overflow-x-auto rounded-2xl bg-[#FAF7F5] p-3 text-[11px] text-[#57534E] dark:bg-[#1C1917] dark:text-[#D6D3D1]">
+                  {lastResponseJson || '(empty)'}
+                </pre>
+              </div>
+            </div>
+          </SectionCard>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/app/pages/agents/agents-utils.ts
+++ b/src/ui/app/pages/agents/agents-utils.ts
@@ -50,6 +50,7 @@ export const VIEW_ITEMS: Array<{ id: AgentHubViewMode; icon: LucideIcon; label: 
   { id: 'history', icon: AlarmClock, label: '信号历史' },
   { id: 'routes', icon: List, label: '路由' },
   { id: 'device', icon: Monitor, label: '设备' },
+  { id: 'api-agent', icon: Webhook, label: 'API Agent' },
 ];
 
 export type AddNodeOption = {

--- a/tests/unit/agent-hub/agent-types-contract.issue204.test.ts
+++ b/tests/unit/agent-hub/agent-types-contract.issue204.test.ts
@@ -93,7 +93,7 @@ class FakeAgentPort implements IAgentPort {
 
 describe('agent hub type contracts issue-204（Agent Hub 类型契约）', () => {
   it('exposes runtime constants for view mode and port contract（暴露运行时常量契约）', () => {
-    expect(AGENT_HUB_VIEW_MODES).toEqual(['topology', 'sessions', 'tiled', 'list', 'history', 'routes', 'device']);
+    expect(AGENT_HUB_VIEW_MODES).toEqual(['topology', 'sessions', 'tiled', 'list', 'history', 'routes', 'device', 'api-agent']);
     expect(AGENT_PORT_KEYWORDS).toContain('streamConversation');
   });
 

--- a/tests/unit/components/settings/DeveloperSection.test.tsx
+++ b/tests/unit/components/settings/DeveloperSection.test.tsx
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import './setup-settings-mocks.tsx';
 import { getDeveloperModeEnabled } from '@/config/developer-mode';
+import { setApiAgentTabEnabled } from '@/config/api-agent-tab-enabled';
 import { setDevtoolsEnabled } from '@/config/devtools-mode';
 import { setCommandPaletteEnabled } from '@/config/command-palette-enabled';
 import { setMePageEnabled } from '@/config/me-page-enabled';
@@ -23,6 +24,7 @@ describe('SettingsPage - Developer Section (developerMode=true)', () => {
     render(<SettingsPage />);
     expect(screen.getByText('Me 页面')).toBeInTheDocument();
     expect(screen.getByText('网络页面')).toBeInTheDocument();
+    expect(screen.getByText('API Agent Tab')).toBeInTheDocument();
     expect(screen.getByText('请求箱（任务域）')).toBeInTheDocument();
     expect(screen.getByText('桌面端适配')).toBeInTheDocument();
     expect(screen.getByText('命令面板')).toBeInTheDocument();
@@ -52,6 +54,14 @@ describe('SettingsPage - Developer Section (developerMode=true)', () => {
     fireEvent.click(toggle);
 
     expect(vi.mocked(setCommandPaletteEnabled)).toHaveBeenCalledWith(true);
+  });
+
+  it('updates api agent tab state inline in developer section（在开发者分组内联更新 API Agent Tab 开关）', () => {
+    render(<SettingsPage />);
+    const toggle = screen.getByTestId('new-settings-api-agent-tab-switch');
+    fireEvent.click(toggle);
+
+    expect(vi.mocked(setApiAgentTabEnabled)).toHaveBeenCalledWith(true);
   });
 
   it('updates me page state inline in developer section（在开发者分组内联更新 Me 页面开关）', () => {

--- a/tests/unit/components/settings/setup-settings-mocks.tsx
+++ b/tests/unit/components/settings/setup-settings-mocks.tsx
@@ -94,6 +94,7 @@ export const settingsPageServiceMocks = {
 
 export const settingsPagePreferenceState = {
   developerMode: false,
+  apiAgentTabEnabled: false,
   agentPageEnabled: false,
   mePageEnabled: false,
   proposalInboxEnabled: true,
@@ -195,6 +196,12 @@ vi.mock('@/config/agent-page-enabled', () => ({
   getAgentPageEnabled: vi.fn(() => settingsPagePreferenceState.agentPageEnabled),
   setAgentPageEnabled: vi.fn(),
   subscribeAgentPageEnabledChanges: vi.fn(() => () => {}),
+}));
+
+vi.mock('@/config/api-agent-tab-enabled', () => ({
+  getApiAgentTabEnabled: vi.fn(() => settingsPagePreferenceState.apiAgentTabEnabled),
+  setApiAgentTabEnabled: vi.fn(),
+  subscribeApiAgentTabEnabledChanges: vi.fn(() => () => {}),
 }));
 
 vi.mock('@/config/me-page-enabled', () => ({

--- a/tests/unit/lib/adapters/agent-session-rt-adapter.test.ts
+++ b/tests/unit/lib/adapters/agent-session-rt-adapter.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AgentSessionRtAdapter } from '@/lib/adapters/agent-session-rt-adapter';
+
+describe('agent session rt adapter（API Agent 会话 RT 适配器）', () => {
+  it('posts broker session payload and parses result（提交 broker 会话并解析结果）', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        sessionId: 'session-api-1',
+        triggerSource: 'http-request',
+        provider: 'openai',
+        model: 'gpt-5',
+        prompt: 'You are helpful.',
+        content: '',
+        assistantTurn: {
+          content: '',
+          toolCalls: [
+            {
+              id: 'tool-1',
+              name: 'get_recent_events',
+              input: { limit: 5 },
+            },
+          ],
+        },
+        toolCalls: [
+          {
+            toolName: 'get_recent_events',
+            input: { limit: 5 },
+          },
+        ],
+        status: 'needs_tool_calls',
+        createdAt: '2026-04-08T10:00:00.000Z',
+        completedAt: '2026-04-08T10:00:01.000Z',
+      }),
+    }));
+
+    const adapter = new AgentSessionRtAdapter({
+      fetchImpl,
+      resolveTarget: () => ({
+        mode: 'external',
+        host: '127.0.0.1',
+        port: 9124,
+        authToken: 'rt-token',
+      }),
+    });
+
+    const result = await adapter.runSession({
+      providerProfile: {
+        profileId: 'registry-openai-main',
+        name: 'OpenAI Main',
+        provider: 'openai',
+        model: 'gpt-5',
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-test',
+        createdAt: '2026-04-08T10:00:00.000Z',
+        updatedAt: '2026-04-08T10:00:00.000Z',
+      },
+      systemPrompt: 'You are helpful.',
+      presets: ['recent_events'],
+      newUserMessage: '今天我做了什么？',
+    });
+
+    expect(result.sessionId).toBe('session-api-1');
+    expect(result.status).toBe('needs_tool_calls');
+    expect(result.assistantTurn.toolCalls[0]?.name).toBe('get_recent_events');
+
+    const [url, requestInit] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/agent-sessions');
+    expect(new Headers(requestInit.headers).get('Authorization')).toBe('Bearer rt-token');
+    expect(JSON.parse(String(requestInit.body))).toEqual(expect.objectContaining({
+      systemPrompt: 'You are helpful.',
+      presets: ['recent_events'],
+      newUserMessage: '今天我做了什么？',
+      providerProfile: expect.objectContaining({
+        provider: 'openai',
+        model: 'gpt-5',
+      }),
+    }));
+  });
+});

--- a/tests/unit/settings/settings-registry-coverage.test.ts
+++ b/tests/unit/settings/settings-registry-coverage.test.ts
@@ -80,6 +80,7 @@ const AUDITED_SETTINGS_IDS = [
   'developer-mode',
   'use-mock-data',
   'devtools',
+  'api-agent-tab-enabled',
   'me-page-enabled',
   'agent-page-enabled',
   'goals-page-enabled',
@@ -132,6 +133,7 @@ const BOOLEAN_IDS = [
   'developer-mode',
   'use-mock-data',
   'devtools',
+  'api-agent-tab-enabled',
   'me-page-enabled',
   'agent-page-enabled',
   'goals-page-enabled',
@@ -201,6 +203,7 @@ const TAURI_DEV_ONLY_IDS = [
 const DEV_ONLY_IDS = [
   'use-mock-data',
   'devtools',
+  'api-agent-tab-enabled',
   'me-page-enabled',
   'agent-page-enabled',
   'goals-page-enabled',

--- a/tests/unit/ui/agent-hub/agents-page.api-agent-tab.test.tsx
+++ b/tests/unit/ui/agent-hub/agents-page.api-agent-tab.test.tsx
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { AGENT_HUB_MOCK_FIXTURE } from '@/lib/adapters/mock/fixtures/agent-hub';
+import { AgentsPage } from '@/ui/app/pages/AgentsPage';
+
+const serviceMocks = vi.hoisted(() => ({
+  getTopology: vi.fn(),
+  getDeviceView: vi.fn(),
+}));
+
+const runtimeManagerMocks = vi.hoisted(() => ({
+  refreshSnapshot: vi.fn(),
+}));
+
+const runtimeControlMocks = vi.hoisted(() => ({
+  getStatus: vi.fn(),
+}));
+
+const apiAgentTabFlagState = vi.hoisted(() => ({
+  enabled: false,
+}));
+
+vi.mock('@/config/api-agent-tab-enabled', () => ({
+  getApiAgentTabEnabled: vi.fn(() => apiAgentTabFlagState.enabled),
+  subscribeApiAgentTabEnabledChanges: vi.fn(() => () => {}),
+}));
+
+vi.mock('@xyflow/react', () => ({
+  ReactFlow: () => <div data-testid="mock-react-flow" />,
+  Background: () => <div data-testid="mock-react-flow-background" />,
+  Controls: () => <div data-testid="mock-react-flow-controls" />,
+  Handle: () => null,
+  Position: { Left: 'left', Right: 'right' },
+  useNodesState: <T,>(initialNodes: T[]) => [initialNodes, vi.fn(), vi.fn()] as const,
+  MarkerType: { ArrowClosed: 'arrowclosed' },
+}));
+
+vi.mock('@/lib/services', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/services')>();
+  return {
+    ...actual,
+    getAgentHubService: () => ({
+      getTopology: serviceMocks.getTopology,
+      getDeviceView: serviceMocks.getDeviceView,
+    }),
+  };
+});
+
+vi.mock('@/services/runtime-manager', () => ({
+  getRuntimeManager: () => runtimeManagerMocks,
+  findPreferredRuntimeHostForAgent: vi.fn(() => null),
+  shouldAutoPollRuntimeHost: vi.fn(() => true),
+}));
+
+vi.mock('@/lib/services/runtime-control.service', () => ({
+  getRuntimeControlService: () => runtimeControlMocks,
+}));
+
+vi.mock('@/ui/app/pages/agents/ApiAgentTabView', () => ({
+  ApiAgentTabView: () => <div data-testid="mock-api-agent-tab-view">API Agent View</div>,
+}));
+
+describe('agents page api agent tab（网络页 API Agent 页签）', () => {
+  beforeEach(() => {
+    apiAgentTabFlagState.enabled = false;
+    serviceMocks.getTopology.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.topology);
+    serviceMocks.getDeviceView.mockResolvedValue(AGENT_HUB_MOCK_FIXTURE.deviceGroups);
+    runtimeControlMocks.getStatus.mockResolvedValue({
+      running: false,
+      host: '127.0.0.1',
+      port: 1949,
+    });
+    runtimeManagerMocks.refreshSnapshot.mockResolvedValue({
+      updatedAt: '2026-04-08T10:00:00.000Z',
+      agents: [],
+      hosts: [],
+    });
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => [],
+    } as Response)));
+  });
+
+  it('hides the API Agent tab when the developer flag is off（开关关闭时隐藏 API Agent 页签）', async () => {
+    render(<AgentsPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-hub-page')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('tab', { name: 'API Agent' })).not.toBeInTheDocument();
+  });
+
+  it('shows the API Agent tab and opens the dedicated view when the flag is on（开关开启时显示 API Agent 页签并进入独立页面）', async () => {
+    apiAgentTabFlagState.enabled = true;
+
+    render(<AgentsPage />);
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'API Agent' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'API Agent' }));
+
+    expect(await screen.findByTestId('mock-api-agent-tab-view')).toBeInTheDocument();
+    expect(screen.getByText('API Agent View')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/ui/agent-hub/api-agent-tab-view.test.tsx
+++ b/tests/unit/ui/agent-hub/api-agent-tab-view.test.tsx
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ApiAgentTabView } from '@/ui/app/pages/agents/ApiAgentTabView';
+
+const providerStorageMocks = vi.hoisted(() => ({
+  listProviderProfiles: vi.fn(),
+  resolveProviderProfile: vi.fn(),
+}));
+
+const adapterMocks = vi.hoisted(() => ({
+  runSession: vi.fn(),
+  getSession: vi.fn(),
+}));
+
+vi.mock('@/lib/agent-provider/provider-profile-storage', () => ({
+  listProviderProfiles: providerStorageMocks.listProviderProfiles,
+  resolveProviderProfile: providerStorageMocks.resolveProviderProfile,
+}));
+
+vi.mock('@/lib/adapters/agent-session-rt-adapter', () => ({
+  AgentSessionRtAdapter: class {
+    runSession = adapterMocks.runSession;
+    getSession = adapterMocks.getSession;
+  },
+}));
+
+describe('api agent tab view（API Agent 调试页）', () => {
+  beforeEach(() => {
+    providerStorageMocks.listProviderProfiles.mockReturnValue([
+      {
+        profileId: 'registry-openai-main',
+        name: 'OpenAI Main',
+        provider: 'openai',
+        model: 'gpt-5',
+        baseUrl: 'https://api.openai.com/v1',
+        createdAt: '2026-04-08T10:00:00.000Z',
+        updatedAt: '2026-04-08T10:00:00.000Z',
+        lastUsedAt: '2026-04-08T10:00:00.000Z',
+      },
+    ]);
+    providerStorageMocks.resolveProviderProfile.mockReturnValue({
+      profileId: 'registry-openai-main',
+      name: 'OpenAI Main',
+      provider: 'openai',
+      model: 'gpt-5',
+      baseUrl: 'https://api.openai.com/v1',
+      apiKey: 'sk-test',
+      createdAt: '2026-04-08T10:00:00.000Z',
+      updatedAt: '2026-04-08T10:00:00.000Z',
+    });
+    adapterMocks.runSession.mockReset();
+    adapterMocks.getSession.mockReset();
+  });
+
+  it('submits broker turn and renders the response（提交 broker 请求并展示结果）', async () => {
+    adapterMocks.runSession.mockResolvedValue({
+      sessionId: 'session-api-1',
+      triggerSource: 'http-request',
+      provider: 'openai',
+      model: 'gpt-5',
+      content: '',
+      assistantTurn: {
+        content: '这是首轮响应',
+        toolCalls: [],
+      },
+      toolCalls: [],
+      status: 'completed',
+      createdAt: '2026-04-08T10:00:00.000Z',
+      completedAt: '2026-04-08T10:00:01.000Z',
+    });
+
+    render(<ApiAgentTabView />);
+
+    fireEvent.change(
+      screen.getByPlaceholderText('输入本轮用户消息，点击“发送首轮 / 继续”'),
+      { target: { value: '今天有什么新进展？' } },
+    );
+    fireEvent.click(screen.getByTestId('api-agent-run-button'));
+
+    await waitFor(() => {
+      expect(adapterMocks.runSession).toHaveBeenCalledWith(expect.objectContaining({
+        newUserMessage: '今天有什么新进展？',
+        presets: [],
+      }));
+    });
+
+    expect(await screen.findByText('这是首轮响应')).toBeInTheDocument();
+    expect(screen.getByText('session-api-1')).toBeInTheDocument();
+    expect(screen.getAllByText('completed').length).toBeGreaterThan(0);
+  });
+
+  it('continues with tool results after tool call response（收到 tool call 后可继续续跑）', async () => {
+    adapterMocks.runSession
+      .mockResolvedValueOnce({
+        sessionId: 'session-api-2',
+        triggerSource: 'http-request',
+        provider: 'openai',
+        model: 'gpt-5',
+        content: '',
+        assistantTurn: {
+          content: '',
+          toolCalls: [
+            {
+              id: 'tool-call-1',
+              name: 'get_recent_events',
+              input: { limit: 5 },
+            },
+          ],
+        },
+        toolCalls: [
+          {
+            toolName: 'get_recent_events',
+            input: { limit: 5 },
+          },
+        ],
+        status: 'needs_tool_calls',
+        createdAt: '2026-04-08T10:00:00.000Z',
+        completedAt: '2026-04-08T10:00:01.000Z',
+      })
+      .mockResolvedValueOnce({
+        sessionId: 'session-api-2',
+        triggerSource: 'http-request',
+        provider: 'openai',
+        model: 'gpt-5',
+        content: '',
+        assistantTurn: {
+          content: '已经根据工具结果继续完成。',
+          toolCalls: [],
+        },
+        toolCalls: [
+          {
+            toolName: 'get_recent_events',
+            input: { limit: 5 },
+            output: '最近事件：A / B / C',
+          },
+        ],
+        status: 'completed',
+        createdAt: '2026-04-08T10:00:00.000Z',
+        completedAt: '2026-04-08T10:00:02.000Z',
+      });
+
+    render(<ApiAgentTabView />);
+
+    fireEvent.change(
+      screen.getByPlaceholderText('输入本轮用户消息，点击“发送首轮 / 继续”'),
+      { target: { value: '总结一下最近事件' } },
+    );
+    fireEvent.click(screen.getByTestId('api-agent-run-button'));
+
+    await waitFor(() => {
+      expect(screen.getAllByText('needs_tool_calls').length).toBeGreaterThan(0);
+    });
+
+    fireEvent.change(
+      screen.getByPlaceholderText('输入该工具的结果文本，续跑时会转成 tool history。'),
+      { target: { value: '最近事件：A / B / C' } },
+    );
+    fireEvent.click(screen.getByTestId('api-agent-continue-tools-button'));
+
+    await waitFor(() => {
+      expect(adapterMocks.runSession).toHaveBeenCalledTimes(2);
+    });
+
+    expect(adapterMocks.runSession).toHaveBeenLastCalledWith(expect.objectContaining({
+      history: expect.arrayContaining([
+        expect.objectContaining({
+          role: 'tool',
+          toolCallId: 'tool-call-1',
+          toolName: 'get_recent_events',
+          content: '最近事件：A / B / C',
+        }),
+      ]),
+    }));
+    expect(await screen.findByText('已经根据工具结果继续完成。')).toBeInTheDocument();
+  });
+
+  it('blocks recent_events preset without scope key（recent_events 缺少 scope key 时前端直接拦截）', async () => {
+    render(<ApiAgentTabView />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'recent_events' }));
+    fireEvent.change(
+      screen.getByPlaceholderText('输入本轮用户消息，点击“发送首轮 / 继续”'),
+      { target: { value: '总结最近事件' } },
+    );
+
+    expect(screen.getByTestId('api-agent-run-button')).toBeDisabled();
+    expect(screen.getByText('当前会附带 1 个 preset。第一版先固定聚焦 `recent_events / proposal_tools`。 recent_events 已启用，发送前请先填写 Scope Key。')).toBeInTheDocument();
+    expect(adapterMocks.runSession).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 摘要
- 在 `网络（AgentsPage）` 顶部新增 `API Agent` tab，并接入独立实验视图 `ApiAgentTabView`
- 在设置页 `开发者` 分组新增 `API Agent Tab` 开关（与现有实验开关同层，不进入功能开关子列表）
- 接入 `RT /agent-sessions` 的最小前端调用链路（首轮、tool 续跑、session 读取）
- 统一测试页 UI/UX 到现有网络页风格，并补齐关键可用性拦截

## 关键实现
- 新增配置：`src/config/api-agent-tab-enabled.ts`
- 新增类型与适配：
  - `src/lib/types/agent-session.ts`
  - `src/lib/adapters/agent-session-rt-adapter.ts`
- 新增页面：`src/ui/app/pages/agents/ApiAgentTabView.tsx`
- 接线更新：
  - `src/ui/app/pages/AgentsPage.tsx`
  - `src/ui/app/pages/agents/agents-utils.ts`
  - `src/lib/types/agent-hub.ts`
  - `src/ui/app/config/settings/settings-registry.ts`
- 验证文档补充：
  - `docs/development/tauri-mcp-windows-playbook.md`

## UX/可用性修正
- `recent_events` 默认改为关闭，避免首屏直接触发 `scope_key` 约束导致 400
- 当手动开启 `recent_events` 且未填写 `Scope Key` 时：
  - 禁用 `发送首轮 / 继续`
  - 禁用 `继续执行 Tool Results`
  - 展示前端提示，防止误判后端不可用

## 测试
- 单测：
  - `bunx vitest run tests/unit/ui/agent-hub/api-agent-tab-view.test.tsx tests/unit/ui/agent-hub/agents-page.api-agent-tab.test.tsx tests/unit/ui/agent-hub/agents-page.issue204.test.tsx`
  - `bunx vitest run tests/unit/agent-hub/agent-types-contract.issue204.test.ts tests/unit/settings/settings-registry-coverage.test.ts tests/unit/components/settings/DeveloperSection.test.tsx tests/unit/lib/adapters/agent-session-rt-adapter.test.ts`
- Tauri MCP 端到端（真机）：
  - 在 `Web:36648 / RT:36651 / MCP:44451` 实例中完成
  - 真实验证 `天气示例 -> 发送首轮 -> tool 续跑 -> completed -> 会话读取` 闭环

## 范围说明
- 本 PR 仅覆盖 API Agent tab 最小接入与相关测试/验收记录
- 未处理仓库内其他并行改动（如 voice-runtime 方向）

## 合并建议
- 建议使用 **Squash and merge（压缩合并）**