### PR TITLE
feat(voice): hide Omni providers behind developer mode

### DIFF
--- a/src/ui/app/components/settings/voice-assistant-provider-settings.tsx
+++ b/src/ui/app/components/settings/voice-assistant-provider-settings.tsx
@@ -86,6 +86,10 @@ const PROVIDER_OPTIONS: ChoiceOption<VoiceAssistantProviderId>[] = [
   },
 ];
 
+const SIMPLE_PROVIDER_OPTIONS: ChoiceOption<VoiceAssistantProviderId>[] = [
+  PROVIDER_OPTIONS[0],
+];
+
 function useSubscribedValue<T>(
   getValue: () => T,
   subscribe: (listener: (value: T) => void) => () => void,
@@ -177,6 +181,14 @@ export function VoiceAssistantProviderSettings({
   const unsupportedCombination = isUnsupportedCombination(currentValue);
   const developerMode = Boolean(ctx?.developerMode);
 
+  const visibleProviderOptions = developerMode ? PROVIDER_OPTIONS : SIMPLE_PROVIDER_OPTIONS;
+
+  useEffect(() => {
+    if (!developerMode && currentValue.provider !== 'doubao-o2-realtime') {
+      setVoiceRuntimeProvider('doubao-o2-realtime');
+    }
+  }, [developerMode, currentValue.provider]);
+
   const updateValue = (patch: Partial<VoiceAssistantProviderSettingsValue>) => {
     const nextValue = {
       ...currentValue,
@@ -261,7 +273,7 @@ export function VoiceAssistantProviderSettings({
           aria-label="常驻语音助手 Provider"
           className="mt-3 grid gap-2"
         >
-          {PROVIDER_OPTIONS.map((option) => (
+          {visibleProviderOptions.map((option) => (
             <ChoiceCard
               key={option.value}
               option={option}

--- a/src/ui/app/components/settings/voice-input-provider-settings.tsx
+++ b/src/ui/app/components/settings/voice-input-provider-settings.tsx
@@ -35,7 +35,9 @@ type VoiceInputProviderSettingsProps = {
   ctx?: SettingsContext;
 };
 
-const PROVIDER_OPTIONS: VoiceInputProviderId[] = ['moss', 'volcano', 'qwen-omni'];
+const ALL_PROVIDER_OPTIONS: VoiceInputProviderId[] = ['moss', 'volcano', 'qwen-omni'];
+
+const SIMPLE_PROVIDER_OPTIONS: VoiceInputProviderId[] = ['moss', 'volcano'];
 
 function useSubscribedValue<T>(
   getValue: () => T,
@@ -92,8 +94,17 @@ function DiagnosticRow({
   );
 }
 
-export function VoiceInputProviderSettings(_props: VoiceInputProviderSettingsProps = {}) {
+export function VoiceInputProviderSettings({ ctx }: VoiceInputProviderSettingsProps = {}) {
   const provider = useSubscribedValue(getVoiceShortcutAsrProvider, subscribeVoiceShortcutAsrProviderChanges);
+  const developerMode = Boolean(ctx?.developerMode);
+
+  const providerOptions = developerMode ? ALL_PROVIDER_OPTIONS : SIMPLE_PROVIDER_OPTIONS;
+
+  useEffect(() => {
+    if (!developerMode && provider === 'qwen-omni') {
+      setVoiceShortcutAsrProvider('moss');
+    }
+  }, [developerMode, provider]);
   const volcanoAppKey = useSubscribedValue(getVolcanoAppKey, subscribeVolcanoAppKeyChanges);
   const volcanoAccessKey = useSubscribedValue(getVolcanoAccessKey, subscribeVolcanoAccessKeyChanges);
   const volcanoResourceId = useSubscribedValue(getVolcanoResourceIdSetting, subscribeVolcanoResourceIdChanges);
@@ -139,7 +150,7 @@ export function VoiceInputProviderSettings(_props: VoiceInputProviderSettingsPro
         </div>
 
         <div className="flex flex-wrap gap-2" role="tablist" aria-label="快捷语音输入 provider 切换">
-          {PROVIDER_OPTIONS.map((providerId) => (
+          {providerOptions.map((providerId) => (
             <ProviderToggleButton
               key={providerId}
               providerId={providerId}

--- a/src/ui/app/config/settings/settings-registry.ts
+++ b/src/ui/app/config/settings/settings-registry.ts
@@ -535,7 +535,7 @@ function mossOnly(ctx: SettingsContext): boolean {
 }
 
 function qwenOmniOnly(ctx: SettingsContext): boolean {
-  return ctx.voiceShortcutAsrProvider === 'qwen-omni';
+  return devOnly(ctx) && ctx.voiceShortcutAsrProvider === 'qwen-omni';
 }
 
 function voiceRuntimeDoubaoOnly(ctx: SettingsContext): boolean {
@@ -543,11 +543,11 @@ function voiceRuntimeDoubaoOnly(ctx: SettingsContext): boolean {
 }
 
 function voiceRuntimeOmniCompatibleOnly(ctx: SettingsContext): boolean {
-  return ctx.voiceRuntimeProvider === VOICE_RUNTIME_OMNI_COMPATIBLE_PROVIDER;
+  return devOnly(ctx) && ctx.voiceRuntimeProvider === VOICE_RUNTIME_OMNI_COMPATIBLE_PROVIDER;
 }
 
 function voiceRuntimeOmniRealtimeOnly(ctx: SettingsContext): boolean {
-  return ctx.voiceRuntimeProvider === VOICE_RUNTIME_OMNI_PROVIDER;
+  return devOnly(ctx) && ctx.voiceRuntimeProvider === VOICE_RUNTIME_OMNI_PROVIDER;
 }
 
 function desktopOperatingSystemOnly(): boolean {


### PR DESCRIPTION
## Summary

Closes #946

Hide all Qwen Omni (全模态) voice entries from normal users; show them only when developer mode is enabled.

## Changes

### `settings-registry.ts` — Predicate compound gate
- `qwenOmniOnly` → `devOnly(ctx) && qwenOmniOnly(ctx)` — hides voice-omni-* settings items
- `voiceRuntimeOmniCompatibleOnly` → `devOnly(ctx) && ...` — hides Omni Compatible settings
- `voiceRuntimeOmniRealtimeOnly` → `devOnly(ctx) && ...` — hides Omni Realtime settings
- All 12+ settings items referencing these predicates automatically gated

### `voice-input-provider-settings.tsx` — Short-cut ASR filter
- Split `PROVIDER_OPTIONS` into `ALL_PROVIDER_OPTIONS` / `SIMPLE_PROVIDER_OPTIONS`
- Filter by `ctx.developerMode`: normal users see only moss + volcano
- Auto-fallback: if stored provider is `qwen-omni` and dev mode is off, reset to `moss`

### `voice-assistant-provider-settings.tsx` — Voice assistant provider filter
- `SIMPLE_PROVIDER_OPTIONS` = `[doubao-o2-realtime]` only
- Normal users see only Doubao card; Omni Compatible/Realtime hidden
- Auto-fallback: non-doubao provider reset to `doubao-o2-realtime` when dev mode off

## Not touched (preserved)
- All Omni adapters, config modules, Tauri commands, service code
- Routes (only entry gating changed, route tree unchanged)
- Test files (existing tests still pass; new dev-mode visibility tests to be added separately)

## Verification
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [ ] Manual verification: toggle developer mode on/off in settings
- [ ] Confirm MOSS + Volcano visible in normal mode, Omni hidden
- [ ] Confirm all providers visible in developer mode
- [ ] Confirm auto-fallback works when switching off dev mode with Omni selected