### PR TITLE
fix(focus): 手动修复 handoff 路径无视 countdownEndMode 配置

### DIFF
--- a/src/lib/timeblock/handoff-policy.test.ts
+++ b/src/lib/timeblock/handoff-policy.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { resolveHandoffAction } from './handoff-policy';
+import type { ActiveBlockData } from '@/lib/types/event';
+
+function makeRunningBlock(startId: string): ActiveBlockData {
+  return {
+    startId,
+    name: 'TB1',
+    mode: 'countdown',
+    targetMinutes: 25,
+    blockType: 'active',
+    startTime: 1_000_000,
+    elapsed: 0,
+    paused: false,
+    phase: 'running',
+    transitions: [{ type: 'start', at: 1_000_000 }],
+  };
+}
+
+function makePausedBlock(startId: string): ActiveBlockData {
+  return {
+    ...makeRunningBlock(startId),
+    paused: true,
+    pausedAt: 1_100_000,
+    phase: 'paused',
+    transitions: [
+      { type: 'start', at: 1_000_000 },
+      { type: 'pause', at: 1_100_000 },
+    ],
+  };
+}
+
+function makeFeedbackBlock(startId: string): ActiveBlockData {
+  return {
+    ...makeRunningBlock(startId),
+    phase: 'feedback_in_progress',
+    actionEndedAt: 1_200_000,
+    feedbackStartedAt: 1_200_000,
+    transitions: [
+      { type: 'start', at: 1_000_000 },
+      { type: 'feedback_start', at: 1_200_000 },
+    ],
+  };
+}
+
+describe('resolveHandoffAction — soft 模式回归测试', () => {
+  // ─────────────────────────────────────────────────────────────────
+  // RED: 这是 bug 的核心 — soft 模式下 handoff 绝不能 markEnding
+  // 旧实现：consumePendingHandoff 无条件调用 markEnding
+  // 新实现：soft 模式必须返回 navigateOnly
+  // ─────────────────────────────────────────────────────────────────
+
+  it('soft 模式 + running block + handoff → navigateOnly（不应 markEnding）', () => {
+    const decision = resolveHandoffAction({
+      pendingStartId: 'tb-1',
+      currentBlock: makeRunningBlock('tb-1'),
+      countdownEndMode: 'soft',
+    });
+    expect(decision.kind).toBe('navigateOnly');
+    expect(decision.reason).toBe('soft_mode_skip');
+  });
+
+  it('soft 模式 + paused block + handoff → navigateOnly（不应 markEnding）', () => {
+    const decision = resolveHandoffAction({
+      pendingStartId: 'tb-1',
+      currentBlock: makePausedBlock('tb-1'),
+      countdownEndMode: 'soft',
+    });
+    expect(decision.kind).toBe('navigateOnly');
+    expect(decision.reason).toBe('soft_mode_skip');
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // GREEN: hard 模式保留原有行为
+  // ─────────────────────────────────────────────────────────────────
+
+  it('hard 模式 + running block + handoff → markEnding', () => {
+    const decision = resolveHandoffAction({
+      pendingStartId: 'tb-1',
+      currentBlock: makeRunningBlock('tb-1'),
+      countdownEndMode: 'hard',
+    });
+    expect(decision.kind).toBe('markEnding');
+    expect(decision.reason).toBe('hard_mode_mark_ending');
+  });
+
+  it('hard 模式 + paused block + handoff → markEnding', () => {
+    const decision = resolveHandoffAction({
+      pendingStartId: 'tb-1',
+      currentBlock: makePausedBlock('tb-1'),
+      countdownEndMode: 'hard',
+    });
+    expect(decision.kind).toBe('markEnding');
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // 前置条件守卫 — 即使 hard 模式也必须满足
+  // ─────────────────────────────────────────────────────────────────
+
+  it('无 pendingStartId → navigateOnly（不依赖 mode）', () => {
+    const decision = resolveHandoffAction({
+      pendingStartId: '',
+      currentBlock: makeRunningBlock('tb-1'),
+      countdownEndMode: 'hard',
+    });
+    expect(decision.kind).toBe('navigateOnly');
+    expect(decision.reason).toBe('no_pending_start_id');
+  });
+
+  it('pendingStartId 与当前块不匹配 → navigateOnly', () => {
+    const decision = resolveHandoffAction({
+      pendingStartId: 'tb-old',
+      currentBlock: makeRunningBlock('tb-new'),
+      countdownEndMode: 'hard',
+    });
+    expect(decision.kind).toBe('navigateOnly');
+    expect(decision.reason).toBe('block_mismatch');
+  });
+
+  it('当前块无活动（已结束/feedback）→ navigateOnly', () => {
+    const decision = resolveHandoffAction({
+      pendingStartId: 'tb-1',
+      currentBlock: makeFeedbackBlock('tb-1'),
+      countdownEndMode: 'hard',
+    });
+    expect(decision.kind).toBe('navigateOnly');
+    expect(decision.reason).toBe('phase_not_active');
+  });
+
+  it('无当前块 → navigateOnly', () => {
+    const decision = resolveHandoffAction({
+      pendingStartId: 'tb-1',
+      currentBlock: null,
+      countdownEndMode: 'hard',
+    });
+    expect(decision.kind).toBe('navigateOnly');
+    expect(decision.reason).toBe('block_mismatch');
+  });
+});

--- a/src/lib/timeblock/handoff-policy.ts
+++ b/src/lib/timeblock/handoff-policy.ts
@@ -1,0 +1,74 @@
+/**
+ * Handoff policy — decides whether consuming a timeblock-end-alert handoff
+ * should actually call markEnding() on the active block.
+ *
+ * Extracted from `TimeblockEndAlertCoordinator.consumePendingHandoff` so the
+ * decision can be unit-tested without rendering React.
+ *
+ * Background: handoff is produced when an Android AlarmManager notification
+ * fires and the user taps it (or autoOpenFocus brings the app forward).
+ * Originally the coordinator unconditionally called markEnding() in that
+ * path, ignoring the user's `countdownEndMode: 'soft' | 'hard'` preference.
+ * Soft mode means "remind but keep running"; the handoff path was treating
+ * any handoff as a hard stop, which silently stopped running timeblocks.
+ */
+import type { ActiveBlockData } from '@/lib/types/event';
+import type { CountdownEndMode } from '@/config/timer-preferences';
+import { resolveTimeBlockPhase } from '@/lib/types/event';
+
+export type HandoffActionKind = 'markEnding' | 'navigateOnly';
+
+export type HandoffDecisionReason =
+  | 'no_pending_start_id'
+  | 'block_mismatch'
+  | 'phase_not_active'
+  | 'soft_mode_skip'
+  | 'hard_mode_mark_ending';
+
+export interface ResolveHandoffActionInput {
+  pendingStartId: string | null | undefined;
+  currentBlock: ActiveBlockData | null;
+  countdownEndMode: CountdownEndMode;
+}
+
+export interface HandoffDecision {
+  kind: HandoffActionKind;
+  reason: HandoffDecisionReason;
+}
+
+/**
+ * Decide what to do when a timeblock-end-alert handoff is consumed.
+ *
+ * Always returns `navigateOnly` unless ALL of:
+ *   1. `pendingStartId` is non-empty
+ *   2. `currentBlock.startId` matches `pendingStartId`
+ *   3. current phase is `running` or `paused`
+ *   4. `countdownEndMode === 'hard'`
+ *
+ * In `soft` mode the timeblock keeps running and the caller should only
+ * navigate to the focus page; no markEnding side effect.
+ */
+export function resolveHandoffAction(
+  input: ResolveHandoffActionInput,
+): HandoffDecision {
+  const { pendingStartId, currentBlock, countdownEndMode } = input;
+
+  if (!pendingStartId) {
+    return { kind: 'navigateOnly', reason: 'no_pending_start_id' };
+  }
+
+  if (!currentBlock || currentBlock.startId !== pendingStartId) {
+    return { kind: 'navigateOnly', reason: 'block_mismatch' };
+  }
+
+  const phase = resolveTimeBlockPhase(currentBlock);
+  if (phase !== 'running' && phase !== 'paused') {
+    return { kind: 'navigateOnly', reason: 'phase_not_active' };
+  }
+
+  if (countdownEndMode !== 'hard') {
+    return { kind: 'navigateOnly', reason: 'soft_mode_skip' };
+  }
+
+  return { kind: 'markEnding', reason: 'hard_mode_mark_ending' };
+}

--- a/src/ui/app/components/TimeblockEndAlertCoordinator.tsx
+++ b/src/ui/app/components/TimeblockEndAlertCoordinator.tsx
@@ -10,6 +10,7 @@ import {
   subscribeTimerPreferencesChanges,
 } from '@/config/timer-preferences';
 import { log } from '@/lib/logger';
+import { resolveHandoffAction } from '@/lib/timeblock/handoff-policy';
 import { getTimeBlockService } from '@/lib/services';
 import {
   resolveTimeblockEndAlertRequest,
@@ -163,13 +164,17 @@ export function TimeblockEndAlertCoordinator(): null {
 
       if (pending.startId) {
         try {
-          const currentBlock = activeBlockRef.current;
-          if (currentBlock?.startId === pending.startId) {
-            armedAlertStartIdsRef.current.add(pending.startId);
-            const phase = resolveTimeBlockPhase(currentBlock);
-            if (phase === 'running' || phase === 'paused') {
-              await timeBlockServiceRef.current.markEnding();
-            }
+          const decision = resolveHandoffAction({
+            pendingStartId: pending.startId,
+            currentBlock: activeBlockRef.current,
+            countdownEndMode: timerPreferences.countdownEndMode,
+          });
+          if (decision.kind === 'markEnding') {
+            await timeBlockServiceRef.current.markEnding();
+          } else {
+            log.info(
+              `[TimeblockEndAlert] handoff skipped markEnding (${decision.reason})`,
+            );
           }
         } catch (error) {
           log.warn(`[TimeblockEndAlert] markEnding from handoff failed ${error instanceof Error ? error.message : String(error)}`);
@@ -183,7 +188,7 @@ export function TimeblockEndAlertCoordinator(): null {
     } catch (error) {
       log.warn(`[TimeblockEndAlert] consume handoff failed ${error instanceof Error ? error.message : String(error)}`);
     }
-  }, [blockStateReady, navigate]);
+  }, [blockStateReady, navigate, timerPreferences.countdownEndMode]);
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
## 关联 Issue

Closes #956

## 改动摘要

提取 `consumePendingHandoff` 的 markEnding 决策逻辑为纯函数 `resolveHandoffAction`，并在调用 `markEnding()` 前检查 `countdownEndMode` 配置。

**修复问题**：当 Android AlarmManager 到点触发时（autoOpenFocus 自动拉起或用户点击通知），`consumePendingHandoff` 无条件调用 `markEnding()`，完全无视用户设置的 `countdownEndMode='soft'`（柔和提醒）。这导致即使配置为"柔和提醒"，B端时间块仍被强制停止，停止状态通过 replication 同步到A端。

## 改动内容

- **新增** `src/lib/timeblock/handoff-policy.ts`：纯函数 `resolveHandoffAction`，在什么条件下应该调 markEnding
- **新增** `src/lib/timeblock/handoff-policy.test.ts`：8 个单元测试，覆盖 soft/hard 模式、startId 不匹配、phase 非活跃等场景
- **修改** `TimeblockEndAlertCoordinator.tsx`：用纯函数替换原来 inline 的 markEnding 决策逻辑

## 验收检查

- [x] 本地构建通过（`npx tsc --noEmit`）
- [x] 相关测试通过（`npx vitest run src/lib/timeblock/handoff-policy.test.ts`）

## 自检清单

- [x] 本地构建通过（`npx tsc --noEmit`）
- [x] 相关测试通过（`npx vitest run src/lib/timeblock/handoff-policy.test.ts`）
- [x] 没有引入 `any` 类型
- [x] 没有硬编码的密钥/token
- [x] commit message 引用了 Issue 编号